### PR TITLE
test(test000_setup): fallback for when os.path.relpath throws

### DIFF
--- a/autotest/test000_setup.py
+++ b/autotest/test000_setup.py
@@ -26,6 +26,14 @@ download_version = '2.0'
 mfexe_pth = 'temp/mfexes'
 
 
+def relpath_fallback(pth):
+    try:
+        # throws ValueError on Windows if pth is on a different drive
+        return os.path.relpath(pth)
+    except ValueError:
+        return os.path.abspath(pth)
+
+
 def create_dir(pth):
     # remove pth directory if it exists
     if os.path.exists(pth):
@@ -173,7 +181,7 @@ def test_build_modflow6():
     pymake.main(srcdir, target, fc=fc, cc=cc, include_subdirs=True,
                 fflags=fflags)
 
-    msg = '{} does not exist.'.format(os.path.relpath(target))
+    msg = '{} does not exist.'.format(relpath_fallback(target))
     assert os.path.isfile(target), msg
 
 
@@ -197,7 +205,7 @@ def test_build_mf5to6():
     pymake.main(srcdir, target, fc=fc, cc=cc, include_subdirs=True,
                 extrafiles=extrafiles)
 
-    msg = '{} does not exist.'.format(os.path.relpath(target))
+    msg = '{} does not exist.'.format(relpath_fallback(target))
     assert os.path.isfile(target), msg
 
 
@@ -219,7 +227,7 @@ def test_build_zonebudget():
 
     pymake.main(srcdir, target, fc=fc, cc=cc, extrafiles=extrafiles)
 
-    msg = '{} does not exist.'.format(os.path.relpath(target))
+    msg = '{} does not exist.'.format(relpath_fallback(target))
     assert os.path.isfile(target), msg
 
 


### PR DESCRIPTION
Happens on Windows only. It is only used for logging, so no functional change.

Example of issue:
```python
>>> import os
>>> os.getcwd()[:2]
'D:'
>>> os.path.relpath("C:\\tmp")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\bin\Miniconda3\lib\ntpath.py", line 586, in relpath
    path_drive, start_drive))
ValueError: path is on mount 'C:', start on mount 'D:'
>>> os.path.relpath("D:\\tmp")
'..\\..\\tmp'
```

And the new behavior:
```python
>>> relpath_fallback("D:\\tmp")
'..\\..\\tmp'
>>> relpath_fallback("C:\\tmp")
'C:\\tmp'
```