### PR TITLE
refactor(InputOutputModule): refactor dclosetest

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 ## Automated Testing Status on Travis-CI
 
-### Version 6.0.3 fix-47 &mdash; build 28
-[![Build Status](https://travis-ci.org/MODFLOW-USGS/modflow6.svg?branch=fix-47)](https://travis-ci.org/MODFLOW-USGS/modflow6)
+### Version 6.0.3 refactor-dclosetest &mdash; build 28
+[![Build Status](https://travis-ci.org/MODFLOW-USGS/modflow6.svg?branch=refactor-dclosetest)](https://travis-ci.org/MODFLOW-USGS/modflow6)
 
 ## Introduction
 
@@ -31,7 +31,7 @@ MODFLOW 6 is the latest core version of MODFLOW. It synthesizes many of the capa
 
 #### ***Software/Code citation for MODFLOW 6:***
 
-[Langevin, C.D., Hughes, J.D., Banta, E.R., Provost, A.M., Niswonger, R.G., and Panday, Sorab, 2018, MODFLOW 6 Modular Hydrologic Model version 6.0.3 &mdash; fix-47: U.S. Geological Survey Software Release, 12 October 2018, https://doi.org/10.5066/F76Q1VQV](https://doi.org/10.5066/F76Q1VQV)
+[Langevin, C.D., Hughes, J.D., Banta, E.R., Provost, A.M., Niswonger, R.G., and Panday, Sorab, 2018, MODFLOW 6 Modular Hydrologic Model version 6.0.3 &mdash; refactor-dclosetest: U.S. Geological Survey Software Release, 12 October 2018, https://doi.org/10.5066/F76Q1VQV](https://doi.org/10.5066/F76Q1VQV)
 
 
 ## Instructions for building definition files for new packages

--- a/code.json
+++ b/code.json
@@ -1,23 +1,23 @@
 [
     {
         "status": "Release Candidate", 
-        "languages": [
-            "Fortran2008"
-        ], 
+        "downloadURL": "https://code.usgs.gov/usgs/modflow/modflow6/archive/master.zip", 
         "repositoryURL": "https://code.usgs.gov/usgs/modflow/modflow6.git", 
-        "laborHours": -1, 
+        "disclaimerURL": "https://code.usgs.gov/usgs/modflow/modflow6/blob/master/DISCLAIMER.md", 
         "description": "MODFLOW is the USGS's modular hydrologic model. MODFLOW is considered an international standard for simulating and predicting groundwater conditions and groundwater/surface-water interactions.", 
         "tags": [
             "MODFLOW", 
             "groundwater model"
         ], 
-        "name": "modflow6", 
-        "downloadURL": "https://code.usgs.gov/usgs/modflow/modflow6/archive/master.zip", 
+        "vcs": "git", 
+        "languages": [
+            "Fortran2008"
+        ], 
         "contact": {
             "name": "Christian D. Langevin", 
             "email": "langevin@usgs.gov"
         }, 
-        "vcs": "git", 
+        "laborHours": -1, 
         "version": "6.0.3.28", 
         "date": {
             "metadataLastUpdated": "2018-10-12"
@@ -33,6 +33,6 @@
             "usageType": "openSource"
         }, 
         "homepageURL": "https://code.usgs.gov/usgs/modflow/modflow6/", 
-        "disclaimerURL": "https://code.usgs.gov/usgs/modflow/modflow6/blob/master/DISCLAIMER.md"
+        "name": "modflow6"
     }
 ]

--- a/src/Solution/NumericalSolution.f90
+++ b/src/Solution/NumericalSolution.f90
@@ -1853,9 +1853,9 @@ contains
     integer(I4B), intent(inout) :: iptc
     real(DP), intent(in) :: ptcf
     ! -- local
+    logical :: lsame
     integer(I4B) :: n
     integer(I4B) :: itestmat, i, i1, i2
-    integer(I4B) :: isame
     integer(I4B) :: iptct
     real(DP) :: adiag, diagval
     real(DP) :: l2norm
@@ -1905,8 +1905,8 @@ contains
           end if
         end if
       else
-        isame = IS_SAME(l2norm, this%l2norm0) 
-        if (isame /= 0) then
+        lsame = IS_SAME(l2norm, this%l2norm0) 
+        if (lsame) then
           iptc = 0
         end if
       end if

--- a/src/Solution/SparseMatrixSolver/ims8linear.f90
+++ b/src/Solution/SparseMatrixSolver/ims8linear.f90
@@ -1522,10 +1522,10 @@
         real(DP), DIMENSION(CONVNMOD, NCONV), INTENT(INOUT) :: CONVDRMAX
 !       + + + LOCAL DEFINITIONS + + + 
         LOGICAL :: LORTH
+        logical :: lsame 
         character(len=31) :: cval
         integer(I4B) :: n 
         integer(I4B) :: iiter 
-        integer(I4B) :: isame 
         integer(I4B) :: xloc, rloc
         integer(I4B) :: im, im0, im1
         real(DP) :: tv 
@@ -1647,9 +1647,8 @@
           IF (rcnvg ==  DZERO) ICNVG = 1 
           IF (ICNVG.NE.0) EXIT INNER 
 !-----------CHECK THAT CURRENT AND PREVIOUS rho ARE DIFFERENT           
-          !isame = IMSLINEARSUB_SAME(rho, rho0) 
-          isame = IS_SAME(rho, rho0) 
-          IF (isame.NE.0) THEN 
+          lsame = IS_SAME(rho, rho0) 
+          IF (lsame) THEN 
             EXIT INNER 
           END IF 
 !-----------RECALCULATE THE RESIDUAL
@@ -1735,10 +1734,10 @@
         real(DP), DIMENSION(CONVNMOD, NCONV), INTENT(INOUT) :: CONVDRMAX
 !       + + + LOCAL DEFINITIONS + + +  
         LOGICAL :: LORTH
+        logical :: lsame 
         character(len=15) :: cval1, cval2
         integer(I4B) :: n 
         integer(I4B) :: iiter 
-        integer(I4B) :: isame 
         integer(I4B) :: xloc, rloc
         integer(I4B) :: im, im0, im1
         real(DP) :: tv 
@@ -1923,19 +1922,16 @@
           IF (ICNVG.NE.0) EXIT INNER
 !-----------CHECK THAT CURRENT AND PREVIOUS rho, alpha, AND omega ARE 
 !           DIFFERENT
-          !isame = IMSLINEARSUB_SAME(rho, rho0) 
-          isame = IS_SAME(rho, rho0) 
-          IF (isame.NE.0) THEN 
+          lsame = IS_SAME(rho, rho0) 
+          IF (lsame) THEN 
             EXIT INNER 
           END IF 
-          !isame = IMSLINEARSUB_SAME(alpha, alpha0) 
-          isame = IS_SAME(alpha, alpha0) 
-          IF (isame.NE.0) THEN 
+          lsame = IS_SAME(alpha, alpha0) 
+          IF (lsame) THEN 
             EXIT INNER 
           END IF 
-          !isame = IMSLINEARSUB_SAME(omega, omega0) 
-          isame = IS_SAME(omega, omega0) 
-          IF (isame.NE.0) THEN 
+          lsame = IS_SAME(omega, omega0) 
+          IF (lsame) THEN 
             EXIT INNER 
           END IF 
 !-----------RECALCULATE THE RESIDUAL

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -7,8 +7,9 @@ module InputOutputModule
                        store_error_filename
   use ConstantsModule, only: LINELENGTH, LENBIGLINE, LENBOUNDNAME,             &
                              NAMEDBOUNDFLAG, LINELENGTH, MAXCHARLEN
+  use GenericUtilities, only: IS_SAME
   private
-  public :: dclosetest, GetUnit, u8rdcom, uget_block,                          &
+  public :: GetUnit, u8rdcom, uget_block,                                      &
             uterminate_block, UPCASE, URWORD, ULSTLB, UBDSV4,                  &
             ubdsv06, UBDSVB, UCOLNO, ULAPRW,                                   &
             ULASAV, ubdsv1, ubdsvc, ubdsvd, UWWORD,                            &
@@ -21,41 +22,6 @@ module InputOutputModule
             BuildFloatFormat, BuildIntFormat
 
   contains
-
-  logical function dclosetest(a,b,eps)
-! ******************************************************************************
-! Check and see if two doubles are close enough to be considered equal
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-    implicit none
-    ! -- dummy
-    real(DP), intent(in) :: a
-    real(DP), intent(in) :: b
-    real(DP), intent(in), optional :: eps
-    ! -- local
-    real(DP) :: epslocal, absval
-! ------------------------------------------------------------------------------
-    !
-    if (present(eps)) then
-      epslocal = eps
-    else
-      epslocal = 1.2d-7
-    endif
-    dclosetest=.true.
-    if(a.gt.b) then
-      absval = abs(a)
-      if((a-b) .le. absval*epslocal) return
-    else
-      absval = abs(b)
-      if((b-a) .le. absval*epslocal) return
-    end if
-    dclosetest=.false.
-    !
-    ! -- Return
-    return
-  end function dclosetest
 
   subroutine openfile(iu, iout, fname, ftype, fmtarg_opt, accarg_opt,          &
                       filstat_opt)
@@ -1652,7 +1618,7 @@ module InputOutputModule
     character(len=100) :: msg
     !
     ! -- don't get bitten by rounding errors or divide-by-zero
-    if (dclosetest(t0, t1) .or. dclosetest(t, t1)) then
+    if (IS_SAME(t0, t1) .or. IS_SAME(t, t1)) then
       y = y1
     elseif (t == t0) then
       y = y0

--- a/src/Utilities/Observation/Observe.f90
+++ b/src/Utilities/Observation/Observe.f90
@@ -15,7 +15,7 @@ module ObserveModule
   use BaseDisModule,     only: DisBaseType
   use ConstantsModule,   only: LENBOUNDNAME, LENOBSNAME, LENOBSTYPE, &
                                MAXOBSTYPES, DNODATA, DZERO
-  use InputOutputModule, only: dclosetest, urword
+  use InputOutputModule, only: urword
   use ListModule,        only: ListType
   use SimModule,         only: store_warning, store_error, &
                                store_error_unit, ustop

--- a/src/Utilities/TimeSeries/TimeArraySeries.f90
+++ b/src/Utilities/TimeSeries/TimeArraySeries.f90
@@ -4,7 +4,8 @@ module TimeArraySeriesModule
   use BlockParserModule,  only: BlockParserType
   use ConstantsModule,    only: LINELENGTH, UNDEFINED, STEPWISE, LINEAR,        &
                                 LENTIMESERIESNAME, LENBIGLINE, DZERO, DONE
-  use InputOutputModule,  only: dclosetest, GetUnit, openfile
+  use GenericUtilities,   only: IS_SAME
+  use InputOutputModule,  only: GetUnit, openfile
   use KindModule,         only: DP, I4B
   use ListModule,         only: ListType, ListNodeType
   use SimModule,          only: count_errors, store_error, store_error_unit, &
@@ -19,9 +20,6 @@ module TimeArraySeriesModule
   private
   public  :: TimeArraySeriesType, ConstructTimeArraySeries, &
              CastAsTimeArraySeriesType, GetTimeArraySeriesFromList
-  private :: epsil
-
-  real(DP), parameter :: epsil = 1.0d-10
 
   type TimeArraySeriesType
     ! -- Public members
@@ -501,7 +499,7 @@ contains
           ierr = 1
         endif
       else
-        if (dclosetest(taEarlier%taTime, time, epsil)) then
+        if (IS_SAME(taEarlier%taTime, time)) then
           values = taEarlier%taArray
         else
           ! -- Only earlier time is available, and it is not time of interest;
@@ -515,7 +513,7 @@ contains
       endif
     else
       if (associated(taLater)) then
-        if (dclosetest(taLater%taTime, time, epsil)) then
+        if (IS_SAME(taLater%taTime, time)) then
           values = taLater%taArray
         else
           ! -- only later time is available, and it is not time of interest
@@ -760,7 +758,7 @@ contains
         if (associated(currNode%nextNode)) then
           obj => currNode%nextNode%GetItem()
           ta => CastAsTimeArrayType(obj)
-          if (ta%taTime < time  .or. dclosetest(ta%taTime, time, epsil)) then
+          if (ta%taTime < time  .or. IS_SAME(ta%taTime, time)) then
             currNode => currNode%nextNode
           else
             exit

--- a/src/Utilities/TimeSeries/TimeSeries.f90
+++ b/src/Utilities/TimeSeries/TimeSeries.f90
@@ -5,8 +5,8 @@ module TimeSeriesModule
   use ConstantsModule,        only: LINELENGTH, UNDEFINED, STEPWISE, LINEAR, &
                                     LINEAREND, LENTIMESERIESNAME, LENHUGELINE, &
                                     DZERO, DONE, DNODATA
-  use InputOutputModule,      only: GetUnit, openfile, ParseLine, upcase, &
-                                    dclosetest
+  use GenericUtilities,       only: IS_SAME
+  use InputOutputModule,      only: GetUnit, openfile, ParseLine, upcase
   use ListModule,             only: ListType, ListNodeType
   use SimModule,              only: count_errors, store_error, &
                                     store_error_unit, ustop
@@ -20,8 +20,6 @@ module TimeSeriesModule
             TimeSeriesContainerType, AddTimeSeriesFileToList, &
             GetTimeSeriesFileFromList, CastAsTimeSeriesFileClass, &
             SameTimeSeries
-
-  real(DP), parameter :: epsil = 1.0d-10
 
   type TimeSeriesType
     ! -- Public members
@@ -339,7 +337,7 @@ contains
         if (associated(currNode%nextNode)) then
           obj => currNode%nextNode%GetItem()
           tsr => CastAsTimeSeriesRecordType(obj)
-          if (tsr%tsrTime < time .and. .not. dclosetest(tsr%tsrTime, time, epsil)) then
+          if (tsr%tsrTime < time .and. .not. IS_SAME(tsr%tsrTime, time)) then
             currNode => currNode%nextNode
           else
             exit
@@ -376,7 +374,7 @@ contains
       obj => tsNode1%GetItem()
       tsrec1 => CastAsTimeSeriesRecordType(obj)
       time1 = tsrec1%tsrTime
-      do while (time1 < time .and. .not. dclosetest(time1,time,epsil))
+      do while (time1 < time .and. .not. IS_SAME(time1, time))
         if (associated(tsNode1%nextNode)) then
           tsNode1 => tsNode1%nextNode
           obj => tsNode1%GetItem()
@@ -393,8 +391,8 @@ contains
       !
     endif
     !
-    if (time0 < time .or. dclosetest(time0,time,epsil)) tsrecEarlier => tsrec0
-    if (time1 > time .or. dclosetest(time1,time,epsil)) tsrecLater => tsrec1
+    if (time0 < time .or. IS_SAME(time0, time)) tsrecEarlier => tsrec0
+    if (time1 > time .or. IS_SAME(time1, time)) tsrecLater => tsrec1
     !
     return
   end subroutine get_surrounding_records
@@ -441,7 +439,7 @@ contains
         if (associated(currNode%nextNode)) then
           obj => currNode%nextNode%GetItem()
           tsr => CastAsTimeSeriesRecordType(obj)
-          if (tsr%tsrTime < time .and. .not. dclosetest(tsr%tsrTime, time, epsil)) then
+          if (tsr%tsrTime < time .and. .not. IS_SAME(tsr%tsrTime, time)) then
             currNode => currNode%nextNode
           else
             exit
@@ -477,7 +475,7 @@ contains
       obj => tsNode1%GetItem()
       tsrec1 => CastAsTimeSeriesRecordType(obj)
       time1 = tsrec1%tsrTime
-      do while (time1 < time .and. .not. dclosetest(time1,time,epsil))
+      do while (time1 < time .and. .not. IS_SAME(time1, time))
         if (associated(tsNode1%nextNode)) then
           tsNode1 => tsNode1%nextNode
           obj => tsNode1%GetItem()
@@ -490,11 +488,11 @@ contains
       !
     endif
     !
-    if (time0 < time .or. dclosetest(time0,time,epsil)) then
+    if (time0 < time .or. IS_SAME(time0, time)) then
       tsrecEarlier => tsrec0
       nodeEarlier => tsNode0
     endif
-    if (time1 > time .or. dclosetest(time1,time,epsil)) then
+    if (time1 > time .or. IS_SAME(time1, time)) then
       tsrecLater => tsrec1
       nodeLater => tsNode1
     endif
@@ -573,7 +571,7 @@ contains
           ierr = 1
         endif
       else
-        if (dclosetest(tsrEarlier%tsrTime, time, epsil)) then
+        if (IS_SAME(tsrEarlier%tsrTime, time)) then
           get_value_at_time = tsrEarlier%tsrValue
         else
           ! -- Only earlier time is available, and it is not time of interest;
@@ -587,7 +585,7 @@ contains
       endif
     else
       if (associated(tsrLater)) then
-        if (dclosetest(tsrLater%tsrTime, time, epsil)) then
+        if (IS_SAME(tsrLater%tsrTime, time)) then
           get_value_at_time = tsrLater%tsrValue
         else
           ! -- only later time is available, and it is not time of interest
@@ -649,7 +647,7 @@ contains
         currObj => currNode%GetItem()
         currRecord => CastAsTimeSeriesRecordType(currObj)
         currTime = currRecord%tsrTime
-        if (dclosetest(currTime, time1, epsil)) then
+        if (IS_SAME(currTime, time1)) then
           ! Current node time = time1 so should be ldone
           ldone = .true.
         elseif (currTime < time1) then
@@ -668,12 +666,12 @@ contains
             nextTime = nextRecord%tsrTime
             ! -- determine lower and upper limits of time span of interest
             !    within current interval
-            if (currTime > time0 .or. dclosetest(currTime,time0,epsil)) then
+            if (currTime > time0 .or. IS_SAME(currTime, time0)) then
               t0 = currTime
             else
               t0 = time0
             endif
-            if (nextTime < time1 .or. dclosetest(nextTime,time1,epsil)) then
+            if (nextTime < time1 .or. IS_SAME(nextTime, time1)) then
               t1 = nextTime
             else
               t1 = time1
@@ -708,7 +706,7 @@ contains
         ! -- Are we done yet?
         if (t1 > time1) then
           ldone = .true.
-        elseif (dclosetest(t1, time1, epsil)) then
+        elseif (IS_SAME(t1, time1)) then
           ldone = .true.
         else
           ! -- We are not done yet
@@ -810,7 +808,7 @@ contains
         if (associated(currNode%nextNode)) then
           obj => currNode%nextNode%GetItem()
           tsr => CastAsTimeSeriesRecordType(obj)
-          if (tsr%tsrTime < time .or. dclosetest(tsr%tsrTime, time, epsil)) then
+          if (tsr%tsrTime < time .or. IS_SAME(tsr%tsrTime, time)) then
             currNode => currNode%nextNode
           else
             exit
@@ -843,7 +841,7 @@ contains
       enddo
     endif
     !
-    if (time0 < time .or. dclosetest(time0,time,epsil)) tslNode => tsNode0
+    if (time0 < time .or. IS_SAME(time0, time)) tslNode => tsNode0
     !
     return
   end subroutine get_latest_preceding_node
@@ -984,7 +982,7 @@ contains
     do
       tsr => this%GetNextTimeSeriesRecord()
       if (associated(tsr)) then
-        if (dclosetest(tsr%tsrTime,time,epsi)) then
+        if (IS_SAME(tsr%tsrTime, time)) then
           res => tsr
           exit
         endif

--- a/src/Utilities/genericutils.f90
+++ b/src/Utilities/genericutils.f90
@@ -9,21 +9,28 @@ module GenericUtilities
 
   contains
   
-  function is_same(a, b) result(ivalue)
+  function is_same(a, b, eps) result(lvalue)
     ! -- return
-    integer(I4B) :: ivalue
+    logical :: lvalue
     ! -- dummy arguments
     real(DP), intent(in)   :: a
     real(DP), intent(in)   :: b
+    real(DP), intent(in), optional :: eps
     ! -- local definitions 
+    real(DP) :: epsloc
     real(DP) :: denom
     real(DP) :: rdiff
     ! -- parameters
     ! -- functions
     ! -- code
-    ivalue = 0
+    if (present(eps)) then
+      epsloc = eps
+    else
+      epsloc = DSAME
+    endif
+    lvalue = .FALSE.
     if (a == b) then
-      ivalue = 1
+      lvalue = .TRUE.
     else
       if (abs(b) > abs(a)) then
         denom = b
@@ -34,8 +41,8 @@ module GenericUtilities
         end if
       end if
       rdiff = abs( (a - b) / denom )
-      if (rdiff <= DSAME) then
-        ivalue = 1
+      if (rdiff <= epsloc) then
+        lvalue = .TRUE.
       end if
     end if
     ! -- return

--- a/utils/mf5to6/msvs/mf5to6.vfproj
+++ b/utils/mf5to6/msvs/mf5to6.vfproj
@@ -90,6 +90,7 @@
 		<File RelativePath="..\..\..\src\Utilities\TimeSeries\TimeSeriesRecord.f90"/></Filter>
 		<File RelativePath="..\..\..\src\Utilities\BlockParser.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\Constants.f90"/>
+		<File RelativePath="..\..\..\src\Utilities\genericutils.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\InputOutput.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\kind.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\List.f90"/>

--- a/utils/mf5to6/pymake/extrafiles.txt
+++ b/utils/mf5to6/pymake/extrafiles.txt
@@ -5,6 +5,7 @@
 ../../../src/Utilities/TimeSeries/TimeSeriesRecord.f90
 ../../../src/Utilities/BlockParser.f90
 ../../../src/Utilities/Constants.f90
+../../../src/Utilities/genericutils.f90
 ../../../src/Utilities/InputOutput.f90
 ../../../src/Utilities/kind.f90
 ../../../src/Utilities/List.f90

--- a/utils/mf5to6/src/MultiLayerObsModule.f90
+++ b/utils/mf5to6/src/MultiLayerObsModule.f90
@@ -2,7 +2,7 @@ module MultiLayerObs
   
   use ConstantsModule, only: DONE, MAXCHARLEN
   use ConstantsPHMFModule, only: LENOBSNAMENEW
-  use InputOutputModule, only: dclosetest
+  use GenericUtilities, only: IS_SAME
   use ListModule, only: ListType
   use SimModule, only: store_error, ustop
 
@@ -153,7 +153,7 @@ module MultiLayerObs
       weightsum = weightsum + layobs%weight
     enddo
     !
-    if (.not. dclosetest(weightsum, DONE, 1.0d-7)) then
+    if (.not. IS_SAME(weightsum, DONE)) then
       write(ermsg,10)trim(this%mlobsname)
       call store_error(ermsg)
       call ustop()

--- a/utils/mf5to6/src/Preproc/Discretization3D.f90
+++ b/utils/mf5to6/src/Preproc/Discretization3D.f90
@@ -5,7 +5,7 @@ module DnmDis3dModule
   use ConstantsPHMFModule,       only: PI
   use DnmDisBaseModule,          only: DisBaseType
   use GlobalVariablesPHMFModule, only: verbose
-  use InputOutputModule,         only: get_ijk, get_node, URWORD, dclosetest
+  use InputOutputModule,         only: get_ijk, get_node, URWORD
   use SimModule,                 only: count_errors, store_error, &
                                        store_error_unit, ustop
   implicit none

--- a/utils/mf5to6/src/Preproc/ObsBlock.f90
+++ b/utils/mf5to6/src/Preproc/ObsBlock.f90
@@ -3,11 +3,11 @@ module ObsBlockModule
   use BlockParserModule,         only: BlockParserType
   use ConstantsModule,           only: DONE, DZERO, &
                                        LINELENGTH, MAXCHARLEN 
+  use GenericUtilities, only: IS_SAME
   use ConstantsPHMFModule,       only: CONTINUOUS, SINGLE, LENOBSNAMENEW
   use DnmDis3dModule,            only: Dis3dType
   use GlobalVariablesPHMFModule, only: verbose
-  use InputOutputModule,         only: dclosetest, UPCASE, URWORD, &
-                                       uterminate_block
+  use InputOutputModule,         only: UPCASE, URWORD, uterminate_block
   use ListModule,                only: ListType
   use ObserveModule,             only: ObserveType, AddObserveToList, &
                                        GetObserveFromList, ConstructObservation
@@ -184,7 +184,7 @@ contains
         iadjrow = 0
         jadjcol = 0
         !
-        if (.not. dclosetest(xoff, DZERO)) then
+        if (.not. IS_SAME(xoff, DZERO)) then
           if (xoff > DZERO) then
             if (jcol < ncol) then
               if (dis3d%idomain(jcol+1, irow, layer) == 1) then
@@ -202,7 +202,7 @@ contains
           endif
         endif
         !
-        if (.not. dclosetest(yoff, DZERO)) then
+        if (.not. IS_SAME(yoff, DZERO)) then
           if (yoff > DZERO) then
             if (irow > 1) then
               if (dis3d%idomain(jcol, irow-1, layer) == 1) then

--- a/utils/mf5to6/src/Preproc/ObservePHMF.f90
+++ b/utils/mf5to6/src/Preproc/ObservePHMF.f90
@@ -15,7 +15,7 @@ module ObserveModule
   use ConstantsModule,   only: DONE, DZERO, LENOBSNAME,  &
                                LENOBSTYPE, MAXCHARLEN
   use ConstantsPHMFModule, only: LENOBSNAMENEW, HUGEDBL, HDRYDEFAULT
-  use InputOutputModule, only: dclosetest
+  use GenericUtilities, only: IS_SAME
   use ListModule,        only: ListType
   use SimModule,         only: store_warning, store_error, &
                                store_error_unit, ustop
@@ -206,7 +206,7 @@ contains
       sumweights = DZERO
       k = 0
       do i=1,nsrc
-        if (dclosetest(this%srcvals(itime, i), this%hdry)) then
+        if (IS_SAME(this%srcvals(itime, i), this%hdry)) then
           k = k + 1
           weights(i) = DZERO
         else

--- a/utils/mf5to6/src/Preproc/Preproc.f90
+++ b/utils/mf5to6/src/Preproc/Preproc.f90
@@ -16,7 +16,7 @@ module PreprocModule
   use GlobalVariablesPHMFModule, only: prognamPHMF, verbose, vnam
   use InputOutputModule,         only: GetUnit, uget_block, urword, &
                                        uterminate_block, GetUnit, openfile, &
-                                       uget_any_block, dclosetest
+                                       uget_any_block
   use ListModule,                only: ListType
   use ObsBlockModule,            only: ObsBlockType, ConstructObsBlockType, &
                                        AddObsBlockToList, GetObsBlockFromList

--- a/utils/zonebudget/pymake/extrafiles.txt
+++ b/utils/zonebudget/pymake/extrafiles.txt
@@ -3,6 +3,7 @@
 ../../../src/Utilities/BlockParser.f90
 ../../../src/Utilities/Budget.f90
 ../../../src/Utilities/Constants.f90
+../../../src/Utilities/genericutils.f90
 ../../../src/Utilities/InputOutput.f90
 ../../../src/Utilities/kind.f90
 ../../../src/Utilities/OpenSpec.f90

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,5 @@
 # MODFLOW 6 version file automatically created using...pre-commit.py
-# created on...October 12, 2018 14:09:30
+# created on...October 12, 2018 17:36:05
 
 # add some comments on how this version file
 # should be manually updated and used


### PR DESCRIPTION
Refactor dclosetest and replace with IS_SAME in GenericUtilities.
Convert IS_SAME to logical function and allow passing of evaluation
value (eps). If eps is not passed then DSAME is used. Modified calls
to dclosetest to IS_SAME but did not pass an eps value (unlike what
was done previously). All tests pass so current tests are not sensitive
to a passed eps value. Need to monitor this for timeseries functionality
which used dclosetest.