### PR TITLE
docs(dfn): fix 3 dfn typos

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwf-npf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-npf.dfn
@@ -77,7 +77,7 @@ description activates model rewetting.  Rewetting is off by default.
 
 block options
 name wetfct
-type double
+type double precision
 in_record true
 reader urword
 optional false

--- a/doc/mf6io/mf6ivar/dfn/sim-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/sim-nam.dfn
@@ -156,7 +156,7 @@ description is the list of solution types and models in the solution.
 block solutiongroup
 name slntype
 type string
-valid_values ims6
+valid ims6
 in_record true
 tagged false
 reader urword

--- a/doc/mf6io/mf6ivar/dfn/utl-obs.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-obs.dfn
@@ -33,7 +33,7 @@ name output
 type record fileout obs_output_file_name binary
 shape
 block_variable true
-in_record = false
+in_record false
 reader urword
 optional false
 longname


### PR DESCRIPTION
- `double` → `double precision`
- `valid_values` → `valid`
- `in_record = false` → `in_record false`