### PR TITLE
refactor(gnc): removed iasln as it was not used and named wrong

### DIFF
--- a/src/Exchange/GhostNode.f90
+++ b/src/Exchange/GhostNode.f90
@@ -307,7 +307,7 @@ module GhostNodeModule
     return
   end subroutine gnc_mc
 
-  subroutine gnc_fmsav(this, kiter, iasln, amatsln)
+  subroutine gnc_fmsav(this, kiter, amatsln)
 ! ******************************************************************************
 ! gnc_fmsav -- Store the n-m Picard conductance in cond prior to the Newton
 !   terms being added.
@@ -320,7 +320,6 @@ module GhostNodeModule
     ! -- dummy
     class(GhostNodeType) :: this
     integer(I4B), intent(in) :: kiter
-    integer(I4B), dimension(:), intent(in) :: iasln
     real(DP), dimension(:), intent(inout) :: amatsln
     ! -- local
     integer(I4B) :: ignc, ipos
@@ -343,7 +342,7 @@ module GhostNodeModule
     return
   end subroutine gnc_fmsav
 
-  subroutine gnc_fc(this, kiter, iasln, amatsln)
+  subroutine gnc_fc(this, kiter, amatsln)
 ! ******************************************************************************
 ! gnc_fc -- Fill matrix terms
 ! Subroutine: (1) Add the GNC terms to the solution amat or model rhs depending
@@ -357,7 +356,6 @@ module GhostNodeModule
     ! -- dummy
     class(GhostNodeType) :: this
     integer(I4B), intent(in) :: kiter
-    integer(I4B), dimension(:), intent(in) :: iasln
     real(DP), dimension(:), intent(inout) :: amatsln
     ! -- local
     integer(I4B) :: ignc, j, noden, nodem, ipos, jidx, iposjn, iposjm
@@ -366,7 +364,7 @@ module GhostNodeModule
     !
     ! -- If this is a single model gnc (not an exchange across models), then
     !    pull conductances out of amatsln and store them in this%cond
-    if(this%smgnc) call this%gnc_fmsav(kiter, iasln, amatsln)
+    if(this%smgnc) call this%gnc_fmsav(kiter, amatsln)
     !
     ! -- Add gnc terms to rhs or to amat depending on whether gnc is implicit
     !    or explicit

--- a/src/Exchange/GwfGwfExchange.f90
+++ b/src/Exchange/GwfGwfExchange.f90
@@ -533,7 +533,7 @@ contains
     !
     ! -- Fill the gnc terms in the solution matrix
     if(this%ingnc > 0) then
-      call this%gnc%gnc_fc(kiter, iasln, amatsln)
+      call this%gnc%gnc_fc(kiter, amatsln)
     endif
     !
     ! -- Call mvr fc routine

--- a/src/Model/GroundWaterFlow/gwf3.f90
+++ b/src/Model/GroundWaterFlow/gwf3.f90
@@ -315,7 +315,7 @@ module GwfModule
     !
     ! -- Define packages and utility objects
     call this%dis%dis_df()
-    call this%npf%npf_df(this%xt3d, this%ingnc)
+    call this%npf%npf_df(this%dis, this%xt3d, this%ingnc)
     call this%oc%oc_df()
     call this%budget%budget_df(niunit, 'VOLUME', 'L**3')
     if(this%ingnc > 0) call this%gnc%gnc_df(this)
@@ -359,12 +359,11 @@ module GwfModule
     integer(I4B) :: ip
 ! ------------------------------------------------------------------------------
     !
-    ! -- Add the internal connections of this model to sparse
+    ! -- Add the primary grid connections of this model to sparse
     call this%dis%dis_ac(this%moffset, sparse)
     !
     ! -- Add any additional connections that NPF may need
-    if(this%innpf > 0) call this%npf%npf_ac(this%moffset, sparse,              &
-      this%dis%nodes, this%ia, this%ja)
+    if(this%innpf > 0) call this%npf%npf_ac(this%moffset, sparse)
     !
     ! -- Add any package connections
     do ip = 1, this%bndlist%Count()
@@ -401,8 +400,7 @@ module GwfModule
     call this%dis%dis_mc(this%moffset, this%idxglo, iasln, jasln)
     !
     ! -- Map any additional connections that NPF may need
-    if(this%innpf > 0) call this%npf%npf_mc(this%moffset, this%dis%nodes,      &
-      this%ia, this%ja, iasln, jasln)
+    if(this%innpf > 0) call this%npf%npf_mc(this%moffset, iasln, jasln)
     !
     ! -- Map any package connections
     do ip=1,this%bndlist%Count()
@@ -436,8 +434,7 @@ module GwfModule
     !
     ! -- Allocate and read modules attached to model
     if(this%inic  > 0) call this%ic%ic_ar(this%x)
-    if(this%innpf > 0) call this%npf%npf_ar(this%dis, this%ic,                 &
-                                            this%ibound, this%x)
+    if(this%innpf > 0) call this%npf%npf_ar(this%ic, this%ibound, this%x)
     if(this%inhfb > 0) call this%hfb%hfb_ar(this%ibound, this%xt3d, this%dis)
     if(this%insto > 0) call this%sto%sto_ar(this%dis, this%ibound)
     if(this%inmvr > 0) call this%mvr%mvr_ar()
@@ -901,10 +898,8 @@ module GwfModule
     do i = 1, this%nja
       this%flowja(i) = DZERO
     enddo
-    if(this%innpf > 0) call this%npf%npf_flowja(this%neq, this%nja, this%x,    &
-                                                this%flowja)
-    if(this%inhfb > 0) call this%hfb%hfb_flowja(this%neq, this%nja, this%x,    &
-                                                this%flowja)
+    if(this%innpf > 0) call this%npf%npf_flowja(this%x, this%flowja)
+    if(this%inhfb > 0) call this%hfb%hfb_flowja(this%x, this%flowja)
     if(this%ingnc > 0) call this%gnc%flowja(this%flowja)
     !
     ! -- Return
@@ -1028,7 +1023,7 @@ module GwfModule
     if(ibudfl /= 0) then
       !
       ! -- NPF output
-      if(this%innpf > 0) call this%npf%npf_ot(this%neq, this%nja, this%flowja)
+      if(this%innpf > 0) call this%npf%npf_ot(this%nja, this%flowja)
       !
       ! -- GNC output
       if(this%ingnc > 0) &

--- a/src/Model/GroundWaterFlow/gwf3.f90
+++ b/src/Model/GroundWaterFlow/gwf3.f90
@@ -600,7 +600,7 @@ module GwfModule
     if(this%inhfb > 0) call this%hfb%hfb_fc(kiter, this%dis%nodes,             &
                                                 this%nja, njasln, amatsln,     &
                                                 this%idxglo, this%rhs, this%x)
-    if(this%ingnc > 0) call this%gnc%gnc_fc(kiter, this%ia, amatsln)
+    if(this%ingnc > 0) call this%gnc%gnc_fc(kiter, amatsln)
     if(this%insto > 0) then
       call this%sto%sto_fc(kiter, this%dis%nodes, this%xold,                   &
                             this%x, this%nja, njasln,                          &

--- a/src/Model/GroundWaterFlow/gwf3hfb8.f90
+++ b/src/Model/GroundWaterFlow/gwf3hfb8.f90
@@ -196,7 +196,7 @@ module GwfHfbModule
     return
   end subroutine hfb_rp
 
-  subroutine hfb_fc(this, kiter, nodes, nja, njasln, amat, idxglo, rhs, hnew)
+  subroutine hfb_fc(this, kiter, njasln, amat, idxglo, rhs, hnew)
 ! ******************************************************************************
 ! hfb_fc -- Fill amatsln for the following conditions:
 !   1.  Not Newton, and
@@ -212,14 +212,13 @@ module GwfHfbModule
     ! -- dummy
     class(GwfHfbType) :: this
     integer(I4B) :: kiter
-    integer(I4B),intent(in) :: nodes
-    integer(I4B),intent(in) :: nja
     integer(I4B),intent(in) :: njasln
     real(DP),dimension(njasln),intent(inout) :: amat
-    integer(I4B),intent(in),dimension(nja) :: idxglo
-    real(DP),intent(inout),dimension(nodes) :: rhs
-    real(DP),intent(inout),dimension(nodes) :: hnew
+    integer(I4B),intent(in),dimension(:) :: idxglo
+    real(DP),intent(inout),dimension(:) :: rhs
+    real(DP),intent(inout),dimension(:) :: hnew
     ! -- local
+    integer(I4B) ::  nodes, nja
     integer(I4B) :: ihfb, n, m
     integer(I4B) :: ipos
     integer(I4B) :: idiag, isymcon
@@ -229,6 +228,8 @@ module GwfHfbModule
     real(DP) :: topn, topm, botn, botm
 ! ------------------------------------------------------------------------------
     !
+    nodes = this%dis%nodes
+    nja = this%dis%con%nja
     if (associated(this%xt3d%ixt3d)) then
       ixt3d = this%xt3d%ixt3d
     else

--- a/src/Model/GroundWaterFlow/gwf3hfb8.f90
+++ b/src/Model/GroundWaterFlow/gwf3hfb8.f90
@@ -335,7 +335,7 @@ module GwfHfbModule
     return
   end subroutine hfb_fc
 
-  subroutine hfb_flowja(this, nodes, nja, hnew, flowja)
+  subroutine hfb_flowja(this, hnew, flowja)
 ! ******************************************************************************
 ! hfb_flowja -- flowja will automatically include the effects of the hfb
 !   for confined and newton cases when xt3d is not used.  This method
@@ -348,10 +348,8 @@ module GwfHfbModule
     use ConstantsModule, only: DHALF, DZERO
     ! -- dummy
     class(GwfHfbType) :: this
-    integer(I4B),intent(in) :: nodes
-    integer(I4B),intent(in) :: nja
-    real(DP),intent(inout),dimension(nodes) :: hnew
-    real(DP),intent(inout),dimension(nja) :: flowja
+    real(DP),intent(inout),dimension(:) :: hnew
+    real(DP),intent(inout),dimension(:) :: flowja
     ! -- local
     integer(I4B) :: ihfb, n, m
     integer(I4B) :: ipos
@@ -405,7 +403,7 @@ module GwfHfbModule
           condhfb = this%hydchr(ihfb)
         endif
         ! -- Make hfb corrections for xt3d
-        call this%xt3d%xt3d_flowjahfb(nodes, n, m, nja, hnew, flowja, condhfb)
+        call this%xt3d%xt3d_flowjahfb(n, m, hnew, flowja, condhfb)
       end do
       !
     else

--- a/src/Model/GroundWaterFlow/gwf3npf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8.f90
@@ -348,7 +348,7 @@ module GwfNpfModule
     return
   end subroutine npf_cf
 
-  subroutine npf_fc(this, kiter, nodes, nja, njasln, amat, idxglo, rhs, hnew)
+  subroutine npf_fc(this, kiter, njasln, amat, idxglo, rhs, hnew)
 ! ******************************************************************************
 ! npf_fc -- Formulate
 ! ******************************************************************************
@@ -360,13 +360,11 @@ module GwfNpfModule
     ! -- dummy
     class(GwfNpfType) :: this
     integer(I4B) :: kiter
-    integer(I4B),intent(in) :: nodes
-    integer(I4B),intent(in) :: nja
     integer(I4B),intent(in) :: njasln
     real(DP),dimension(njasln),intent(inout) :: amat
-    integer(I4B),intent(in),dimension(nja) :: idxglo
-    real(DP),intent(inout),dimension(nodes) :: rhs
-    real(DP),intent(inout),dimension(nodes) :: hnew
+    integer(I4B),intent(in),dimension(:) :: idxglo
+    real(DP),intent(inout),dimension(:) :: rhs
+    real(DP),intent(inout),dimension(:) :: hnew
     ! -- local
     integer(I4B) :: n, m, ii, idiag, ihc
     integer(I4B) :: isymcon, idiagm
@@ -377,10 +375,10 @@ module GwfNpfModule
     ! -- Calculate conductance and put into amat
     !
     if(this%ixt3d > 0) then
-      call this%xt3d%xt3d_fc(kiter, nodes, nja, njasln, amat, idxglo, rhs, hnew)
+      call this%xt3d%xt3d_fc(kiter, njasln, amat, idxglo, rhs, hnew)
     else
     !
-    do n = 1, nodes
+    do n = 1, this%dis%nodes
       do ii = this%dis%con%ia(n) + 1, this%dis%con%ia(n + 1) - 1
         m = this%dis%con%ja(ii)
         !
@@ -464,7 +462,7 @@ module GwfNpfModule
   end subroutine npf_fc
 
 
-  subroutine npf_fn(this, kiter, nodes, nja, njasln, amat, idxglo, rhs, hnew)
+  subroutine npf_fn(this, kiter, njasln, amat, idxglo, rhs, hnew)
 ! ******************************************************************************
 ! npf_fn -- Fill newton terms
 ! ******************************************************************************
@@ -474,14 +472,13 @@ module GwfNpfModule
     ! -- dummy
     class(GwfNpfType) :: this
     integer(I4B) :: kiter
-    integer(I4B),intent(in) :: nodes
-    integer(I4B),intent(in) :: nja
     integer(I4B),intent(in) :: njasln
     real(DP),dimension(njasln),intent(inout) :: amat
-    integer(I4B),intent(in),dimension(nja) :: idxglo
-    real(DP),intent(inout),dimension(nodes) :: rhs
-    real(DP),intent(inout),dimension(nodes) :: hnew
+    integer(I4B),intent(in),dimension(:) :: idxglo
+    real(DP),intent(inout),dimension(:) :: rhs
+    real(DP),intent(inout),dimension(:) :: hnew
     ! -- local
+    integer(I4B) :: nodes, nja
     integer(I4B) :: n,m,ii,idiag
     integer(I4B) :: isymcon, idiagm
     integer(I4B) :: iups
@@ -501,6 +498,8 @@ module GwfNpfModule
     !
     ! -- add newton terms to solution matrix
     !
+    nodes = this%dis%nodes
+    nja = this%dis%con%nja
     if(this%ixt3d > 0) then
       call this%xt3d%xt3d_fn(kiter, nodes, nja, njasln, amat, idxglo, rhs, hnew)
     else
@@ -795,7 +794,7 @@ module GwfNpfModule
     return
   end subroutine sgwf_npf_qcalc
 
-  subroutine npf_bdadj(this, nja, flowja, icbcfl, icbcun)
+  subroutine npf_bdadj(this, flowja, icbcfl, icbcun)
 ! ******************************************************************************
 ! npf_bdadj -- Calculate intercell flows
 ! ******************************************************************************
@@ -804,8 +803,7 @@ module GwfNpfModule
 ! ------------------------------------------------------------------------------
     ! -- dummy
     class(GwfNpfType) :: this
-    integer(I4B),intent(in) :: nja
-    real(DP),dimension(nja),intent(in) :: flowja
+    real(DP),dimension(:),intent(in) :: flowja
     integer(I4B), intent(in) :: icbcfl
     integer(I4B), intent(in) :: icbcun
     ! -- local
@@ -839,7 +837,7 @@ module GwfNpfModule
     return
   end subroutine npf_bdadj
 
-  subroutine npf_ot(this, nja, flowja)
+  subroutine npf_ot(this, flowja)
 ! ******************************************************************************
 ! npf_ot -- Budget
 ! ******************************************************************************
@@ -851,8 +849,7 @@ module GwfNpfModule
     use ConstantsModule, only: LENBIGLINE
     ! -- dummy
     class(GwfNpfType) :: this
-    integer(I4B),intent(in) :: nja
-    real(DP),intent(inout),dimension(nja) :: flowja
+    real(DP),intent(inout),dimension(:) :: flowja
     ! -- local
     character(len=LENBIGLINE) :: line
     character(len=30) :: tempstr

--- a/src/Model/GroundWaterFlow/gwf3sto8.f90
+++ b/src/Model/GroundWaterFlow/gwf3sto8.f90
@@ -232,8 +232,7 @@ module GwfStoModule
     return
   end subroutine sto_ad
 
-  subroutine sto_fc(this, kiter, nodes, hold, hnew, nja, njasln, amat, &
-                            idxglo, rhs)
+  subroutine sto_fc(this, kiter, hold, hnew, njasln, amat, idxglo, rhs)
 ! ******************************************************************************
 ! sto_fc -- Fill the solution amat and rhs with storage contribution newton
 !               term
@@ -248,14 +247,12 @@ module GwfStoModule
     ! -- dummy
     class(GwfStoType) :: this
     integer(I4B),intent(in) :: kiter
-    integer(I4B),intent(in) :: nodes
-    real(DP), intent(in), dimension(nodes) :: hold
-    real(DP), intent(in), dimension(nodes) :: hnew
-    integer(I4B),intent(in) :: nja
+    real(DP), intent(in), dimension(:) :: hold
+    real(DP), intent(in), dimension(:) :: hnew
     integer(I4B),intent(in) :: njasln
     real(DP), dimension(njasln),intent(inout) :: amat
-    integer(I4B), intent(in),dimension(nja) :: idxglo
-    real(DP),intent(inout),dimension(nodes) :: rhs
+    integer(I4B), intent(in),dimension(:) :: idxglo
+    real(DP),intent(inout),dimension(:) :: rhs
     ! -- local
     integer(I4B) :: n, idiag
     real(DP) :: tled, rho1, rho2
@@ -345,8 +342,7 @@ module GwfStoModule
     return
   end subroutine sto_fc
 
-  subroutine sto_fn(this, kiter, nodes, hold, hnew, nja, njasln, amat,         &
-                    idxglo, rhs)
+  subroutine sto_fn(this, kiter, hold, hnew, njasln, amat, idxglo, rhs)
 ! ******************************************************************************
 ! sto_fn -- Fill the solution amat and rhs with storage contribution
 ! ******************************************************************************
@@ -357,14 +353,12 @@ module GwfStoModule
     ! -- dummy
     class(GwfStoType) :: this
     integer(I4B),intent(in) :: kiter
-    integer(I4B),intent(in) :: nodes
-    real(DP), intent(in), dimension(nodes) :: hold
-    real(DP), intent(in), dimension(nodes) :: hnew
-    integer(I4B),intent(in) :: nja
+    real(DP), intent(in), dimension(:) :: hold
+    real(DP), intent(in), dimension(:) :: hnew
     integer(I4B),intent(in) :: njasln
     real(DP), dimension(njasln),intent(inout) :: amat
-    integer(I4B), intent(in),dimension(nja) :: idxglo
-    real(DP),intent(inout),dimension(nodes) :: rhs
+    integer(I4B), intent(in),dimension(:) :: idxglo
+    real(DP),intent(inout),dimension(:) :: rhs
     ! -- local
     integer(I4B) :: n, idiag
     real(DP) :: tled, rho1, rho2

--- a/src/Model/ModelUtilities/Xt3dInterface.f90
+++ b/src/Model/ModelUtilities/Xt3dInterface.f90
@@ -114,7 +114,7 @@ module Xt3dModule
 
   subroutine xt3d_df(this, dis)
 ! ******************************************************************************
-! xt3d_ac -- Add connections for extended neighbors to the sparse matrix
+! xt3d_df -- define the xt3d object
 ! ******************************************************************************
 !
 !    SPECIFICATIONS:
@@ -305,7 +305,6 @@ module Xt3dModule
     write(this%iout, fmtheader)
     !
     ! -- Store pointers to arguments that were passed in
-    !this%dis this needs to be pointed earlier
     this%ibound  => ibound
     this%k11 => k11
     this%ik33 => ik33

--- a/src/Model/ModelUtilities/Xt3dInterface.f90
+++ b/src/Model/ModelUtilities/Xt3dInterface.f90
@@ -363,7 +363,7 @@ module Xt3dModule
     return
   end subroutine xt3d_ar
 
-  subroutine xt3d_fc(this, kiter, nodes, nja, njasln, amat, idxglo, rhs, hnew)
+  subroutine xt3d_fc(this, kiter, njasln, amat, idxglo, rhs, hnew)
 ! ******************************************************************************
 ! xt3d_fc -- Formulate
 ! ******************************************************************************
@@ -375,14 +375,13 @@ module Xt3dModule
     ! -- dummy
     class(Xt3dType) :: this
     integer(I4B) :: kiter
-    integer(I4B),intent(in) :: nodes
-    integer(I4B),intent(in) :: nja
     integer(I4B),intent(in) :: njasln
     real(DP),dimension(njasln),intent(inout) :: amat
-    integer(I4B),intent(in),dimension(nja) :: idxglo
-    real(DP),intent(inout),dimension(nodes) :: rhs
-    real(DP),intent(inout),dimension(nodes) :: hnew
+    integer(I4B),intent(in),dimension(:) :: idxglo
+    real(DP),intent(inout),dimension(:) :: rhs
+    real(DP),intent(inout),dimension(:) :: hnew
     ! -- local
+    integer(I4B) :: nodes, nja
     integer(I4B) :: n, m
     !
     logical :: allhc0, allhc1
@@ -402,8 +401,10 @@ module Xt3dModule
     ! -- Calculate xt3d conductance-like coefficients and put into amat and rhs
     ! -- as appropriate
     !
+    nodes = this%dis%nodes
+    nja = this%dis%con%nja
     if (this%lamatsaved) then
-      do i = 1, nja
+      do i = 1, this%dis%con%nja
         amat(idxglo(i)) = amat(idxglo(i)) + this%amatpc(i)
       end do
       do i = 1, this%numextnbrs

--- a/src/Model/ModelUtilities/Xt3dInterface.f90
+++ b/src/Model/ModelUtilities/Xt3dInterface.f90
@@ -51,6 +51,7 @@ module Xt3dModule
     real(DP), dimension(:), pointer, contiguous     :: angle3      => null()     !k tensor rotation around x axis (roll)
     logical, pointer                                :: ldispersion => null()     !flag to indicate dispersion
   contains
+    procedure :: xt3d_df
     procedure :: xt3d_ac
     procedure :: xt3d_mc
     procedure :: xt3d_ar
@@ -111,7 +112,26 @@ module Xt3dModule
     return
     end subroutine xt3d_cr
 
-  subroutine xt3d_ac(this, moffset, sparse, nodes, ia, ja)
+  subroutine xt3d_df(this, dis)
+! ******************************************************************************
+! xt3d_ac -- Add connections for extended neighbors to the sparse matrix
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    ! -- modules
+    ! -- dummy
+    class(Xt3dType) :: this
+    class(DisBaseType), pointer, intent(inout) :: dis
+! ------------------------------------------------------------------------------
+    !
+    this%dis => dis
+    !
+    ! -- Return
+    return
+  end subroutine xt3d_df
+  
+  subroutine xt3d_ac(this, moffset, sparse)
 ! ******************************************************************************
 ! xt3d_ac -- Add connections for extended neighbors to the sparse matrix
 ! ******************************************************************************
@@ -120,12 +140,9 @@ module Xt3dModule
 ! ------------------------------------------------------------------------------
     ! -- modules
     use SparseModule, only: sparsematrix
-    use MemoryManagerModule, only: mem_allocate
     ! -- dummy
     class(Xt3dType) :: this
-    integer(I4B), intent(in) :: moffset, nodes
-    integer(I4B), dimension(:), intent(in) :: ia
-    integer(I4B), dimension(:), intent(in) :: ja
+    integer(I4B), intent(in) :: moffset
     type(sparsematrix), intent(inout) :: sparse
     ! -- local
     integer(I4B) :: i, j, k, jj, kk, iglo, kglo, iadded
@@ -134,14 +151,14 @@ module Xt3dModule
     ! -- If not rhs, add connections
     if (this%ixt3d == 1) then
        ! -- loop over nodes
-       do i = 1, nodes
+       do i = 1, this%dis%nodes
          iglo = i + moffset
          ! -- loop over neighbors
-         do jj = ia(i), ia(i+1) - 1
-           j = ja(jj)
+         do jj = this%dis%con%ia(i), this%dis%con%ia(i+1) - 1
+           j = this%dis%con%ja(jj)
            ! -- loop over neighbors of neighbors
-           do kk = ia(j), ia(j+1) - 1
-             k = ja(kk)
+           do kk = this%dis%con%ia(j), this%dis%con%ia(j+1) - 1
+             k = this%dis%con%ja(kk)
              kglo = k + moffset
              call sparse%addconnection(iglo, kglo, 1, iadded)
              this%numextnbrs = this%numextnbrs + iadded
@@ -154,7 +171,7 @@ module Xt3dModule
     return
   end subroutine xt3d_ac
   
-  subroutine xt3d_mc(this, moffset, nodes, ia, ja, iasln, jasln, inewton)
+  subroutine xt3d_mc(this, moffset, iasln, jasln, inewton)
 ! ******************************************************************************
 ! xt3d_mc -- Map connections and construct iax, jax, and idxglox
 ! ******************************************************************************
@@ -166,9 +183,6 @@ module Xt3dModule
     ! -- dummy
     class(Xt3dType) :: this
     integer(I4B), intent(in) :: moffset
-    integer(I4B), intent(in) :: nodes
-    integer(I4B), dimension(:), intent(in) :: ia
-    integer(I4B), dimension(:), intent(in) :: ja
     integer(I4B), dimension(:), intent(in) :: iasln
     integer(I4B), dimension(:), intent(in) :: jasln
     ! -- local
@@ -184,10 +198,10 @@ module Xt3dModule
       ! -- calculate the first node for the model and the last node in global
       !    numbers
       igfirstnod = moffset + 1
-      iglastnod = moffset + nodes
+      iglastnod = moffset + this%dis%nodes
       !
       ! -- allocate iax, jax, and idxglox
-      niax = nodes + 1
+      niax = this%dis%nodes + 1
       njax = this%numextnbrs ! + 1
       call mem_allocate(this%iax, niax, 'IAX', trim(this%origin))
       call mem_allocate(this%jax, njax, 'JAX', trim(this%origin))
@@ -198,7 +212,7 @@ module Xt3dModule
       this%iax(1) = ipos
       !
       ! -- loop over nodes
-      do i = 1, nodes
+      do i = 1, this%dis%nodes
         !
         ! -- calculate global node number
         iglo = i + moffset
@@ -216,8 +230,8 @@ module Xt3dModule
           ! -- determine whether this neighbor is an extended neighbor
           !    by searching the original neighbors
           isextnbr = .true.
-          searchloop: do jj = ia(i), ia(i+1) - 1
-            j = ja(jj)
+          searchloop: do jj = this%dis%con%ia(i), this%dis%con%ia(i+1) - 1
+            j = this%dis%con%ja(jj)
             jglo = j + moffset
             !
             ! -- if an original neighbor, note that and end the search
@@ -250,7 +264,7 @@ module Xt3dModule
     return
   end subroutine xt3d_mc
   
-  subroutine xt3d_ar(this, dis, ibound, k11, ik33, k33, sat, ik22, k22,        &
+  subroutine xt3d_ar(this, ibound, k11, ik33, k33, sat, ik22, k22,             &
     inewton, min_satthk, icelltype, iangle1, iangle2, iangle3, angle1, angle2, &
     angle3)
 ! ******************************************************************************
@@ -263,7 +277,6 @@ module Xt3dModule
     use SimModule, only: store_error, ustop
     ! -- dummy
     class(Xt3dType) :: this
-    class(DisBaseType),pointer,intent(inout) :: dis
     integer(I4B), dimension(:), pointer, contiguous, intent(inout) :: ibound
     real(DP), dimension(:), intent(in), pointer, contiguous :: k11
     integer(I4B), intent(in), pointer :: ik33
@@ -292,7 +305,7 @@ module Xt3dModule
     write(this%iout, fmtheader)
     !
     ! -- Store pointers to arguments that were passed in
-    this%dis     => dis
+    !this%dis this needs to be pointed earlier
     this%ibound  => ibound
     this%k11 => k11
     this%ik33 => ik33
@@ -785,7 +798,7 @@ module Xt3dModule
     return
   end subroutine xt3d_fn
 
-  subroutine xt3d_flowja(this, nodes, nja, hnew, flowja)
+  subroutine xt3d_flowja(this, hnew, flowja)
 ! ******************************************************************************
 ! xt3d_flowja -- Budget
 ! ******************************************************************************
@@ -795,12 +808,10 @@ module Xt3dModule
     use Xt3dAlgorithmModule, only: qconds
     ! -- dummy
     class(Xt3dType) :: this
-    integer(I4B),intent(in) :: nodes
-    integer(I4B),intent(in) :: nja
-    real(DP),intent(inout),dimension(nodes) :: hnew
-    real(DP),intent(inout),dimension(nja) :: flowja
+    real(DP),intent(inout),dimension(:) :: hnew
+    real(DP),intent(inout),dimension(:) :: flowja
     ! -- local
-    integer(I4B) :: n,ipos,m
+    integer(I4B) :: n, ipos, m, nodes
     real(DP) :: qnm, qnbrs
     logical :: allhc0, allhc1
     integer(I4B) :: nnbr0, nnbr1
@@ -815,6 +826,7 @@ module Xt3dModule
 ! ------------------------------------------------------------------------------
     !
     ! -- Calculate the flow across each cell face and store in flowja
+    nodes = this%dis%nodes
     do n = 1, nodes
       ! -- Skip if inactive.
       if (this%ibound(n).eq.0) cycle
@@ -862,7 +874,7 @@ module Xt3dModule
     return
   end subroutine xt3d_flowja
 
-  subroutine xt3d_flowjahfb(this, nodes, n, m, nja, hnew, flowja, condhfb)
+  subroutine xt3d_flowjahfb(this, n, m, hnew, flowja, condhfb)
 ! ******************************************************************************
 ! xt3d_flowjahfb -- hfb contribution to flowja when xt3d is used
 ! ******************************************************************************
@@ -873,14 +885,13 @@ module Xt3dModule
     use Xt3dAlgorithmModule, only: qconds
     ! -- dummy
     class(Xt3dType) :: this
-    integer(I4B),intent(in) :: nodes
-    integer(I4B),intent(in) :: nja
     integer(I4B) :: n, m
-    real(DP),intent(inout),dimension(nodes) :: hnew
-    real(DP),intent(inout),dimension(nja) :: flowja
+    real(DP),intent(inout),dimension(:) :: hnew
+    real(DP),intent(inout),dimension(:) :: flowja
     real(DP) :: condhfb
     ! -- local
     !
+    integer(I4B) :: nodes
     logical :: allhc0, allhc1
 !!!    integer(I4B), parameter :: nbrmax = 10
     integer(I4B) :: nnbr0, nnbr1
@@ -900,6 +911,7 @@ module Xt3dModule
     ! -- Calculate hfb corrections to xt3d conductance-like coefficients and
     ! -- put into amat and rhs as appropriate
     !
+    nodes = this%dis%nodes
     nnbr0 = this%dis%con%ia(n+1) - this%dis%con%ia(n) - 1
     ! -- Load conductivity and connection info for cell 0.
     call this%xt3d_load(nodes, n, nnbr0, inbr0, vc0, vn0, dl0, dl0n,    &


### PR DESCRIPTION
iasln was being passed in as iasln of the dis%con object, so it was named wrong and it was not used.  Removed so that it would help make code clearer.  Should not affect model results.