### PR TITLE
feat(cmask): add mask for calculation of amat terms

### DIFF
--- a/src/Model/GroundWaterFlow/gwf3npf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8.f90
@@ -83,6 +83,7 @@ module GwfNpfModule
     procedure                               :: npf_ac
     procedure                               :: npf_mc
     procedure                               :: npf_ar
+    procedure                               :: npf_init_mem
     procedure                               :: npf_ad
     procedure                               :: npf_cf
     procedure                               :: npf_fc
@@ -469,6 +470,8 @@ module GwfNpfModule
     !
     do n = 1, this%dis%nodes
       do ii = this%dis%con%ia(n) + 1, this%dis%con%ia(n + 1) - 1
+        if (this%dis%con%mask(ii) == 0) cycle
+        
         m = this%dis%con%ja(ii)
         !
         ! -- Calculate conductance only for upper triangle but insert into
@@ -596,6 +599,8 @@ module GwfNpfModule
     do n=1, nodes
       idiag=this%dis%con%ia(n)
       do ii=this%dis%con%ia(n)+1,this%dis%con%ia(n+1)-1
+        if (this%dis%con%mask(ii) == 0) cycle
+        
         m=this%dis%con%ja(ii)
         isymcon = this%dis%con%isym(ii)
         ! work on upper triangle

--- a/src/Model/ModelUtilities/Connections.f90
+++ b/src/Model/ModelUtilities/Connections.f90
@@ -33,6 +33,7 @@ module ConnectionsModule
     procedure :: con_da
     procedure :: allocate_scalars
     procedure :: allocate_arrays
+    procedure, private :: init_arrays
     procedure :: read_from_block
     procedure :: con_finalize
     procedure :: read_connectivity_from_block
@@ -157,7 +158,21 @@ module ConnectionsModule
     ! -- Return
     return
   end subroutine allocate_arrays
-
+  
+  subroutine init_arrays(this)  
+  ! ******************************************************************************
+  ! init_arrays -- Sets default array values after allocation
+  ! ******************************************************************************
+    class(ConnectionsType) :: this
+    integer(I4B) :: i
+    
+    ! set default: unmasked
+    do i = 1, this%nja
+      this%mask(i) = 1  
+    end do
+    
+  end subroutine init_arrays
+  
   subroutine read_from_block(this, name_model, nodes, nja, inunit, iout)
 ! ******************************************************************************
 ! read_from_block -- Read connection information from input block
@@ -205,10 +220,7 @@ module ConnectionsModule
     this%njas = (this%nja - this%nodes) / 2
     !
     call this%allocate_arrays()
-    ! TODO_MJR: we now have to set the default in 3 places (for dis, disv, disu)
-    do n = 1, this%nja
-      this%mask = 1  
-    end do
+    call this%init_arrays()    
     !
     ! -- allocate temporary arrays for reading
     allocate(ihctemp(this%nja))
@@ -527,6 +539,7 @@ module ConnectionsModule
     !
     ! -- Allocate space for connection arrays
     call this%allocate_arrays()
+    call this%init_arrays()
     !
     ! -- get connectiondata block
     call this%parser%GetBlock('CONNECTIONDATA', isfound, ierr)
@@ -802,10 +815,7 @@ module ConnectionsModule
     !
     ! -- Allocate index arrays of size nja and symmetric arrays
     call this%allocate_arrays()
-    ! TODO_MJR: we now have to set the default in 3 places (for dis, disv, disu)
-    do n = 1, this%nja
-      this%mask = 1  
-    end do
+    call this%init_arrays()
     !
     ! -- Fill the IA and JA arrays from sparse, then destroy sparse
     call sparse%filliaja(this%ia, this%ja, ierror)
@@ -974,10 +984,7 @@ module ConnectionsModule
     !
     ! -- Allocate index arrays of size nja and symmetric arrays
     call this%allocate_arrays()
-    ! TODO_MJR: we now have to set the default in 3 places (for dis, disv, disu)
-    do n = 1, this%nja
-      this%mask = 1  
-    end do
+    call this%init_arrays()
     !
     ! -- Fill the IA and JA arrays from sparse, then destroy sparse
     call sparse%sort()

--- a/src/Model/ModelUtilities/Connections.f90
+++ b/src/Model/ModelUtilities/Connections.f90
@@ -80,6 +80,12 @@ module ConnectionsModule
     else
       call mem_deallocate(this%jausr)
     endif
+    ! -- mask
+    if (associated(this%mask, this%ja)) then
+      nullify(this%mask)
+    else
+      call mem_deallocate(this%mask)
+    end if 
     !
     ! -- Arrays
     call mem_deallocate(this%ia)
@@ -90,13 +96,7 @@ module ConnectionsModule
     call mem_deallocate(this%anglex)
     call mem_deallocate(this%ihc)
     call mem_deallocate(this%cl1)
-    call mem_deallocate(this%cl2)
-    !
-    if (associated(this%mask, this%ja)) then
-      nullify(this%mask)
-    else
-      call mem_deallocate(this%mask)
-    end if  
+    call mem_deallocate(this%cl2)     
     !
     ! -- return
     return
@@ -159,7 +159,7 @@ module ConnectionsModule
     call mem_allocate(this%iausr, 1, 'IAUSR', this%cid)
     call mem_allocate(this%jausr, 1, 'JAUSR', this%cid)
     ! 
-    ! let mask point to nja, which is always nonzero, 
+    ! let mask point to ja, which is always nonzero, 
     ! until someone decides to do a 'set_mask'
     this%mask => this%ja
     !

--- a/src/Model/ModelUtilities/Connections.f90
+++ b/src/Model/ModelUtilities/Connections.f90
@@ -18,7 +18,7 @@ module ConnectionsModule
     integer(I4B), pointer                           :: ianglex    => null()      !indicates whether or not anglex was read
     integer(I4B), dimension(:), pointer, contiguous :: ia         => null()      !(size:nodes+1) csr index array
     integer(I4B), dimension(:), pointer, contiguous :: ja         => null()      !(size:nja) csr pointer array
-    integer(I4B), dimension(:), pointer, contiguous :: mask       => null()      !(size:nja) to mask certain connections: ==0 means masked 
+    integer(I4B), dimension(:), pointer, contiguous :: mask       => null()      !(size:nja) to mask certain connections: ==0 means masked. Do not set the mask directly, use set_mask instead!    
     real(DP), dimension(:), pointer, contiguous     :: cl1        => null()      !(size:njas) connection length between node n and shared face with node m
     real(DP), dimension(:), pointer, contiguous     :: cl2        => null()      !(size:njas) connection length between node m and shared face with node n
     real(DP), dimension(:), pointer, contiguous     :: hwva       => null()      !(size:njas) horizontal perpendicular width (ihc>0) or vertical flow area (ihc=0)
@@ -33,7 +33,6 @@ module ConnectionsModule
     procedure :: con_da
     procedure :: allocate_scalars
     procedure :: allocate_arrays
-    procedure, private :: init_arrays
     procedure :: read_from_block
     procedure :: con_finalize
     procedure :: read_connectivity_from_block
@@ -42,6 +41,7 @@ module ConnectionsModule
     procedure :: disvconnections
     procedure :: iajausr
     procedure :: getjaindex
+    procedure :: set_mask
   end type ConnectionsType
 
   contains
@@ -83,8 +83,7 @@ module ConnectionsModule
     !
     ! -- Arrays
     call mem_deallocate(this%ia)
-    call mem_deallocate(this%ja)
-    call mem_deallocate(this%mask)
+    call mem_deallocate(this%ja)  
     call mem_deallocate(this%isym)
     call mem_deallocate(this%jas)
     call mem_deallocate(this%hwva)
@@ -92,6 +91,12 @@ module ConnectionsModule
     call mem_deallocate(this%ihc)
     call mem_deallocate(this%cl1)
     call mem_deallocate(this%cl2)
+    !
+    if (associated(this%mask, this%ja)) then
+      nullify(this%mask)
+    else
+      call mem_deallocate(this%mask)
+    end if  
     !
     ! -- return
     return
@@ -144,7 +149,6 @@ module ConnectionsModule
     ! -- allocate space for connection arrays
     call mem_allocate(this%ia, this%nodes+1, 'IA', this%cid)
     call mem_allocate(this%ja, this%nja, 'JA', this%cid)
-    call mem_allocate(this%mask, this%nja, 'MASK', this%cid)
     call mem_allocate(this%isym, this%nja, 'ISYM', this%cid)
     call mem_allocate(this%jas, this%nja, 'JAS', this%cid)
     call mem_allocate(this%hwva, this%njas, 'HWVA', this%cid)
@@ -154,24 +158,14 @@ module ConnectionsModule
     call mem_allocate(this%cl2, this%njas, 'CL2', this%cid)
     call mem_allocate(this%iausr, 1, 'IAUSR', this%cid)
     call mem_allocate(this%jausr, 1, 'JAUSR', this%cid)
+    ! 
+    ! let mask point to nja, which is always nonzero, 
+    ! until someone decides to do a 'set_mask'
+    this%mask => this%ja
     !
     ! -- Return
     return
   end subroutine allocate_arrays
-  
-  subroutine init_arrays(this)  
-  ! ******************************************************************************
-  ! init_arrays -- Sets default array values after allocation
-  ! ******************************************************************************
-    class(ConnectionsType) :: this
-    integer(I4B) :: i
-    
-    ! set default: unmasked
-    do i = 1, this%nja
-      this%mask(i) = 1  
-    end do
-    
-  end subroutine init_arrays
   
   subroutine read_from_block(this, name_model, nodes, nja, inunit, iout)
 ! ******************************************************************************
@@ -220,7 +214,6 @@ module ConnectionsModule
     this%njas = (this%nja - this%nodes) / 2
     !
     call this%allocate_arrays()
-    call this%init_arrays()    
     !
     ! -- allocate temporary arrays for reading
     allocate(ihctemp(this%nja))
@@ -539,7 +532,6 @@ module ConnectionsModule
     !
     ! -- Allocate space for connection arrays
     call this%allocate_arrays()
-    call this%init_arrays()
     !
     ! -- get connectiondata block
     call this%parser%GetBlock('CONNECTIONDATA', isfound, ierr)
@@ -815,7 +807,6 @@ module ConnectionsModule
     !
     ! -- Allocate index arrays of size nja and symmetric arrays
     call this%allocate_arrays()
-    call this%init_arrays()
     !
     ! -- Fill the IA and JA arrays from sparse, then destroy sparse
     call sparse%filliaja(this%ia, this%ja, ierror)
@@ -984,7 +975,6 @@ module ConnectionsModule
     !
     ! -- Allocate index arrays of size nja and symmetric arrays
     call this%allocate_arrays()
-    call this%init_arrays()
     !
     ! -- Fill the IA and JA arrays from sparse, then destroy sparse
     call sparse%sort()
@@ -1311,5 +1301,32 @@ module ConnectionsModule
     return
   end subroutine vertexconnect
   
+  subroutine set_mask(this, ipos, maskval)
+! ******************************************************************************
+! set_mask -- routine to set a value in the mask array 
+! (which has the same shape as this%ja)
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------ 
+  use MemoryManagerModule, only: mem_allocate
+  class(ConnectionsType) :: this
+  integer(I4B), intent(in) :: ipos
+  integer(I4B), intent(in) :: maskval
+  ! local
+  integer(I4B) :: i
   
+  ! if we still point to this%ja, we first need to allocate space
+  if (associated(this%mask, this%ja)) then
+    call mem_allocate(this%mask, this%nja, 'MASK', this%cid)
+    ! and initialize with unmasked
+    do i = 1, this%nja
+      this%mask(i) = 1 
+    end do
+  end if
+  
+  this%mask(ipos) = maskVal
+  
+  end subroutine set_mask
+                           
 end module ConnectionsModule

--- a/src/Model/ModelUtilities/Connections.f90
+++ b/src/Model/ModelUtilities/Connections.f90
@@ -682,7 +682,7 @@ module ConnectionsModule
     integer(I4B), dimension(:, :, :), pointer :: nrdcd_ptr => null() !non-contiguous because is a slice
     integer(I4B), dimension(:), allocatable :: rowmaxnnz
     type(sparsematrix) :: sparse
-    integer(I4B) :: i, j, k, kk, ierror, isympos, nodesuser, n
+    integer(I4B) :: i, j, k, kk, ierror, isympos, nodesuser
     integer(I4B) :: nr, mr
 ! ------------------------------------------------------------------------------
     !

--- a/src/Model/ModelUtilities/Xt3dInterface.f90
+++ b/src/Model/ModelUtilities/Xt3dInterface.f90
@@ -381,7 +381,7 @@ module Xt3dModule
     real(DP),intent(inout),dimension(:) :: hnew
     ! -- local
     integer(I4B) :: nodes, nja
-    integer(I4B) :: n, m
+    integer(I4B) :: n, m, ipos
     !
     logical :: allhc0, allhc1
     integer(I4B) :: nnbr0, nnbr1
@@ -425,6 +425,9 @@ module Xt3dModule
       ! -- Loop over active neighbors of cell 0 that have a higher
       ! -- cell number (taking advantage of reciprocity).
       do il0 = 1,nnbr0
+        ipos = this%dis%con%ia(n) + il0
+        if (this%dis%con%mask(ipos) == 0) cycle
+        
         m = inbr0(il0)
         ! -- Skip if neighbor is inactive or has lower cell number.
         if ((m.eq.0).or.(m.lt.n)) cycle
@@ -512,7 +515,7 @@ module Xt3dModule
     class(Xt3dType) :: this
     integer(I4B) :: nodes
     ! -- local
-    integer(I4B) :: n, m
+    integer(I4B) :: n, m, ipos
     !
     logical :: allhc0, allhc1
     integer(I4B) :: nnbr0, nnbr1
@@ -538,6 +541,9 @@ module Xt3dModule
       ! -- Loop over active neighbors of cell 0 that have a higher
       ! -- cell number (taking advantage of reciprocity).
       do il0 = 1,nnbr0
+        ipos = this%dis%con%ia(n) + il0
+        if (this%dis%con%mask(ipos) == 0) cycle
+        
         m = inbr0(il0)
         ! -- Skip if neighbor has lower cell number.
         if (m.lt.n) cycle
@@ -719,7 +725,7 @@ module Xt3dModule
     real(DP),intent(inout),dimension(nodes) :: rhs
     real(DP),intent(inout),dimension(nodes) :: hnew
     ! -- local
-    integer(I4B) :: n, m
+    integer(I4B) :: n, m, ipos
     !
     integer(I4B) :: nnbr0
     integer(I4B) :: il0, ii01, jjs01, il01, il10, ii00, ii11, ii10
@@ -744,6 +750,9 @@ module Xt3dModule
       ! -- Loop over active neighbors of cell 0 that have a higher
       ! -- cell number (taking advantage of reciprocity).
       do il0 = 1,nnbr0
+        ipos = this%dis%con%ia(n) + il0
+        if (this%dis%con%mask(ipos) == 0) cycle
+        
         m = inbr0(il0)
         ! -- Skip if neighbor is inactive or has lower cell number.
         if ((inbr0(il0).eq.0).or.(m.lt.n)) cycle


### PR DESCRIPTION
(to prepare for the upcoming interface model) the mask allows to skip insertion and calculation of amat coefficients for certain connections.