### PR TITLE
feat(maxerrors): limit the number of errors stored to maxerrors

### DIFF
--- a/autotest/test_z03_nightly_build_largeexamples.py
+++ b/autotest/test_z03_nightly_build_largeexamples.py
@@ -26,7 +26,7 @@ fdir = 'modflow6-largetests'
 exdir = None
 for root, dirs, files in os.walk(home):
     for d in dirs:
-        if d == fdir:
+        if d == fdir or d == fdir + '.git':
             exdir = os.path.join(root, d)
             break
     if exdir is not None:

--- a/doc/mf6io/mf6ivar/dfn/sim-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/sim-nam.dfn
@@ -24,6 +24,14 @@ optional true
 longname memory print option
 description is a flag that controls printing of detailed memory manager usage to the end of the simulation list file.  NONE means do not print detailed information. SUMMARY means print only the total memory for each simulation component. ALL means print information for each variable stored in the memory manager. NONE is default if MEMORY\_PRINT\_OPTION is not specified.
 
+block options
+name maxerrors
+type integer
+reader urword
+optional true
+longname maximum number of errors
+description maximum number of errors that will be stored and printed.
+default_value 1000
 
 
 # --------------------- sim nam timing ---------------------

--- a/src/SimulationCreate.f90
+++ b/src/SimulationCreate.f90
@@ -4,7 +4,7 @@ module SimulationCreateModule
   use ConstantsModule,        only: LINELENGTH, LENMODELNAME, LENBIGLINE, DZERO
   use SimVariablesModule,     only: simfile, simlstfile, iout
   use SimModule,              only: ustop, store_error, count_errors,          &
-                                    store_error_unit
+                                    store_error_unit, maxerrors
   use InputOutputModule,      only: getunit, urword, openfile
   use ArrayHandlersModule,    only: expandarray, ifind
   use BaseModelModule,        only: BaseModelType
@@ -240,6 +240,10 @@ module SimulationCreateModule
               call parser%StoreErrorUnit()
               call ustop()
             endif
+          case ('MAXERRORS')
+            maxerrors = parser%GetInteger()
+            write(iout, '(4x, a, i0)')                                         &
+                  'MAXIMUM NUMBER OF ERRORS THAT WILL BE STORED IS ', maxerrors
           case default
             write(errmsg, '(4x,a,a)') &
                   '****ERROR. UNKNOWN SIMULATION OPTION: ',                    &


### PR DESCRIPTION
Error messages are stored in memory.  If something goes terribly wrong, the number of errors can be so large that memory runs out.  Limit the number of errors stored, by default, to 1000.  The user can control this maximum number by specifying MAXERRORS in the mfsim.nam options block.  Number of errors and number of errors above maxerrors are not written to mfsim.lst and to terminal.

Closes #106