### PR TITLE
Add get_cellxy procedure to DisBaseType #204

### DIFF
--- a/src/Model/GroundWaterFlow/gwf3dis8.f90
+++ b/src/Model/GroundWaterFlow/gwf3dis8.f90
@@ -32,6 +32,7 @@ module GwfDisModule
   contains
     procedure :: dis_df => dis3d_df
     procedure :: dis_da => dis3d_da
+    procedure :: get_cellxy => get_cellxy_dis3d
     procedure, public :: record_array
     procedure, public :: read_layer_array
     procedure, public :: record_srcdst_list_header
@@ -47,7 +48,6 @@ module GwfDisModule
     procedure :: get_ncpl
     procedure :: connection_vector
     procedure :: connection_normal
-    procedure :: get_cellxy
     ! -- private
     procedure :: read_options
     procedure :: read_dimensions
@@ -683,8 +683,8 @@ module GwfDisModule
     enddo
     !
     ! -- fill x,y coordinate arrays  
-    this%cellx(1) = DHALF*this%delr(1) + this%xorigin
-    this%celly(1) = DHALF*this%delc(1) + this%yorigin
+    this%cellx(1) = DHALF*this%delr(1)
+    this%celly(1) = DHALF*this%delc(1)
     do j = 2, this%ncol
       this%cellx(j) = this%cellx(j-1) + DHALF*this%delr(j-1) + DHALF*this%delr(j)
     enddo
@@ -1418,7 +1418,7 @@ module GwfDisModule
   end subroutine
    
   ! return x,y coordinate for a node
-  subroutine get_cellxy(this, node, xcell, ycell)
+  subroutine get_cellxy_dis3d(this, node, xcell, ycell)
     use InputOutputModule, only: get_ijk
     class(GwfDisType), intent(in) :: this
     integer(I4B), intent(in)      :: node         ! the reduced node number
@@ -1432,7 +1432,7 @@ module GwfDisModule
     xcell = this%cellx(j)
     ycell = this%celly(i)
     
-  end subroutine get_cellxy
+  end subroutine get_cellxy_dis3d
                                
   subroutine read_int_array(this, line, lloc, istart, istop, iout, in, &
                             iarray, aname)

--- a/src/Model/GroundWaterFlow/gwf3disu8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disu8.f90
@@ -1141,6 +1141,17 @@ module GwfDisuModule
     return
   end subroutine connection_vector
 
+  ! return x,y coordinate for a node
+  subroutine get_cellxy(this, node, xcell, ycell)
+    class(GwfDisuType), intent(in)  :: this
+    integer(I4B), intent(in)        :: node         ! the reduced node number
+    real(DP), intent(out)           :: xcell, ycell ! the x,y for the cell
+    
+    xcell = this%cellxy(1, node)
+    ycell = this%cellxy(2, node)
+    
+  end subroutine get_cellxy                             
+
   subroutine allocate_scalars(this, name_model)
 ! ******************************************************************************
 ! allocate_scalars -- Allocate and initialize scalar variables in this class

--- a/src/Model/GroundWaterFlow/gwf3disu8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disu8.f90
@@ -28,6 +28,7 @@ module GwfDisuModule
   contains
     procedure :: dis_df => disu_df
     procedure :: dis_da => disu_da
+    procedure :: get_cellxy => get_cellxy_disu
     procedure :: disu_ck
     procedure :: get_nodenumber_idx1
     procedure :: get_nodeuser
@@ -1142,7 +1143,7 @@ module GwfDisuModule
   end subroutine connection_vector
 
   ! return x,y coordinate for a node
-  subroutine get_cellxy(this, node, xcell, ycell)
+  subroutine get_cellxy_disu(this, node, xcell, ycell)
     class(GwfDisuType), intent(in)  :: this
     integer(I4B), intent(in)        :: node         ! the reduced node number
     real(DP), intent(out)           :: xcell, ycell ! the x,y for the cell
@@ -1150,7 +1151,7 @@ module GwfDisuModule
     xcell = this%cellxy(1, node)
     ycell = this%cellxy(2, node)
     
-  end subroutine get_cellxy                             
+  end subroutine get_cellxy_disu                             
 
   subroutine allocate_scalars(this, name_model)
 ! ******************************************************************************

--- a/src/Model/GroundWaterFlow/gwf3disv8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disv8.f90
@@ -1517,6 +1517,23 @@ module GwfDisvModule
     return
   end subroutine connection_vector
 
+  ! return x,y coordinate for a node
+  subroutine get_cellxy(this, node, xcell, ycell)
+    use InputOutputModule, only: get_jk
+    class(GwfDisvType), intent(in)  :: this
+    integer(I4B), intent(in)        :: node         ! the reduced node number
+    real(DP), intent(out)           :: xcell, ycell ! the x,y for the cell
+    ! local
+    integer(I4B) :: nodeuser, ncell2d, k
+    
+    nodeuser = this%get_nodeuser(node)
+    call get_jk(nodeuser, this%ncpl, this%nlay, ncell2d, k)
+    
+    xcell = this%cellxy(1, ncell2d)
+    ycell = this%cellxy(2, ncell2d)
+    
+  end subroutine get_cellxy 
+                               
   subroutine allocate_scalars(this, name_model)
 ! ******************************************************************************
 ! allocate_scalars -- Allocate and initialize scalars

--- a/src/Model/GroundWaterFlow/gwf3disv8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disv8.f90
@@ -34,6 +34,7 @@ module GwfDisvModule
   contains
     procedure :: dis_df => disv_df
     procedure :: dis_da => disv_da
+    procedure :: get_cellxy => get_cellxy_disv
     procedure, public :: record_array
     procedure, public :: read_layer_array
     procedure, public :: record_srcdst_list_header
@@ -1518,7 +1519,7 @@ module GwfDisvModule
   end subroutine connection_vector
 
   ! return x,y coordinate for a node
-  subroutine get_cellxy(this, node, xcell, ycell)
+  subroutine get_cellxy_disv(this, node, xcell, ycell)
     use InputOutputModule, only: get_jk
     class(GwfDisvType), intent(in)  :: this
     integer(I4B), intent(in)        :: node         ! the reduced node number
@@ -1532,7 +1533,7 @@ module GwfDisvModule
     xcell = this%cellxy(1, ncell2d)
     ycell = this%cellxy(2, ncell2d)
     
-  end subroutine get_cellxy 
+  end subroutine get_cellxy_disv 
                                
   subroutine allocate_scalars(this, name_model)
 ! ******************************************************************************

--- a/src/Model/ModelUtilities/DiscretizationBase.f90
+++ b/src/Model/ModelUtilities/DiscretizationBase.f90
@@ -481,10 +481,14 @@ module BaseDisModule
                                  
   ! return x,y coordinate for a node
   subroutine get_cellxy(this, node, xcell, ycell)
-    class(DisBaseType), intent(in) :: this
-    integer(I4B), intent(in) :: node
-    real(DP), intent(out) :: xcell, ycell
+    class(DisBaseType), intent(in)  :: this
+    integer(I4B), intent(in)        :: node
+    real(DP), intent(out)           :: xcell, ycell
       
+    ! suppress warning
+    xcell = -999999.0
+    ycell = -999999.0
+    
     call store_error('Program error: getcellxy not implemented.')
     call ustop()
     

--- a/src/Model/ModelUtilities/DiscretizationBase.f90
+++ b/src/Model/ModelUtilities/DiscretizationBase.f90
@@ -68,6 +68,7 @@ module BaseDisModule
     procedure :: noder_from_cellid
     procedure :: connection_normal
     procedure :: connection_vector
+    procedure :: get_cellxy
     procedure :: supports_layers
     procedure :: allocate_scalars
     procedure :: allocate_arrays
@@ -95,7 +96,7 @@ module BaseDisModule
     procedure, public  :: highest_active
     procedure, public  :: get_area
   end type DisBaseType
-
+  
   contains
 
   subroutine dis_df(this)
@@ -477,7 +478,18 @@ module BaseDisModule
     ! -- return
     return
   end subroutine connection_vector
+                                 
+  ! return x,y coordinate for a node
+  subroutine get_cellxy(this, node, xcell, ycell)
+    class(DisBaseType), intent(in) :: this
+    integer(I4B), intent(in) :: node
+    real(DP), intent(out) :: xcell, ycell
+      
+    call store_error('Program error: getcellxy not implemented.')
+    call ustop()
     
+  end subroutine get_cellxy                             
+                               
   subroutine allocate_scalars(this, name_model)
 ! ******************************************************************************
 ! allocate_scalars -- Allocate and initialize scalar variables in this class


### PR DESCRIPTION
this is a PR for issue #204 

It adds cellxy to DIS and DISV, and makes it available through a subroutine getcellxy(...). The upcoming interface model needs it to construct an interface grid (of type DISU) out of multiple discretizations, which can be either DIS, DISV, or DISU.