### PR TITLE
refactor(advanced packages): read static data as part of df()

### DIFF
--- a/src/Model/GroundWaterFlow/gwf3lak8.f90
+++ b/src/Model/GroundWaterFlow/gwf3lak8.f90
@@ -1615,6 +1615,9 @@ contains
     !    when PRINT_INPUT option is used.
     call this%define_listlabel()
     !
+    ! -- setup the budget object
+    call this%lak_setup_budobj()
+    !
     ! -- return
     return
   end subroutine lak_read_dimensions
@@ -3399,9 +3402,6 @@ contains
       allocate(this%pakmvrobj)
       call this%pakmvrobj%ar(this%noutlets, this%nlakes, this%origin)
     endif
-    !
-    ! -- setup the budget object
-    call this%lak_setup_budobj()
     !
     ! -- return
     return
@@ -5989,7 +5989,7 @@ contains
         hgwf = this%xnew(n2)
         call this%lak_calculate_conn_warea(n, j, hlak, hgwf, this%qauxcbc(1))
         q = this%qleak(j)
-        call this%budobj%budterm(idx)%update_term(n1, n2, q, this%qauxcbc)
+        call this%budobj%budterm(idx)%update_term(n, n2, q, this%qauxcbc)
       end do
     end do
 

--- a/src/Model/GroundWaterFlow/gwf3lak8.f90
+++ b/src/Model/GroundWaterFlow/gwf3lak8.f90
@@ -5717,9 +5717,10 @@ contains
     ! -- local
     integer(I4B) :: nbudterm
     integer(I4B) :: nlen
-    integer(I4B) :: n
+    integer(I4B) :: j, n, n1, n2
     integer(I4B) :: maxlist, naux
     integer(I4B) :: idx
+    real(DP) :: q
     character(len=LENBUDTXT) :: text
     character(len=LENBUDTXT), dimension(1) :: auxtxt
 ! ------------------------------------------------------------------------------
@@ -5755,6 +5756,18 @@ contains
                                                this%name, &
                                                maxlist, .false., .false., &
                                                naux)
+      !
+      ! -- store connectivity
+      call this%budobj%budterm(idx)%reset(2 * nlen)
+      q = DZERO
+      do n = 1, this%noutlets
+        n1 = this%lakein(n)
+        n2 = this%lakeout(n)
+        if (n1 > 0 .and. n2 > 0) then
+          call this%budobj%budterm(idx)%update_term(n1, n2, q)
+          call this%budobj%budterm(idx)%update_term(n2, n1, -q)
+        end if
+      end do
     end if
     !
     ! -- 
@@ -5770,6 +5783,14 @@ contains
                                              this%name_model, &
                                              maxlist, .false., .true., &
                                              naux, auxtxt)
+    call this%budobj%budterm(idx)%reset(this%maxbound)
+    q = DZERO
+    do n = 1, this%nlakes
+      do j = this%idxlakeconn(n), this%idxlakeconn(n + 1) - 1
+        n2 = this%cellid(j)
+        call this%budobj%budterm(idx)%update_term(n, n2, q)
+      end do
+    end do
     !
     ! -- 
     text = '        RAINFALL'

--- a/src/Model/GroundWaterFlow/gwf3maw8.f90
+++ b/src/Model/GroundWaterFlow/gwf3maw8.f90
@@ -3924,6 +3924,8 @@ contains
     class(MawType) :: this
     ! -- local
     integer(I4B) :: nbudterm
+    integer(I4B) :: n, j, n2
+    real(DP) :: q
     integer(I4B) :: maxlist, naux
     integer(I4B) :: idx
     character(len=LENBUDTXT) :: text
@@ -3962,6 +3964,14 @@ contains
                                              this%name_model, &
                                              maxlist, .false., .true., &
                                              naux, auxtxt)
+    call this%budobj%budterm(idx)%reset(this%maxbound)
+    q = DZERO
+    do n = 1, this%nmawwells
+      do j = 1, this%mawwells(n)%ngwfnodes
+        n2 = this%mawwells(n)%gwfnodes(j)
+        call this%budobj%budterm(idx)%update_term(n, n2, q)
+      end do
+    end do
     !
     ! -- 
     text = '            RATE'

--- a/src/Model/GroundWaterFlow/gwf3maw8.f90
+++ b/src/Model/GroundWaterFlow/gwf3maw8.f90
@@ -882,6 +882,9 @@ contains
     !    when PRINT_INPUT option is used.
     call this%define_listlabel()
     !
+    ! -- setup the budget object
+    call this%maw_setup_budobj()
+    !
     ! -- return
     return
   end subroutine maw_read_dimensions
@@ -1588,9 +1591,6 @@ contains
       allocate(this%pakmvrobj)
       call this%pakmvrobj%ar(this%nmawwells, this%nmawwells, this%origin)
     endif
-    !
-    ! -- setup the budget object
-    call this%maw_setup_budobj()
     !
     ! -- return
     return

--- a/src/Model/GroundWaterFlow/gwf3sfr8.f90
+++ b/src/Model/GroundWaterFlow/gwf3sfr8.f90
@@ -4214,8 +4214,10 @@ contains
     class(SfrType) :: this
     ! -- local
     integer(I4B) :: nbudterm
+    integer(I4B) :: i, n, n1, n2
     integer(I4B) :: maxlist, naux
     integer(I4B) :: idx
+    real(DP) :: q
     character(len=LENBUDTXT) :: text
     character(len=LENBUDTXT), dimension(1) :: auxtxt
 ! ------------------------------------------------------------------------------
@@ -4247,6 +4249,17 @@ contains
                                              maxlist, .false., .false., &
                                              naux, auxtxt)
     !
+    ! -- store connectivity
+    call this%budobj%budterm(idx)%reset(this%nconn)
+    q = DZERO
+    do n = 1, this%maxbound
+      n1 = n
+      do i = 1, this%nconnreach(n)
+        n2 = this%reaches(n)%iconn(i)
+        call this%budobj%budterm(idx)%update_term(n1, n2, q)
+      end do
+    end do
+    !
     ! -- 
     text = '             GWF'
     idx = idx + 1
@@ -4260,6 +4273,12 @@ contains
                                              this%name_model, &
                                              maxlist, .false., .true., &
                                              naux, auxtxt)
+    call this%budobj%budterm(idx)%reset(this%maxbound)
+    q = DZERO
+    do n = 1, this%maxbound
+      n2 = this%igwfnode(n)
+      call this%budobj%budterm(idx)%update_term(n, n2, q)
+    end do
     !
     ! -- 
     text = '        RAINFALL'
@@ -4407,6 +4426,7 @@ contains
     idx = idx + 1
     call this%budobj%budterm(idx)%reset(this%nconn)
     do n = 1, this%maxbound
+      n1 = n
       do i = 1, this%nconnreach(n)
         n2 = this%reaches(n)%iconn(i)
         ! flow to downstream reaches

--- a/src/Model/GroundWaterFlow/gwf3uzf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3uzf8.f90
@@ -3166,8 +3166,9 @@ contains
     integer(I4B) :: maxlist, naux
     integer(I4B) :: idx
     integer(I4B) :: nlen
-    integer(I4B) :: n
+    integer(I4B) :: n, n1, n2
     integer(I4B) :: ivertflag
+    real(DP) :: q
     character(len=LENBUDTXT) :: text
     character(len=LENBUDTXT), dimension(1) :: auxtxt
 ! ------------------------------------------------------------------------------
@@ -3210,6 +3211,19 @@ contains
                                                this%name, &
                                                maxlist, .false., .false., &
                                                naux, auxtxt)
+      !
+      ! -- store connectivity
+      call this%budobj%budterm(idx)%reset(nlen * 2)
+      q = DZERO
+      do n = 1, this%nodes
+        ivertflag = this%uzfobj%ivertcon(n)
+        if (ivertflag > 0) then
+          n1 = n
+          n2 = ivertflag
+          call this%budobj%budterm(idx)%update_term(n1, n2, q)
+          call this%budobj%budterm(idx)%update_term(n2, n1, -q)
+        end if
+      end do
     end if
     !
     ! -- 
@@ -3225,6 +3239,12 @@ contains
                                              this%name_model, &
                                              maxlist, .false., .true., &
                                              naux, auxtxt)
+    call this%budobj%budterm(idx)%reset(this%nodes)
+    q = DZERO
+    do n = 1, this%nodes
+      n2 = this%mfcellid(n)
+      call this%budobj%budterm(idx)%update_term(n, n2, q)
+    end do
     !
     ! -- 
     text = '    INFILTRATION'

--- a/src/Model/ModelUtilities/UzfCellGroup.f90
+++ b/src/Model/ModelUtilities/UzfCellGroup.f90
@@ -61,6 +61,7 @@ module UzfCellGroupModule
   contains
       procedure :: init
       procedure :: setdata
+      procedure :: sethead
       procedure :: setdatauzfarea
       procedure :: setdatafinf
       procedure :: setdataet
@@ -374,7 +375,7 @@ module UzfCellGroupModule
   end subroutine dealloc
 
   subroutine setdata(this, icell, area, top, bot, surfdep, vks, thtr, thts,     &
-                     thti, eps, ntrail, landflag, ivertcon, hgwf)
+                     thti, eps, ntrail, landflag, ivertcon)
 ! ******************************************************************************
 ! setdata -- set uzf object material properties
 ! ******************************************************************************
@@ -397,7 +398,6 @@ module UzfCellGroupModule
     integer(I4B), intent(in) :: ntrail
     integer(I4B), intent(in) :: landflag
     integer(I4B), intent(in) :: ivertcon
-    real(DP), intent(in) :: hgwf 
 ! ------------------------------------------------------------------------------
     !
     ! -- set the values for uzf cell icell
@@ -413,10 +413,6 @@ module UzfCellGroupModule
     end if
     this%celbot(icell) = bot
     this%vks(icell) = vks
-    this%watab(icell) = this%celbot(icell)
-    if (hgwf > this%celbot(icell)) this%watab(icell) = hgwf
-    if (this%watab(icell) > this%celtop(icell)) this%watab(icell) = this%celtop(icell)
-    this%watabold(icell) = this%watab(icell)
     this%thtr(icell) = thtr
     this%thts(icell) = thts
     this%thti(icell) = thti
@@ -428,6 +424,28 @@ module UzfCellGroupModule
     this%ha(icell) = DZERO
     this%hroot(icell) = DZERO
   end subroutine setdata
+                     
+  subroutine sethead(this, icell, hgwf)
+! ******************************************************************************
+! sethead -- set uzf object material properties
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    ! -- modules
+    ! -- dummy
+    class(UzfCellGroupType) :: this
+    integer(I4B), intent(in) :: icell
+    real(DP), intent(in) :: hgwf 
+! ------------------------------------------------------------------------------
+    !
+    ! -- set initial head
+    this%watab(icell) = this%celbot(icell)
+    if (hgwf > this%celbot(icell)) this%watab(icell) = hgwf
+    if (this%watab(icell) > this%celtop(icell)) &
+      this%watab(icell) = this%celtop(icell)
+    this%watabold(icell) = this%watab(icell)
+  end subroutine sethead
                      
   subroutine setdatafinf(this, icell, finf)
 ! ******************************************************************************


### PR DESCRIPTION
There is good reason to read all of the static advanced package data as part of DF rather than as part of AR.  This will allow this information to be available earlier in the program so that a transport model, for example, has access to it early on.