### PR TITLE
fix(lak): added sign checks for user specified lak flow terms

### DIFF
--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -115,7 +115,22 @@ Version numbers for MODFLOW 6 will follow a major.minor.revision format.  The ma
 This section describes changes introduced into MODFLOW 6 with each release.  These changes may substantially affect users.
 
 \begin{itemize}
-\item Version mf6.1.0--Release Candidate
+\item Version mf6.1.1--Release Candidate
+
+\underline{NEW FUNCTIONALITY}
+
+\underline{BASIC FUNCTIONALITY}
+
+\underline{STRESS PACKAGES}
+
+\underline{ADVANCED STRESS PACKAGES}
+\begin{itemize}
+\item The LAK Package would accept negative user-input values for  RAINFALL, EVAPORATION, RUNOFF, INFLOW, and WITHDRAWAL even though the user guide mentioned that negative values are not allowed for these flow terms.  Error checks were added to ensure these values are specified as positive.
+\end{itemize}
+
+\underline{SOLUTION}
+
+\item Version mf6.1.0
 
 \underline{NEW FUNCTIONALITY}
 \begin{itemize}

--- a/doc/mf6io/mf6ivar/dfn/gwf-lak.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-lak.dfn
@@ -627,7 +627,7 @@ tagged false
 in_record true
 reader urword
 longname
-description line of information that is parsed into a keyword and values.  Keyword values that can be used to start the LAKSETTING string include: STATUS, STAGE, RAINFALL, EVAPORATION, RUNOFFON, WITHDRAWAL, and AUXILIARY.
+description line of information that is parsed into a keyword and values.  Keyword values that can be used to start the LAKSETTING string include: STATUS, STAGE, RAINFALL, EVAPORATION, RUNOFF, INFLOW, WITHDRAWAL, and AUXILIARY.
 
 block period
 name status
@@ -692,7 +692,7 @@ in_record true
 reader urword
 time_series true
 longname inflow rate
-description real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.
+description real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.
 
 block period
 name withdrawal

--- a/src/Model/GroundWaterFlow/gwf3lak8.f90
+++ b/src/Model/GroundWaterFlow/gwf3lak8.f90
@@ -3038,6 +3038,12 @@ contains
                                               this%name, 'BND', this%TsManager, &
                                               this%iprpak, itmp, jj, 'RAINFALL', &
                                               bndName, this%inunit)
+        if (this%rainfall(itmp)%value < DZERO) then
+          write(errmsg, '(4x, a, i0, a, G0, a)') &
+            '****ERROR. LAKE ', itmp, ' WAS ASSIGNED A RAINFALL VALUE OF ', &
+            this%rainfall(itmp)%value, '. RAINFALL MUST BE POSITIVE.'
+          call store_error(errmsg)
+        end if
       case ('EVAPORATION')
         ierr = this%lak_check_valid(itemno)
         if (ierr /= 0) goto 999
@@ -3052,6 +3058,12 @@ contains
                                               this%name, 'BND', this%TsManager, &
                                               this%iprpak, itmp, jj, 'EVAPORATION', &
                                               bndName, this%inunit)
+        if (this%evaporation(itmp)%value < DZERO) then
+          write(errmsg, '(4x, a, i0, a, G0, a)') &
+            '****ERROR. LAKE ', itmp, ' WAS ASSIGNED AN EVAPORATION VALUE OF ', &
+            this%evaporation(itmp)%value, '. EVAPORATION MUST BE POSITIVE.'
+          call store_error(errmsg)
+        end if
       case ('RUNOFF')
         ierr = this%lak_check_valid(itemno)
         if (ierr /= 0) goto 999
@@ -3066,6 +3078,12 @@ contains
                                               this%name, 'BND', this%TsManager, &
                                               this%iprpak, itmp, jj, 'RUNOFF', &
                                               bndName, this%inunit)
+        if (this%runoff(itmp)%value < DZERO) then
+          write(errmsg, '(4x, a, i0, a, G0, a)') &
+            '****ERROR. LAKE ', itmp, ' WAS ASSIGNED A RUNOFF VALUE OF ', &
+            this%runoff(itmp)%value, '. RUNOFF MUST BE POSITIVE.'
+          call store_error(errmsg)
+        end if
       case ('INFLOW')
         ierr = this%lak_check_valid(itemno)
         if (ierr /= 0) goto 999
@@ -3080,6 +3098,12 @@ contains
                                               this%name, 'BND', this%TsManager, &
                                               this%iprpak, itmp, jj, 'INFLOW', &
                                               bndName, this%inunit)
+        if (this%inflow(itmp)%value < DZERO) then
+          write(errmsg, '(4x, a, i0, a, G0, a)') &
+            '****ERROR. LAKE ', itmp, ' WAS ASSIGNED AN INFLOW VALUE OF ', &
+            this%inflow(itmp)%value, '. INFLOW MUST BE POSITIVE.'
+          call store_error(errmsg)
+        end if
       case ('WITHDRAWAL')
         ierr = this%lak_check_valid(itemno)
         if (ierr /= 0) goto 999
@@ -3094,6 +3118,12 @@ contains
                                               this%name, 'BND', this%TsManager, &
                                               this%iprpak, itmp, jj, 'WITHDRAWAL', &
                                               bndName, this%inunit)
+        if (this%withdrawal(itmp)%value < DZERO) then
+          write(errmsg, '(4x, a, i0, a, G0, a)') &
+            '****ERROR. LAKE ', itmp, ' WAS ASSIGNED A WITHDRAWAL VALUE OF ', &
+            this%withdrawal(itmp)%value, '. WITHDRAWAL MUST BE POSITIVE.'
+          call store_error(errmsg)
+        end if
       case ('RATE')
         ierr = this%lak_check_valid(-itemno)
         if (ierr /= 0) goto 999


### PR DESCRIPTION
* User-specified values for RAINFALL, EVAPORATION, RUNOFF, INFLOW, and WITHDRAWAL must be positive.  The program worked if these values were negative, but that doesn't necessarily make sense and is probably an input error.
* Updated definition file to reflect these changes
* Corrected minor typo in lake definition file
* Updated release notes to reflect this change
* Close #287