### PR TITLE
fix(dis): corrected connection vector error in DIS package

### DIFF
--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -120,6 +120,9 @@ This section describes changes introduced into MODFLOW 6 with each release.  The
 \underline{NEW FUNCTIONALITY}
 
 \underline{BASIC FUNCTIONALITY}
+\begin{itemize}
+\item Corrected an error in how the discretization package (for regular MODFLOW grids) calculates the distance between two cells when one or both of the cells are unconfined.  The error in the code would have only affected XT3D simulations with a regular grid, unconfined conditions, and specification of ANGLE2 in the NPF Package.  
+\end{itemize}
 
 \underline{STRESS PACKAGES}
 \begin{itemize}

--- a/src/Model/GroundWaterFlow/gwf3dis8.f90
+++ b/src/Model/GroundWaterFlow/gwf3dis8.f90
@@ -1344,10 +1344,6 @@ module GwfDisModule
     integer(I4B) :: nodeu1, nodeu2, ipos
 ! ------------------------------------------------------------------------------
     !
-    ! -- Calculate cell center z values
-    z1 = this%bot(noden) + DHALF * (this%top(noden) - this%bot(noden))
-    z2 = this%bot(nodem) + DHALF * (this%top(nodem) - this%bot(nodem))
-    !
     ! -- Set vector components based on ihc
     if(ihc == 0) then
       !
@@ -1359,6 +1355,8 @@ module GwfDisModule
       else
         zcomp = -DONE
       endif
+      z1 = this%bot(noden) + DHALF * (this%top(noden) - this%bot(noden))
+      z2 = this%bot(nodem) + DHALF * (this%top(nodem) - this%bot(nodem))
       conlen = abs(z2 - z1)
     else
       !
@@ -1366,8 +1364,8 @@ module GwfDisModule
         z1 = DZERO
         z2 = DZERO
       else
-        z1 = z1 * satn
-        z2 = z2 * satm
+        z1 = this%bot(noden) + DHALF * satn * (this%top(noden) - this%bot(noden))
+        z2 = this%bot(nodem) + DHALF * satm * (this%top(nodem) - this%bot(nodem))
       endif
       ipos = this%con%getjaindex(noden, nodem)
       ds = this%con%cl1(this%con%jas(ipos)) + this%con%cl2(this%con%jas(ipos))


### PR DESCRIPTION
Code was incorrectly calculating cell center elevations when nozee was .false.  This error would have affected XT3D simulations with unconfined flow and non-zero values specified for ANGLE2 in the NPF Package.  It also would affect dispersive transport with XT3D for unconfined conditions.