### PR TITLE
fix(exg-mvr): dis object not associated for binary save flows

### DIFF
--- a/src/Exchange/GwfGwfExchange.f90
+++ b/src/Exchange/GwfGwfExchange.f90
@@ -1542,8 +1542,14 @@ contains
     ! -- local
 ! ------------------------------------------------------------------------------
     !
-    ! -- Create and initialize the mover object
-    call mvr_cr(this%mvr, this%name, this%inmvr, iout, iexgmvr=1)
+    ! -- Create and initialize the mover object  Here, dis is set to the one
+    !    for gwfmodel1 so that a call to save flows has an associated dis
+    !    object.  Because the conversion flags for the mover are both false,
+    !    the dis object does not convert from reduced to user node numbers. 
+    !    So in this case, the dis object is just writing unconverted package
+    !    numbers to the binary budget file.
+    call mvr_cr(this%mvr, this%name, this%inmvr, iout, this%gwfmodel1%dis,     &
+                iexgmvr=1)
     !
     ! -- Return
     return

--- a/src/Model/GroundWaterFlow/gwf3.f90
+++ b/src/Model/GroundWaterFlow/gwf3.f90
@@ -282,7 +282,7 @@ module GwfModule
     call csub_cr(this%csub, this%name, this%insto, this%sto%name,               &
                  this%incsub, this%iout)
     call ic_cr(this%ic, this%name, this%inic, this%iout, this%dis)
-    call mvr_cr(this%mvr, this%name, this%inmvr, this%iout, dis=this%dis)
+    call mvr_cr(this%mvr, this%name, this%inmvr, this%iout, this%dis)
     call oc_cr(this%oc, this%name, this%inoc, this%iout)
     call gwf_obs_cr(this%obs, this%inobs)
     !

--- a/src/Model/GroundWaterFlow/gwf3mvr8.f90
+++ b/src/Model/GroundWaterFlow/gwf3mvr8.f90
@@ -163,7 +163,7 @@ module GwfMvrModule
 
   contains
 
-  subroutine mvr_cr(mvrobj, name_parent, inunit, iout, iexgmvr, dis)
+  subroutine mvr_cr(mvrobj, name_parent, inunit, iout, dis, iexgmvr)
 ! ******************************************************************************
 ! mvr_cr -- Create a new mvr object
 ! ******************************************************************************
@@ -175,8 +175,8 @@ module GwfMvrModule
     character(len=*), intent(in) :: name_parent
     integer(I4B), intent(in) :: inunit
     integer(I4B), intent(in) :: iout
+    class(DisBaseType), pointer, intent(in) :: dis
     integer(I4B), optional :: iexgmvr
-    class(DisBaseType), pointer, intent(in), optional :: dis
 ! ------------------------------------------------------------------------------
     !
     ! -- Create the object
@@ -190,7 +190,7 @@ module GwfMvrModule
     call mvrobj%allocate_scalars()
     !
     ! -- Set pointer to dis
-    if (present(dis)) mvrobj%dis => dis
+    mvrobj%dis => dis
     !
     ! -- Set variables
     mvrobj%inunit = inunit


### PR DESCRIPTION
* refactoring of the budget object resulted in an unassociated dis object when writing flows for exchange water mover
* dis is no longer optional for mvr_cr()
* closes #423