### PR TITLE
fix(NumericalSolution): add counter for time step iteration total

### DIFF
--- a/autotest/test_gwf_npf03_sfr.py
+++ b/autotest/test_gwf_npf03_sfr.py
@@ -97,8 +97,15 @@ def get_model(idx, dir):
     tdis = flopy.mf6.ModflowTdis(sim, time_units='DAYS',
                                  nper=nper, perioddata=tdis_rc)
 
+    # set ims csv files
+    csv0 = '{}.outer.ims.csv'.format(name)
+    csv1 = '{}.inner.ims.csv'.format(name)
+
     # create iterative model solution and register the gwf model with it
-    ims = flopy.mf6.ModflowIms(sim, print_option='SUMMARY',
+    ims = flopy.mf6.ModflowIms(sim,
+                               print_option='ALL',
+                               csv_outer_output_filerecord=csv0,
+                               csv_inner_output_filerecord=csv1,
                                outer_dvclose=hclose * 10.,
                                outer_maximum=nouter,
                                under_relaxation='NONE',

--- a/autotest/test_gwf_ts_sfr01.py
+++ b/autotest/test_gwf_ts_sfr01.py
@@ -62,9 +62,15 @@ def build_model(ws, name, timeseries=False):
     # create tdis package
     tdis = flopy.mf6.ModflowTdis(sim, time_units='DAYS',
                                  nper=nper, perioddata=tdis_rc)
+    # set ims csv files
+    csv0 = '{}.outer.ims.csv'.format(name)
+    csv1 = '{}.inner.ims.csv'.format(name)
+
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(sim,
-                               print_option='SUMMARY',
+                               print_option='ALL',
+                               csv_outer_output_filerecord=csv0,
+                               csv_inner_output_filerecord=csv1,
                                outer_dvclose=hclose,
                                outer_maximum=nouter,
                                under_relaxation='NONE',


### PR DESCRIPTION
Refactor iteration total for time step and simulation to clarify
data stored in these variables. Updated test_gwf_npf03_sfr.py and
test_gwf_ts_sfr01.py to output inner and outer iteration convergence
information to listing and csv files for evaluation of proper output.
Also evaluated results for test_gwf_npf02_rewet.py autotest since it
has more than 1 time step.

Closes #410