### PR TITLE
refactor(model_ad): revert the model advance back to numerical model

### DIFF
--- a/src/Exchange/BaseExchange.f90
+++ b/src/Exchange/BaseExchange.f90
@@ -19,7 +19,6 @@ module BaseExchangeModule
     procedure(exg_df), deferred :: exg_df
     procedure(exg_ar), deferred :: exg_ar
     procedure :: exg_rp
-    procedure :: exg_ad
     procedure :: exg_ot
     procedure :: exg_fp
     procedure :: exg_da
@@ -62,23 +61,6 @@ module BaseExchangeModule
     ! -- Return
     return
   end subroutine exg_rp
-  
-  subroutine exg_ad(this)
-! ******************************************************************************
-! exg_ad -- Advance
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-    ! -- dummy
-    class(BaseExchangeType) :: this
-    ! -- local
-! ------------------------------------------------------------------------------
-    !
-    !
-    ! -- return
-    return
-  end subroutine exg_ad
   
   subroutine exg_ot(this)
 ! ******************************************************************************

--- a/src/Exchange/NumericalExchange.f90
+++ b/src/Exchange/NumericalExchange.f90
@@ -41,6 +41,7 @@ module NumericalExchangeModule
     procedure :: exg_mc
     procedure :: exg_ar
     !procedure :: exg_rp (not needed yet; base exg_rp does nothing)
+    procedure :: exg_ad
     procedure :: exg_cf
     procedure :: exg_fc
     procedure :: exg_nr
@@ -163,6 +164,23 @@ contains
     return
   end subroutine exg_ar
 
+  subroutine exg_ad(this)
+! ******************************************************************************
+! exg_ad -- Advance
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    ! -- dummy
+    class(NumericalExchangeType) :: this
+    ! -- local
+! ------------------------------------------------------------------------------
+    !
+    !
+    ! -- return
+    return
+  end subroutine exg_ad
+  
   subroutine exg_cf(this, kiter)
 ! ******************************************************************************
 ! exg_cf -- Calculate conductance, and for explicit exchanges, set the

--- a/src/Model/BaseModel.f90
+++ b/src/Model/BaseModel.f90
@@ -26,7 +26,6 @@ module BaseModelModule
     procedure :: model_df
     procedure :: model_ar
     procedure :: model_rp
-    procedure :: model_ad
     procedure :: model_ot
     procedure :: model_fp
     procedure :: model_da
@@ -76,20 +75,6 @@ module BaseModelModule
     ! -- return
     return
   end subroutine model_rp
-  
-  subroutine model_ad(this)
-! ******************************************************************************
-! model_ad -- advance the model
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-    class(BaseModelType) :: this
-! ------------------------------------------------------------------------------
-    !
-    ! -- return
-    return
-  end subroutine model_ad
   
   subroutine model_ot(this)
 ! ******************************************************************************

--- a/src/Model/GroundWaterFlow/gwf3npf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8.f90
@@ -1045,6 +1045,7 @@ module GwfNpfModule
     call mem_deallocate(this%ik33overk)
     !
     ! -- Deallocate arrays
+    deallocate(this%aname)
     call mem_deallocate(this%icelltype)
     call mem_deallocate(this%k11)
     call mem_deallocate(this%k22, 'K22', trim(this%origin))
@@ -1197,6 +1198,9 @@ module GwfNpfModule
       call mem_allocate(this%ihcedge, this%nedges, 'IHCEDGE', trim(this%origin))
       call mem_allocate(this%propsedge, 5, this%nedges, 'PROPSEDGE',           &
         trim(this%origin))
+      do n = 1, ncells
+        this%spdis(:, n) = DZERO
+      end do
     else
       call mem_allocate(this%spdis, 3, 0, 'SPDIS', trim(this%origin))
       call mem_allocate(this%nodedge, 0, 'NODEDGE', trim(this%origin))

--- a/src/Model/ModelUtilities/BoundaryPackage.f90
+++ b/src/Model/ModelUtilities/BoundaryPackage.f90
@@ -978,6 +978,9 @@ module BndModule
     allocate(this%TsManager)
     allocate(this%TasManager)
     !
+    ! -- allocate text strings
+    call mem_allocate(this%auxname, LENAUXNAME, 0, 'AUXNAME', this%origin)
+    !
     ! -- Initialize variables
     this%ibcnum = 0
     this%maxbound = 0
@@ -1147,7 +1150,7 @@ module BndModule
 ! ------------------------------------------------------------------------------
     ! -- modules
     use InputOutputModule,   only: urdaux
-    use MemoryManagerModule, only: mem_allocate
+    use MemoryManagerModule, only: mem_reallocate
     use SimModule,           only: ustop, store_error, store_error_unit
     ! -- dummy
     class(BndType),intent(inout) :: this
@@ -1201,7 +1204,7 @@ module BndModule
             lloc = 1
             call urdaux(this%naux, this%parser%iuactive, this%iout, lloc,        &
                         istart, istop, caux, line, this%text)
-            call mem_allocate(this%auxname, LENAUXNAME, this%naux,               &
+            call mem_reallocate(this%auxname, LENAUXNAME, this%naux,             &
                                 'AUXNAME', this%origin)
             do n = 1, this%naux
               this%auxname(n) = caux(n)

--- a/src/Model/NumericalModel.f90
+++ b/src/Model/NumericalModel.f90
@@ -45,6 +45,7 @@ module NumericalModelModule
     procedure :: model_ac
     procedure :: model_mc
     procedure :: model_rp
+    procedure :: model_ad
     procedure :: model_cf
     procedure :: model_fc
     procedure :: model_ptcchk
@@ -100,6 +101,10 @@ module NumericalModelModule
     class(NumericalModelType) :: this
   end subroutine model_rp
 
+  subroutine model_ad(this)
+    class(NumericalModelType) :: this
+  end subroutine model_ad
+  
   subroutine model_cf(this,kiter)
     class(NumericalModelType) :: this
     integer(I4B),intent(in) :: kiter

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -359,34 +359,32 @@ module MemoryManagerModule
     isize = ilen * nrow
     !
     ! -- allocate defined length string array
-    if (isize > 0) Then
-      allocate(character(len=ilen) :: astr1d(nrow), stat=istat, errmsg=errmsg)
-      !
-      ! -- check for error condition
-      if (istat /= 0) then
-        call allocate_error(name, origin, istat, isize)
-      end if
-      !
-      ! -- fill deferred length string with empty string
-      do n = 1, nrow
-        astr1d(n) = string
-      end do
-      !
-      ! -- update string counter
-      nvalues_astr = nvalues_astr + isize
-      !
-      ! -- allocate memory type
-      allocate(mt)
-      !
-      ! -- set memory type
-      mt%isize = isize
-      mt%name = name
-      mt%origin = origin
-      write(mt%memtype, "(a,' LEN=',i0,' (',i0,')')") 'STRING', ilen, nrow
-      !
-      ! -- add deferred length character array to the memory manager
-      call memorylist%add(mt)
+    allocate(character(len=ilen) :: astr1d(nrow), stat=istat, errmsg=errmsg)
+    !
+    ! -- check for error condition
+    if (istat /= 0) then
+      call allocate_error(name, origin, istat, isize)
     end if
+    !
+    ! -- fill deferred length string with empty string
+    do n = 1, nrow
+      astr1d(n) = string
+    end do
+    !
+    ! -- update string counter
+    nvalues_astr = nvalues_astr + isize
+    !
+    ! -- allocate memory type
+    allocate(mt)
+    !
+    ! -- set memory type
+    mt%isize = isize
+    mt%name = name
+    mt%origin = origin
+    write(mt%memtype, "(a,' LEN=',i0,' (',i0,')')") 'STRING', ilen, nrow
+    !
+    ! -- add deferred length character array to the memory manager
+    call memorylist%add(mt)
     !
     ! -- return
     return

--- a/src/mf6core.f90
+++ b/src/mf6core.f90
@@ -263,18 +263,6 @@ contains
       call ep%exg_rp()
     enddo
     !      
-    ! -- Exchange advance
-    do ic=1,baseexchangelist%Count()
-      ep => GetBaseExchangeFromList(baseexchangelist, ic)
-      call ep%exg_ad()
-    enddo
-    !
-    ! -- Model advance
-    do im = 1, basemodellist%Count()
-      mp => GetBaseModelFromList(basemodellist, im)
-      call mp%model_ad()
-    enddo
-    !
     ! -- Solution advance
     do is=1,basesolutionlist%Count()
       sp => GetBaseSolutionFromList(basesolutionlist, is)


### PR DESCRIPTION
* we refactored the model_ad and exchange_ad calls for bmi, but these changes broke transport.  
* allocate auxname to size 0 and then reallocate when auxiliary detected