### PR TITLE
Further refactoring BMI for upcoming release

### DIFF
--- a/src/mf6core.f90
+++ b/src/mf6core.f90
@@ -262,12 +262,6 @@ contains
       ep => GetBaseExchangeFromList(baseexchangelist, ic)
       call ep%exg_rp()
     enddo
-    !      
-    ! -- Solution advance
-    do is=1,basesolutionlist%Count()
-      sp => GetBaseSolutionFromList(basesolutionlist, is)
-      call sp%sln_ad()    
-    enddo
     !
     call converge_reset()
     

--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -45,7 +45,9 @@ module mf6bmi
   function bmi_initialize() result(bmi_status) bind(C, name="initialize")
   !DEC$ ATTRIBUTES DLLEXPORT :: bmi_initialize
     integer(kind=c_int) :: bmi_status
-        
+    ! local
+    logical :: isValid
+    
     if (istdout_to_file > 0) then
       ! -- open stdout file mfsim.stdout
       istdout = getunit() 
@@ -56,6 +58,13 @@ module mf6bmi
     !
     ! -- initialize MODFLOW 6
     call Mf6Initialize()
+    
+    isValid = validateSimulation()
+    if (.not. isValid) then      
+      bmi_status = BMI_FAILURE
+      return  
+    end if
+    
     bmi_status = BMI_SUCCESS
     
   end function bmi_initialize
@@ -718,6 +727,16 @@ module mf6bmi
   ! -----------------------------------------------------------------------
   ! convenience functions follow here, TODO_MJR: move to dedicated module?
   ! -----------------------------------------------------------------------
+  
+  ! Validation of the MODFLOW 6 simulation for use with BMI/AMI.  
+  function validateSimulation() result(isValid)
+      logical :: isValid
+  
+      isValid = .true.
+      
+      
+  
+  end function validateSimulation
   
   ! Helper function to check the grid, not all bmi routines are implemented
   ! for all types of discretizations


### PR DESCRIPTION
- Finished refactoring, considering the work in #462
- renaming: prepare_iteration, ... now is prepare_solve, solve, finalize_solve
- style: prepare_timestep becomes prepare_time_step etc.
- add safety check no to use the subcomponent concept of AMI in combination with multiple solution groups: this is not supported (yet)

Note: the python BMI/AMI wrapper (https://github.com/mjr-deltares/modflow6-bmipy) will be updated accordingly
