### PR TITLE
Refactor model_da and fix typo

### DIFF
--- a/src/Model/NumericalModel.f90
+++ b/src/Model/NumericalModel.f90
@@ -211,10 +211,7 @@ module NumericalModelModule
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
     class(NumericalModelType) :: this
-    !
-    ! -- BaseModelType
-    call this%BaseModelType%model_da()
-    !
+
     ! -- Scalars
     call mem_deallocate(this%neq)
     call mem_deallocate(this%nja)
@@ -232,9 +229,13 @@ module NumericalModelModule
     deallocate(this%bndlist)
     !
     ! -- nullify pointers
-    call mem_deallocate(this%x)
-    call mem_deallocate(this%rhs)
-    call mem_deallocate(this%ibound)
+    call mem_deallocate(this%x, 'X', this%name)
+    call mem_deallocate(this%rhs, 'RHS', this%name)
+    call mem_deallocate(this%ibound, 'IBOUND', this%name)
+    !
+    ! -- BaseModelType
+    call this%BaseModelType%model_da()
+    !
     !
     ! -- Return
     return

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -1254,7 +1254,7 @@ module MemoryManagerModule
     !
     ! -- set master information
     mt%master = .false.
-    mt%mastername = name
+    mt%mastername = name2
     mt%masterorigin = origin2
     !
     ! -- set memory access permission


### PR DESCRIPTION
@mjr-deltares  and I pair-programmed in order to find out why https://github.com/MODFLOW-USGS/modflow6/pull/492 broke our scripts.
This PR solves a few smaller problems and lets our scripts run, but leaves the bigger problem untouched.
The discussion of this one might be more suitable for a separate meeting.

- BaseModelType will be deallocated last
- Specify optional arguments in mem_deallocate
(this is only a workaround for a bigger problem)
- Fix typo: name -> name2