### PR TITLE
fix(gwt): fix error when using gwt and disu when vertices not specified

### DIFF
--- a/autotest/targets.py
+++ b/autotest/targets.py
@@ -35,6 +35,10 @@ target = target_pth('mfusgdbl{}'.format(target_ext), ebindir)
 target_dict['mfusg'] = target
 target = target_pth('mflgrdbl{}'.format(target_ext), ebindir)
 target_dict['mflgr'] = target
+target = target_pth('mf2005{}'.format(target_ext), ebindir)
+target_dict['mf2005s'] = target
+target = target_pth('mt3dms{}'.format(target_ext), ebindir)
+target_dict['mt3dms'] = target
 
 # create MODFLOW 6 target name and add to dictionary
 program = 'mf6{}'.format(target_ext)

--- a/autotest/test_gwt_mt3dms_p01.py
+++ b/autotest/test_gwt_mt3dms_p01.py
@@ -1,11 +1,11 @@
 """
 MODFLOW 6 Autotest
-Test to compare MODFLOW 6 groundwater transport simulation results to MT3DMS 
-results.  This test was first documented in Zheng and Wang (1999) (MT3DMS: 
-A Modular Three-Dimensional Multispecies Transport Model for Simulation of 
-Advection, Dispersion, and Chemical Reactions of Contaminants in Groundwater 
-Systems; Documentation and User's Guide) on page 130.  This is a 1D set of 4 
-test problems that apply incrementally varying combinations of advection, 
+Test to compare MODFLOW 6 groundwater transport simulation results to MT3DMS
+results.  This test was first documented in Zheng and Wang (1999) (MT3DMS:
+A Modular Three-Dimensional Multispecies Transport Model for Simulation of
+Advection, Dispersion, and Chemical Reactions of Contaminants in Groundwater
+Systems; Documentation and User's Guide) on page 130.  This is a 1D set of 4
+test problems that apply incrementally varying combinations of advection,
 dispersion, and reaction (sorption and decay):
 
 * Case 1a: Advection only
@@ -42,8 +42,8 @@ except:
 
 import targets
 
-exe_name_mf = os.path.abspath('./temp/mfexes/mf2005')
-exe_name_mt = os.path.abspath('./temp/mfexes/mt3dms')
+exe_name_mf = targets.target_dict['mf2005s']
+exe_name_mt = targets.target_dict['mt3dms']
 exe_name_mf6 = targets.target_dict['mf6']
 testdir = './temp'
 testgroup = 'mt3dms_p01'

--- a/src/Exchange/GwfGwtExchange.f90
+++ b/src/Exchange/GwfGwtExchange.f90
@@ -162,9 +162,11 @@ module GwfGwtExchangeModule
     ! -- Set pointer to flowja
     gwtmodel%fmi%gwfflowja => gwfmodel%flowja
     !
-    ! -- Set the npf flag so that specific discharge is always calculated and
-    !    available for transport calculations
-    gwfmodel%npf%icalcspdis = 1
+    ! -- Set the npf flag so that specific discharge is available for 
+    !    transport calculations if dispersion is active
+    if (gwtmodel%indsp > 0) then
+      gwfmodel%npf%icalcspdis = 1
+    end if
     !
     ! -- Set the auxiliary names for gwf flow packages in gwt%fmi
     ngwfpack = gwfmodel%bndlist%Count()

--- a/src/Model/GroundWaterFlow/gwf3disu8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disu8.f90
@@ -1338,19 +1338,8 @@ module GwfDisuModule
     real(DP), intent(inout) :: zcomp
     integer(I4B), intent(in) :: ipos
     ! -- local
-    !integer(I4B) :: ipos
     real(DP) :: angle, dmult
 ! ------------------------------------------------------------------------------
-    !
-    ! -- Terminate with error if requesting normal vector components for problems 
-    !    without vertex data
-    if (this%nvert < 1) then
-      write(errmsg, '(a)') &
-        'Cannot calculate normal vector components for DISU grid if VERTEX ' //  &
-        'data are not specified'
-      call store_error(errmsg)
-      call ustop()
-    end if
     !
     ! -- Set vector components based on ihc
     if(ihc == 0) then


### PR DESCRIPTION
Data for calculating normal vector and unit vector components are
not available with DISU grids if VERTEX data are not specified.
Also modified GWF-GWT exchange to reset integer flag to calculate
specific discharge data (icalcspdis=1) only if the GWT dispersion
package is on. Previously, the specific discharge integer flag was
reset to 1 anytime the GWF-GWT exchange was used. This resulted in
segfault issues for DISU models without VERTEX data but only used
advection (ADV).