### PR TITLE
Revert "Modified to allow XT3D to be applied selectively by connectio…

### DIFF
--- a/src/Model/GroundWaterFlow/gwf3.f90
+++ b/src/Model/GroundWaterFlow/gwf3.f90
@@ -1,6 +1,6 @@
 module GwfModule
 
-  use KindModule,                  only: DP, I4B, LGP
+  use KindModule,                  only: DP, I4B
   use InputOutputModule,           only: ParseLine, upcase
   use ConstantsModule,             only: LENFTYPE, LENPAKLOC, DZERO, DEM1, DTEN, DEP20
   use VersionModule,               only: write_listfile_header
@@ -55,7 +55,6 @@ module GwfModule
     integer(I4B),                   pointer :: inobs   => null()                ! unit number OBS
     integer(I4B),                   pointer :: iss     => null()                ! steady state flag
     integer(I4B),                   pointer :: inewtonur => null()              ! newton under relaxation flag
-    logical(LGP),                   pointer :: allgncnonstdff => null()         ! flag to indicate whether all gnc connections are using a non-standard flow formulation
 
   contains
 
@@ -426,44 +425,18 @@ module GwfModule
     class(GwfModelType) :: this
     ! -- locals
     integer(I4B) :: ip
-    integer(I4B) :: ignc,noden,nodem,ii,iis
     class(BndType), pointer :: packobj
-    integer(I4B), pointer :: inonstdf
-    integer(I4B), dimension(:), pointer, contiguous :: iflowform
 ! ------------------------------------------------------------------------------
     !
     ! -- Allocate and read modules attached to model
     if(this%inic  > 0) call this%ic%ic_ar(this%x)
-    if(this%innpf > 0) then
-      call this%npf%npf_ar(this%ic, this%ibound, this%x)
-      inonstdf => this%npf%inonstdf
-      iflowform => this%npf%iflowform
-    end if
+    if(this%innpf > 0) call this%npf%npf_ar(this%ic, this%ibound, this%x)
     if(this%inbuy > 0) call this%buy%buy_ar(this%npf, this%ibound)
-    if(this%inhfb > 0) call this%hfb%hfb_ar(this%ibound, this%xt3d, this%dis,  &
-                                            inonstdf, iflowform)
+    if(this%inhfb > 0) call this%hfb%hfb_ar(this%ibound, this%xt3d, this%dis)
     if(this%insto > 0) call this%sto%sto_ar(this%dis, this%ibound)
     if(this%incsub > 0) call this%csub%csub_ar(this%dis, this%ibound)
     if(this%inmvr > 0) call this%mvr%mvr_ar()
     if(this%inobs > 0) call this%obs%gwf_obs_ar(this%ic, this%x, this%flowja)
-    if(this%ingnc > 0) call this%gnc%gnc_ar(inonstdf, iflowform)
-    !
-    ! -- If gnc active, set allgncnonstdff to .true. if all gnc connections
-    !    use a non-standard flow formulation, and to .false. otherwise
-    if (this%ingnc > 0) then
-      if (this%gnc%inonstdf /= 0) then
-        this%allgncnonstdff = .true.
-        do ignc = 1, this%gnc%nexg
-          noden = this%gnc%nodem1(ignc)
-          nodem = this%gnc%nodem2(ignc)
-          ii = this%gnc%m1%dis%con%getjaindex(noden, nodem)
-          iis = this%gnc%m1%dis%con%jas(ii)
-          if (this%gnc%iflowform(iis) == 0) then
-            this%allgncnonstdff = .false.
-          end if
-        enddo
-      end if
-    end if
     !
     ! -- Call dis_ar to write binary grid file
     call this%dis%dis_ar(this%npf%icelltype)
@@ -631,8 +604,7 @@ module GwfModule
                                             this%idxglo, this%rhs, this%x)
     if(this%inhfb > 0) call this%hfb%hfb_fc(kiter, njasln, amatsln,            &
                                             this%idxglo, this%rhs, this%x)
-    if((this%ingnc > 0).and.(.not.this%allgncnonstdff))                        &
-                       call this%gnc%gnc_fc(kiter, amatsln)
+    if(this%ingnc > 0) call this%gnc%gnc_fc(kiter, amatsln)
     ! -- storage
     if(this%insto > 0) then
       call this%sto%sto_fc(kiter, this%xold, this%x, njasln, amatsln,          &
@@ -658,7 +630,7 @@ module GwfModule
     endif
     !
     ! -- Fill newton terms for ghost nodes
-    if((this%ingnc > 0).and.(.not.this%allgncnonstdff)) then
+    if(this%ingnc > 0) then
       if(inwt /= 0) then
         call this%gnc%gnc_fn(kiter, njasln, amatsln, this%npf%condsat,         &
           ivarcv_opt=this%npf%ivarcv,                                          &
@@ -959,8 +931,7 @@ module GwfModule
     if(this%innpf > 0) call this%npf%npf_flowja(this%x, this%flowja)
     if(this%inbuy > 0) call this%buy%buy_flowja(this%x, this%flowja)
     if(this%inhfb > 0) call this%hfb%hfb_flowja(this%x, this%flowja)
-    if((this%ingnc > 0).and.(.not.this%allgncnonstdff))                        &
-                       call this%gnc%flowja(this%flowja)
+    if(this%ingnc > 0) call this%gnc%flowja(this%flowja)
     !
     ! -- Return
     return
@@ -1230,7 +1201,6 @@ module GwfModule
     call mem_deallocate(this%ingnc)
     call mem_deallocate(this%iss)
     call mem_deallocate(this%inewtonur)
-    call mem_deallocate(this%allgncnonstdff)
     !
     ! -- NumericalModelType
     call this%NumericalModelType%model_da()
@@ -1335,7 +1305,6 @@ module GwfModule
     call mem_allocate(this%inobs, 'INOBS', this%memoryPath)
     call mem_allocate(this%iss,   'ISS',   this%memoryPath)
     call mem_allocate(this%inewtonur, 'INEWTONUR', this%memoryPath)
-    call mem_allocate(this%allgncnonstdff, 'ALLGNCNONSTDFF', this%memoryPath)
     !
     this%inic = 0
     this%inoc = 0
@@ -1349,7 +1318,6 @@ module GwfModule
     this%inobs = 0
     this%iss = 1       !default is steady-state (i.e., no STO package)
     this%inewtonur = 0 !default is to not use newton bottom head dampening
-    this%allgncnonstdff = .false.
     !
     ! -- return
     return

--- a/src/Model/GroundWaterFlow/gwf3hfb8.f90
+++ b/src/Model/GroundWaterFlow/gwf3hfb8.f90
@@ -23,8 +23,6 @@ module GwfHfbModule
     real(DP), dimension(:), pointer, contiguous :: csatsav => null()             !value of condsat prior to hfb modification
     real(DP), dimension(:), pointer, contiguous :: condsav => null()             !saved conductance of combined npf and hfb
     type(Xt3dType), pointer :: xt3d => null()                                    !pointer to xt3d object
-    integer(I4B), pointer :: inonstdf => null()                                  !non-standard flow formulation flag is (0) if standard only and (1) if any non-standard
-    integer(I4B), dimension(:), pointer, contiguous :: iflowform => null()       !flag to indicate use of non-standard flow formulations by connection
     !
     integer(I4B), dimension(:), pointer, contiguous :: ibound  => null()         !pointer to model ibound
     integer(I4B), dimension(:), pointer, contiguous :: icelltype => null()       !pointer to model icelltype
@@ -89,7 +87,7 @@ module GwfHfbModule
     return
   end subroutine hfb_cr
 
-  subroutine hfb_ar(this, ibound, xt3d, dis, inonstdf, iflowform)
+  subroutine hfb_ar(this, ibound, xt3d, dis)
 ! ******************************************************************************
 ! hfb_ar -- Allocate and read
 ! ******************************************************************************
@@ -104,8 +102,6 @@ module GwfHfbModule
     integer(I4B), dimension(:), pointer, contiguous :: ibound
     type(Xt3dType), pointer :: xt3d
     class(DisBaseType), pointer, intent(inout) :: dis
-    integer(I4B), pointer :: inonstdf
-    integer(I4B), dimension(:), pointer, contiguous :: iflowform
     ! -- formats
     character(len=*), parameter :: fmtheader =                                 &
       &"(1x, /1x, 'HFB -- HORIZONTAL FLOW BARRIER PACKAGE, VERSION 8, ',       &
@@ -119,8 +115,6 @@ module GwfHfbModule
     this%dis => dis
     this%ibound => ibound
     this%xt3d => xt3d
-    this%inonstdf => inonstdf
-    if (this%inonstdf /= 0) this%iflowform => iflowform
 
     call mem_setptr(this%icelltype, 'ICELLTYPE', create_mem_path(this%name_model, 'NPF'))
     call mem_setptr(this%ihc, 'IHC', create_mem_path(this%name_model, 'CON'))
@@ -206,7 +200,7 @@ module GwfHfbModule
 
   subroutine hfb_fc(this, kiter, njasln, amat, idxglo, rhs, hnew)
 ! ******************************************************************************
-! hfb_fc -- Fill amat and/or rhs for the following conditions:
+! hfb_fc -- Fill amatsln for the following conditions:
 !   1.  Not Newton, and
 !   2.  Cell type n is convertible or cell type m is convertible
 !  OR
@@ -227,7 +221,7 @@ module GwfHfbModule
     real(DP),intent(inout),dimension(:) :: hnew
     ! -- local
     integer(I4B) ::  nodes, nja
-    integer(I4B) :: ihfb, n, m, ii, iis, il, ig, ilp1
+    integer(I4B) :: ihfb, n, m
     integer(I4B) :: ipos
     integer(I4B) :: idiag, isymcon
     integer(I4B) :: ixt3d
@@ -244,15 +238,11 @@ module GwfHfbModule
       ixt3d = 0
     end if
     !
-    ! -- Fill amat and/or rhs for XT3D connections
-    if(ixt3d /= 0) then      ! amp_note: will need to add cases if other flow formulations are added
+    if(ixt3d > 0) then
+      !
       do ihfb = 1, this%nhfb
         n = min(this%noden(ihfb), this%nodem(ihfb))
-        m = max(this%noden(ihfb), this%nodem(ihfb))     ! amp_note: don't want an m<n check here
-        ! -- Skip if XT3D not used for this connection
-        ii = this%dis%con%getjaindex(n, m)
-        iis = this%dis%con%jas(ii)
-        if (this%iflowform(iis) /= 1) cycle
+        m = max(this%noden(ihfb), this%nodem(ihfb))
         ! -- Skip if either cell is inactive.
         if(this%ibound(n) == 0 .or. this%ibound(m) == 0) cycle
   !!!      if(this%icelltype(n) == 1 .or. this%icelltype(m) == 1) then
@@ -287,65 +277,61 @@ module GwfHfbModule
         call this%xt3d%xt3d_fhfb(kiter, nodes, nja, njasln, amat, idxglo,      &
           rhs, hnew, n, m, condhfb)
       end do
-    end if
-    !
-    ! -- Fill amat for non-XT3D, non-Newton, convertible connections.
-    !    (For Newton, and for confined connections, the effect of the 
-    !    barrier is included in condsat.)
-    if(this%inewton == 0) then
-      do ihfb = 1, this%nhfb
-        n = this%noden(ihfb)
-        m = this%nodem(ihfb)
-        ! -- Skip if XT3D used for this connection
-        ii = this%dis%con%getjaindex(n, m)
-        iis = this%dis%con%jas(ii)
-        if (this%iflowform(iis) == 1) cycle
-        if(this%ibound(n) == 0 .or. this%ibound(m) == 0) cycle
-        if(this%icelltype(n) == 1 .or. this%icelltype(m) == 1) then
-          !
+      !
+    else
+      !
+      ! -- For Newton, the effect of the barrier is included in condsat.
+      if(this%inewton == 0) then
+        do ihfb = 1, this%nhfb
           ipos = this%idxloc(ihfb)
           aterm = amat(idxglo(ipos))
-          !
-          ! -- Calculate hfb conductance
-          topn = this%top(n)
-          topm = this%top(m)
-          botn = this%bot(n)
-          botm = this%bot(m)
-          if(this%icelltype(n) == 1) then
-            if(hnew(n) < topn) topn = hnew(n)
+          n = this%noden(ihfb)
+          m = this%nodem(ihfb)
+          if(this%ibound(n) == 0 .or. this%ibound(m) == 0) cycle
+          if(this%icelltype(n) == 1 .or. this%icelltype(m) == 1) then
+            !
+            ! -- Calculate hfb conductance
+            topn = this%top(n)
+            topm = this%top(m)
+            botn = this%bot(n)
+            botm = this%bot(m)
+            if(this%icelltype(n) == 1) then
+              if(hnew(n) < topn) topn = hnew(n)
+            endif
+            if(this%icelltype(m) == 1) then
+              if(hnew(m) < topm) topm = hnew(m)
+            endif
+            if(this%ihc(this%jas(ipos)) == 2) then
+              faheight = min(topn, topm) - max(botn, botm)
+            else
+              faheight = DHALF * ( (topn - botn) + (topm - botm) )
+            endif
+            if(this%hydchr(ihfb) > DZERO) then
+              fawidth = this%hwva(this%jas(ipos))
+              condhfb = this%hydchr(ihfb) * fawidth * faheight
+              cond = aterm * condhfb / (aterm + condhfb)
+            else
+              cond = - aterm * this%hydchr(ihfb)
+            endif
+            !
+            ! -- Save cond for budget calculation
+            this%condsav(ihfb) = cond
+            !
+            ! -- Fill row n diag and off diag
+            idiag = this%ia(n)
+            amat(idxglo(idiag)) = amat(idxglo(idiag)) + aterm - cond
+            amat(idxglo(ipos)) = cond
+            !
+            ! -- Fill row m diag and off diag
+            isymcon = this%isym(ipos)
+            idiag = this%ia(m)
+            amat(idxglo(idiag)) = amat(idxglo(idiag)) + aterm - cond
+            amat(idxglo(isymcon)) = cond
+            !
           endif
-          if(this%icelltype(m) == 1) then
-            if(hnew(m) < topm) topm = hnew(m)
-          endif
-          if(this%ihc(this%jas(ipos)) == 2) then
-            faheight = min(topn, topm) - max(botn, botm)
-          else
-            faheight = DHALF * ( (topn - botn) + (topm - botm) )
-          endif
-          if(this%hydchr(ihfb) > DZERO) then
-            fawidth = this%hwva(this%jas(ipos))
-            condhfb = this%hydchr(ihfb) * fawidth * faheight
-            cond = aterm * condhfb / (aterm + condhfb)
-          else
-            cond = - aterm * this%hydchr(ihfb)
-          endif
-          !
-          ! -- Save cond for budget calculation
-          this%condsav(ihfb) = cond
-          !
-          ! -- Fill row n diag and off diag
-          idiag = this%ia(n)
-          amat(idxglo(idiag)) = amat(idxglo(idiag)) + aterm - cond
-          amat(idxglo(ipos)) = cond
-          !
-          ! -- Fill row m diag and off diag
-          isymcon = this%isym(ipos)
-          idiag = this%ia(m)
-          amat(idxglo(idiag)) = amat(idxglo(idiag)) + aterm - cond
-          amat(idxglo(isymcon)) = cond
-          !
-        endif
-      enddo
+        enddo
+      endif
+      !
     endif
     !
     ! -- return
@@ -368,7 +354,7 @@ module GwfHfbModule
     real(DP),intent(inout),dimension(:) :: hnew
     real(DP),intent(inout),dimension(:) :: flowja
     ! -- local
-    integer(I4B) :: ihfb, n, m, ii, iis
+    integer(I4B) :: ihfb, n, m
     integer(I4B) :: ipos
     real(DP) :: qnm
     real(DP) :: cond
@@ -384,15 +370,11 @@ module GwfHfbModule
       ixt3d = 0
     end if
     !
-    ! -- Recalculate flowja for XT3D connections
-    if(ixt3d /= 0) then      ! amp_note: will need to add cases if other flow formulations are added
+    if(ixt3d > 0) then
+      !
       do ihfb = 1, this%nhfb
         n = min(this%noden(ihfb), this%nodem(ihfb))
         m = max(this%noden(ihfb), this%nodem(ihfb))
-        ! -- Skip if XT3D not used for this connection
-        ii = this%dis%con%getjaindex(n, m)
-        iis = this%dis%con%jas(ii)
-        if (this%xt3d%iflowform(iis) /= 1) cycle
         ! -- Skip if either cell is inactive.
         if(this%ibound(n) == 0 .or. this%ibound(m) == 0) cycle
   !!!      if(this%icelltype(n) == 1 .or. this%icelltype(m) == 1) then
@@ -426,29 +408,28 @@ module GwfHfbModule
         ! -- Make hfb corrections for xt3d
         call this%xt3d%xt3d_flowjahfb(n, m, hnew, flowja, condhfb)
       end do
+      !
+    else
+      !
+      ! -- Recalculate flowja for non-newton unconfined.
+      if(this%inewton == 0) then
+        do ihfb = 1, this%nhfb
+          n = this%noden(ihfb)
+          m = this%nodem(ihfb)
+          if(this%ibound(n) == 0 .or. this%ibound(m) == 0) cycle
+          if(this%icelltype(n) == 1 .or. this%icelltype(m) == 1) then
+            ipos = this%dis%con%getjaindex(n, m)
+            cond = this%condsav(ihfb)
+            qnm = cond * (hnew(m) - hnew(n))
+            flowja(ipos) = qnm
+            ipos = this%dis%con%getjaindex(m, n)
+            flowja(ipos) = -qnm
+            !
+          endif
+        enddo
+      endif
+      !
     end if
-    !
-    ! -- Recalculate flowja for non-XT3D, non-newton, convertible connections
-    if(this%inewton == 0) then
-      do ihfb = 1, this%nhfb
-        n = this%noden(ihfb)
-        m = this%nodem(ihfb)
-        ! -- Skip if XT3D used for this connection
-        ii = this%dis%con%getjaindex(n, m)
-        iis = this%dis%con%jas(ii)
-        if (this%xt3d%iflowform(iis) == 1) cycle
-        if(this%ibound(n) == 0 .or. this%ibound(m) == 0) cycle
-        if(this%icelltype(n) == 1 .or. this%icelltype(m) == 1) then
-          ipos = this%dis%con%getjaindex(n, m)
-          cond = this%condsav(ihfb)
-          qnm = cond * (hnew(m) - hnew(n))
-          flowja(ipos) = qnm
-          ipos = this%dis%con%getjaindex(m, n)
-          flowja(ipos) = -qnm
-          !
-        endif
-      enddo
-    endif
     !
     ! -- return
     return

--- a/src/Model/GroundWaterFlow/gwf3npf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8.f90
@@ -1,5 +1,5 @@
 module GwfNpfModule
-  use KindModule,                 only: DP, I4B, LGP
+  use KindModule,                 only: DP, I4B
   use ConstantsModule,            only: DZERO, DEM9, DEM8, DEM7, DEM6, DEM2,    &
                                         DHALF, DP9, DONE, DTWO,                 &
                                         DLNLOW, DLNHIGH,                        &
@@ -51,12 +51,6 @@ module GwfNpfModule
     real(DP), pointer                               :: wetfct       => null()    ! wetting factor
     real(DP), pointer                               :: hdry         => null()    ! default is -1.d30
     integer(I4B), dimension(:), pointer, contiguous :: icelltype    => null()    ! confined (0) or convertible (1)
-    logical(LGP), pointer                           :: xt3dbyconn   => null()    ! flag to indicate whether application of xt3d is specified by connection
-    logical(LGP), pointer                           :: allnonstdf   => null()    ! flag to indicate whether all connections are using a non-standard flow formulation
-    integer(I4B), dimension(:), pointer, contiguous :: iflowform    => null()    ! flag to indicate use of non-standard flow formulations by connection
-    integer(I4B), pointer                           :: iprxt3d      => null()    ! print (1) or do not print (0) xt3d connections in XT3DDATA block
-    integer(I4B), pointer                           :: inonstdf     => null()    ! non-standard flow formulation flag is (0) if standard only and (1) if any non-standard
-    integer(I4B), pointer                           :: nbrmax       => null()    ! maximum number of standard neighbors for any cell
     !
     ! K properties
     real(DP), dimension(:), pointer, contiguous     :: k11          => null()    ! hydraulic conductivity; if anisotropic, then this is Kx prior to rotation
@@ -102,7 +96,6 @@ module GwfNpfModule
     procedure                               :: npf_nur
     procedure                               :: npf_ot
     procedure                               :: npf_da
-    procedure, private                      :: stdcond_fc
     procedure, private                      :: thksat     => sgwf_npf_thksat
     procedure, private                      :: qcalc      => sgwf_npf_qcalc
     procedure, private                      :: wd         => sgwf_npf_wetdry
@@ -113,7 +106,6 @@ module GwfNpfModule
     procedure, private                      :: rewet_options
     procedure, private                      :: check_options
     procedure, private                      :: read_data
-    procedure, private                      :: read_xt3d_data
     procedure, private                      :: prepcheck
     procedure, public                       :: rewet_check
     procedure, public                       :: hy_eff
@@ -174,6 +166,7 @@ module GwfNpfModule
     class(DisBaseType), pointer, intent(inout) :: dis
     type(Xt3dType), pointer :: xt3d
     integer(I4B), intent(in) :: ingnc
+    ! -- local
     ! -- formats
     character(len=*), parameter :: fmtheader =                                 &
       "(1x, /1x, 'NPF -- NODE PROPERTY FLOW PACKAGE, VERSION 1, 3/30/2015',    &
@@ -197,30 +190,14 @@ module GwfNpfModule
     ! -- Save pointer to xt3d object
     this%xt3d => xt3d
     if (this%ixt3d /= 0) xt3d%ixt3d = this%ixt3d
+    call this%xt3d%xt3d_df(dis)
     !
-    ! -- check whether a non-standard flow formulation and GNC are both active,
-    !    and if so, warn
-    if (this%inonstdf /= 0 .and. ingnc > 0) then
-      write(this%iout, '(4x,a,2(1x,a))')                                        &
-        '****WARNING. A non-standard flow formulation and the GNC Package are', &
-        'both active. The non-standard flow formulation will override GNC at',  &
-        'any connections for which both are specified.'    ! amp_note: say which formulation???
-    end if
-    !
-    ! -- If xt3d active:
-    !    Temporarily allocate and initialize iflowform array. Read the xt3d
-    !    data block if necessary to set iflowform, otherwise set it to 1.    ! amp_note: doing this here because we need to know iflowform array before call to _ac
-    !    Call xt3d_df.
-    if (this%ixt3d /= 0) then
-      allocate(this%iflowform(this%dis%njas))
-      this%iflowform = 0
-      if (this%xt3dbyconn /= 0) then
-        call this%read_xt3d_data(.true.)
-      else
-        this%iflowform = 1
-      end if
-      call this%xt3d%xt3d_df(dis,this%iflowform)
-    end if
+    ! -- Ensure GNC and XT3D are not both on at the same time
+    if (this%ixt3d /= 0 .and. ingnc > 0) then
+      call store_error('Error in model ' // trim(this%name_model) // &
+        '.  The XT3D option cannot be used with the GNC Package.')
+      call ustop()
+    endif
     !
     ! -- Return
     return
@@ -274,7 +251,7 @@ module GwfNpfModule
   end subroutine npf_mc
   
   subroutine npf_init_mem(this, dis, ixt3d, icelltype, k11, k22, k33, wetdry,    &
-                          angle1, angle2, angle3)    ! amp_note: this subroutine appears to be unused
+                          angle1, angle2, angle3)
 ! ******************************************************************************
 ! npf_cr -- Create a new NPF object from memory
 ! ******************************************************************************
@@ -363,7 +340,6 @@ module GwfNpfModule
     integer(I4B), dimension(:), pointer, contiguous, intent(inout) :: ibound
     real(DP), dimension(:), pointer, contiguous, intent(inout) :: hnew
     ! -- local
-    integer(I4B) :: i, nnbrs, nbrxmax
     ! -- formats
     ! -- data
 ! ------------------------------------------------------------------------------
@@ -376,36 +352,11 @@ module GwfNpfModule
     ! -- read data from files
     if (this%inunit /= 0)  then
       !
-      ! -- Determine the maximum number of standard neighbors
-      !    for any cell (excluding self)
-      this%nbrmax = 0
-      do i = 1, this%dis%nodes
-        nnbrs = this%dis%con%ia(i+1) - this%dis%con%ia(i) - 1
-        this%nbrmax = max(nnbrs, this%nbrmax)
-      end do
-      !
       ! -- allocate arrays
       call this%allocate_arrays(this%dis%nodes, this%dis%njas)
       !
       ! -- read the data block
       call this%read_data()
-      !
-      ! -- Initialize the iflowform and allnonstdf flags
-      this%iflowform = 0
-      this%allnonstdf = .false.
-      ! -- If xt3d active:
-      !    Read the xt3d data block if necessary to set iflowform, otherwise
-      !    set it to 1. Set allnonstdf flag to .true. if all connections use XT3D.
-      if (this%ixt3d /= 0) then
-        if (this%xt3dbyconn /= 0) then
-          call this%read_xt3d_data(.false.)
-          this%allnonstdf = all(this%iflowform /= 0)
-        else
-          this%iflowform = 1
-          this%allnonstdf = .true.
-        end if
-      end if
-      !
     end if
     !
     ! -- Initialize and check data
@@ -413,11 +364,10 @@ module GwfNpfModule
     !
     ! -- xt3d
     if (this%ixt3d /= 0) then
-      call this%xt3d%xt3d_ar(ibound, this%k11, this%ik33, this%k33,            &
-                             this%sat, this%ik22, this%k22,                    &
-                             this%iangle1, this%iangle2, this%iangle3,         &
-                             this%angle1, this%angle2, this%angle3,            &
-                             this%iflowform, this%nbrmax,                      &
+      call this%xt3d%xt3d_ar(ibound, this%k11, this%ik33, this%k33,              &
+                             this%sat, this%ik22, this%k22,                      &
+                             this%iangle1, this%iangle2, this%iangle3,           &
+                             this%angle1, this%angle2, this%angle3,              &
                              this%inewton, this%icelltype)
     end if
     !
@@ -509,57 +459,103 @@ module GwfNpfModule
     real(DP),intent(inout),dimension(:) :: rhs
     real(DP),intent(inout),dimension(:) :: hnew
     ! -- local
-    integer(I4B) :: n, m, ii, iis
-    integer(I4B) :: i, il, ig, iil, ilp1
+    integer(I4B) :: n, m, ii, idiag, ihc
+    integer(I4B) :: isymcon, idiagm
+    real(DP) :: hyn, hym
+    real(DP) :: cond
 ! ------------------------------------------------------------------------------
     !
-    ! -- Update amat and rhs for flow formulation
+    ! -- Calculate conductance and put into amat
     !
-!!    this%xt3d%lamatsaved = .false.       ! kluge to debug and test
-!!    !
-    ! -- Apply any saved coefficient updates
-    if(this%ixt3d /= 0) call this%xt3d%xt3d_amatsaved_fc(njasln, amat, idxglo)
+    if(this%ixt3d /= 0) then
+      call this%xt3d%xt3d_fc(kiter, njasln, amat, idxglo, rhs, hnew)
+    else
     !
-    ! -- Loop over rows (nodes)
     do n = 1, this%dis%nodes
-      !
-      ! -- Loop over connections of node n (columns) and apply the
-      !    the appropriate flow formulations
       do ii = this%dis%con%ia(n) + 1, this%dis%con%ia(n + 1) - 1
         if (this%dis%con%mask(ii) == 0) cycle
-        !
+        
         m = this%dis%con%ja(ii)
-        ! -- Skip if neighbor has lower cell number
-        if (m < n) cycle
         !
-        iis = this%dis%con%jas(ii)
+        ! -- Calculate conductance only for upper triangle but insert into
+        !    upper and lower parts of amat.
+        if(m < n) cycle
+        ihc = this%dis%con%ihc(this%dis%con%jas(ii))
+        hyn = this%hy_eff(n, m, ihc, ipos=ii)
+        hym = this%hy_eff(m, n, ihc, ipos=ii)
         !
-        ! -- If no non-standard conductance formulations used at any
-        !    connections, always use standard conductance formulation.
-        !    Otherwise, use the appropriate formulation for the connection.
-        if (this%inonstdf == 0) then
+        ! -- Vertical connection
+        if(ihc == 0) then
           !
-          ! -- Standard conductance formulation
-          call this%stdcond_fc(n, ii, njasln, amat, idxglo, rhs, hnew)
+          ! -- Calculate vertical conductance
+          cond =  vcond(this%ibound(n), this%ibound(m),                        &
+                        this%icelltype(n), this%icelltype(m), this%inewton,    &
+                        this%ivarcv, this%idewatcv,                            &
+                        this%condsat(this%dis%con%jas(ii)), hnew(n), hnew(m),  &
+                        hyn, hym,                                              &
+                        this%sat(n), this%sat(m),                              &
+                        this%dis%top(n), this%dis%top(m),                      &
+                        this%dis%bot(n), this%dis%bot(m),                      &
+                        this%dis%con%hwva(this%dis%con%jas(ii)))
+          !
+          ! -- Vertical flow for perched conditions
+          if(this%iperched /= 0) then
+            if(this%icelltype(m) /= 0) then
+              if(hnew(m) < this%dis%top(m)) then
+                !
+                ! -- Fill row n
+                idiag = this%dis%con%ia(n)
+                rhs(n) = rhs(n) - cond * this%dis%bot(n)
+                amat(idxglo(idiag)) = amat(idxglo(idiag)) - cond
+                !
+                ! -- Fill row m
+                isymcon = this%dis%con%isym(ii)
+                amat(idxglo(isymcon)) = amat(idxglo(isymcon)) + cond
+                rhs(m) = rhs(m) + cond * this%dis%bot(n)
+                !
+                ! -- cycle the connection loop
+                cycle
+              endif
+            endif
+          endif
           !
         else
           !
-          ! -- Standard conductance formulation
-          if (this%iflowform(iis) == 0)                                          &
-             call this%stdcond_fc(n, ii, njasln, amat, idxglo, rhs, hnew)
-          !
-          ! -- XT3D formulation
-          if (this%iflowform(iis) == 1)                                          &
-             call this%xt3d%xt3d_fc(n, ii, njasln, amat, idxglo, rhs, hnew)
-          !
-        end if
+          ! -- Horizontal conductance
+          cond = hcond(this%ibound(n), this%ibound(m),                       &
+                       this%icelltype(n), this%icelltype(m),                 &
+                       this%inewton, this%inewton,                           &
+                       this%dis%con%ihc(this%dis%con%jas(ii)),               &
+                       this%icellavg, this%iusgnrhc, this%inwtupw,           &
+                       this%condsat(this%dis%con%jas(ii)),                   &
+                       hnew(n), hnew(m), this%sat(n), this%sat(m), hyn, hym, &
+                       this%dis%top(n), this%dis%top(m),                     &
+                       this%dis%bot(n), this%dis%bot(m),                     &
+                       this%dis%con%cl1(this%dis%con%jas(ii)),               &
+                       this%dis%con%cl2(this%dis%con%jas(ii)),               &
+                       this%dis%con%hwva(this%dis%con%jas(ii)),              &
+                       this%satomega, this%satmin)
+        endif
         !
+        ! -- Fill row n
+        idiag = this%dis%con%ia(n)
+        amat(idxglo(ii)) = amat(idxglo(ii)) + cond
+        amat(idxglo(idiag)) = amat(idxglo(idiag)) - cond
+        !
+        ! -- Fill row m
+        isymcon = this%dis%con%isym(ii)
+        idiagm = this%dis%con%ia(m)
+        amat(idxglo(isymcon)) = amat(idxglo(isymcon)) + cond
+        amat(idxglo(idiagm)) = amat(idxglo(idiagm)) - cond
       enddo
     enddo
+    !
+    endif
     !
     ! -- Return
     return
   end subroutine npf_fc
+
 
   subroutine npf_fn(this, kiter, njasln, amat, idxglo, rhs, hnew)
 ! ******************************************************************************
@@ -578,7 +574,7 @@ module GwfNpfModule
     real(DP),intent(inout),dimension(:) :: hnew
     ! -- local
     integer(I4B) :: nodes, nja
-    integer(I4B) :: n,m,ii,idiag,iis
+    integer(I4B) :: n,m,ii,idiag
     integer(I4B) :: isymcon, idiagm
     integer(I4B) :: iups
     integer(I4B) :: idn
@@ -599,108 +595,104 @@ module GwfNpfModule
     !
     nodes = this%dis%nodes
     nja = this%dis%con%nja
-    if(this%ixt3d /= 0)                                                        &
+    if(this%ixt3d /= 0) then
       call this%xt3d%xt3d_fn(kiter, nodes, nja, njasln, amat, idxglo, rhs, hnew)
+    else
     !
-    if (.not.this%allnonstdf) then
-      do n=1, nodes
-        idiag=this%dis%con%ia(n)
-        do ii=this%dis%con%ia(n)+1,this%dis%con%ia(n+1)-1
-          if (this%dis%con%mask(ii) == 0) cycle
-          ! -- Skip if non-standard flow formulation used for this connection
-          if(this%inonstdf /= 0) then
-            iis = this%dis%con%jas(ii)
-            if (this%iflowform(iis) /= 0) cycle
+    do n=1, nodes
+      idiag=this%dis%con%ia(n)
+      do ii=this%dis%con%ia(n)+1,this%dis%con%ia(n+1)-1
+        if (this%dis%con%mask(ii) == 0) cycle
+        
+        m=this%dis%con%ja(ii)
+        isymcon = this%dis%con%isym(ii)
+        ! work on upper triangle
+        if(m < n) cycle
+        if(this%dis%con%ihc(this%dis%con%jas(ii))==0 .and.                     &
+           this%ivarcv == 0) then
+          !call this%vcond(n,m,hnew(n),hnew(m),ii,cond)
+          ! do nothing
+        else
+          ! determine upstream node
+          iups = m
+          if (hnew(m) < hnew(n)) iups = n
+          idn = n
+          if (iups == n) idn = m
+          !
+          ! -- no newton terms if upstream cell is confined
+          if (this%icelltype(iups) == 0) cycle
+          !
+          ! -- Set the upstream top and bot, and then recalculate for a
+          !    vertically staggered horizontal connection
+          topup = this%dis%top(iups)
+          botup = this%dis%bot(iups)
+          if(this%dis%con%ihc(this%dis%con%jas(ii)) == 2) then
+            topup = min(this%dis%top(n), this%dis%top(m))
+            botup = max(this%dis%bot(n), this%dis%bot(m))
+          endif
+          !
+          ! get saturated conductivity for derivative
+          cond = this%condsat(this%dis%con%jas(ii))
+          !
+          ! -- if using MODFLOW-NWT upstream weighting option apply
+          !    factor to remove average thickness
+          if (this%inwtupw /= 0) then
+            topdn = this%dis%top(idn)
+            botdn = this%dis%bot(idn)
+            afac = DTWO / (DONE + (topdn - botdn) / (topup - botup))
+            cond = cond * afac
           end if
           !
-          m=this%dis%con%ja(ii)
-          isymcon = this%dis%con%isym(ii)
-          ! work on upper triangle
-          if(m < n) cycle
-          if(this%dis%con%ihc(this%dis%con%jas(ii))==0 .and.                     &
-             this%ivarcv == 0) then
-            !call this%vcond(n,m,hnew(n),hnew(m),ii,cond)
-            ! do nothing
+          ! compute additional term
+          consterm = -cond * (hnew(iups) - hnew(idn)) !needs to use hwadi instead of hnew(idn)
+          !filledterm = cond
+          filledterm = amat(idxglo(ii))
+          derv = sQuadraticSaturationDerivative(topup, botup, hnew(iups),       &
+                                                this%satomega, this%satmin)
+          idiagm = this%dis%con%ia(m)
+          ! fill jacobian for n being the upstream node
+          if (iups == n) then
+            hds = hnew(m)
+            !isymcon =  this%dis%con%isym(ii)
+            term = consterm * derv
+            rhs(n) = rhs(n) + term * hnew(n) !+ amat(idxglo(isymcon)) * (dwadi * hds - hds) !need to add dwadi
+            rhs(m) = rhs(m) - term * hnew(n) !- amat(idxglo(isymcon)) * (dwadi * hds - hds) !need to add dwadi
+            ! fill in row of n
+            amat(idxglo(idiag)) = amat(idxglo(idiag)) + term
+            ! fill newton term in off diagonal if active cell
+            if (this%ibound(n) > 0) then
+              amat(idxglo(ii)) = amat(idxglo(ii)) !* dwadi !need to add dwadi
+            end if
+            !fill row of m
+            amat(idxglo(idiagm)) = amat(idxglo(idiagm)) !- filledterm * (dwadi - DONE) !need to add dwadi
+            ! fill newton term in off diagonal if active cell
+            if (this%ibound(m) > 0) then
+              amat(idxglo(isymcon)) = amat(idxglo(isymcon)) - term
+            end if
+          ! fill jacobian for m being the upstream node
           else
-            ! determine upstream node
-            iups = m
-            if (hnew(m) < hnew(n)) iups = n
-            idn = n
-            if (iups == n) idn = m
-            !
-            ! -- no newton terms if upstream cell is confined
-            if (this%icelltype(iups) == 0) cycle
-            !
-            ! -- Set the upstream top and bot, and then recalculate for a
-            !    vertically staggered horizontal connection
-            topup = this%dis%top(iups)
-            botup = this%dis%bot(iups)
-            if(this%dis%con%ihc(this%dis%con%jas(ii)) == 2) then
-              topup = min(this%dis%top(n), this%dis%top(m))
-              botup = max(this%dis%bot(n), this%dis%bot(m))
-            endif
-            !
-            ! get saturated conductivity for derivative
-            cond = this%condsat(this%dis%con%jas(ii))
-            !
-            ! -- if using MODFLOW-NWT upstream weighting option apply
-            !    factor to remove average thickness
-            if (this%inwtupw /= 0) then
-              topdn = this%dis%top(idn)
-              botdn = this%dis%bot(idn)
-              afac = DTWO / (DONE + (topdn - botdn) / (topup - botup))
-              cond = cond * afac
+            hds = hnew(n)
+            term = -consterm * derv
+            rhs(n) = rhs(n) + term * hnew(m) !+ amat(idxglo(ii)) * (dwadi * hds - hds) !need to add dwadi
+            rhs(m) = rhs(m) - term * hnew(m) !- amat(idxglo(ii)) * (dwadi * hds - hds) !need to add dwadi
+            ! fill in row of n
+            amat(idxglo(idiag)) = amat(idxglo(idiag)) !- filledterm * (dwadi - DONE) !need to add dwadi
+            ! fill newton term in off diagonal if active cell
+            if (this%ibound(n) > 0) then
+              amat(idxglo(ii)) = amat(idxglo(ii)) + term
             end if
-            !
-            ! compute additional term
-            consterm = -cond * (hnew(iups) - hnew(idn)) !needs to use hwadi instead of hnew(idn)
-            !filledterm = cond
-            filledterm = amat(idxglo(ii))
-            derv = sQuadraticSaturationDerivative(topup, botup, hnew(iups),    &
-                                                  this%satomega, this%satmin)
-            idiagm = this%dis%con%ia(m)
-            ! fill jacobian for n being the upstream node
-            if (iups == n) then
-              hds = hnew(m)
-              !isymcon =  this%dis%con%isym(ii)
-              term = consterm * derv
-              rhs(n) = rhs(n) + term * hnew(n) !+ amat(idxglo(isymcon)) * (dwadi * hds - hds) !need to add dwadi
-              rhs(m) = rhs(m) - term * hnew(n) !- amat(idxglo(isymcon)) * (dwadi * hds - hds) !need to add dwadi
-              ! fill in row of n
-              amat(idxglo(idiag)) = amat(idxglo(idiag)) + term
-              ! fill newton term in off diagonal if active cell
-              if (this%ibound(n) > 0) then
-                amat(idxglo(ii)) = amat(idxglo(ii)) !* dwadi !need to add dwadi
-              end if
-              !fill row of m
-              amat(idxglo(idiagm)) = amat(idxglo(idiagm)) !- filledterm * (dwadi - DONE) !need to add dwadi
-              ! fill newton term in off diagonal if active cell
-              if (this%ibound(m) > 0) then
-                amat(idxglo(isymcon)) = amat(idxglo(isymcon)) - term
-              end if
-            ! fill jacobian for m being the upstream node
-            else
-              hds = hnew(n)
-              term = -consterm * derv
-              rhs(n) = rhs(n) + term * hnew(m) !+ amat(idxglo(ii)) * (dwadi * hds - hds) !need to add dwadi
-              rhs(m) = rhs(m) - term * hnew(m) !- amat(idxglo(ii)) * (dwadi * hds - hds) !need to add dwadi
-              ! fill in row of n
-              amat(idxglo(idiag)) = amat(idxglo(idiag)) !- filledterm * (dwadi - DONE) !need to add dwadi
-              ! fill newton term in off diagonal if active cell
-              if (this%ibound(n) > 0) then
-                amat(idxglo(ii)) = amat(idxglo(ii)) + term
-              end if
-              !fill row of m
-              amat(idxglo(idiagm)) = amat(idxglo(idiagm)) - term
-              ! fill newton term in off diagonal if active cell
-              if (this%ibound(m) > 0) then
-                amat(idxglo(isymcon)) = amat(idxglo(isymcon)) !* dwadi  !need to add dwadi
-              end if
+            !fill row of m
+            amat(idxglo(idiagm)) = amat(idxglo(idiagm)) - term
+            ! fill newton term in off diagonal if active cell
+            if (this%ibound(m) > 0) then
+              amat(idxglo(isymcon)) = amat(idxglo(isymcon)) !* dwadi  !need to add dwadi
             end if
-          endif
+          end if
+        endif
 
-        enddo
-      end do
+      enddo
+    end do
+    !
     end if
     !
     ! -- Return
@@ -771,141 +763,31 @@ module GwfNpfModule
     real(DP),intent(inout),dimension(:) :: hnew
     real(DP),intent(inout),dimension(:) :: flowja
     ! -- local
-    integer(I4B) :: n, ipos, m, isympos
+    integer(I4B) :: n, ipos, m
     real(DP) :: qnm
 ! ------------------------------------------------------------------------------
     !
     ! -- Calculate the flow across each cell face and store in flowja
     !
-    if(this%ixt3d /= 0) call this%xt3d%xt3d_flowja(hnew, flowja)
+    if(this%ixt3d /= 0) then
+      call this%xt3d%xt3d_flowja(hnew, flowja)
+    else
     !
-    if (.not.this%allnonstdf) then
-      do n = 1, this%dis%nodes
-        do ipos = this%dis%con%ia(n) + 1, this%dis%con%ia(n + 1) - 1
-          ! -- Skip if non-standard flow formulation used for this connection
-          if(this%inonstdf /= 0) then
-            isympos = this%dis%con%jas(ipos)
-            if (this%iflowform(isympos) /= 0) cycle
-          end if
-          m = this%dis%con%ja(ipos)
-          if(m < n) cycle
-          call this%qcalc(n, m, hnew(n), hnew(m), ipos, qnm)
-          flowja(ipos) = qnm
-          flowja(this%dis%con%isym(ipos)) = -qnm
-        enddo
+    do n = 1, this%dis%nodes
+      do ipos = this%dis%con%ia(n) + 1, this%dis%con%ia(n + 1) - 1
+        m = this%dis%con%ja(ipos)
+        if(m < n) cycle
+        call this%qcalc(n, m, hnew(n), hnew(m), ipos, qnm)
+        flowja(ipos) = qnm
+        flowja(this%dis%con%isym(ipos)) = -qnm
       enddo
-    end if
+    enddo
+    !
+    endif
     !
     ! -- Return
     return
   end subroutine npf_flowja
-
-  subroutine stdcond_fc(this, n, ii, njasln, amat, idxglo, rhs, hnew)
-! ******************************************************************************
-! stdcond_fc -- Formulate a connection
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-    ! -- modules
-    use ConstantsModule, only: DONE
-    ! -- dummy
-    class(GwfNpfType) :: this
-    integer(I4B) :: n, ii
-    integer(I4B),intent(in) :: njasln
-    real(DP),dimension(njasln),intent(inout) :: amat
-    integer(I4B),intent(in),dimension(:) :: idxglo
-    real(DP),intent(inout),dimension(:) :: rhs
-    real(DP),intent(inout),dimension(:) :: hnew
-    ! -- local
-    integer(I4B) :: m, idiag, ihc, iil, iilp1
-    integer(I4B) :: isymcon, idiagm
-    real(DP) :: hyn, hym
-    real(DP) :: cond
- ! ------------------------------------------------------------------------------
-    !
-    ! -- Get neighbor's node number
-    m = this%dis%con%ja(ii)
-    !
-    ! -- Calculate conductance only for upper triangle but insert into
-    !    upper and lower parts of amat.
-!!    if(m < n) return
-    if(m < n) then
-      print *,"stdcond_fc should not be called for m < n"   ! amp_note: because perched calc assumes m > n???
-      pause                                                 ! kluge
-      stop
-    end if
-    !
-    ihc = this%dis%con%ihc(this%dis%con%jas(ii))
-    hyn = this%hy_eff(n, m, ihc, ipos=ii)
-    hym = this%hy_eff(m, n, ihc, ipos=ii)
-    !
-    ! -- Vertical connection
-    if(ihc == 0) then
-      !
-      ! -- Calculate vertical conductance
-      cond = vcond(this%ibound(n), this%ibound(m),                       &
-                   this%icelltype(n), this%icelltype(m), this%inewton,   &
-                   this%ivarcv, this%idewatcv,                           &
-                   this%condsat(this%dis%con%jas(ii)), hnew(n), hnew(m), &
-                   hyn, hym,                                             &
-                   this%sat(n), this%sat(m),                             &
-                   this%dis%top(n), this%dis%top(m),                     &
-                   this%dis%bot(n), this%dis%bot(m),                     &
-                   this%dis%con%hwva(this%dis%con%jas(ii)))
-      !
-      ! -- Vertical flow for perched conditions
-      if(this%iperched /= 0) then
-        if(this%icelltype(m) /= 0) then
-          if(hnew(m) < this%dis%top(m)) then
-            !
-            ! -- Fill row n
-            idiag = this%dis%con%ia(n)
-            rhs(n) = rhs(n) - cond * this%dis%bot(n)
-            amat(idxglo(idiag)) = amat(idxglo(idiag)) - cond
-            !
-            ! -- Fill row m
-            isymcon = this%dis%con%isym(ii)
-            amat(idxglo(isymcon)) = amat(idxglo(isymcon)) + cond
-            rhs(m) = rhs(m) + cond * this%dis%bot(n)
-            !
-          endif
-        endif
-      endif
-      !
-    else
-      !
-      ! -- Horizontal conductance
-      cond = hcond(this%ibound(n), this%ibound(m),                       &
-                   this%icelltype(n), this%icelltype(m),                 &
-                   this%inewton, this%inewton,                           &
-                   this%dis%con%ihc(this%dis%con%jas(ii)),               &
-                   this%icellavg, this%iusgnrhc, this%inwtupw,           &
-                   this%condsat(this%dis%con%jas(ii)),                   &
-                   hnew(n), hnew(m), this%sat(n), this%sat(m), hyn, hym, &
-                   this%dis%top(n), this%dis%top(m),                     &
-                   this%dis%bot(n), this%dis%bot(m),                     &
-                   this%dis%con%cl1(this%dis%con%jas(ii)),               &
-                   this%dis%con%cl2(this%dis%con%jas(ii)),               &
-                   this%dis%con%hwva(this%dis%con%jas(ii)),              &
-                   this%satomega, this%satmin)
-    endif
-    !
-    ! -- Fill row n
-    idiag = this%dis%con%ia(n)
-    amat(idxglo(ii)) = amat(idxglo(ii)) + cond
-    amat(idxglo(idiag)) = amat(idxglo(idiag)) - cond
-    !
-    ! -- Fill row m
-    isymcon = this%dis%con%isym(ii)
-    idiagm = this%dis%con%ia(m)
-    amat(idxglo(isymcon)) = amat(idxglo(isymcon)) + cond
-    amat(idxglo(idiagm)) = amat(idxglo(idiagm)) - cond
-    !
-    ! -- Return
-    return
-  end subroutine stdcond_fc
-
 
   subroutine sgwf_npf_thksat(this, n, hn, thksat)
 ! ******************************************************************************
@@ -1124,11 +1006,7 @@ module GwfNpfModule
     use MemoryManagerModule, only: mem_deallocate
     ! -- dummy
     class(GwfNpftype) :: this
-    ! -- local
-    integer(I4B) :: inonstdf
 ! ------------------------------------------------------------------------------
-    !
-    inonstdf = this%inonstdf
     !
     ! -- Strings
     !
@@ -1164,11 +1042,6 @@ module GwfNpfModule
     call mem_deallocate(this%lastedge)
     call mem_deallocate(this%ik22overk)
     call mem_deallocate(this%ik33overk)
-    call mem_deallocate(this%allnonstdf)
-    call mem_deallocate(this%xt3dbyconn)
-    call mem_deallocate(this%iprxt3d)
-    call mem_deallocate(this%inonstdf)
-    call mem_deallocate(this%nbrmax)
     !
     ! -- Deallocate arrays
     deallocate(this%aname)
@@ -1186,7 +1059,6 @@ module GwfNpfModule
     call mem_deallocate(this%ihcedge)
     call mem_deallocate(this%propsedge)
     call mem_deallocate(this%spdis)
-    if (inonstdf /= 0) call mem_deallocate(this%iflowform)
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
@@ -1243,11 +1115,6 @@ module GwfNpfModule
     call mem_allocate(this%iwetdry, 'IWETDRY', this%memoryPath)
     call mem_allocate(this%nedges, 'NEDGES', this%memoryPath)
     call mem_allocate(this%lastedge, 'LASTEDGE', this%memoryPath)
-    call mem_allocate(this%allnonstdf, 'allnonstdf', this%memoryPath)
-    call mem_allocate(this%xt3dbyconn, 'XT3DBYCONN', this%memoryPath)
-    call mem_allocate(this%iprxt3d, 'IPRXT3D', this%memoryPath)
-    call mem_allocate(this%inonstdf, 'inonstdf', this%memoryPath)
-    call mem_allocate(this%nbrmax, 'NBRMAX', this%memoryPath)
     !
     ! -- set pointer to inewtonur
     call mem_setptr(this%igwfnewtonur, 'INEWTONUR', create_mem_path(this%name_model))
@@ -1283,11 +1150,6 @@ module GwfNpfModule
     this%iwetdry = 0
     this%nedges = 0
     this%lastedge = 0
-    this%allnonstdf = .false.
-    this%xt3dbyconn = .false.
-    this%iprxt3d = 0
-    this%inonstdf = 0
-    this%nbrmax = 0
     !
     ! -- If newton is on, then NPF creates asymmetric matrix
     this%iasym = this%inewton
@@ -1346,12 +1208,6 @@ module GwfNpfModule
       call mem_allocate(this%propsedge, 0, 0, 'PROPSEDGE', this%memoryPath)
     endif
     !
-    ! -- Non-standard flow formulation flag array
-    ! -- Deallocate temporary allocation in npf_df and allocate permanently
-    if (this%ixt3d /= 0) deallocate(this%iflowform)
-    if (this%inonstdf /= 0)                                                    &
-       call mem_allocate(this%iflowform, njas, 'IFLOWFORM', this%memoryPath)
-    !
     ! -- initialize iangle1, iangle2, iangle3, and wetdry
     do n = 1, ncells
       this%angle1(n) = DZERO
@@ -1359,9 +1215,6 @@ module GwfNpfModule
       this%angle3(n) = DZERO
       this%wetdry(n) = DZERO
     end do
-    !
-    ! -- initialize flow formulation flag array
-    if (this%inonstdf /= 0) this%iflowform = 0
     !
     ! -- allocate variable names
     allocate(this%aname(this%iname))
@@ -1389,7 +1242,7 @@ module GwfNpfModule
     class(GwfNpftype) :: this
     ! -- local
     character(len=LINELENGTH) :: errmsg, keyword
-    integer(I4B) :: ierr, isubopt
+    integer(I4B) :: ierr
     logical :: isfound, endOfBlock
     ! -- formats
     character(len=*), parameter :: fmtiprflow =                                &
@@ -1468,26 +1321,10 @@ module GwfNpfModule
             this%ixt3d = 1
             write(this%iout, '(4x,a)')                                         &
                              'XT3D FORMULATION IS SELECTED.'
-            this%inonstdf = 1
-            do isubopt=1,3
-              call this%parser%GetStringCaps(keyword)
-              if(keyword == 'RHS') then
-                this%ixt3d = 2
-                write(this%iout, '(8x,a)')                                     &
-                                 'XT3D RHS OPTION IS SELECTED.'
-              else if(keyword == 'BY_CONNECTION') then
-                this%xt3dbyconn = .true.
-                write(this%iout, '(8x,a)')                                     &
-                                 'APPLICATION OF XT3D IS SPECIFIED BY ' //     &
-                                 'CONNECTION.'
-              else if(keyword == 'PRINT_INPUT') then
-                this%iprxt3d = 1
-                write(this%iout, '(8x,a)')                                     &
-                                 'THE LIST OF XT3D CONNECTIONS WILL BE '   //  &
-                                 'PRINTED IF APPLICATION OF XT3D IS '      //  &
-                                 'SPECIFIED BY CONNECTION.'
-              endif
-            end do
+            call this%parser%GetStringCaps(keyword)
+            if(keyword == 'RHS') then
+              this%ixt3d = 2
+            endif
           case ('SAVE_SPECIFIC_DISCHARGE')
             this%icalcspdis = 1
             this%isavspdis = 1
@@ -1885,21 +1722,21 @@ module GwfNpfModule
     if (lname(6)) then
       this%iangle1 = 1
     else
-      if (this%inonstdf == 0) then
+      if (this%ixt3d == 0) then
         call mem_reallocate(this%angle1, 1, 'ANGLE1', trim(this%memoryPath))        
       end if
     endif
     if (lname(7)) then
       this%iangle2 = 1
     else
-      if (this%inonstdf == 0) then
+      if (this%ixt3d == 0) then
         call mem_reallocate(this%angle2, 1, 'ANGLE2', trim(this%memoryPath))        
       end if
     endif
     if (lname(8)) then
       this%iangle3 = 1
     else
-      if (this%inonstdf == 0) then
+      if (this%ixt3d == 0) then
         call mem_reallocate(this%angle3, 1, 'ANGLE3', trim(this%memoryPath))        
       end if
     endif
@@ -1916,95 +1753,6 @@ module GwfNpfModule
     ! -- Return
     return
   end subroutine read_data
-
-  subroutine read_xt3d_data(this,isdfcall)
-! ******************************************************************************
-! read_xt3d_data -- read the npf xt3d data block
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-    ! -- modules
-    use ConstantsModule,   only: LINELENGTH, DONE, DPIO180
-    use MemoryManagerModule, only: mem_allocate, mem_reallocate, mem_deallocate, &
-                                   mem_reassignptr
-    use SimModule,         only: ustop, store_error, count_errors
-    ! -- dummy
-    class(GwfNpftype) :: this
-    logical :: isdfcall
-    ! -- local
-    character(len=LINELENGTH) :: errmsg, line, nodestr, cellidm, cellidn
-    integer(I4B) :: n, m, ierr, iux, nodeun, nodeum, ii, iis
-    integer(I4B) :: nxt3ddata
-    logical :: isfound, endOfBlock
-! ------------------------------------------------------------------------------
-    !
-    ! -- If call from _df, skip past GRIDDATA block
-    if (isdfcall) call this%parser%GetBlock('GRIDDATA', isfound, ierr)
-    !
-    ! -- Check for XT3DDATA block
-    call this%parser%GetBlock('XT3DDATA', isfound, ierr)
-    if(.not.isfound) then
-      write(errmsg,'(1x,a)')'ERROR.  REQUIRED XT3DDATA BLOCK NOT FOUND.'
-      call store_error(errmsg)
-      call this%parser%StoreErrorUnit()
-      call ustop()
-    end if
-    !
-    ! -- Read XT3DDATA block
-    if (.not.isdfcall) write(this%iout,'(1x,a)')'PROCESSING XT3DDATA'
-    nxt3ddata = 0                    ! amp_note: specify nxt3ddata in dimensions block???
-    do
-      call this%parser%GetNextLine(endOfBlock)
-      if (endOfBlock) exit
-      call this%parser%GetCurrentLine(line)
-      !
-      ! -- cellidn (read as cellid and convert to user node)
-      call this%parser%GetCellid(this%dis%ndim, cellidn)
-      ! -- convert user node to reduced node number     ! amp_note: confirm that conversion is appropriate here
-      n = this%dis%noder_from_cellid(cellidn, &
-                                       this%parser%iuactive, this%iout)
-      ! -- cellidm (read as cellid and convert to user node)
-      call this%parser%GetCellid(this%dis%ndim, cellidm)
-      ! -- convert user node to reduced node number     ! amp_note: confirm that conversion is appropriate here
-      m = this%dis%noder_from_cellid(cellidm, &
-                                       this%parser%iuactive, this%iout)
-      ! -- set iflowform flag for connection to 1
-      ii = this%dis%con%getjaindex(n, m)
-      iis = this%dis%con%jas(ii)
-      this%iflowform(iis) = 1
-      nxt3ddata = nxt3ddata + 1
-      !
-      if ((.not.isdfcall).and.(this%iprxt3d /= 0))                             &
-        write(this%iout, '(2a10)') trim(adjustl(cellidn)),                     &
-                                   trim(adjustl(cellidm))
-    end do
-    ! -- terminate if read errors encountered
-    if(count_errors() > 0) then
-      call this%parser%StoreErrorUnit()
-      call ustop()
-    endif
-    !
-    ! -- If call from _df, rewind npf input file and skip past OPTIONS block
-    !    so data can be reread later
-    if (isdfcall) then
-      rewind(this%parser%GetUnit())
-      call this%parser%GetBlock('OPTIONS', isfound, ierr)
-    else
-      ! -- Print number of connections listed in GRIDDATA block
-      write(this%iout, '(1x,a,i10)')                                           &
-          'NUMBER OF XT3D CONNECTIONS LISTED:', nxt3ddata
-      ! -- Specification is by connection, so warn if no connections listed
-      if (nxt3ddata.eq.0) write(this%iout, '(4x,a,1(1x,a))')                   &
-          '****WARNING. Application of XT3D is specified by connection',       &
-          'but no connections are listed in the XT3DDATA block.'
-      ! -- Final XT3DDATA message
-      write(this%iout,'(1x,a)')'END PROCESSING XT3DDATA'
-    end if
-    !
-    ! -- Return
-    return
-  end subroutine read_xt3d_data
 
   subroutine prepcheck(this)
 ! ******************************************************************************
@@ -2028,7 +1776,7 @@ module GwfNpfModule
     real(DP) :: fawidth
     real(DP) :: hn, hm
     real(DP) :: hyn, hym
-    integer(I4B) :: n, m, ii, nn, ihc, iis
+    integer(I4B) :: n, m, ii, nn, ihc
     integer(I4B) :: nextn
     real(DP) :: minbot, botm
     integer(I4B), dimension(:), pointer, contiguous :: ithickstartflag
@@ -2295,76 +2043,70 @@ module GwfNpfModule
       call ustop()
     endif
     !
-    ! -- Calculate condsatu only where the standard conductance formulation is
-    !    in use.  If a non-standard conductance formulation is in use at all
-    !    connections, condsat is allocated to size of zero.  ! amp_note: make this change - not made previously???
-    if (.not.this%allnonstdf) then
+    ! -- Calculate condsatu, but only if xt3d is not active.  If xt3d is
+    !    active, then condsat is allocated to size of zero.
+    if (this%ixt3d == 0) then
+    !
+    ! -- Calculate the saturated conductance for all connections assuming
+    !    that saturation is 1 (except for case where icelltype was entered
+    !    as a negative value and THCKSTRT option in effect)
+    do n = 1, this%dis%nodes
       !
-      ! -- Calculate the saturated conductance for all connections assuming
-      !    that saturation is 1 (except for case where icelltype was entered
-      !    as a negative value and THCKSTRT option in effect)
-      do n = 1, this%dis%nodes
+      topn = this%dis%top(n)
+      !
+      ! -- Go through the connecting cells
+      do ii = this%dis%con%ia(n) + 1, this%dis%con%ia(n + 1) - 1
         !
-        topn = this%dis%top(n)
+        ! -- Set the m cell number and cycle if lower triangle connection
+        m = this%dis%con%ja(ii)
+        if (m < n) cycle
+        ihc = this%dis%con%ihc(this%dis%con%jas(ii))
+        topm = this%dis%top(m)
+        hyn = this%hy_eff(n, m, ihc, ipos=ii)
+        hym = this%hy_eff(m, n, ihc, ipos=ii)
+        if (ithickstartflag(n) == 0) then
+          hn = topn
+        else
+          hn = this%ic%strt(n)
+        end if
+        if (ithickstartflag(m) == 0) then
+          hm = topm
+        else
+          hm = this%ic%strt(m)
+        end if
         !
-        ! -- Go through the connecting cells
-        do ii = this%dis%con%ia(n) + 1, this%dis%con%ia(n + 1) - 1
-          ! -- Skip if nonstandard flow formulation used for this connection
-          if(this%inonstdf /= 0) then
-            iis = this%dis%con%jas(ii)
-            if (this%iflowform(iis) /= 0) cycle
-          end if
+        ! -- Calculate conductance depending on whether connection is
+        !    vertical (0), horizontal (1), or staggered horizontal (2)
+        if(ihc == 0) then
           !
-          ! -- Set the m cell number and cycle if lower triangle connection
-          m = this%dis%con%ja(ii)
-          if (m < n) cycle
-          ihc = this%dis%con%ihc(this%dis%con%jas(ii))
-          topm = this%dis%top(m)
-          hyn = this%hy_eff(n, m, ihc, ipos=ii)
-          hym = this%hy_eff(m, n, ihc, ipos=ii)
-          if (ithickstartflag(n) == 0) then
-            hn = topn
-          else
-            hn = this%ic%strt(n)
-          end if
-          if (ithickstartflag(m) == 0) then
-            hm = topm
-          else
-            hm = this%ic%strt(m)
-          end if
+          ! -- Vertical conductance for fully saturated conditions
+          csat =  vcond(1, 1, 1, 1, 0, 1, 1, DONE,                             &
+                        this%dis%bot(n), this%dis%bot(m),                      &
+                        hyn, hym,                                              &
+                        this%sat(n), this%sat(m),                              &
+                        topn, topm,                                            &
+                        this%dis%bot(n), this%dis%bot(m),                      &
+                        this%dis%con%hwva(this%dis%con%jas(ii)))
+        else
           !
-          ! -- Calculate conductance depending on whether connection is
-          !    vertical (0), horizontal (1), or staggered horizontal (2)
-          if(ihc == 0) then
-            !
-            ! -- Vertical conductance for fully saturated conditions
-            csat =  vcond(1, 1, 1, 1, 0, 1, 1, DONE,                             &
-                          this%dis%bot(n), this%dis%bot(m),                      &
-                          hyn, hym,                                              &
-                          this%sat(n), this%sat(m),                              &
-                          topn, topm,                                            &
-                          this%dis%bot(n), this%dis%bot(m),                      &
-                          this%dis%con%hwva(this%dis%con%jas(ii)))
-          else
-            !
-            ! -- Horizontal conductance for fully saturated conditions
-            fawidth = this%dis%con%hwva(this%dis%con%jas(ii))
-            csat = hcond(1, 1, 1, 1, this%inewton, 0,                            &
-                         this%dis%con%ihc(this%dis%con%jas(ii)),                 &
-                         this%icellavg, this%iusgnrhc, this%inwtupw,             &
-                         DONE,                                                   &
-                         hn, hm, this%sat(n), this%sat(m), hyn, hym,             &
-                         topn, topm,                                             &
-                         this%dis%bot(n), this%dis%bot(m),                       &
-                         this%dis%con%cl1(this%dis%con%jas(ii)),                 &
-                         this%dis%con%cl2(this%dis%con%jas(ii)),                 &
-                         fawidth, this%satomega, this%satmin)
-          end if
-          this%condsat(this%dis%con%jas(ii)) = csat
-        enddo
+          ! -- Horizontal conductance for fully saturated conditions
+          fawidth = this%dis%con%hwva(this%dis%con%jas(ii))
+          csat = hcond(1, 1, 1, 1, this%inewton, 0,                            &
+                       this%dis%con%ihc(this%dis%con%jas(ii)),                 &
+                       this%icellavg, this%iusgnrhc, this%inwtupw,             &
+                       DONE,                                                   &
+                       hn, hm, this%sat(n), this%sat(m), hyn, hym,             &
+                       topn, topm,                                             &
+                       this%dis%bot(n), this%dis%bot(m),                       &
+                       this%dis%con%cl1(this%dis%con%jas(ii)),                 &
+                       this%dis%con%cl2(this%dis%con%jas(ii)),                 &
+                       fawidth, this%satomega, this%satmin)
+        end if
+        this%condsat(this%dis%con%jas(ii)) = csat
       enddo
-
-    end if
+    enddo
+    !
+    endif
     !
     ! -- Determine the lower most node
     if (this%igwfnewtonur /= 0) then

--- a/src/Model/ModelUtilities/Xt3dInterface.f90
+++ b/src/Model/ModelUtilities/Xt3dInterface.f90
@@ -25,8 +25,7 @@ module Xt3dModule
     real(DP), dimension(:,:), pointer, contiguous   :: rmatck      => null()     !< rotation matrix for the conductivity tensor
     real(DP), dimension(:), pointer, contiguous     :: qsat        => null()     !< saturated flow saved for Newton
     real(DP), dimension(:), pointer, contiguous     :: qrhs        => null()     !< rhs part of flow saved for Newton
-    integer(I4B), pointer                           :: nbrmax      => null()     !< maximum number of standard neighbors for any cell
-    integer(I4B), pointer                           :: nbrxmax     => null()     !< maximum number of extended neighbors for any cell
+    integer(I4B), pointer                           :: nbrmax      => null()     !< maximum number of neighbors for any cell
     real(DP), dimension(:), pointer, contiguous     :: amatpc      => null()     !< saved contributions to amat from permanently confined connections, direct neighbors
     real(DP), dimension(:), pointer, contiguous     :: amatpcx     => null()     !< saved contributions to amat from permanently confined connections, extended neighbors
     integer(I4B), dimension(:), pointer, contiguous :: iallpc      => null()     !< indicates for each node whether all connections processed by xt3d are permanently confined (0 no, 1 yes)
@@ -47,14 +46,12 @@ module Xt3dModule
     real(DP), dimension(:), pointer, contiguous     :: angle2      => null()     !< k ellipse rotation up from xy plane around y axis (pitch)
     real(DP), dimension(:), pointer, contiguous     :: angle3      => null()     !< k tensor rotation around x axis (roll)
     logical, pointer                                :: ldispersion => null()     !< flag to indicate dispersion
-    integer(I4B), dimension(:), pointer, contiguous :: iflowform   => null()     !< flag to indicate use of xt3d by connection
   contains
     procedure :: xt3d_df
     procedure :: xt3d_ac
     procedure :: xt3d_mc
     procedure :: xt3d_ar
     procedure :: xt3d_fc
-    procedure :: xt3d_amatsaved_fc
     procedure :: xt3d_fcpc
     procedure :: xt3d_fhfb
     procedure :: xt3d_flowjahfb
@@ -115,7 +112,7 @@ module Xt3dModule
     return
   end subroutine xt3d_cr
 
-  subroutine xt3d_df(this, dis, iflowform)
+  subroutine xt3d_df(this, dis)
 ! ******************************************************************************
 ! xt3d_df -- define the xt3d object
 ! ******************************************************************************
@@ -126,11 +123,9 @@ module Xt3dModule
     ! -- dummy
     class(Xt3dType) :: this
     class(DisBaseType), pointer, intent(inout) :: dis
-    integer(I4B), pointer :: iflowform(:)
 ! ------------------------------------------------------------------------------
     !
     this%dis => dis
-    this%iflowform => iflowform
     !
     ! -- Return
     return
@@ -145,89 +140,31 @@ module Xt3dModule
 ! ------------------------------------------------------------------------------
     ! -- modules
     use SparseModule, only: sparsematrix
-    use MemoryManagerModule, only: mem_allocate, mem_reallocate
     ! -- dummy
     class(Xt3dType) :: this
     integer(I4B), intent(in) :: moffset
     type(sparsematrix), intent(inout) :: sparse
     ! -- local
-    integer(I4B) :: i, j, k, jj, kk, iglo, kglo, iadded, jjs
-    integer(I4B) :: niax, njax, ipos, ierror, nnbrs
+    integer(I4B) :: i, j, k, jj, kk, iglo, kglo, iadded
 ! ------------------------------------------------------------------------------
     !
     ! -- If not rhs, add connections
     if (this%ixt3d == 1) then
-      !
-      ! -- Allocate iax and jax; initially allocate jax to size nja
-      niax = this%dis%nodes + 1
-      njax = this%dis%con%nja
-      call mem_allocate(this%iax, niax, 'IAX', trim(this%memoryPath))
-      call mem_allocate(this%jax, njax, 'JAX', trim(this%memoryPath))
-      !
-      ! -- load first iax entry
-      ipos = 1
-      this%iax(1) = ipos
-      !
-      ! -- loop over nodes
-      do i = 1, this%dis%nodes
-        iglo = i + moffset
-        !
-        ! -- loop over neighbors
-        do jj = this%dis%con%ia(i), this%dis%con%ia(i+1) - 1  ! amp_note: add "+ 1" to starting index to skip self ???
-          ! -- Skip if xt3d not used for this connection.
-          jjs = this%dis%con%jas(jj)
-          if (jjs.ne.0) then
-            if (this%iflowform(jjs) /= 1) cycle
-          end if
-          !
-          j = this%dis%con%ja(jj)
-          !
-          ! -- loop over neighbors of neighbors
-          do kk = this%dis%con%ia(j), this%dis%con%ia(j+1) - 1
-            k = this%dis%con%ja(kk)
-            kglo = k + moffset
-            call sparse%addconnection(iglo, kglo, 1, iadded)
-            ! -- If extended connection added, register it in jax
-            if (iadded /= 0) then
-              if (ipos > njax) then
-                ! -- If jax too small, double its size
-                njax = njax*2
-                call mem_reallocate(this%jax, njax, 'JAX',   &
-                                    trim(this%memoryPath))
-              end if
-              this%jax(ipos) = k
-              ipos = ipos + 1
-            endif
-          enddo
-          !
-        enddo
-        ! -- load next iax entry
-        this%iax(i+1) = ipos
-      enddo
-      !
-      ! -- Set number of extended neighbors
-      this%numextnbrs = ipos - 1
-      ! -- Reduce size of jax to minimum required (numextnbrs)
-      if (njax > this%numextnbrs) then
-        njax = this%numextnbrs
-        call mem_reallocate(this%jax, njax, 'JAX', trim(this%memoryPath))
-      end if
-      !
-      ! -- Determine the maximum number of extended neighbors for any cell
-      this%nbrxmax = 0
-      do i = 1, this%dis%nodes
-        nnbrs = this%iax(i+1) - this%iax(i)
-        this%nbrxmax = max(nnbrs, this%nbrxmax)
-      end do
-       !
-    else
-      !
-      call mem_allocate(this%iax, 0, 'IAX', trim(this%memoryPath))
-      call mem_allocate(this%jax, 0, 'JAX', trim(this%memoryPath))
-      !
-      ! -- Set the maximum number of extended neighbors for any cell to 0
-      this%nbrxmax = 0
-      !
+       ! -- loop over nodes
+       do i = 1, this%dis%nodes
+         iglo = i + moffset
+         ! -- loop over neighbors
+         do jj = this%dis%con%ia(i), this%dis%con%ia(i+1) - 1
+           j = this%dis%con%ja(jj)
+           ! -- loop over neighbors of neighbors
+           do kk = this%dis%con%ia(j), this%dis%con%ia(j+1) - 1
+             k = this%dis%con%ja(kk)
+             kglo = k + moffset
+             call sparse%addconnection(iglo, kglo, 1, iadded)
+             this%numextnbrs = this%numextnbrs + iadded
+            enddo
+         enddo
+       enddo
     endif
     !
     ! -- Return
@@ -249,13 +186,13 @@ module Xt3dModule
     integer(I4B), dimension(:), intent(in) :: iasln
     integer(I4B), dimension(:), intent(in) :: jasln
     ! -- local
-    integer(I4B) :: i, j, jj, iglo, jglo, jjg, njax
+    integer(I4B) :: i, j, jj, iglo, jglo, jjg, niax, njax, ipos
     integer(I4B) :: igfirstnod, iglastnod
     logical :: isextnbr
 ! ------------------------------------------------------------------------------
     !
-    ! -- If not rhs, map connections for extended neighbors and construct
-    ! -- idxglox
+    ! -- If not rhs, map connections for extended neighbors and construct iax,
+    ! -- jax, and idxglox
     if (this%ixt3d == 1) then
       !
       ! -- calculate the first node for the model and the last node in global
@@ -263,17 +200,26 @@ module Xt3dModule
       igfirstnod = moffset + 1
       iglastnod = moffset + this%dis%nodes
       !
-      ! -- allocate idxglox
-      njax = this%numextnbrs
+      ! -- allocate iax, jax, and idxglox
+      niax = this%dis%nodes + 1
+      njax = this%numextnbrs ! + 1
+      call mem_allocate(this%iax, niax, 'IAX', trim(this%memoryPath))
+      call mem_allocate(this%jax, njax, 'JAX', trim(this%memoryPath))
       call mem_allocate(this%idxglox, njax, 'IDXGLOX', trim(this%memoryPath))
+      !
+      ! -- load first iax entry
+      ipos = 1
+      this%iax(1) = ipos
       !
       ! -- loop over nodes
       do i = 1, this%dis%nodes
+        !
         ! -- calculate global node number
         iglo = i + moffset
         !
         ! -- loop over neighbors in global matrix
-        do jjg = iasln(iglo), iasln(iglo + 1) - 1    ! amp_note: add "+ 1" to starting index to skip self ???
+        do jjg = iasln(iglo), iasln(iglo + 1) - 1
+          !
           ! -- if jglo is in a different model, then it cannot be an extended
           !    neighbor, so skip over it
           jglo = jasln(jjg)
@@ -281,27 +227,35 @@ module Xt3dModule
             cycle
           endif
           !
-          ! -- determine whether this global neighbor is an extended neighbor
-          !    by searching the extended neighbors
-          isextnbr = .false.
-          searchloop: do jj = this%iax(i), this%iax(i+1) - 1
-            j = this%jax(jj)
+          ! -- determine whether this neighbor is an extended neighbor
+          !    by searching the original neighbors
+          isextnbr = .true.
+          searchloop: do jj = this%dis%con%ia(i), this%dis%con%ia(i+1) - 1
+            j = this%dis%con%ja(jj)
             jglo = j + moffset
             !
-            ! -- if an extended neighbor, note that and end the search
+            ! -- if an original neighbor, note that and end the search
             if(jglo == jasln(jjg)) then
-              isextnbr = .true.
+              isextnbr = .false.
               exit searchloop
             endif
           enddo searchloop
           !
-          ! -- if an extended neighbor, add it to idxglox
-          if (isextnbr) this%idxglox(jj) = jjg
+          ! -- if an extended neighbor, add it to jax and idxglox
+          if (isextnbr) then
+            this%jax(ipos) = jasln(jjg) - moffset
+            this%idxglox(ipos) = jjg
+            ipos = ipos + 1
+          endif
         enddo
+        ! -- load next iax entry
+        this%iax(i+1) = ipos
       enddo
       !
     else
       !
+      call mem_allocate(this%iax, 0, 'IAX', trim(this%memoryPath))
+      call mem_allocate(this%jax, 0, 'JAX', trim(this%memoryPath))
       call mem_allocate(this%idxglox, 0, 'IDXGLOX', trim(this%memoryPath))
       !
     endif
@@ -311,8 +265,7 @@ module Xt3dModule
   end subroutine xt3d_mc
   
   subroutine xt3d_ar(this, ibound, k11, ik33, k33, sat, ik22, k22,             &
-    iangle1, iangle2, iangle3, angle1, angle2, angle3, iflowform, nbrmax,      &
-    inewton, icelltype)
+    iangle1, iangle2, iangle3, angle1, angle2, angle3, inewton, icelltype)
 ! ******************************************************************************
 ! xt3d_ar -- Allocate and Read
 ! ******************************************************************************
@@ -336,8 +289,6 @@ module Xt3dModule
     real(DP), dimension(:), intent(in), pointer, contiguous :: angle1
     real(DP), dimension(:), intent(in), pointer, contiguous :: angle2
     real(DP), dimension(:), intent(in), pointer, contiguous :: angle3
-    integer(I4B), dimension(:), intent(in), pointer, contiguous :: iflowform
-    integer(I4B), pointer :: nbrmax
     integer(I4B), intent(in), pointer, optional :: inewton
     integer(I4B), dimension(:), intent(in), pointer, &
       contiguous, optional :: icelltype
@@ -366,8 +317,6 @@ module Xt3dModule
     this%angle1 => angle1
     this%angle2 => angle2
     this%angle3 => angle3
-    this%iflowform => iflowform
-    this%nbrmax => nbrmax
     if (present(inewton)) then
       ! -- inewton is not needed for transport so it's optional.
       this%inewton = inewton
@@ -382,6 +331,13 @@ module Xt3dModule
     ! -- If angle1 and angle2 were not specified, then there is no z
     !    component in the xt3d formulation for horizontal connections.
     if(this%iangle2 == 0) this%nozee = .true.
+    !
+    ! -- Determine the maximum number of neighbors for any cell.
+    this%nbrmax = 0
+    do n = 1, this%dis%nodes
+      nnbrs = this%dis%con%ia(n+1) - this%dis%con%ia(n) - 1
+      this%nbrmax = max(nnbrs, this%nbrmax)
+    end do
     !
     ! -- Check to make sure dis package can calculate connection direction info
     if (this%dis%icondir == 0) then
@@ -413,9 +369,9 @@ module Xt3dModule
     return
   end subroutine xt3d_ar
 
-  subroutine xt3d_fc(this, n, ipos, njasln, amat, idxglo, rhs, hnew)
+  subroutine xt3d_fc(this, kiter, njasln, amat, idxglo, rhs, hnew)
 ! ******************************************************************************
-! xt3d_fc -- Formulate a connection
+! xt3d_fc -- Formulate
 ! ******************************************************************************
 !
 !    SPECIFICATIONS:
@@ -424,7 +380,7 @@ module Xt3dModule
     use Xt3dAlgorithmModule, only: qconds
     ! -- dummy
     class(Xt3dType) :: this
-    integer(I4B) :: n, ipos
+    integer(I4B) :: kiter
     integer(I4B),intent(in) :: njasln
     real(DP),dimension(njasln),intent(inout) :: amat
     integer(I4B),intent(in),dimension(:) :: idxglo
@@ -432,11 +388,12 @@ module Xt3dModule
     real(DP),intent(inout),dimension(:) :: hnew
     ! -- local
     integer(I4B) :: nodes, nja
+    integer(I4B) :: n, m, ipos
+    !
     logical :: allhc0, allhc1
     integer(I4B) :: nnbr0, nnbr1
     integer(I4B) :: il0, ii01, jjs01, il01, il10, ii00, ii11, ii10
-    integer(I4B) :: il01p1, il10p1
-    integer(I4B) :: m
+    integer(I4B) :: i
     integer(I4B),dimension(this%nbrmax) :: inbr0, inbr1
     real(DP) :: ar01, ar10
     real(DP),dimension(this%nbrmax,3) :: vc0, vn0, vc1, vn1
@@ -447,123 +404,11 @@ module Xt3dModule
     real(DP) :: qnm, qnbrs
 ! ------------------------------------------------------------------------------
     !
-    ! -- Skip if all connections for node n are permanently confined
-    if (this%lamatsaved) then
-      if (this%iallpc(n) == 1) return
-    end if
+    ! -- Calculate xt3d conductance-like coefficients and put into amat and rhs
+    ! -- as appropriate
     !
-    ! -- Skip if cell n is inactive.
-    if (this%ibound(n).eq.0) return
-    !
-    ! -- Get neighbor's node number
-    m = this%dis%con%ja(ipos)
-    !
-!!    ! -- Skip if neighbor m is inactive or has lower cell number.
-!!    if ((this%ibound(m).eq.0).or.(m.lt.n)) return     ! amp_note: check for m<n now done in calling routine loop
-    ! -- Skip if neighbor m is inactive.
-    if (this%ibound(m).eq.0) return
-    !
-    ! -- Set local dimension variables for convenience
     nodes = this%dis%nodes
     nja = this%dis%con%nja
-    !
-    ! -- Get number of neighbors for node n (locally, "cell 0")
-    nnbr0 = this%dis%con%ia(n+1) - this%dis%con%ia(n) - 1
-    ! -- Load conductivity and connection info for cell 0.
-    call this%xt3d_load(nodes, n, nnbr0, inbr0, vc0, vn0, dl0, dl0n,   &
-      ck0, allhc0)
-    !
-    ! -- Get number of neighbors for node m (locally, "cell 1")
-    nnbr1 = this%dis%con%ia(m+1) - this%dis%con%ia(m) - 1
-    ! -- Load conductivity and connection info for cell 1.
-    call this%xt3d_load(nodes, m, nnbr1, inbr1, vc1, vn1, dl1, dl1n,    &
-      ck1, allhc1)
-    !
-    ! -- Set various indices.
-    il0 = ipos - this%dis%con%ia(n)
-    call this%xt3d_indices(n, m, il0, ii01, jjs01, il01, il10,          &
-      ii00, ii11, ii10)
-    !
-    ! -- Compute areas.
-    if (this%inewton /= 0) then
-      ar01 = DONE
-      ar10 = DONE
-    else
-      call this%xt3d_areas(nodes, n, m, jjs01, .false., ar01, ar10, hnew)
-    end if
-    !
-    ! -- Compute "conductances" for interface between
-    ! -- cells 0 and 1.
-    call qconds(this%nbrmax, nnbr0, inbr0, il01, vc0, vn0, dl0, dl0n,    &
-      ck0, nnbr1, inbr1, il10, vc1, vn1, dl1, dl1n, ck1, ar01, ar10,     &
-      this%vcthresh, allhc0, allhc1, chat01, chati0, chat1j)
-    !
-    ! -- If Newton, compute and save saturated flow, then scale
-    ! -- conductance-like coefficients by the actual area for
-    ! -- subsequent amat and rhs assembly.
-    if (this%inewton /= 0) then
-      ! -- Contribution to flow from primary connection.
-      qnm = chat01*(hnew(m) - hnew(n))
-      ! -- Contribution from immediate neighbors of node 0.
-      call this%xt3d_qnbrs(nodes, n, m, nnbr0, inbr0, chati0, hnew, qnbrs)
-      qnm = qnm + qnbrs
-      ! -- Contribution from immediate neighbors of node 1.
-      call this%xt3d_qnbrs(nodes, m, n, nnbr1, inbr1, chat1j, hnew, qnbrs)
-      qnm = qnm - qnbrs
-      ! -- Multiply by saturated area and save in qsat.
-      call this%xt3d_areas(nodes, n, m, jjs01, .true., ar01, ar10, hnew)
-      this%qsat(ii01) = qnm*ar01
-      ! -- Scale coefficients by actual area.  If RHS
-      ! -- formulation, also compute and save qrhs.
-      call this%xt3d_areas(nodes, n, m, jjs01, .false., ar01, ar10, hnew)
-      if (this%ixt3d == 2) then
-        this%qrhs(ii01) = -qnbrs*ar01
-      end if
-      chat01 = chat01*ar01
-      chati0 = chati0*ar01
-      chat1j = chat1j*ar01
-    end if
-    !
-    ! -- Contribute to rows for cells 0 and 1.
-    amat(idxglo(ii00)) = amat(idxglo(ii00)) - chat01
-    amat(idxglo(ii01)) = amat(idxglo(ii01)) + chat01
-    amat(idxglo(ii11)) = amat(idxglo(ii11)) - chat01
-    amat(idxglo(ii10)) = amat(idxglo(ii10)) + chat01
-    if (this%ixt3d == 1) then
-       call this%xt3d_amat_nbrs(nodes, n, ii00, nnbr0, nja, njasln,        &
-         inbr0, amat, idxglo, chati0)
-       call this%xt3d_amat_nbrnbrs(nodes, n, m, ii01, nnbr1, nja, njasln,  &
-         inbr1, amat, idxglo, chat1j)
-       call this%xt3d_amat_nbrs(nodes, m, ii11, nnbr1, nja, njasln,        &
-         inbr1, amat, idxglo, chat1j)
-       call this%xt3d_amat_nbrnbrs(nodes, m, n, ii10, nnbr0, nja, njasln,  &
-         inbr0, amat, idxglo, chati0)
-    else
-       call this%xt3d_rhs(nodes, n, m, nnbr0, inbr0, chati0, hnew, rhs)
-       call this%xt3d_rhs(nodes, m, n, nnbr1, inbr1, chat1j, hnew, rhs)
-    endif
-    !
-    ! -- Return
-    return
-  end subroutine xt3d_fc
-
-  subroutine xt3d_amatsaved_fc(this, njasln, amat, idxglo)
-! ******************************************************************************
-! xt3d_amatsaved_fc -- Formulate for saved coefficients
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-    ! -- dummy
-    class(Xt3dType) :: this
-    integer(I4B),intent(in) :: njasln
-    real(DP),dimension(njasln),intent(inout) :: amat
-    integer(I4B),intent(in),dimension(:) :: idxglo
-    ! -- local
-    integer(I4B) :: i
-! ------------------------------------------------------------------------------
-    !
-    ! -- If coefficient updates saved, apply them to amat
     if (this%lamatsaved) then
       do i = 1, this%dis%con%nja
         amat(idxglo(i)) = amat(idxglo(i)) + this%amatpc(i)
@@ -573,9 +418,95 @@ module Xt3dModule
       end do
     end if
     !
+    do n = 1, nodes
+      ! -- Skip if inactive.
+      if (this%ibound(n).eq.0) cycle
+      ! -- Skip if all connections are permanently confined
+      if (this%lamatsaved) then
+        if (this%iallpc(n) == 1) cycle
+      end if
+      nnbr0 = this%dis%con%ia(n+1) - this%dis%con%ia(n) - 1
+      ! -- Load conductivity and connection info for cell 0.
+      call this%xt3d_load(nodes, n, nnbr0, inbr0, vc0, vn0, dl0, dl0n,   &
+        ck0, allhc0)
+      ! -- Loop over active neighbors of cell 0 that have a higher
+      ! -- cell number (taking advantage of reciprocity).
+      do il0 = 1,nnbr0
+        ipos = this%dis%con%ia(n) + il0
+        if (this%dis%con%mask(ipos) == 0) cycle
+        
+        m = inbr0(il0)
+        ! -- Skip if neighbor is inactive or has lower cell number.
+        if ((m.eq.0).or.(m.lt.n)) cycle
+        nnbr1 = this%dis%con%ia(m+1) - this%dis%con%ia(m) - 1
+         ! -- Load conductivity and connection info for cell 1.
+        call this%xt3d_load(nodes, m, nnbr1, inbr1, vc1, vn1, dl1, dl1n,    &
+          ck1, allhc1)
+        ! -- Set various indices.
+        call this%xt3d_indices(n, m, il0, ii01, jjs01, il01, il10,          &
+          ii00, ii11, ii10)
+        ! -- Compute areas.
+        if (this%inewton /= 0) then
+          ar01 = DONE
+          ar10 = DONE
+        else
+          call this%xt3d_areas(nodes, n, m, jjs01, .false., ar01, ar10, hnew)
+        end if
+        ! -- Compute "conductances" for interface between
+        ! -- cells 0 and 1.
+        call qconds(this%nbrmax, nnbr0, inbr0, il01, vc0, vn0, dl0, dl0n,    &
+          ck0, nnbr1, inbr1, il10, vc1, vn1, dl1, dl1n, ck1, ar01, ar10,     &
+          this%vcthresh, allhc0, allhc1, chat01, chati0, chat1j)
+        ! -- If Newton, compute and save saturated flow, then scale
+        ! -- conductance-like coefficients by the actual area for
+        ! -- subsequent amat and rhs assembly.
+        if (this%inewton /= 0) then
+          ! -- Contribution to flow from primary connection.
+          qnm = chat01*(hnew(m) - hnew(n))
+          ! -- Contribution from immediate neighbors of node 0.
+          call this%xt3d_qnbrs(nodes, n, m, nnbr0, inbr0, chati0, hnew, qnbrs)
+          qnm = qnm + qnbrs
+          ! -- Contribution from immediate neighbors of node 1.
+          call this%xt3d_qnbrs(nodes, m, n, nnbr1, inbr1, chat1j, hnew, qnbrs)
+          qnm = qnm - qnbrs
+          ! -- Multiply by saturated area and save in qsat.
+          call this%xt3d_areas(nodes, n, m, jjs01, .true., ar01, ar10, hnew)
+          this%qsat(ii01) = qnm*ar01
+          ! -- Scale coefficients by actual area.  If RHS
+          ! -- formulation, also compute and save qrhs.
+          call this%xt3d_areas(nodes, n, m, jjs01, .false., ar01, ar10, hnew)
+          if (this%ixt3d == 2) then
+            this%qrhs(ii01) = -qnbrs*ar01
+          end if
+          chat01 = chat01*ar01
+          chati0 = chati0*ar01
+          chat1j = chat1j*ar01
+        end if
+        ! -- Contribute to rows for cells 0 and 1.
+        amat(idxglo(ii00)) = amat(idxglo(ii00)) - chat01
+        amat(idxglo(ii01)) = amat(idxglo(ii01)) + chat01
+        amat(idxglo(ii11)) = amat(idxglo(ii11)) - chat01
+        amat(idxglo(ii10)) = amat(idxglo(ii10)) + chat01
+        if (this%ixt3d == 1) then
+           call this%xt3d_amat_nbrs(nodes, n, ii00, nnbr0, nja, njasln,        &
+             inbr0, amat, idxglo, chati0)
+           call this%xt3d_amat_nbrnbrs(nodes, n, m, ii01, nnbr1, nja, njasln,  &
+             inbr1, amat, idxglo, chat1j)
+           call this%xt3d_amat_nbrs(nodes, m, ii11, nnbr1, nja, njasln,        &
+             inbr1, amat, idxglo, chat1j)
+           call this%xt3d_amat_nbrnbrs(nodes, m, n, ii10, nnbr0, nja, njasln,  &
+             inbr0, amat, idxglo, chati0)
+        else
+           call this%xt3d_rhs(nodes, n, m, nnbr0, inbr0, chati0, hnew, rhs)
+           call this%xt3d_rhs(nodes, m, n, nnbr1, inbr1, chat1j, hnew, rhs)
+        endif
+        !
+      enddo
+    enddo
+    !
     ! -- Return
     return
-  end subroutine xt3d_amatsaved_fc
+  end subroutine xt3d_fc
 
   subroutine xt3d_fcpc(this, nodes, lsat)
 ! ******************************************************************************
@@ -592,7 +523,7 @@ module Xt3dModule
     integer(I4B), intent(in) :: nodes
     logical, intent(in) :: lsat  !< if true, then calculations made with saturated areas (should be false for dispersion)
     ! -- local
-    integer(I4B) :: n, m, ipos, isympos
+    integer(I4B) :: n, m, ipos
     !
     logical :: allhc0, allhc1
     integer(I4B) :: nnbr0, nnbr1
@@ -628,14 +559,11 @@ module Xt3dModule
       ! -- cell number (taking advantage of reciprocity).
       do il0 = 1,nnbr0
         ipos = this%dis%con%ia(n) + il0
-        ! -- Skip if xt3d not used for this connection.
-        isympos = this%dis%con%jas(ipos)
-        if (this%iflowform(isympos) /= 1) cycle
         if (this%dis%con%mask(ipos) == 0) cycle
-        !
+        
         m = inbr0(il0)
         ! -- Skip if neighbor has lower cell number.
-        if (m.lt.n) cycle        ! amp_note: if loops get moved out to calling routine, do m<n check there
+        if (m.lt.n) cycle
         nnbr1 = this%dis%con%ia(m+1) - this%dis%con%ia(m) - 1
         ! -- Load conductivity and connection info for cell 1.
         call this%xt3d_load(nodes, m, nnbr1, inbr1, vc1, vn1, dl1, dl1n,    &
@@ -689,10 +617,10 @@ module Xt3dModule
     real(DP),intent(inout),dimension(nodes) :: hnew
     real(DP) :: condhfb
     ! -- local
+    !
     logical :: allhc0, allhc1
     integer(I4B) :: nnbr0, nnbr1
     integer(I4B) :: il0, ii01, jjs01, il01, il10, ii00, ii11, ii10, il
-    integer(I4B) :: il01p1, il10p1
     integer(I4B),dimension(this%nbrmax) :: inbr0, inbr1
     real(DP) :: ar01, ar10
     real(DP),dimension(this%nbrmax,3) :: vc0, vn0, vc1, vn1
@@ -705,30 +633,26 @@ module Xt3dModule
 ! ------------------------------------------------------------------------------
     !
     ! -- Calculate hfb corrections to xt3d conductance-like coefficients and
-    !    put into amat and rhs as appropriate.
+    ! -- put into amat and rhs as appropriate
     !
     nnbr0 = this%dis%con%ia(n+1) - this%dis%con%ia(n) - 1
     ! -- Load conductivity and connection info for cell 0.
     call this%xt3d_load(nodes, n, nnbr0, inbr0, vc0, vn0, dl0, dl0n,    &
       ck0, allhc0)
-    !
     ! -- Find local neighbor number of cell 1.
     do il = 1,nnbr0
-      if (inbr0(il).eq.m) then     ! amp_note: better to pass in ipos (ii in calling subroutine) instead of m???
+      if (inbr0(il).eq.m) then
         il0 = il
         exit
       end if
     end do
-    !
     nnbr1 = this%dis%con%ia(m+1) - this%dis%con%ia(m) - 1
     ! -- Load conductivity and connection info for cell 1.
     call this%xt3d_load(nodes, m, nnbr1, inbr1, vc1, vn1, dl1, dl1n,    &
       ck1, allhc1)
-    !
     ! -- Set various indices.
     call this%xt3d_indices(n, m, il0, ii01, jjs01, il01, il10,          &
       ii00, ii11, ii10)
-    !
     ! -- Compute areas.
     if (this%inewton /= 0) then
       ar01 = DONE
@@ -736,13 +660,11 @@ module Xt3dModule
     else
       call this%xt3d_areas(nodes, n, m, jjs01, .false., ar01, ar10, hnew)
     end if
-    !
     ! -- Compute "conductances" for interface between
     ! -- cells 0 and 1.
     call qconds(this%nbrmax, nnbr0, inbr0, il01, vc0, vn0, dl0, dl0n,    &
       ck0, nnbr1, inbr1, il10, vc1, vn1, dl1, dl1n, ck1, ar01, ar10,     &
       this%vcthresh, allhc0, allhc1, chat01, chati0, chat1j)
-    !
     ! -- Apply scale factor to compute "conductances" for hfb correction
     if(condhfb > DZERO) then
       term = chat01/(chat01 + condhfb)
@@ -752,7 +674,6 @@ module Xt3dModule
     chat01 = -chat01*term
     chati0 = -chati0*term
     chat1j = -chat1j*term
-    !
     ! -- If Newton, compute and save saturated flow, then scale
     ! -- conductance-like coefficients by the actual area for
     ! -- subsequent amat and rhs assembly.
@@ -778,7 +699,6 @@ module Xt3dModule
       chati0 = chati0*ar01
       chat1j = chat1j*ar01
     end if
-    !
     ! -- Contribute to rows for cells 0 and 1.
     amat(idxglo(ii00)) = amat(idxglo(ii00)) - chat01
     amat(idxglo(ii01)) = amat(idxglo(ii01)) + chat01
@@ -822,7 +742,7 @@ module Xt3dModule
     real(DP),intent(inout),dimension(nodes) :: rhs
     real(DP),intent(inout),dimension(nodes) :: hnew
     ! -- local
-    integer(I4B) :: n, m, ipos, isympos
+    integer(I4B) :: n, m, ipos
     !
     integer(I4B) :: nnbr0
     integer(I4B) :: il0, ii01, jjs01, il01, il10, ii00, ii11, ii10
@@ -848,14 +768,11 @@ module Xt3dModule
       ! -- cell number (taking advantage of reciprocity).
       do il0 = 1,nnbr0
         ipos = this%dis%con%ia(n) + il0
-        ! -- Skip if xt3d not used for this connection.
-        isympos = this%dis%con%jas(ipos)
-        if (this%iflowform(isympos) /= 1) cycle
         if (this%dis%con%mask(ipos) == 0) cycle
-        !
+        
         m = inbr0(il0)
         ! -- Skip if neighbor is inactive or has lower cell number.
-        if ((inbr0(il0).eq.0).or.(m.lt.n)) cycle     ! amp_note: if loops get moved out to calling routine, do m<n check there
+        if ((inbr0(il0).eq.0).or.(m.lt.n)) cycle
         ! -- Set various indices.
         call this%xt3d_indices(n, m, il0, ii01, jjs01, il01, il10,          &
           ii00, ii11, ii10)
@@ -865,8 +782,8 @@ module Xt3dModule
         idn = n
         if (iups == n) idn = m
         ! -- no Newton terms if upstream cell is confined
-        !    and no rhs option
-        if ((this%icelltype(iups) == 0).and.(this%ixt3d == 1)) cycle
+        ! -- and no rhs option
+        if ((this%icelltype(iups) == 0).and.(this%ixt3d.eq.1)) cycle
         ! -- Set the upstream top and bot, and then recalculate for a
         !    vertically staggered horizontal connection
         topup = this%dis%top(iups)
@@ -920,7 +837,7 @@ module Xt3dModule
     real(DP),intent(inout),dimension(:) :: hnew
     real(DP),intent(inout),dimension(:) :: flowja
     ! -- local
-    integer(I4B) :: n, ipos, m, nodes, isympos
+    integer(I4B) :: n, ipos, m, nodes
     real(DP) :: qnm, qnbrs
     logical :: allhc0, allhc1
     integer(I4B) :: nnbr0, nnbr1
@@ -946,14 +863,9 @@ module Xt3dModule
       ! -- Loop over active neighbors of cell 0 that have a higher
       ! -- cell number (taking advantage of reciprocity).
       do il0 = 1,nnbr0
-        ! -- Skip if xt3d not used for this connection.
-        ipos = this%dis%con%ia(n) + il0
-        isympos = this%dis%con%jas(ipos)
-        if (this%iflowform(isympos) /= 1) cycle
-        !
         m = inbr0(il0)
         ! -- Skip if neighbor is inactive or has lower cell number.
-        if ((inbr0(il0).eq.0).or.(m.lt.n)) cycle   ! amp_note: if loops get moved out to calling routine, do m<n check there
+        if ((inbr0(il0).eq.0).or.(m.lt.n)) cycle
         nnbr1 = this%dis%con%ia(m+1) - this%dis%con%ia(m) - 1
         ! -- Load conductivity and connection info for cell 1.
         call this%xt3d_load(nodes, m, nnbr1, inbr1, vc1, vn1, dl1, dl1n,     &
@@ -1123,8 +1035,7 @@ module Xt3dModule
     call mem_deallocate(this%nozee)
     call mem_deallocate(this%vcthresh)
     call mem_deallocate(this%lamatsaved)
-!!    call mem_deallocate(this%nbrmax)
-    call mem_deallocate(this%nbrxmax)
+    call mem_deallocate(this%nbrmax)
     call mem_deallocate(this%ldispersion)
     !
     ! -- Return
@@ -1146,8 +1057,7 @@ module Xt3dModule
     !
     ! -- Allocate scalars
     call mem_allocate(this%ixt3d, 'IXT3D', this%memoryPath)
-!!    call mem_allocate(this%nbrmax, 'NBRMAX', this%memoryPath)
-    call mem_allocate(this%nbrxmax, 'NBRXMAX', this%memoryPath)
+    call mem_allocate(this%nbrmax, 'NBRMAX', this%memoryPath)
     call mem_allocate(this%inunit, 'INUNIT', this%memoryPath)
     call mem_allocate(this%iout, 'IOUT', this%memoryPath)
     call mem_allocate(this%inewton, 'INEWTON', this%memoryPath)
@@ -1159,8 +1069,7 @@ module Xt3dModule
     !  
     ! -- Initialize value
     this%ixt3d = 0
-!!    this%nbrmax = 0
-    this%nbrxmax = 0
+    this%nbrmax = 0
     this%inunit = 0
     this%iout = 0
     this%inewton = 0
@@ -1204,7 +1113,7 @@ module Xt3dModule
     end if
     !
     ! -- If dispersion, set iallpc to 1 otherwise call xt3d_iallpc to go through
-    !    each connection and mark cells that are permanently confined and can
+    !    each connection and mark cells that are permanenntly confined and can
     !    have their coefficients precalculated
     if (this%ldispersion) then
       !
@@ -1262,7 +1171,7 @@ module Xt3dModule
     ! -- dummy
     class(Xt3dType) :: this
     ! -- local
-    integer(I4B) :: n, m, mm, il0, il1, ipos, isympos
+    integer(I4B) :: n, m, mm, il0, il1
     integer(I4B) :: nnbr0, nnbr1
     integer(I4B),dimension(this%nbrmax) :: inbr0, inbr1
 ! ------------------------------------------------------------------------------
@@ -1288,12 +1197,8 @@ module Xt3dModule
         nnbr0 = this%dis%con%ia(n+1) - this%dis%con%ia(n) - 1
         call this%xt3d_load_inbr(n, nnbr0, inbr0)
         do il0 = 1,nnbr0
-          ipos = this%dis%con%ia(n) + il0
-          ! -- Skip if xt3d not used for this connection.
-          isympos = this%dis%con%jas(ipos)
-          if (this%iflowform(isympos) /= 1) cycle
           m = inbr0(il0)
-          if (m.lt.n) cycle    ! amp_note: if loops get moved out to calling routine, do m<n check there
+          if (m.lt.n) cycle
           if (this%icelltype(m) /= 0) then
             this%iallpc(n) = 0
             this%iallpc(m) = 0
@@ -1662,10 +1567,8 @@ module Xt3dModule
     integer(I4B) :: iil, iii
 ! ------------------------------------------------------------------------------
     !
-    ! -- Loop over neighbors of node n
     do iil = 1,nnbr
-!!      iii = this%dis%con%ia(n) + iil
-      iii = idiag + iil
+      iii = this%dis%con%ia(n) + iil
       this%amatpc(idiag) = this%amatpc(idiag) - chat(iil)
       this%amatpc(iii) = this%amatpc(iii) + chat(iil)            
     enddo
@@ -1692,7 +1595,6 @@ module Xt3dModule
     integer(I4B) :: iil, iii, jjj, iixjjj, iijjj
 ! ------------------------------------------------------------------------------
     !
-    ! -- Loop over neighbors of node m
     do iil = 1,nnbr
       this%amatpc(ii01) = this%amatpc(ii01) + chat(iil)
       iii = this%dis%con%ia(m) + iil


### PR DESCRIPTION
…n. Plays nicely with all affected modules: GWF, NPF, GNC, HFB, and GWT/DSP. For example, can now have a mix of standard-conductance connections (with or without GNC) and XT3D connections.  Refactored to have the NPF and DSP formulate routines loop over connections, applying the appropriate flow or dispersion formulation to each connection."

This reverts commit 528337d1e84ffafa1e515269662d68f7c3ceede8.