### PR TITLE
doc(dfn): small changes to dfn for flopy disu support

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
@@ -260,6 +260,6 @@ in_record true
 tagged false
 reader urword
 optional false
-longname number of cell vertices
+longname array of vertex numbers
 description is an array of integer values containing vertex numbers (in the VERTICES block) used to define the cell.  Vertices must be listed in clockwise order.
-
+numeric_index true

--- a/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disv.dfn
@@ -197,6 +197,6 @@ in_record true
 tagged false
 reader urword
 optional false
-longname number of cell vertices
+longname array of vertex numbers
 description is an array of integer values containing vertex numbers (in the VERTICES block) used to define the cell.  Vertices must be listed in clockwise order.  Cells that are connected must share vertices.
 numeric_index true

--- a/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
@@ -246,6 +246,6 @@ in_record true
 tagged false
 reader urword
 optional false
-longname number of cell vertices
+longname array of vertex numbers
 description is an array of integer values containing vertex numbers (in the VERTICES block) used to define the cell.  Vertices must be listed in clockwise order.
-
+numeric_index true

--- a/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disv.dfn
@@ -197,6 +197,6 @@ in_record true
 tagged false
 reader urword
 optional false
-longname number of cell vertices
+longname array of vertex numbers
 description is an array of integer values containing vertex numbers (in the VERTICES block) used to define the cell.  Vertices must be listed in clockwise order.  Cells that are connected must share vertices.
 numeric_index true


### PR DESCRIPTION
FloPy was updated to better support plotting and export for unstructured grid models.  The numeric index tag was added to the vertex numbers for the disu package so that flopy would know that they are numeric indices that flopy should convert to and from zero-based values.