### PR TITLE
feat(csub): add initial support for water table conditions in delay interbeds

### DIFF
--- a/autotest/test_gwf_csub_wtgeo.py
+++ b/autotest/test_gwf_csub_wtgeo.py
@@ -30,7 +30,7 @@ for s in ex:
 constantcv = [True for idx in range(len(exdirs))]
 
 cmppth = 'mfnwt'
-compare = [True, True, True, True, False, False, False]
+compare = [True, True, True, False, False, False, False]
 tops = [0., 0., 150., 0., 0., 150., 150.]
 ump = [None, None, True, None, True, None, True]
 iump = [0, 0, 1, 0, 1, 0, 1]

--- a/src/Model/ModelUtilities/BoundaryPackage.f90
+++ b/src/Model/ModelUtilities/BoundaryPackage.f90
@@ -992,8 +992,8 @@ module BndModule
     !
     ! -- allocate integer variables
     call mem_allocate(this%ibcnum, 'IBCNUM', this%memoryPath)
-    call mem_allocate(this%maxbound, 'MAXBOUND', this%memoryPath)
-    call mem_allocate(this%nbound, 'NBOUND', this%memoryPath)
+    call mem_allocate(this%maxbound, 'MAXBOUND', this%memoryPath, MEMREADWRITE)
+    call mem_allocate(this%nbound, 'NBOUND', this%memoryPath, MEMREADWRITE)
     call mem_allocate(this%ncolbnd, 'NCOLBND', this%memoryPath)
     call mem_allocate(this%iscloc, 'ISCLOC', this%memoryPath)
     call mem_allocate(this%naux, 'NAUX', this%memoryPath)
@@ -1062,8 +1062,11 @@ module BndModule
     if(present(nodelist)) then
       this%nodelist => nodelist
     else
-      call mem_allocate(this%nodelist, this%maxbound, 'NODELIST', this%memoryPath)
-      this%nodelist = 0
+      call mem_allocate(this%nodelist, this%maxbound, 'NODELIST',                &
+                        this%memoryPath, MEMREADWRITE)
+      do j = 1, this%maxbound
+        this%nodelist(j) = 0
+      end do
     endif
     !
     ! -- noupdateauxvar (allows an external caller to stop auxvars from being


### PR DESCRIPTION
Add water compressibility directly to delay bed flow equation formulation instead of calculating after delay bed solution.