### PR TITLE
fix(numpy): aliases of builtin types is deprecated as of numpy 1.20

### DIFF
--- a/autotest/disu_util.py
+++ b/autotest/disu_util.py
@@ -5,11 +5,11 @@ def get_disu_kwargs(nlay, nrow, ncol, delr, delc, tp, botm):
     def get_nn(k, i, j):
         return k * nrow * ncol + i * ncol + j
     nodes = nlay * nrow * ncol
-    iac = np.zeros((nodes), dtype=np.int)
+    iac = np.zeros((nodes), dtype=int)
     ja = []
-    area = np.zeros((nodes), dtype=np.float)
-    top = np.zeros((nodes), dtype=np.float)
-    bot = np.zeros((nodes), dtype=np.float)
+    area = np.zeros((nodes), dtype=float)
+    top = np.zeros((nodes), dtype=float)
+    bot = np.zeros((nodes), dtype=float)
     ihc = []
     cl12 = []
     hwva = []
@@ -76,9 +76,9 @@ def get_disu_kwargs(nlay, nrow, ncol, delr, delc, tp, botm):
                         dz = botm[k - 1] - botm[k]
                     cl12.append(.5 * dz)
                     hwva.append(delr[i] * delc[j])
-    ja = np.array(ja, dtype=np.int)
+    ja = np.array(ja, dtype=int)
     nja = ja.shape[0]
-    hwva = np.array(hwva, dtype=np.float)
+    hwva = np.array(hwva, dtype=float)
     kw = {}
     kw['nodes'] = nodes
     kw['nja'] = nja

--- a/autotest/test_gwf_buy_lak01.py
+++ b/autotest/test_gwf_buy_lak01.py
@@ -96,7 +96,7 @@ def get_model(idx, dir):
                                   top=top, botm=botm, idomain=idomain)
 
     # initial conditions
-    strt = np.zeros((nlay, nrow, ncol), dtype=np.float)
+    strt = np.zeros((nlay, nrow, ncol), dtype=float)
     strt[0, 0, :] = 3.5
     strt[1, 0, :] = 3.0
     strt[1, 0, 1:6] = 2.5

--- a/autotest/test_gwf_buy_lak02.py
+++ b/autotest/test_gwf_buy_lak02.py
@@ -99,7 +99,7 @@ def get_model(idx, dir):
                                   top=top, botm=botm, idomain=idomain)
 
     # initial conditions
-    strt = np.zeros((nlay, nrow, ncol), dtype=np.float)
+    strt = np.zeros((nlay, nrow, ncol), dtype=float)
     strt[0, 0, :] = 3.5
     strt[1, 0, :] = 3.0
     strt[1, 0, 1:6] = 2.5

--- a/autotest/test_gwf_chd01.py
+++ b/autotest/test_gwf_chd01.py
@@ -85,7 +85,7 @@ def get_model(idx, dir):
     dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                   delr=delr, delc=delc,
                                   top=top, botm=botm,
-                                  idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                  idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                   filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwf_csub_db01_nr.py
+++ b/autotest/test_gwf_csub_db01_nr.py
@@ -398,7 +398,7 @@ def eval_comp(sim):
             key = "{}_OUT".format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_ndb01_nr.py
+++ b/autotest/test_gwf_csub_ndb01_nr.py
@@ -363,7 +363,7 @@ def eval_comp(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_sk01.py
+++ b/autotest/test_gwf_csub_sk01.py
@@ -67,7 +67,7 @@ hdry = -1e30
 
 # calculate hk
 hk1fact = 1. / zthick[1]
-hk1 = np.ones((nrow, ncol), dtype=np.float) * 0.5 * hk1fact
+hk1 = np.ones((nrow, ncol), dtype=float) * 0.5 * hk1fact
 hk1[0, :] = 1000. * hk1fact
 hk1[-1, :] = 1000. * hk1fact
 hk1[:, 0] = 1000. * hk1fact
@@ -120,7 +120,7 @@ maxwel = len(wd[1])
 
 # recharge data
 q = 3000. / (delr * delc)
-v = np.zeros((nrow, ncol), dtype=np.float)
+v = np.zeros((nrow, ncol), dtype=float)
 for r, c in zip(wr, wc):
     v[r, c] = q
 rech = {0: v}
@@ -441,7 +441,7 @@ def eval_comp(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_sk02.py
+++ b/autotest/test_gwf_csub_sk02.py
@@ -67,7 +67,7 @@ hdry = -1e30
 
 # calculate hk
 hk1fact = 1. / zthick[1]
-hk1 = np.ones((nrow, ncol), dtype=np.float) * 0.5 * hk1fact
+hk1 = np.ones((nrow, ncol), dtype=float) * 0.5 * hk1fact
 hk1[0, :] = 1000. * hk1fact
 hk1[-1, :] = 1000. * hk1fact
 hk1[:, 0] = 1000. * hk1fact
@@ -120,7 +120,7 @@ maxwel = len(wd[1])
 
 # recharge data
 q = 3000. / (delr * delc)
-v = np.zeros((nrow, ncol), dtype=np.float)
+v = np.zeros((nrow, ncol), dtype=float)
 for r, c in zip(wr, wc):
     v[r, c] = q
 rech = {0: v}
@@ -417,7 +417,7 @@ def eval_comp(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_sk03.py
+++ b/autotest/test_gwf_csub_sk03.py
@@ -61,12 +61,12 @@ steady = [True] + [False for i in range(nper - 1)]
 # spatial discretization
 ft2m = 1. / 3.28081
 nlay, nrow, ncol = 3, 21, 20
-delr = np.ones(ncol, dtype=np.float) * 0.5
+delr = np.ones(ncol, dtype=float) * 0.5
 for idx in range(1, ncol):
     delr[idx] = min(delr[idx - 1] * 1.2, 15.)
 delc = 50.
 top = 0.
-botm = np.array([-40, -70., -100.], dtype=np.float) * ft2m
+botm = np.array([-40, -70., -100.], dtype=float) * ft2m
 zthick = [top - botm[0],
           botm[0] - botm[1],
           botm[1] - botm[2]]
@@ -121,10 +121,10 @@ lnd = [0, 1, 2]
 thicknd0 = [zthick[0], zthick[1], zthick[2]]
 sske = np.array([1.e-5, 2.e-4, 9.e-8]) / ft2m
 
-gl0 = np.zeros((nrow, ncol), dtype=np.float)
+gl0 = np.zeros((nrow, ncol), dtype=float)
 jj = 0
 gl0[0, jj] = 1.86
-sig0 = np.zeros((nlay, nrow, ncol), dtype=np.float)
+sig0 = np.zeros((nlay, nrow, ncol), dtype=float)
 sig0[0, 0, jj] = 1.86
 tsnames = []
 sig0 = []
@@ -143,7 +143,7 @@ train2 = 2.8274
 fcar1 = 0.8165
 fcar2 = 1.63293447
 fcar3 = 2.8274  # 2.9635 #2.4494
-icnt = np.zeros((nrow), dtype=np.int)
+icnt = np.zeros((nrow), dtype=int)
 v = []
 tstime = []
 i0 = 0
@@ -494,7 +494,7 @@ def eval_comp(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_sk04_nr.py
+++ b/autotest/test_gwf_csub_sk04_nr.py
@@ -102,7 +102,7 @@ sgs = 2.0
 void = 0.82
 theta = void / (1. + void)
 beta = 0.
-crnd0 = 6e-6 * np.ones(shape3d, dtype=np.float)
+crnd0 = 6e-6 * np.ones(shape3d, dtype=float)
 crnd0[:, 0, 0] = 0.
 
 
@@ -315,7 +315,7 @@ def eval_comp(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_sub01.py
+++ b/autotest/test_gwf_csub_sub01.py
@@ -330,7 +330,7 @@ def cbc_compare(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node - 1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -350,7 +350,7 @@ def cbc_compare(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_sub01_adjmat.py
+++ b/autotest/test_gwf_csub_sub01_adjmat.py
@@ -270,7 +270,7 @@ def eval_sub(sim):
 
     # calculate theta and porosity from total interbed compaction
     comp = tc['TCOMP']
-    dtype = [('THICK', np.float), ('THETA', np.float)]
+    dtype = [('THICK', float), ('THETA', float)]
     ovalsi = np.zeros((comp.shape[0]), dtype=dtype)
     ovalsi['THICK'] = tc['THICK']
     ovalsi['THETA'] = tc['THETA']
@@ -382,7 +382,7 @@ def cbc_compare(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node - 1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -402,7 +402,7 @@ def cbc_compare(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_sub01_elastic.py
+++ b/autotest/test_gwf_csub_sub01_elastic.py
@@ -289,7 +289,7 @@ def cbc_compare(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node - 1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -309,7 +309,7 @@ def cbc_compare(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_sub01_pch.py
+++ b/autotest/test_gwf_csub_sub01_pch.py
@@ -303,7 +303,7 @@ def cbc_compare(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node - 1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -323,7 +323,7 @@ def cbc_compare(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_sub03.py
+++ b/autotest/test_gwf_csub_sub03.py
@@ -63,7 +63,7 @@ hdry = -1e30
 
 # calculate hk
 hk1fact = 1. / zthick[1]
-hk1 = np.ones((nrow, ncol), dtype=np.float) * 0.5 * hk1fact
+hk1 = np.ones((nrow, ncol), dtype=float) * 0.5 * hk1fact
 hk1[0, :] = 1000. * hk1fact
 hk1[-1, :] = 1000. * hk1fact
 hk1[:, 0] = 1000. * hk1fact
@@ -117,7 +117,7 @@ maxwel = len(wd[1])
 
 # recharge data
 q = 3000. / (delr * delc)
-v = np.zeros((nrow, ncol), dtype=np.float)
+v = np.zeros((nrow, ncol), dtype=float)
 for r, c in zip(wr, wc):
     v[r, c] = q
 rech = {0: v}
@@ -429,7 +429,7 @@ def eval_comp(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_subwt01.py
+++ b/autotest/test_gwf_csub_subwt01.py
@@ -92,7 +92,7 @@ for idx in range(nper):
     tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
 
 # this used to work
-# ib = np.zeros((nlay, nrow, ncol), dtype=np.int)
+# ib = np.zeros((nlay, nrow, ncol), dtype=int)
 # for k in range(nlay):
 ib = [1]
 
@@ -383,7 +383,7 @@ def cbc_compare(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node - 1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -403,7 +403,7 @@ def cbc_compare(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_subwt02.py
+++ b/autotest/test_gwf_csub_subwt02.py
@@ -54,7 +54,7 @@ perlen = [1., 21915., 21915.]
 nstp = [1, 60, 60]
 tsmult = [1., 1., 1.]
 steady = [True, False, False]
-ts_times = np.arange(0., 60000, 10000., dtype=np.float)
+ts_times = np.arange(0., 60000, 10000., dtype=float)
 
 # spatial discretization
 nlay, nrow, ncol = 4, ib0.shape[0], ib0.shape[1]
@@ -171,12 +171,12 @@ for idx in range(nper):
     tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
 
 # this used to work
-# ib = np.zeros((nlay, nrow, ncol), dtype=np.int)
+# ib = np.zeros((nlay, nrow, ncol), dtype=int)
 # for k in range(nlay):
 #    ib[k, :, :] = ib0.copy()
 ib = []
 for k in range(nlay):
-    ib.append(ib0.astype(np.int).copy())
+    ib.append(ib0.astype(int).copy())
 
 # subwt data
 cc = 0.25
@@ -523,7 +523,7 @@ def cbc_compare(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node - 1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -543,7 +543,7 @@ def cbc_compare(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_subwt03.py
+++ b/autotest/test_gwf_csub_subwt03.py
@@ -72,7 +72,7 @@ strt = 100.
 # create ibound/idomain
 ib = []
 for k in range(nlay):
-    ib.append(ib0.astype(np.int).copy())
+    ib.append(ib0.astype(int).copy())
 
 # upw data
 laytyp = [1, 0, 0, 0]
@@ -137,10 +137,10 @@ beta = 0.
 gammaw = 9806.65000000
 
 def get_ske():
-    gsb = np.zeros((nlay), dtype=np.float)
-    ub = np.zeros((nlay), dtype=np.float)
-    esb = np.zeros((nlay), dtype=np.float)
-    ske = np.zeros((nlay), dtype=np.float)
+    gsb = np.zeros((nlay), dtype=float)
+    ub = np.zeros((nlay), dtype=float)
+    esb = np.zeros((nlay), dtype=float)
+    ske = np.zeros((nlay), dtype=float)
 
     # calculate incremental geostatic stress and hydrostatic stress
     for k in range(nlay):
@@ -450,7 +450,7 @@ def cbc_compare(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node - 1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -470,7 +470,7 @@ def cbc_compare(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_wc01.py
+++ b/autotest/test_gwf_csub_wc01.py
@@ -70,7 +70,7 @@ strt = 100.
 # create ibound/idomain
 ib = []
 for k in range(nlay):
-    ib.append(ib0.astype(np.int).copy())
+    ib.append(ib0.astype(int).copy())
 ib = np.array(ib)
 print(ib[0])
 
@@ -386,7 +386,7 @@ def cbc_compare(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node - 1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -406,7 +406,7 @@ def cbc_compare(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_wtgeo.py
+++ b/autotest/test_gwf_csub_wtgeo.py
@@ -78,7 +78,7 @@ hdry = -1e30
 
 # calculate hk
 hk1fact = 1. / 50.
-hk1 = np.ones((nrow, ncol), dtype=np.float) * 0.5 * hk1fact
+hk1 = np.ones((nrow, ncol), dtype=float) * 0.5 * hk1fact
 hk1[0, :] = 1000. * hk1fact
 hk1[-1, :] = 1000. * hk1fact
 hk1[:, 0] = 1000. * hk1fact
@@ -125,7 +125,7 @@ maxwel = len(wd[1])
 
 # recharge data
 q = 3000. / (delr * delc)
-v = np.zeros((nrow, ncol), dtype=np.float)
+v = np.zeros((nrow, ncol), dtype=float)
 for r, c in zip(wr, wc):
     v[r, c] = q
 rech = {0: v}
@@ -633,7 +633,7 @@ def cbc_compare(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node - 1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -653,7 +653,7 @@ def cbc_compare(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_csub_zdisp01.py
+++ b/autotest/test_gwf_csub_zdisp01.py
@@ -420,7 +420,7 @@ def eval_zdisplacement(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node - 1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -440,7 +440,7 @@ def eval_zdisplacement(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_disu01.py
+++ b/autotest/test_gwf_disu01.py
@@ -82,7 +82,7 @@ def test_disu_idomain_simple():
     delc = 10. * np.ones(nrow)
     top = 0
     botm = [-10, -20, -30]
-    idomain = np.ones(nlay*nrow*ncol, dtype=np.int)
+    idomain = np.ones(nlay*nrow*ncol, dtype=int)
     idomain[1] = 0
     disukwargs = get_disu_kwargs(nlay, nrow, ncol, delr, delc, top, botm)
     disukwargs['idomain'] = idomain

--- a/autotest/test_gwf_maw02.py
+++ b/autotest/test_gwf_maw02.py
@@ -204,7 +204,7 @@ def eval_maw(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 wq = []
                 for jdx, node in enumerate(v['node']):
                     vt[node-1] += v['q'][jdx]
@@ -243,7 +243,7 @@ def eval_maw(sim):
     msg =  '\nmaximum absolute maw rate difference     ({})\n'.format(diffv)
 
     # calculate difference between water budget items in the lst and cbc files
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_maw04.py
+++ b/autotest/test_gwf_maw04.py
@@ -56,7 +56,7 @@ xlen = 1000.
 common_ratio = 1.01
 nhalf = int(0.5 * ncol) + 1
 first_term = 0.5 * xlen / ((1 - common_ratio**nhalf) / (1 - common_ratio))
-delr = np.zeros((ncol), dtype=np.float)
+delr = np.zeros((ncol), dtype=float)
 for n in range(nhalf):
     if n == 0:
         v = first_term

--- a/autotest/test_gwf_npf02_rewet.py
+++ b/autotest/test_gwf_npf02_rewet.py
@@ -245,7 +245,7 @@ def eval_hds(sim):
     ncolt = 0
     for ncol in ncolst:
         ncolt += ncol
-    hval = np.zeros((nper, ncolt), dtype=np.float)
+    hval = np.zeros((nper, ncolt), dtype=float)
     imid = int(nrow/2)
 
     for j in range(nmodels):
@@ -258,7 +258,7 @@ def eval_hds(sim):
         for n, t in enumerate(times):
             h = hobj.get_data(totim=t)[:, imid, :]
             h = h.reshape((nlay, ncolst[j]))
-            ht = np.ones(h.shape[1], dtype=np.float) * 1e30
+            ht = np.ones(h.shape[1], dtype=float) * 1e30
             for k in range(nlay):
                 v = h[k, :].copy()
                 kdx = (ht == 1e30) & (v != -1e30)

--- a/autotest/test_gwf_npf03_sfr.py
+++ b/autotest/test_gwf_npf03_sfr.py
@@ -26,7 +26,7 @@ continuous_integration = [True for idx in range(len(exdirs))]
 # read hk data
 fpth = os.path.join(ddir, 'npf03_hk.ref')
 shape = (50, 108)
-hk = flopy.utils.Util2d.load_txt(shape, fpth, dtype=np.float, fmtin='(FREE)')
+hk = flopy.utils.Util2d.load_txt(shape, fpth, dtype=float, fmtin='(FREE)')
 n1 = hk.shape[1]
 nd = 40
 
@@ -3022,7 +3022,7 @@ def eval_hds(sim):
     ncolt = 0
     for ncol in ncolst:
         ncolt += ncol
-    hval = np.zeros(hdata.shape, dtype=np.float)
+    hval = np.zeros(hdata.shape, dtype=float)
 
     i0 = 0
     for j in range(nmodels):

--- a/autotest/test_gwf_npf04_spdis.py
+++ b/autotest/test_gwf_npf04_spdis.py
@@ -154,9 +154,9 @@ def qxqyqz(fname, nlay, nrow, ncol):
     nodes = nlay * nrow * ncol
     cbb = flopy.utils.CellBudgetFile(fname, precision='double')
     spdis = cbb.get_data(text='DATA-SPDIS')[0]
-    qx = np.ones((nodes), dtype=np.float) * 1.e30
-    qy = np.ones((nodes), dtype=np.float) * 1.e30
-    qz = np.ones((nodes), dtype=np.float) * 1.e30
+    qx = np.ones((nodes), dtype=float) * 1.e30
+    qy = np.ones((nodes), dtype=float) * 1.e30
+    qz = np.ones((nodes), dtype=float) * 1.e30
     n0 = spdis['node'] - 1
     qx[n0] = spdis['qx']
     qy[n0] = spdis['qy']

--- a/autotest/test_gwf_obs01.py
+++ b/autotest/test_gwf_obs01.py
@@ -116,7 +116,7 @@ def get_model(idx, dir):
                             delr=delr, delc=delc,
                             top=top, botm=botm,
                             idomain=np.ones((nlay, nrow, ncol),
-                                            dtype=np.int))
+                                            dtype=int))
     flopy.mf6.ModflowUtlobs(gwf, pname='head_obs',
                             digits=20,
                             continuous=get_obs(idx))

--- a/autotest/test_gwf_obs02.py
+++ b/autotest/test_gwf_obs02.py
@@ -85,7 +85,7 @@ def get_model(idx, dir):
                             delr=delr, delc=delc,
                             top=top, botm=botm,
                             idomain=np.ones((nlay, nrow, ncol),
-                                            dtype=np.int))
+                                            dtype=int))
 
     # build list of obs csv files to create
     obsdict = {}
@@ -138,7 +138,7 @@ def build_models():
 def eval_model(sim):
     print('evaluating model observations...')
     name = ex[sim.idxsim]
-    headcsv = np.empty((nlay, nrow, ncol), dtype=np.float)
+    headcsv = np.empty((nlay, nrow, ncol), dtype=float)
     for i in range(nrow):
         fname = '{}.{}.obs.csv'.format(name, i)
         print('Loading and testing {}'.format(fname))

--- a/autotest/test_gwf_ptc01.py
+++ b/autotest/test_gwf_ptc01.py
@@ -21,7 +21,7 @@ ddir = 'data'
 
 # read bottom data
 fpth = os.path.join(ddir, 'nwtp03_bot.ref')
-botm = np.loadtxt(fpth, dtype=np.float)
+botm = np.loadtxt(fpth, dtype=float)
 nlay = 1
 nrow, ncol = botm.shape
 top = 200
@@ -38,7 +38,7 @@ strt = botm + 20.
 
 # read recharge data
 fpth = os.path.join(ddir, 'nwtp03_rch.ref')
-rch = np.loadtxt(fpth, dtype=np.float)
+rch = np.loadtxt(fpth, dtype=float)
 
 
 def build_mf6(idx, ws, storage=True):

--- a/autotest/test_gwf_rch01.py
+++ b/autotest/test_gwf_rch01.py
@@ -49,7 +49,7 @@ def get_model(idx, dir):
 
     delr = delc = 1.
     strt = [[[25., 25., 75., 25., 25.], [25., 25., 75., 25., 25.]]]
-    strt = np.array(strt, dtype=np.float)
+    strt = np.array(strt, dtype=float)
 
     nouter, ninner = 100, 300
     hclose, rclose, relax = 1e-9, 1e-3, 0.97

--- a/autotest/test_gwf_sto01.py
+++ b/autotest/test_gwf_sto01.py
@@ -59,7 +59,7 @@ hdry = -1e30
 
 # calculate hk
 hk1fact = 1. / 50.
-hk1 = np.ones((nrow, ncol), dtype=np.float) * 0.5 * hk1fact
+hk1 = np.ones((nrow, ncol), dtype=float) * 0.5 * hk1fact
 hk1[0, :] = 1000. * hk1fact
 hk1[-1, :] = 1000. * hk1fact
 hk1[:, 0] = 1000. * hk1fact
@@ -107,7 +107,7 @@ maxwel = len(wd[1])
 
 # recharge data
 q = 3000. / (delr * delc)
-v = np.zeros((nrow, ncol), dtype=np.float)
+v = np.zeros((nrow, ncol), dtype=float)
 for r, c in zip(wr, wc):
     v[r, c] = q
 rech = {0: v}
@@ -269,7 +269,7 @@ def eval_sto(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node-1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -289,7 +289,7 @@ def eval_sto(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()

--- a/autotest/test_gwf_ts_lak01.py
+++ b/autotest/test_gwf_ts_lak01.py
@@ -45,7 +45,7 @@ delr = delc = [250.00, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0,
                1000.0, 1000.0, 1000.0, 1000.0, 250.00]
 top = 500.
 botm = [107., 97., 87., 77., 67.]
-idomain = np.ones(shape3d, dtype=np.int)
+idomain = np.ones(shape3d, dtype=int)
 idomain[0, 6:11, 6:11] = 0
 idomain[1, 7:10, 7:10] = 0
 
@@ -186,7 +186,7 @@ ts_names = ['stage', 'rainfall', 'evap', 'runoff', 'withdrawal', 'outlet',
 ts_methods = ['linearend'] * len(ts_names)
 
 ts_data = []
-ts_times = np.arange(0., sim_time + 2. * pertime, pertime, dtype=np.float)
+ts_times = np.arange(0., sim_time + 2. * pertime, pertime, dtype=float)
 for t in ts_times:
     ts_data.append((t, stage, recharge, evap, runoff, withdrawal, rate,
                     temp, conc, recharge, -rate, -withdrawal))

--- a/autotest/test_gwf_ts_maw01.py
+++ b/autotest/test_gwf_ts_maw01.py
@@ -32,7 +32,7 @@ def build_model(ws, name, timeseries=False):
     tdis_rc = []
     for idx in range(nper):
         tdis_rc.append((1., 1, 1.0))
-    ts_times = np.arange(0., 2., 1., dtype=np.float)
+    ts_times = np.arange(0., 2., 1., dtype=float)
 
     auxnames = ['temp', 'conc']
     temp, conc = 32.5, 0.1

--- a/autotest/test_gwf_ts_sfr01.py
+++ b/autotest/test_gwf_ts_sfr01.py
@@ -32,7 +32,7 @@ def build_model(ws, name, timeseries=False):
     tdis_rc = []
     for idx in range(nper):
         tdis_rc.append((1., 1, 1.0))
-    ts_times = np.arange(0., 2., 1., dtype=np.float)
+    ts_times = np.arange(0., 2., 1., dtype=float)
 
     auxnames = ['temp', 'conc']
     temp, conc = 32.5, 0.1
@@ -387,7 +387,7 @@ def eval_model(sim):
         if node > 5:
             q.append(v0['q'][idx])
     v0 = np.array(q)
-    check = np.ones(v0.shape, dtype=np.float) * 5e-2
+    check = np.ones(v0.shape, dtype=float) * 5e-2
     check[-2] = 4e-2
     assert np.allclose(v0, check), 'FLOW-JA-FACE failed'
 

--- a/autotest/test_gwf_ts_sfr02.py
+++ b/autotest/test_gwf_ts_sfr02.py
@@ -32,7 +32,7 @@ def build_model(ws, name, timeseries=False):
     tdis_rc = []
     for idx in range(nper):
         tdis_rc.append((1., 1, 1.0))
-    ts_times = np.arange(0., 2., 1., dtype=np.float)
+    ts_times = np.arange(0., 2., 1., dtype=float)
 
     auxnames = ['temp', 'conc']
     temp, conc = 32.5, 0.1
@@ -379,7 +379,7 @@ def eval_model(sim):
         if node in nodes:
             q.append(v0['q'][idx])
     v0 = np.array(q)
-    check = np.ones(v0.shape, dtype=np.float) * 5e-2
+    check = np.ones(v0.shape, dtype=float) * 5e-2
     check[1] = 0.76743
     check[-2] = 4e-2
     assert np.allclose(v0, check), 'FLOW-JA-FACE failed'

--- a/autotest/test_gwf_ts_uzf01.py
+++ b/autotest/test_gwf_ts_uzf01.py
@@ -32,7 +32,7 @@ def build_model(ws, name, timeseries=False):
     tdis_rc = []
     for idx in range(nper):
         tdis_rc.append((1., 1, 1.0))
-    ts_times = np.arange(0., 2., 1., dtype=np.float)
+    ts_times = np.arange(0., 2., 1., dtype=float)
 
     auxnames = ['temp', 'conc']
     temp, conc = 32.5, 0.1

--- a/autotest/test_gwf_utl05_budparse.py
+++ b/autotest/test_gwf_utl05_budparse.py
@@ -93,7 +93,7 @@ def build_models():
                                       delr=delr, delc=delc,
                                       top=top, botm=botm,
                                       idomain=np.ones((nlay, nrow, ncol),
-                                                      dtype=np.int))
+                                                      dtype=int))
 
         # initial conditions
         ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)

--- a/autotest/test_gwf_zb01.py
+++ b/autotest/test_gwf_zb01.py
@@ -66,7 +66,7 @@ hdry = -1e30
 
 # calculate hk
 hk1fact = 1. / 50.
-hk1 = np.ones((nrow, ncol), dtype=np.float) * 0.5 * hk1fact
+hk1 = np.ones((nrow, ncol), dtype=float) * 0.5 * hk1fact
 hk1[0, :] = 1000. * hk1fact
 hk1[-1, :] = 1000. * hk1fact
 hk1[:, 0] = 1000. * hk1fact
@@ -114,7 +114,7 @@ maxwel = len(wd[1])
 
 # recharge data
 q = 3000. / (delr * delc)
-v = np.zeros((nrow, ncol), dtype=np.float)
+v = np.zeros((nrow, ncol), dtype=float)
 for r, c in zip(wr, wc):
     v[r, c] = q
 rech = {0: v}
@@ -309,7 +309,7 @@ def eval_zb6(sim):
             qout = 0.
             v = cobj.get_data(kstpkper=k, text=text)[0]
             if isinstance(v, np.recarray):
-                vt = np.zeros(size3d, dtype=np.float)
+                vt = np.zeros(size3d, dtype=float)
                 for jdx, node in enumerate(v['node']):
                     vt[node-1] += v['q'][jdx]
                 v = vt.reshape(shape3d)
@@ -329,7 +329,7 @@ def eval_zb6(sim):
             key = '{}_OUT'.format(text)
             d[key][idx] = qout
 
-    diff = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
         diff[:, idx] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
@@ -356,7 +356,7 @@ def eval_zb6(sim):
     f.close()
 
     # compare zone budget to cbc output
-    diffzb = np.zeros((nbud, len(bud_lst)), dtype=np.float)
+    diffzb = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, (key0, key) in enumerate(zip(zone_lst, bud_lst)):
         diffzb[:, idx] = zbsum[key0] - d[key]
     diffzbmax = np.abs(diffzb).max()

--- a/autotest/test_gwt_adv01.py
+++ b/autotest/test_gwt_adv01.py
@@ -86,7 +86,7 @@ def get_model(idx, dir):
     dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                   delr=delr, delc=delc,
                                   top=top, botm=botm,
-                                  idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                  idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                   filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_adv02.py
+++ b/autotest/test_gwt_adv02.py
@@ -125,7 +125,7 @@ def get_model(idx, dir):
                                   filename='{}.ims'.format(gwfname))
     sim.register_ims_package(imsgwf, [gwf.name])
 
-    itri = np.zeros((nrow, ncol), dtype=np.int)
+    itri = np.zeros((nrow, ncol), dtype=int)
     itri[:, 1:ncol - 1] = 1
     verts, iverts = grid_triangulator(itri, delr, delc)
     vertices, cell2d = cvfd_to_cell2d(verts, iverts)
@@ -143,7 +143,7 @@ def get_model(idx, dir):
     #dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
     #                              delr=delr, delc=delc,
     #                              top=top, botm=botm,
-    #                              idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+    #                              idomain=np.ones((nlay, nrow, ncol), dtype=int),
     #                              filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_adv03.py
+++ b/autotest/test_gwt_adv03.py
@@ -131,7 +131,7 @@ def get_model(idx, dir):
                                   filename='{}.ims'.format(gwfname))
     sim.register_ims_package(imsgwf, [gwf.name])
 
-    itri = np.zeros((nrow, ncol), dtype=np.int)
+    itri = np.zeros((nrow, ncol), dtype=int)
     itri[:, 1:ncol - 1] = 1
     verts, iverts = grid_triangulator(itri, delr, delc)
     vertices, cell2d = cvfd_to_cell2d(verts, iverts)
@@ -140,7 +140,7 @@ def get_model(idx, dir):
 
     # A grid array that has the cellnumber of the first triangular cell in
     # the original grid
-    itricellnum = np.empty((nrow, ncol), dtype=np.int)
+    itricellnum = np.empty((nrow, ncol), dtype=int)
     icell = 0
     for i in range(nrow):
         for j in range(ncol):
@@ -173,7 +173,7 @@ def get_model(idx, dir):
     #dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
     #                              delr=delr, delc=delc,
     #                              top=top, botm=botm,
-    #                              idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+    #                              idomain=np.ones((nlay, nrow, ncol), dtype=int),
     #                              filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_adv04.py
+++ b/autotest/test_gwt_adv04.py
@@ -57,7 +57,7 @@ def get_model(idx, dir):
 
     # put constant heads all around the box
     chdlist = []
-    ib = np.ones((nlay, nrow, ncol), dtype=np.int)
+    ib = np.ones((nlay, nrow, ncol), dtype=int)
     ib[:, 1:nrow-1, 1:ncol-1] = 0
     idloc = np.where(ib > 0)
     for k, i, j in zip(idloc[0], idloc[1], idloc[2]):
@@ -107,7 +107,7 @@ def get_model(idx, dir):
     dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                   delr=delr, delc=delc,
                                   top=top, botm=botm,
-                                  idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                  idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                   filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_dsp01.py
+++ b/autotest/test_gwt_dsp01.py
@@ -91,7 +91,7 @@ def get_model(idx, dir):
     dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                   delr=delr, delc=delc,
                                   top=top, botm=botm,
-                                  idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                  idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                   filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_dsp02.py
+++ b/autotest/test_gwt_dsp02.py
@@ -125,7 +125,7 @@ def get_model(idx, dir):
                                   filename='{}.ims'.format(gwfname))
     sim.register_ims_package(imsgwf, [gwf.name])
 
-    itri = np.zeros((nrow, ncol), dtype=np.int)
+    itri = np.zeros((nrow, ncol), dtype=int)
     itri[:, 1:ncol - 1] = 1
     verts, iverts = grid_triangulator(itri, delr, delc)
     vertices, cell2d = cvfd_to_cell2d(verts, iverts)

--- a/autotest/test_gwt_dsp03.py
+++ b/autotest/test_gwt_dsp03.py
@@ -132,7 +132,7 @@ def get_model(idx, dir):
     sim.register_ims_package(imsgwf, [gwf.name])
 
     ihalfrow = int(nrow / 2)
-    itri = np.zeros((nrow, ncol), dtype=np.int)
+    itri = np.zeros((nrow, ncol), dtype=int)
     itri[:ihalfrow, 1:ncol - 1] = 1
     itri[ihalfrow:, 1:ncol - 1] = 2
     verts, iverts = grid_triangulator(itri, delr, delc)
@@ -142,7 +142,7 @@ def get_model(idx, dir):
 
     # A grid array that has the cellnumber of the first triangular cell in
     # the original grid
-    itricellnum = np.empty((nrow, ncol), dtype=np.int)
+    itricellnum = np.empty((nrow, ncol), dtype=int)
     icell = 0
     for i in range(nrow):
         for j in range(ncol):
@@ -178,7 +178,7 @@ def get_model(idx, dir):
     #dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
     #                              delr=delr, delc=delc,
     #                              top=top, botm=botm,
-    #                              idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+    #                              idomain=np.ones((nlay, nrow, ncol), dtype=int),
     #                              filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_dsp04.py
+++ b/autotest/test_gwt_dsp04.py
@@ -50,7 +50,7 @@ def get_model(idx, dir):
     sy = 0.1
 
     chdlist = []
-    ib = np.ones((nlay, nrow, ncol), dtype=np.int)
+    ib = np.ones((nlay, nrow, ncol), dtype=int)
     ib[:, 1:nrow-1, 1:ncol-1] = 0
     idloc = np.where(ib > 0)
     for k, i, j in zip(idloc[0], idloc[1], idloc[2]):
@@ -97,7 +97,7 @@ def get_model(idx, dir):
     dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                   delr=delr, delc=delc,
                                   top=top, botm=botm,
-                                  idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                  idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                   filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_henry_nr.py
+++ b/autotest/test_gwt_henry_nr.py
@@ -38,7 +38,7 @@ frequency = 4
 wellfact = 0.25
 
 def get_idomain(nlay, nrow, ncol, lx, lz, fx, fz):
-    idomain = np.ones((nlay, nrow, ncol), dtype=np.int)
+    idomain = np.ones((nlay, nrow, ncol), dtype=int)
     x1 = fx * lx
     y1 = lz
     x2 = lx

--- a/autotest/test_gwt_ist01.py
+++ b/autotest/test_gwt_ist01.py
@@ -96,7 +96,7 @@ def build_models():
                                       delr=delr, delc=delc,
                                       top=top, botm=botm,
                                       idomain=np.ones((nlay, nrow, ncol),
-                                                      dtype=np.int))
+                                                      dtype=int))
 
         # initial conditions
         ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)

--- a/autotest/test_gwt_moc3d01.py
+++ b/autotest/test_gwt_moc3d01.py
@@ -94,7 +94,7 @@ def get_model(idx, dir):
     dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                   delr=delr, delc=delc,
                                   top=top, botm=botm,
-                                  idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                  idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                   filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_moc3d02.py
+++ b/autotest/test_gwt_moc3d02.py
@@ -94,7 +94,7 @@ def get_model(idx, dir):
     dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                   delr=delr, delc=delc,
                                   top=top, botm=botm,
-                                  idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                  idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                   filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_moc3d03.py
+++ b/autotest/test_gwt_moc3d03.py
@@ -94,7 +94,7 @@ def build_models():
         dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                       delr=delr, delc=delc,
                                       top=top, botm=botm,
-                                      idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                      idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                       filename='{}.dis'.format(gwfname))
 
         # initial conditions

--- a/autotest/test_gwt_mst01.py
+++ b/autotest/test_gwt_mst01.py
@@ -88,7 +88,7 @@ def build_models():
         dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                       delr=delr, delc=delc,
                                       top=top, botm=botm,
-                                      idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                      idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                       filename='{}.dis'.format(gwfname))
 
         # initial conditions
@@ -209,7 +209,7 @@ def eval_transport(sim):
         assert False, 'could not load data from "{}"'.format(fpth)
 
     # end of stress period 1
-    cres1 = np.ones((nlay, nrow, ncol), np.float)
+    cres1 = np.ones((nlay, nrow, ncol), float)
     assert np.allclose(cres1, conc1), ('simulated concentrations do not match '
                                        'with known solution.')
 

--- a/autotest/test_gwt_mst02.py
+++ b/autotest/test_gwt_mst02.py
@@ -115,7 +115,7 @@ def build_models():
         dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                       delr=delr, delc=delc,
                                       top=top, botm=botm,
-                                      idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                      idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                       filename='{}.dis'.format(gwfname))
 
         # initial conditions

--- a/autotest/test_gwt_mst03.py
+++ b/autotest/test_gwt_mst03.py
@@ -95,7 +95,7 @@ def build_models():
                                       delr=delr, delc=delc,
                                       top=top, botm=botm,
                                       idomain=np.ones((nlay, nrow, ncol),
-                                                      dtype=np.int))
+                                                      dtype=int))
 
         # initial conditions
         ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)

--- a/autotest/test_gwt_mt3dms_p01.py
+++ b/autotest/test_gwt_mt3dms_p01.py
@@ -78,10 +78,10 @@ def p01mt3d(model_ws, al, retardation, rc1, mixelm,
     dis = flopy.modflow.ModflowDis(mf, nlay=nlay, nrow=nrow, ncol=ncol,
                                    delr=delr, delc=delc, top=top, botm=botm,
                                    perlen=perlen)
-    ibound = np.ones((nlay, nrow, ncol), dtype=np.int)
+    ibound = np.ones((nlay, nrow, ncol), dtype=int)
     ibound[0, 0, 0] = -1
     ibound[0, 0, -1] = -1
-    strt = np.zeros((nlay, nrow, ncol), dtype=np.float)
+    strt = np.zeros((nlay, nrow, ncol), dtype=float)
     h1 = q * Lx
     strt[0, 0, 0] = h1
     bas = flopy.modflow.ModflowBas(mf, ibound=ibound, strt=strt)
@@ -95,9 +95,9 @@ def p01mt3d(model_ws, al, retardation, rc1, mixelm,
     mt = flopy.mt3d.Mt3dms(modelname=modelname_mt, model_ws=model_ws,
                            exe_name=exe_name_mt, modflowmodel=mf)
     c0 = 1.
-    icbund = np.ones((nlay, nrow, ncol), dtype=np.int)
+    icbund = np.ones((nlay, nrow, ncol), dtype=int)
     icbund[0, 0, 0] = -1
-    sconc = np.zeros((nlay, nrow, ncol), dtype=np.float)
+    sconc = np.zeros((nlay, nrow, ncol), dtype=float)
     sconc[0, 0, 0] = c0
     btn = flopy.mt3d.Mt3dBtn(mt, laycon=laytyp, icbund=icbund,
                              prsity=prsity, sconc=sconc, dt0=dt0, ifmtcn=1)
@@ -224,11 +224,11 @@ def p01mf6(model_ws, al, retardation, decay_rate, mixelm, zeta=None,
                                   delr=delr, delc=delc,
                                   top=top, botm=botm,
                                   idomain=np.ones((nlay, nrow, ncol),
-                                                  dtype=np.int),
+                                                  dtype=int),
                                   filename='{}.dis'.format(gwfname))
 
     # initial conditions
-    strt = np.zeros((nlay, nrow, ncol), dtype=np.float)
+    strt = np.zeros((nlay, nrow, ncol), dtype=float)
     h1 = q * Lx
     strt[0, 0, 0] = h1
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt,

--- a/autotest/test_gwt_obs01.py
+++ b/autotest/test_gwt_obs01.py
@@ -84,7 +84,7 @@ def get_model(idx, dir):
     dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                   delr=delr, delc=delc,
                                   top=top, botm=botm,
-                                  idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                  idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                   filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_prudic2004t2.py
+++ b/autotest/test_gwt_prudic2004t2.py
@@ -73,7 +73,7 @@ def get_model(idx, dir):
     bot0 = np.loadtxt(fname)
     botm = [bot0] + [bot0 - (15. * k) for k in range(1, nlay)]
     fname = os.path.join(data_ws, 'idomain1.dat')
-    idomain0 = np.loadtxt(fname, dtype=np.int)
+    idomain0 = np.loadtxt(fname, dtype=int)
     idomain = nlay * [idomain0]
     dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                   delr=delr, delc=delc,
@@ -174,7 +174,7 @@ def get_model(idx, dir):
                                       perioddata=sfrperioddata)
 
     fname = os.path.join(data_ws, 'lakibd.dat')
-    lakibd = np.loadtxt(fname, dtype=np.int)
+    lakibd = np.loadtxt(fname, dtype=int)
     lakeconnectiondata = []
     nlakecon = [0, 0]
     lak_leakance = 1.

--- a/autotest/test_gwt_prudic2004t2fmi.py
+++ b/autotest/test_gwt_prudic2004t2fmi.py
@@ -42,7 +42,7 @@ fname = os.path.join(data_ws, 'bot1.dat')
 bot0 = np.loadtxt(fname)
 botm = [bot0] + [bot0 - (15. * k) for k in range(1, nlay)]
 fname = os.path.join(data_ws, 'idomain1.dat')
-idomain0 = np.loadtxt(fname, dtype=np.int)
+idomain0 = np.loadtxt(fname, dtype=int)
 idomain = nlay * [idomain0]
 
 
@@ -190,7 +190,7 @@ def run_flow_model():
                                       observations=sfr_obs)
 
     fname = os.path.join(data_ws, 'lakibd.dat')
-    lakibd = np.loadtxt(fname, dtype=np.int)
+    lakibd = np.loadtxt(fname, dtype=int)
     lakeconnectiondata = []
     nlakecon = [0, 0]
     lak_leakance = 1.

--- a/autotest/test_gwt_src01.py
+++ b/autotest/test_gwt_src01.py
@@ -99,7 +99,7 @@ def get_model(idx, dir):
     dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
                                   delr=delr, delc=delc,
                                   top=top, botm=botm,
-                                  idomain=np.ones((nlay, nrow, ncol), dtype=np.int),
+                                  idomain=np.ones((nlay, nrow, ncol), dtype=int),
                                   filename='{}.dis'.format(gwfname))
 
     # initial conditions

--- a/autotest/test_gwt_ssm02.py
+++ b/autotest/test_gwt_ssm02.py
@@ -96,7 +96,7 @@ def build_models():
                                       delr=delr, delc=delc,
                                       top=top, botm=botm,
                                       idomain=np.ones((nlay, nrow, ncol),
-                                                      dtype=np.int))
+                                                      dtype=int))
 
         # initial conditions
         ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)


### PR DESCRIPTION
This fix is similar to https://github.com/modflowpy/flopy/pull/1052

These changes shouldn't change anything, since types like `np.int` are alias to builtin `int` types. These alias are deprecated as of [numpy 1.20](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).