### PR TITLE
Enhancing diagnostics in BMI

### DIFF
--- a/msvs/mf6bmi.vfproj
+++ b/msvs/mf6bmi.vfproj
@@ -29,6 +29,7 @@
 		<Filter Name="Source Files" Filter="f90;for;f;fpp;ftn;def;odl;idl">
 		<File RelativePath="..\srcbmi\bmi.f90"/>
 		<File RelativePath="..\srcbmi\mf6bmi.f90"/>
+		<File RelativePath="..\srcbmi\mf6bmiError.f90"/>
 		<File RelativePath="..\srcbmi\mf6bmiGrid.f90"/>
 		<File RelativePath="..\srcbmi\mf6bmiUtil.f90"/>
 		<File RelativePath="..\srcbmi\mf6xmi.f90"/></Filter></Files>

--- a/src/Utilities/Memory/MemoryHelper.f90
+++ b/src/Utilities/Memory/MemoryHelper.f90
@@ -1,5 +1,5 @@
 module MemoryHelperModule
-  use KindModule, only: I4B
+  use KindModule, only: I4B, LGP
   use ConstantsModule, only: LENMEMPATH, LENMEMSEPARATOR, LENMEMADDRESS, LENVARNAME, LENCOMPONENTNAME
   use SimModule, only: store_error, ustop
   use SimVariablesModule, only: errmsg
@@ -53,10 +53,11 @@ contains
 
   !> @brief Split a memory address string into memory path and variable name
   !<
-  subroutine split_mem_address(mem_address, mem_path, var_name)
+  subroutine split_mem_address(mem_address, mem_path, var_name, success)
     character(len=*), intent(in) :: mem_address         !< the full memory address string
     character(len=LENMEMPATH), intent(out) :: mem_path  !< the memory path
     character(len=LENVARNAME), intent(out) :: var_name  !< the variable name
+    logical(LGP), intent(out) :: success                !< true when successful
     ! local
     integer(I4B) :: idx
 
@@ -65,17 +66,14 @@ contains
     ! if no separator, or it's at the end of the string,
     ! the memory address is not valid:
     if(idx < 1 .or. idx == len(mem_address)) then
-      write(errmsg, '(*(G0))')                                                  &
-        'Fatal error in Memory Manager, cannot split invalid memory address: ', &
-         mem_address
-
-      ! -- store error and stop program execution
-      call store_error(errmsg)
-      call ustop()
+      success = .false.
+      mem_path = ''
+      var_name = ''
+    else
+      success = .true.
+      mem_path = mem_address(:idx-1)
+      var_name = mem_address(idx+1:)
     end if
-
-    mem_path = mem_address(:idx-1)
-    var_name = mem_address(idx+1:)
     
   end subroutine split_mem_address
 

--- a/srcbmi/mf6bmiError.f90
+++ b/srcbmi/mf6bmiError.f90
@@ -1,0 +1,64 @@
+!> @brief Detailed error information for the BMI
+!!
+!! This module contains error codes and detailed error 
+!! messages (as format strings) for the BMI/XMI.
+!< 
+module mf6bmiError
+  use iso_c_binding, only: c_char, c_int, C_NULL_CHAR
+  use KindModule, only: I4B
+  use ConstantsModule, only: MAXCHARLEN
+  use SimVariablesModule, only: istdout
+
+  integer, parameter :: BMI_FAILURE = 1 !< BMI status code for failure (taken from bmi.f90, CSDMS)
+  integer, parameter :: BMI_SUCCESS = 0 !< BMI status code for success (taken from bmi.f90, CSDMS)
+
+  integer(I4B), parameter :: LENERRMESSAGE = 1024 !< max length for the error message
+  integer(c_int), bind(C, name="BMI_LENERRMESSAGE") :: BMI_LENERRMESSAGE = LENERRMESSAGE + 1 !< max. length for the (exported) C-style error message
+  !DEC$ ATTRIBUTES DLLEXPORT :: BMI_LENERRMESSAGE
+
+  character(len=LENERRMESSAGE) :: bmi_last_error = 'No BMI error reported' !< module variable containing the last error as a Fortran string
+
+  character(len=*), parameter :: fmt_general_err = &        !< General bmi error, args: context/detail
+    "('BMI Error, ', a)"
+  character(len=*), parameter :: fmt_unknown_var = &        !< Variable unknown, args: variable name, memory path
+    "('BMI Error, unknown variable: ', a, ' at ', a)"
+  character(len=*), parameter :: fmt_invalid_var = &        !< Invalid variable address, args: variable address
+    "('BMI Error, invalid address string: ', a)"
+  character(len=*), parameter :: fmt_unsupported_rank = &   !< Unsupported rank, args: variable name
+    "('BMI Error, unsupported rank for variable: ', a)"
+  character(len=*), parameter :: fmt_invalid_mem_access = & !< Invalid memory access, args: variable name
+    "('Fatal BMI Error, invalid access of memory for variable: ', a)"
+  character(len=*), parameter :: fmt_fail_cvg_sol = &       !< Solution failed to converge, args: detail
+    "('BMI Error, Numerical Solution ', i3, ' failed to converge')"
+
+    contains
+
+    !> @brief Sets the last BMI error message and copies
+    !! it to an exported C-string
+    !<
+    subroutine report_bmi_error(err_msg)
+      character(len=*), intent(in) :: err_msg !< the error message
+      bmi_last_error = err_msg
+      write(istdout,*) trim(err_msg)
+    end subroutine report_bmi_error
+
+    !> @brief Get the last error in the BMI as a character array
+    !! with size BMI_LENERRMESSAGE
+    !<
+    function get_last_bmi_error(c_error) result(bmi_status) bind(C, name="get_last_bmi_error")
+      !DEC$ ATTRIBUTES DLLEXPORT :: get_last_bmi_error
+        character(kind=c_char,len=1), intent(out) :: c_error(BMI_LENERRMESSAGE)  !< C style char array with error
+        integer(kind=c_int) :: bmi_status !< BMI status code
+        ! local
+        integer(I4B) :: i, length
+
+        length = len(trim(bmi_last_error))
+        do i = 1, length
+          c_error(i) = bmi_last_error(i:i)
+        enddo
+        c_error(length+1) = C_NULL_CHAR
+
+        bmi_status = BMI_SUCCESS
+    end function get_last_bmi_error
+
+end module mf6bmiError

--- a/srcbmi/mf6xmi.f90
+++ b/srcbmi/mf6xmi.f90
@@ -87,9 +87,9 @@
 module mf6xmi
   use mf6bmi
   use mf6bmiUtil
+  use mf6bmiError
   use Mf6CoreModule
   use KindModule
-  use bmif, only: BMI_SUCCESS, BMI_FAILURE
   use iso_c_binding, only: c_int, c_char  
   implicit none
  
@@ -143,6 +143,8 @@ module mf6xmi
     if (hasConverged) then
       bmi_status = BMI_SUCCESS
     else
+      write(bmi_last_error, fmt_general_err) 'simulation failed to converge'
+      call report_bmi_error(bmi_last_error)
       bmi_status = BMI_FAILURE
     end if
     
@@ -279,6 +281,8 @@ module mf6xmi
     if (hasConverged == 1) then
       bmi_status = BMI_SUCCESS
     else
+      write(bmi_last_error, fmt_fail_cvg_sol) subcomponent_idx
+      call report_bmi_error(bmi_last_error)
       bmi_status = BMI_FAILURE
     end if
     


### PR DESCRIPTION
- implemented error module (e.g. xmipy can now get the last error to provide the user with diagnostics)
- add get_component_name
- add error messages throughout the BMI and XMI
- prevent MODFLOW from crashing on invalid address strings passed in through the BMI functions