### PR TITLE
refactor(mf5to6): initialize local class(*) to null()

### DIFF
--- a/autotest/test_z02_nightly_build_mf5to6.py
+++ b/autotest/test_z02_nightly_build_mf5to6.py
@@ -72,11 +72,11 @@ def get_mf5to6_models():
         'testTwrip',
         'test028_sfr_simple',
     ]
-    os_name = sys.platform.lower()
-    if os_name in ("win32", "linux", "darwin"):
-        exclude.append("testlgrsfr")
-    elif os_name in ("linux", "darwin"):
-        exclude.append("test059_mvlake_laksfr_tr")
+    # os_name = sys.platform.lower()
+    # if os_name in ("win32", "linux", "darwin"):
+    #     exclude.append("testlgrsfr")
+    # elif os_name in ("linux", "darwin"):
+    #     exclude.append("test059_mvlake_laksfr_tr")
 
     # write a summary of the files to exclude
     print('list of tests to exclude:')

--- a/src/Utilities/Memory/MemoryList.f90
+++ b/src/Utilities/Memory/MemoryList.f90
@@ -19,7 +19,7 @@ module MemoryListModule
   subroutine add(this, mt)
     class(MemoryListType) :: this
     type(MemoryType), pointer :: mt
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     obj => mt
     call this%list%add(obj)
   end subroutine add
@@ -28,7 +28,7 @@ module MemoryListModule
     class(MemoryListType) :: this
     integer(I4B), intent(in) :: ipos
     type(MemoryType), pointer :: res
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     obj => this%list%getitem(ipos)
     select type (obj)
     type is (MemoryType)

--- a/src/Utilities/TimeSeries/TimeSeries.f90
+++ b/src/Utilities/TimeSeries/TimeSeries.f90
@@ -157,7 +157,7 @@ contains
     type(ListType),                      intent(inout) :: list
     class(TimeSeriesFileType), pointer, intent(inout) :: tsfile
     ! -- local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
 ! ------------------------------------------------------------------------------
     !
     obj => tsfile
@@ -178,7 +178,7 @@ contains
     integer(I4B),             intent(in)    :: idx
     type(TimeSeriesFileType), pointer :: res
     ! -- local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
 ! ------------------------------------------------------------------------------
     !
     obj => list%GetItem(idx)
@@ -876,7 +876,7 @@ contains
     class(TimeSeriesType) :: this
     type(TimeSeriesRecordType), pointer, intent(inout) :: tsr
     ! -- local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
 ! ------------------------------------------------------------------------------
     !
     obj => tsr
@@ -897,7 +897,7 @@ contains
     ! result
     type(TimeSeriesRecordType), pointer :: res
     ! -- local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
 ! ------------------------------------------------------------------------------
     !
     obj => null()
@@ -922,7 +922,7 @@ contains
     ! result
     type(TimeSeriesRecordType), pointer :: res
     ! -- local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
 ! ------------------------------------------------------------------------------
     !
     obj => null()
@@ -947,7 +947,7 @@ contains
     ! result
     type(TimeSeriesRecordType), pointer :: res
     ! -- local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
 ! ------------------------------------------------------------------------------
     !
     obj => null()
@@ -1025,7 +1025,7 @@ contains
     double precision :: badtime, time, time0, time1
     type(TimeSeriesRecordType), pointer :: tsrEarlier, tsrLater
     type(ListNodeType), pointer :: nodeEarlier, nodeLater
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
 ! ------------------------------------------------------------------------------
     !
     badtime = -9.0d30
@@ -1110,7 +1110,7 @@ contains
     integer :: nrecords
     double precision :: endtime
     type(TimeSeriesRecordType), pointer :: tsr
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
 ! ------------------------------------------------------------------------------
     !
     nrecords = this%list%Count()

--- a/src/Utilities/TimeSeries/TimeSeriesRecord.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesRecord.f90
@@ -49,7 +49,7 @@ contains
     type(ListType),             intent(inout) :: list
     type(TimeSeriesRecordType), pointer, intent(inout) :: tsrecord
     ! -- local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => tsrecord
     call list%Add(obj)

--- a/utils/mf5to6/src/Auxiliary.f90
+++ b/utils/mf5to6/src/Auxiliary.f90
@@ -67,7 +67,7 @@ contains
     type(ListType), pointer :: list
     type(AuxiliaryType), pointer :: auxiliary
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => auxiliary
     call list%Add(obj)
@@ -82,7 +82,7 @@ contains
     integer, intent(in) :: idx
     type(AuxiliaryType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     res => null()
     obj => list%GetItem(idx)

--- a/utils/mf5to6/src/CharacterContainer.f90
+++ b/utils/mf5to6/src/CharacterContainer.f90
@@ -46,7 +46,7 @@ contains
     type(ListType), intent(inout) :: list
     character(len=*), intent(in) :: string
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     type(CharacterContainerType), pointer :: newCharacterContainer
     !
     newCharacterContainer => null()
@@ -66,7 +66,7 @@ contains
     integer, intent(in) :: indx
     character(len=:), allocatable :: string
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     type(CharacterContainerType), pointer :: charcont
     !
     string = ''

--- a/utils/mf5to6/src/ChdPackageWriter.f90
+++ b/utils/mf5to6/src/ChdPackageWriter.f90
@@ -689,7 +689,7 @@ contains
     !logical, allocatable, dimension(:) :: complete
     type(TimeSeriesRecordType), pointer :: tsr, tsRecEarlier, tsRecLater, tsrNew
     type(ChdType), pointer :: chd
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     lasttime = .false.
     badtime = huge(badtime)

--- a/utils/mf5to6/src/ChdType.f90
+++ b/utils/mf5to6/src/ChdType.f90
@@ -104,7 +104,7 @@ contains
     type(ListType) :: chdList
     type(ChdType), pointer :: chd
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => chd
     call chdList%Add(obj)

--- a/utils/mf5to6/src/ExchangeWriter.f90
+++ b/utils/mf5to6/src/ExchangeWriter.f90
@@ -55,7 +55,7 @@ contains
     type(ModelConverterType), pointer :: parentConverter
     type(ExchangeType), pointer :: exchange
     type(ModelType), pointer :: parent => null(), child => null()
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     ! formats
     10 format()
     !
@@ -106,7 +106,7 @@ contains
     class(ExchangeWriterType) :: this
     ! local
     integer :: i, nexg
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     type(ExchangeType), pointer :: exg => null()
     !
     nexg = this%Exchanges%Count()

--- a/utils/mf5to6/src/Lake.f90
+++ b/utils/mf5to6/src/Lake.f90
@@ -249,7 +249,7 @@ contains
     type(ListType), pointer :: list
     type(LakeType), pointer :: lake
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => lake
     call list%Add(obj)
@@ -264,7 +264,7 @@ contains
     integer, intent(in) :: idx
     type(LakeType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => list%GetItem(idx)
     res => CastAsLakeType(obj)

--- a/utils/mf5to6/src/LakeConnection.f90
+++ b/utils/mf5to6/src/LakeConnection.f90
@@ -80,7 +80,7 @@ contains
     type(ListType), pointer :: list
     type(LakeConnectionType), pointer :: lakeConnection
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => lakeConnection
     call list%Add(obj)
@@ -95,7 +95,7 @@ contains
     integer, intent(in) :: idx
     type(LakeConnectionType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => list%GetItem(idx)
     res => CastAsLakeConnectionType(obj)

--- a/utils/mf5to6/src/LakeOutlet.f90
+++ b/utils/mf5to6/src/LakeOutlet.f90
@@ -80,7 +80,7 @@ contains
     type(ListType), pointer :: list
     type(LakeOutletType), pointer :: lakeOutlet
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => lakeOutlet
     call list%Add(obj)
@@ -95,7 +95,7 @@ contains
     integer, intent(in) :: idx
     type(LakeOutletType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => list%GetItem(idx)
     res => CastAsLakeOutletType(obj)

--- a/utils/mf5to6/src/LakeTributary.f90
+++ b/utils/mf5to6/src/LakeTributary.f90
@@ -49,7 +49,7 @@ contains
     type(ListType), pointer :: list
     type(LakeTributaryType), pointer :: lakeTrib
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => lakeTrib
     call list%Add(obj)
@@ -64,7 +64,7 @@ contains
     integer, intent(in) :: idx
     type(LakeTributaryType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => list%GetItem(idx)
     res => CastAsLakeTributaryType(obj)

--- a/utils/mf5to6/src/Model.f90
+++ b/utils/mf5to6/src/Model.f90
@@ -760,7 +760,7 @@ contains
     class(ModelType) :: this
     class(PackageWriterType), pointer :: PkgWriter
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     PkgWriter%iulist = this%iulist
     obj => PkgWriter
@@ -1157,7 +1157,7 @@ contains
     ! local
     class(PackageWriterType), pointer :: pkgWriter => null()
     integer :: i, indxLak, indxSfr, npkg
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     logical :: destroyValue
     !
     indxLak = 0

--- a/utils/mf5to6/src/ModelPackage.f90
+++ b/utils/mf5to6/src/ModelPackage.f90
@@ -43,7 +43,7 @@ contains
     type(ListType) :: modpkglist
     type(ModelPackageType), pointer, intent(inout) :: modpkg
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => modpkg
     call modpkglist%Add(obj)
@@ -58,7 +58,7 @@ contains
     integer, intent(in) :: idx
     type(ModelPackageType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => modpkgList%GetItem(idx)
     res => CastAsModelPackageType(obj)

--- a/utils/mf5to6/src/Mover.f90
+++ b/utils/mf5to6/src/Mover.f90
@@ -101,7 +101,7 @@ contains
     type(ListType) :: moverList
     type(MoverType), pointer :: mover
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => mover
     call moverList%Add(obj)
@@ -116,7 +116,7 @@ contains
     integer, intent(in) :: idx
     type(MoverType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => moverList%GetItem(idx)
     res => CastAsMoverType(obj)

--- a/utils/mf5to6/src/Preproc/FileList.f90
+++ b/utils/mf5to6/src/Preproc/FileList.f90
@@ -143,7 +143,7 @@ contains
     type(FileType), pointer :: file
     ! local variables
     character(len=500) :: msg
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     type(FileType), pointer :: filePtr => null()
     logical :: killonfailurelocal
     ! format
@@ -187,7 +187,7 @@ contains
     character(len=*),    intent(in) :: ftype
     type(FileType), pointer :: file
     ! local variables
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     type(FileType), pointer :: filePtr => null()
     character(len=500) :: msg
     ! format
@@ -221,7 +221,7 @@ contains
     integer, intent(in) :: indx
     type(FileType), pointer :: fil
     ! local variables
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     fil => null()
     obj => this%files%GetItem(indx)
@@ -237,7 +237,7 @@ contains
     class(FileListType), intent(inout) :: this
     type(FileType), pointer :: fil
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     fil => null()
     obj => this%files%GetNextItem()
@@ -255,7 +255,7 @@ contains
     ! local variables
     type(FileType), pointer :: fileptr
     integer :: iu
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     character(len=MAXCHARLEN) :: ermsg, ermsgio
     !
     obj => this%files%GetItem(1)

--- a/utils/mf5to6/src/Preproc/Preproc.f90
+++ b/utils/mf5to6/src/Preproc/Preproc.f90
@@ -555,7 +555,7 @@ contains
     integer :: i
     character(len=MAXCHARLEN) :: ermsg
     type(Dis3dType), pointer :: dis3d
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => this%dis
     dis3d => CastAsDis3dType(obj)

--- a/utils/mf5to6/src/SfrDiversion.f90
+++ b/utils/mf5to6/src/SfrDiversion.f90
@@ -62,7 +62,7 @@ contains
     type(ListType), pointer :: DiversionList
     type(SfrDiversionType), pointer :: diversion
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => diversion
     call DiversionList%Add(obj)
@@ -77,7 +77,7 @@ contains
     integer, intent(in) :: idx
     type(SfrDiversionType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     res => null()
     obj => DiversionList%GetItem(idx)

--- a/utils/mf5to6/src/SfrPackageWriter.f90
+++ b/utils/mf5to6/src/SfrPackageWriter.f90
@@ -83,7 +83,7 @@ contains
     ! dummy
     type(SfrPackageWriterType), pointer, intent(inout) :: sfrPkgWriter
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => sfrPkgWriter
     call AllSfrPkgWriters%Add(obj)
@@ -97,7 +97,7 @@ contains
     integer, intent(in) :: idx
     type(SfrPackageWriterType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     res => null()
     obj => AllSfrPkgWriters%GetItem(idx)

--- a/utils/mf5to6/src/SfrReach.f90
+++ b/utils/mf5to6/src/SfrReach.f90
@@ -181,7 +181,7 @@ contains
     integer, intent(in) :: idx
     type(SfrReachType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => reachList%GetItem(idx)
     res => CastAsSfrReachType(obj)
@@ -195,7 +195,7 @@ contains
     type(ListType), pointer :: reachList
     type(SfrReachType), pointer :: reach
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => reach
     call reachList%Add(obj)

--- a/utils/mf5to6/src/SfrSegment.f90
+++ b/utils/mf5to6/src/SfrSegment.f90
@@ -61,7 +61,7 @@ contains
     class(SfrSegmentType) :: this
     type(SfrReachType), pointer :: reach
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => reach
     call this%SegReaches%Add(obj)
@@ -117,7 +117,7 @@ contains
     integer, intent(in) :: idx
     type(SfrSegmentType), pointer :: res
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => segmentList%GetItem(idx)
     res => CastAsSfrSegmentType(obj)
@@ -131,7 +131,7 @@ contains
     type(ListType), pointer :: segmentList
     type(SfrSegmentType), pointer :: segmnt
     ! local
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     !
     obj => segmnt
     call segmentList%Add(obj)

--- a/utils/mf5to6/src/SimFileWriter.f90
+++ b/utils/mf5to6/src/SimFileWriter.f90
@@ -125,7 +125,7 @@ contains
     type(ModelType), pointer  :: parent => null()
     type(ModelType), pointer  :: child => null()
     type(ExchangeType), pointer :: exchange => null()
-    class(*), pointer :: obj
+    class(*), pointer :: obj => null()
     ! formats
     1 format()
     10 format(a)


### PR DESCRIPTION
Initilization to null() to determine if the intermittent mf5to6 CI
segfault errors can be eliminated.