### PR TITLE
fix(uzf): set proper iuzno index for water-content observation type

### DIFF
--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -174,7 +174,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
 	\underline{BASIC FUNCTIONALITY}
 	\begin{itemize}
-	        \item --
+	        \item -- The UZF water-content observation was inappropriately erroring-out owing to a check that was using the wrong index to retrieve the cell top and bottom elevations for the requested uzf observation.  With the properindex now applied, the output works as expected.
 	        \item --
 	\end{itemize}
 

--- a/src/Model/GroundWaterFlow/gwf3uzf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3uzf8.f90
@@ -2544,6 +2544,7 @@ contains
     integer(I4B) :: j
     integer(I4B) :: n
     integer(I4B) :: nn
+    integer(I4B) :: iuzid
     real(DP) :: obsdepth
     real(DP) :: dmax
     character(len=LENBOUNDNAME) :: bname
@@ -2617,7 +2618,8 @@ contains
           obsrv%dblPak1 = obsdepth
           !
           ! -- determine maximum cell depth
-          dmax = this%uzfobj%celtop(n) - this%uzfobj%celbot(n)
+          iuzid = obsrv%intPak1
+          dmax = this%uzfobj%celtop(iuzid) - this%uzfobj%celbot(iuzid)
           ! -- check that obs depth is valid; call store_error if not
           ! -- need to think about a way to put bounds on this depth
           if (obsdepth < DZERO .or. obsdepth > dmax) then


### PR DESCRIPTION
Clean redo of #660 that now includes fixes from #662