### PR TITLE
fix(warnings): resolve character truncation warnings

### DIFF
--- a/src/Model/GroundWaterTransport/gwt1fmi1.f90
+++ b/src/Model/GroundWaterTransport/gwt1fmi1.f90
@@ -913,7 +913,7 @@ module GwtFmiModule
             !
             ! -- Open the budget file and start filling it
             iapt = iapt + 1
-            pname = keyword
+            pname = keyword(1:LENPACKAGENAME)
             call this%parser%GetStringCaps(keyword)
             if(keyword /= 'FILEIN') then
               call store_error('PACKAGE NAME MUST BE FOLLOWED BY ' //     &

--- a/src/Model/NumericalPackage.f90
+++ b/src/Model/NumericalPackage.f90
@@ -235,6 +235,7 @@ module NumericalPackageModule
     logical :: endOfBlock
     integer(I4B) :: nsize
     integer(I4B) :: j
+    character(len=24)         :: tmpvar
     character(len=LENVARNAME) :: varname
     character(len=LINELENGTH) :: errmsg, keyword
     character(len=:), allocatable :: line
@@ -256,10 +257,11 @@ module NumericalPackageModule
           lkeyword = .true.
           lfound(j) = .true.
           if (present(varinames)) then
-            varname = adjustl(varinames(j))
+            tmpvar = adjustl(varinames(j))
           else
-            varname = adjustl(tags(j))
+            tmpvar = adjustl(tags(j))
           end if
+          varname = tmpvar(1:LENVARNAME)
           if (keyword(1:1) == 'I') then
             call mem_setptr(aint, trim(varname), trim(this%memoryPath))
             call this%dis%read_grid_array(line, lloc, istart, istop, this%iout,  &

--- a/src/Utilities/Constants.f90
+++ b/src/Utilities/Constants.f90
@@ -23,7 +23,7 @@ module ConstantsModule
   integer(I4B), parameter :: LENOBSNAME = 40
   integer(I4B), parameter :: LENOBSTYPE = 30
   integer(I4B), parameter :: LENTIMESERIESNAME = LENOBSNAME
-  integer(I4B), parameter :: LENTIMESERIESTEXT = 12
+  integer(I4B), parameter :: LENTIMESERIESTEXT = 16
   integer(I4B), parameter :: LENDATETIME = 30
   integer(I4B), parameter :: LINELENGTH = 300
   integer(I4B), parameter :: LENLISTLABEL = 500

--- a/utils/mf5to6/src/MF2005/pcgn2.f90
+++ b/utils/mf5to6/src/MF2005/pcgn2.f90
@@ -83,7 +83,7 @@ CONTAINS
           STOP
        ELSE
           IF (LEN_TRIM(CHAR_STRING)==0) CYCLE
-          CHECK=CHAR_STRING
+          CHECK=CHAR_STRING(1:1)
           IF (CHECK=='#') CYCLE
           L_COUNT=L_COUNT+1
           DATA_STRING(L_COUNT)=TRIM(CHAR_STRING)

--- a/utils/mf5to6/src/ModelConverter.f90
+++ b/utils/mf5to6/src/ModelConverter.f90
@@ -7,7 +7,7 @@ module ModelConverterModule
   ! own ModelConverterType object.
 
   use ConstantsModule, only: LINELENGTH, MAXCHARLEN, LENBIGLINE, &
-                             LENMODELNAME, LENPACKAGENAME
+                             LENMODELNAME, LENPACKAGENAME, LENFTYPE
   use DrnObsWriterModule, only: createDrnObsWriter, DrnObsWriterType
   use FileTypeModule, only: FileType
   use GLOBAL, only: IFREFM, IUNIT, MXITER, iout, cbcfilename
@@ -94,7 +94,7 @@ contains
     character(len=maxcharlen) :: msg
     character(len=MAXCHARLEN) :: fname, fname15
     character(len=12)         :: filtyp15
-    character(len=4)          :: filtype
+    character(len=LENFTYPE)   :: filtype
     logical                   :: lex, lop
     class(PackageWriterType), pointer :: pkgWriPtr => null()
     type(FileType),           pointer :: cbcfil => null(), filptr => null()

--- a/utils/mf5to6/src/Mover.f90
+++ b/utils/mf5to6/src/Mover.f90
@@ -45,7 +45,7 @@ contains
     character(len=*), intent(in) :: provPkgType, recPkgType
     double precision, optional, intent(in):: valu
     ! local
-    character(len=10) :: mvrTypeCaps
+    character(len=9) :: mvrTypeCaps
     character(len=MAXCHARLEN) :: ermsg
     !
     allocate(newMover)

--- a/utils/mf5to6/src/OutputControlWriter.f90
+++ b/utils/mf5to6/src/OutputControlWriter.f90
@@ -209,7 +209,7 @@ contains
     !
     ! Find CBC file - identified by I**CB option in one or more packages.
     ! E.g. ILPFCB for LPF package.
-    this%BdSvFil = cbcfilename
+    this%BdSvFil = cbcfilename(1:LINELENGTH)
     !
 !    ! Ensure that HdSvFil and DdSvFil are not the same file.
 !    if (this%HdSvFil /= '') then

--- a/utils/mf5to6/src/Preproc/FileList.f90
+++ b/utils/mf5to6/src/Preproc/FileList.f90
@@ -1,6 +1,6 @@
 module FileListModule
 
-  use ConstantsModule,     only: LENBIGLINE, MAXCHARLEN
+  use ConstantsModule,     only: LINELENGTH, MAXCHARLEN
   use ConstantsPHMFModule, only: FCUNKNOWN, FCINPUT, FCDATAIN, FCDATABIN, &
                                  FCDATAOUT, FCOUTPUT, FCDATABOUT
   use FileTypeModule,      only: FileType, ConstructFileType, CastAsFileType
@@ -51,7 +51,7 @@ contains
     implicit none
     ! dummy arguments
     class(FileListType), intent(inout) :: this
-    character(len=*),    intent(in) :: fname
+    character(len=LINELENGTH), intent(in) :: fname
     character(len=*),    intent(in) :: ftype
     integer,             intent(in) :: iu
     integer,             intent(in) :: FCode
@@ -293,7 +293,7 @@ contains
     implicit none
     ! dummy
     character(len=*), intent(in) :: fnamein
-    character(len=LENBIGLINE)    :: fnameout
+    character(len=LINELENGTH)    :: fnameout
     ! local
     integer :: i, j, leng
     !logical :: relative

--- a/utils/mf5to6/src/Preproc/GlobalVariables.f90
+++ b/utils/mf5to6/src/Preproc/GlobalVariables.f90
@@ -13,7 +13,7 @@ module GlobalVariablesModule
             msgc
 
   character(len=60) :: prognamconv, prognamlong
-  character(len=40) :: mfvnam
+  character(len=48) :: mfvnam
   parameter (prognamconv='Mf5to6')
   parameter (prognamlong=trim(prognamconv)//' - Converter for MODFLOW (2005, NWT, LGR) to MODFLOW 6')
   parameter (mfvnam='Version ' // VERSION)

--- a/utils/mf5to6/src/Preproc/ObsBlock.f90
+++ b/utils/mf5to6/src/Preproc/ObsBlock.f90
@@ -2,7 +2,7 @@ module ObsBlockModule
   
   use BlockParserModule,         only: BlockParserType
   use ConstantsModule,           only: DONE, DZERO, &
-                                       LINELENGTH, MAXCHARLEN 
+                                       LINELENGTH, MAXCHARLEN, LENOBSNAME
   use GenericUtilitiesModule,    only: IS_SAME
   use ConstantsPHMFModule,       only: CONTINUOUS, SINGLE, LENOBSNAMENEW
   use DnmDis3dModule,            only: Dis3dType
@@ -156,7 +156,7 @@ contains
         !
         ! Construct an ObserveType object for this observation.
         call ConstructObservation(newobs, this%isorc, time, layer, 0, fmtd)
-        newobs%Name = word
+        newobs%Name = word(1:LENOBSNAME)
         !
         ! Determine row and column indices based on X and Y coordinates.
         call dis3d%get_cell(xcoord, ycoord, irow, jcol, gridX, gridY)

--- a/utils/mf5to6/src/Preproc/SimPHMF.f90
+++ b/utils/mf5to6/src/Preproc/SimPHMF.f90
@@ -580,7 +580,7 @@ subroutine ustop(stopmess,ioutlocal)
 !  character(len=*), parameter :: msgc = 'Conversion successful!'
   character(len=*), parameter :: msgw = &
       'Program terminated normally, but see warning(s) above.'
-  character(len=300) :: msg
+  character(len=MAXCHARLEN) :: msg
   logical :: warnings_found
   logical :: errorfound
   logical :: success


### PR DESCRIPTION
Compiling with gfortran's -Wcharacter-truncation option, the following warnings appear:
```
/home/mtoews/src/modflow6/src/Model/NumericalPackage.f90:259:43:

             varname = adjustl(varinames(j))
                                           1
Warning: CHARACTER expression will be truncated in assignment (16/24) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/src/Model/NumericalPackage.f90:261:38:

             varname = adjustl(tags(j))
                                      1
Warning: CHARACTER expression will be truncated in assignment (16/24) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/src/Model/GroundWaterTransport/gwt1fmi1.f90:916:27:

             pname = keyword
                           1
Warning: CHARACTER expression will be truncated in assignment (16/300) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/src/Model/GroundWaterTransport/gwt1cnc1.f90:480:39:

           tslink%Text = 'CONCENTRATION'
                                       1
Warning: CHARACTER expression will be truncated in assignment (12/13) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/src/Model/NumericalPackage.f90:259:43:

             varname = adjustl(varinames(j))
                                           1
Warning: CHARACTER expression will be truncated in assignment (16/24) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/src/Model/NumericalPackage.f90:261:38:

             varname = adjustl(tags(j))
                                      1
Warning: CHARACTER expression will be truncated in assignment (16/24) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/src/Model/GroundWaterTransport/gwt1fmi1.f90:916:27:

             pname = keyword
                           1
Warning: CHARACTER expression will be truncated in assignment (16/300) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/src/Model/GroundWaterTransport/gwt1cnc1.f90:480:39:

           tslink%Text = 'CONCENTRATION'
                                       1
Warning: CHARACTER expression will be truncated in assignment (12/13) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/utils/mf5to6/src/Preproc/GlobalVariables.f90:19:20:

   parameter (mfvnam='Version ' // VERSION)
                    1
Warning: CHARACTER expression at (1) is being truncated (48/40) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/utils/mf5to6/src/Preproc/SimPHMF.f90:613:14:

     msg = msgc
              1
Warning: CHARACTER expression will be truncated in assignment (300/5000) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/utils/mf5to6/src/Preproc/FileList.f90:68:49:

         newFile%fname = localize_file_name(fname)
                                                 1
Warning: CHARACTER expression will be truncated in assignment (300/5000) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/utils/mf5to6/src/Preproc/ObsBlock.f90:159:26:

         newobs%Name = word
                          1
Warning: CHARACTER expression will be truncated in assignment (40/300) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/utils/mf5to6/src/Mover.f90:69:36:

       newMover%MvrType = mvrTypeCaps
                                    1
Warning: CHARACTER expression will be truncated in assignment (9/10) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/utils/mf5to6/src/MF2005/pcgn2.f90:86:27:

           CHECK=CHAR_STRING
                           1
Warning: CHARACTER expression will be truncated in assignment (1/256) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/utils/mf5to6/src/OutputControlWriter.f90:212:30:

     this%BdSvFil = cbcfilename
                              1
Warning: CHARACTER expression will be truncated in assignment (300/5000) at (1) [-Wcharacter-truncation]
/home/mtoews/src/modflow6/utils/mf5to6/src/ModelConverter.f90:411:28:

       filtype = filptr%FType
                            1
Warning: CHARACTER expression will be truncated in assignment (4/5) at (1) [-Wcharacter-truncation]
```
Changes to resolve these warnings include:
 * ConstantsModule: increase LENTIMESERIESTEXT from 12 to 16
 * GwtFmiModule: cut pname to LENPACKAGENAME
 * NumericalPackageModule: cut varname to LENVARNAME
 * pcgn2: cut CHAR_STRING to 1
 * ModelConverterModule: increase filtype from 4 to 5 (LENFTYPE)
 * ConstructWaterMover: decrease mvrTypeCaps frm 10 to 9 (matches MvrType)
 * OutputControlWriterModule: cut cbcfilename to LINELENGTH
 * FileListModule: reduce fname from LENBIGLINE to LINELENGTH
 * GlobalVariablesModule: increase mfvnam from 40 to 48
 * ObsBlockModule: cut word to LENOBSNAME
 * SimModule: increase msg from 300 to MAXCHARLEN (matches msgc)