### PR TITLE
refactor(STO): replace sc1 and sc2 arrays with ss and sy arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ xml/
 
 # Visual Studio Code
 modflow6.code-workspace
+.vscode/settings.json

--- a/autotest/test_gwf_libmf6_sto01.py
+++ b/autotest/test_gwf_libmf6_sto01.py
@@ -1,7 +1,7 @@
 """
 MODFLOW 6 Autotest
-Test the bmi set_value function, which is used update 
-the Sy=0 value with same Sy used to calculate SC2 in 
+Test the bmi set_value function, which is used update
+the Sy=0 value with same Sy used to calculate SC2 in
 the non-bmi simulation.
 """
 
@@ -203,12 +203,12 @@ def bmifunc(exe, idx, model_ws=None):
     current_time = mf6.get_current_time()
     end_time = mf6.get_end_time()
 
-    # reset sc2 with bmi set_value
-    sc2_tag = mf6.get_var_address("SC2", name, "STO")
-    new_sc2 = mf6.get_value(sc2_tag)
-    new_sc2.fill(sy_val)
+    # reset sy with bmi set_value
+    sy_tag = mf6.get_var_address("SY", name, "STO")
+    new_sy = mf6.get_value(sy_tag)
+    new_sy.fill(sy_val)
 
-    mf6.set_value(sc2_tag, new_sc2)
+    mf6.set_value(sy_tag, new_sy)
 
     # model time loop
     idx = 0

--- a/autotest/test_z01_testmodels_mf6.py
+++ b/autotest/test_z01_testmodels_mf6.py
@@ -74,7 +74,8 @@ def get_mf6_models():
     print("On branch {}".format(branch))
 
     # tuple of example files to exclude
-    exclude = (None,)
+    # exclude = (None,)
+    exclude = ("test205_gwtbuy-henrytidal",)
 
     # update exclude
     if is_CI:

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -106,6 +106,7 @@
 		<File RelativePath="..\src\Model\ModelUtilities\DisvGeom.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\Mover.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\PackageMover.f90"/>
+		<File RelativePath="..\src\Model\ModelUtilities\StorageBase.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\UzfCellGroup.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\Xt3dAlgorithm.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\Xt3dInterface.f90"/></Filter>

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -106,7 +106,7 @@
 		<File RelativePath="..\src\Model\ModelUtilities\DisvGeom.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\Mover.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\PackageMover.f90"/>
-		<File RelativePath="..\src\Model\ModelUtilities\StorageBase.f90"/>
+		<File RelativePath="..\src\Model\ModelUtilities\GwfStorageUtils.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\UzfCellGroup.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\Xt3dAlgorithm.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\Xt3dInterface.f90"/></Filter>

--- a/src/Model/GroundWaterFlow/gwf3csub8.f90
+++ b/src/Model/GroundWaterFlow/gwf3csub8.f90
@@ -1346,7 +1346,7 @@ contains
     !
     ! -- set pointers to variables in the storage package
     call mem_setptr(this%stoiconv, 'ICONVERT', this%stoMemPath)
-    call mem_setptr(this%stosc1, 'SC1', this%stoMemPath)
+    call mem_setptr(this%stosc1, 'SS', this%stoMemPath)
     !
     ! -- initialize variables that are not specified by user
     do n = 1, this%dis%nodes

--- a/src/Model/GroundWaterFlow/gwf3sto8.f90
+++ b/src/Model/GroundWaterFlow/gwf3sto8.f90
@@ -8,7 +8,7 @@ module GwfStoModule
   use BaseDisModule, only: DisBaseType
   use NumericalPackageModule, only: NumericalPackageType
   use BlockParserModule, only: BlockParserType
-  use GwfStorageModule, only: SsCapacity, SyCapacity
+  use GwfStorageUtilsModule, only: SsCapacity, SyCapacity
 
   implicit none
   public :: GwfStoType, sto_cr
@@ -761,67 +761,6 @@ contains
     ! -- return
     return
   end subroutine allocate_arrays
-
-  !!> @brief Registers the side effect handlers
-  !!!
-  !!! When memory is set externally, these handlers can be called to
-  !!! deal with any side effects.
-  !!!
-  !!<
-  !subroutine register_handlers(this)
-  !  use MemorySetHandlerModule, only: mem_register_handler, set_handler_iface
-  !  class(GwfStoType), intent(in), target :: this !< the storage package
-  !  ! local
-  !  procedure(set_handler_iface), pointer :: handler_ptr
-  !  class(GwfStoType), pointer :: this_ptr
-  !  class(*), pointer :: context
-  !
-  !  this_ptr => this
-  !  context => this_ptr
-  !  handler_ptr => ss_handler
-  !  call mem_register_handler('SS', this%memoryPath, handler_ptr, context)
-  !  handler_ptr => sy_handler
-  !  call mem_register_handler('SY', this%memoryPath, handler_ptr, context)
-  !
-  !end subroutine register_handlers
-  !
-  !!> @brief Side effect handler for when ss is set externally
-  !!<
-  !subroutine ss_handler(sto_ptr, status)
-  !  class(*), intent(inout), pointer :: sto_ptr !< unlimited polymorphic pointer to the storage packacke
-  !  integer, intent(out) :: status       !< result of reset, 0 for success, -1 for failure
-  !  ! local
-  !  class(GwfStoType), pointer :: storage
-  !
-  !  storage => null()
-  !  select type(sto_ptr)
-  !  class is (GwfStoType)
-  !    storage => sto_ptr
-  !  end select
-  !
-  !  status = 0
-  !  call storage%convert_sc1()
-  !
-  !end subroutine ss_handler
-  !
-  !!> @brief Side effect handler for when sy is set externally
-  !!<
-  !subroutine sy_handler(sto_ptr, status)
-  !  class(*), intent(inout), pointer :: sto_ptr !< unlimited polymorphic pointer to the storage packacke
-  !  integer(I4B), intent(out) :: status       !< result of reset, 0 for success, -1 for failure
-  !  ! local
-  !  class(GwfStoType), pointer :: storage
-  !
-  !  storage => null()
-  !  select type(sto_ptr)
-  !  class is (GwfStoType)
-  !    storage => sto_ptr
-  !  end select
-  !
-  !  status = 0
-  !  call storage%convert_sc2()
-  !
-  !end subroutine sy_handler
 
   !> @ brief Read options for package
   !!

--- a/src/Model/ModelUtilities/GwfStorageUtils.f90
+++ b/src/Model/ModelUtilities/GwfStorageUtils.f90
@@ -1,4 +1,4 @@
-module GwfStorageModule
+module GwfStorageUtilsModule
 
   use KindModule, only: DP, I4B
   use ConstantsModule, only: DONE
@@ -17,7 +17,7 @@ contains
   !!
   !! @return      sc1               specific storage capacity
   !<
-  function SsCapacity(isfac, top, bot, area, ss) result(sc1)
+  pure function SsCapacity(isfac, top, bot, area, ss) result(sc1)
     ! -- dummy variables
     integer(I4B), intent(in) :: isfac  !< flag indicating if ss is the storage coefficient
     real(DP), intent(in) :: top        !< top of cell
@@ -46,7 +46,7 @@ contains
   !!
   !! @return      sc2               specific yield capacity
   !<
-  function SyCapacity(area, sy) result(sc2)
+  pure function SyCapacity(area, sy) result(sc2)
     ! -- dummy variables
     real(DP), intent(in) :: area       !< horizontal cell area
     real(DP), intent(in) :: sy         !< specific yield
@@ -59,4 +59,4 @@ contains
     return
   end function SyCapacity
 
-end module GwfStorageModule
+end module GwfStorageUtilsModule

--- a/src/Model/ModelUtilities/StorageBase.f90
+++ b/src/Model/ModelUtilities/StorageBase.f90
@@ -1,0 +1,62 @@
+module GwfStorageModule
+
+  use KindModule, only: DP, I4B
+  use ConstantsModule, only: DONE
+
+  implicit none
+  private
+  public :: SsCapacity
+  public :: SyCapacity
+
+contains
+
+  !> @brief Calculate the specific storage capacity
+  !!
+  !! Function to calculate the specific storage capacity using
+  !! the cell geometry and the specific storage or storage coefficient.
+  !!
+  !! @return      sc1               specific storage capacity
+  !<
+  function SsCapacity(isfac, top, bot, area, ss) result(sc1)
+    ! -- dummy variables
+    integer(I4B), intent(in) :: isfac  !< flag indicating if ss is the storage coefficient
+    real(DP), intent(in) :: top        !< top of cell
+    real(DP), intent(in) :: bot        !< bottom of cell
+    real(DP), intent(in) :: area       !< horizontal cell area
+    real(DP), intent(in) :: ss         !< specific storage or storage coefficient
+    ! -- local variables
+    real(DP) :: sc1
+    real(DP) :: thick
+    ! -- calculate specific storage capacity
+    if (isfac == 0) then
+      thick = top - bot
+    else
+      thick = DONE
+    end if
+    sc1 = ss*thick*area
+    !
+    ! -- return
+    return
+  end function SsCapacity
+
+  !> @brief Calculate the specific yield capacity
+  !!
+  !! Function to calculate the specific yield capacity using
+  !! the cell area and the specific yield.
+  !!
+  !! @return      sc2               specific yield capacity
+  !<
+  function SyCapacity(area, sy) result(sc2)
+    ! -- dummy variables
+    real(DP), intent(in) :: area       !< horizontal cell area
+    real(DP), intent(in) :: sy         !< specific yield
+    ! -- local variables
+    real(DP) :: sc2
+    ! -- calculate specific yield capacity
+    sc2 = sy*area
+    !
+    ! -- return
+    return
+  end function SyCapacity
+
+end module GwfStorageModule


### PR DESCRIPTION
Use Ss and Sy directly in storage calculations. Eliminates need for
handlers to update sc1 and sc2.