### PR TITLE
fix(SmoothingFunctions): process optional ta in sSlope and sSlopeDerivative

### DIFF
--- a/src/Utilities/SmoothingFunctions.f90
+++ b/src/Utilities/SmoothingFunctions.f90
@@ -634,7 +634,7 @@ end subroutine sChSmooth
     !
     ! -- set smoothing variable a
     if (present(ta)) then
-      a = a
+      a = ta
     else
       a = DEM8
     end if
@@ -683,7 +683,7 @@ end subroutine sChSmooth
     !
     ! -- set smoothing variable a
     if (present(ta)) then
-      a = a
+      a = ta
     else
       a = DEM8
     end if
@@ -907,5 +907,3 @@ end subroutine sChSmooth
   end function sQuadraticSlopeDerivative 
   
 end module SmoothingModule
-    
-    


### PR DESCRIPTION
The optional `ta` argument was not properly processed in functions `sSlope` and `sSlopeDerivative`.

These functions are not used anywhere else in the codebase.