### PR TITLE
fix(NumericalSolution): revert fix for issue 655

### DIFF
--- a/autotest/common_regression.py
+++ b/autotest/common_regression.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 try:
     import pymake
@@ -45,6 +46,15 @@ def get_home_dir():
     print("HOME: {}".format(home))
 
     return home
+
+
+def set_mf6_regression():
+    mf6_regression = True
+    for arg in sys.argv:
+        if arg.lower() in ("--original_regression", "-oreg"):
+            mf6_regression = False
+            break
+    return mf6_regression
 
 
 def is_directory_available(example_basedir):

--- a/autotest/simulation.py
+++ b/autotest/simulation.py
@@ -698,9 +698,7 @@ class Simulation(object):
                         100.0 * abs(v0[idx] - v1[idx]) / abs(v0[idx])
                     )
                     percent_diffmax = percent_diff.max()
-                    indices = np.where(
-                        percent_diff == percent_diffmax
-                    )[0]
+                    indices = np.where(percent_diff == percent_diffmax)[0]
                     if percent_diffmax > self.pdtol:
                         success_tst = False
                         msg = (

--- a/autotest/test_z01_testmodels_mf6.py
+++ b/autotest/test_z01_testmodels_mf6.py
@@ -27,6 +27,7 @@ from common_regression import (
     get_example_dirs,
     get_select_dirs,
     get_select_packages,
+    set_mf6_regression,
 )
 
 
@@ -175,7 +176,7 @@ def test_mf6model():
     for on_dir in example_dirs:
         yield run_mf6, Simulation(
             on_dir,
-            mf6_regression=True,
+            mf6_regression=set_mf6_regression(),
             cmp_verbose=False,
         )
 
@@ -200,7 +201,7 @@ def main():
     for on_dir in example_dirs:
         sim = Simulation(
             on_dir,
-            mf6_regression=True,
+            mf6_regression=set_mf6_regression(),
             cmp_verbose=False,
         )
         run_mf6(sim)

--- a/autotest/test_z02_testmodels_mf5to6.py
+++ b/autotest/test_z02_testmodels_mf5to6.py
@@ -31,6 +31,7 @@ from common_regression import (
     get_example_dirs,
     get_select_dirs,
     get_select_packages,
+    set_mf6_regression,
 )
 
 
@@ -201,7 +202,7 @@ def test_model():
     # run the test models
     for on_dir in example_dirs:
         yield run_mf5to6, Simulation(
-            on_dir, mf6_regression=True, cmp_verbose=False
+            on_dir, mf6_regression=set_mf6_regression(), cmp_verbose=False
         )
 
     return
@@ -226,7 +227,9 @@ def main():
 
     # run the test models
     for on_dir in example_dirs:
-        sim = Simulation(on_dir, mf6_regression=True, cmp_verbose=False)
+        sim = Simulation(
+            on_dir, mf6_regression=set_mf6_regression(), cmp_verbose=False
+        )
         run_mf5to6(sim)
 
     return

--- a/autotest/test_z03_largetests.py
+++ b/autotest/test_z03_largetests.py
@@ -25,6 +25,7 @@ from common_regression import (
     get_example_dirs,
     get_select_dirs,
     get_select_packages,
+    set_mf6_regression,
 )
 
 home = get_home_dir()
@@ -125,7 +126,7 @@ def test_mf6model():
     # run the test models
     for on_dir in example_dirs:
         yield run_mf6, Simulation(
-            on_dir, mf6_regression=True, cmp_verbose=False
+            on_dir, mf6_regression=set_mf6_regression(), cmp_verbose=False
         )
 
     return
@@ -147,7 +148,9 @@ def main():
 
     # run the test models
     for on_dir in example_dirs:
-        sim = Simulation(on_dir, mf6_regression=True, cmp_verbose=False)
+        sim = Simulation(
+            on_dir, mf6_regression=set_mf6_regression(), cmp_verbose=False
+        )
         run_mf6(sim)
 
     return


### PR DESCRIPTION
Previous changes to address issue 655 are not necessary as a result
of changes to linear accelerators to trap potential divide by zero
errors and exit the linear iteration loop. Partial refactor of
comments in ims8linear.f90 to be consistent with rest of MODFLOW 6 code.
Added some doxygen comments to ims8linear.f90.