### PR TITLE
feat(uzf): new uzf output option - mean water content for all objects

### DIFF
--- a/autotest/test_gwf_uzf_wc_output.py
+++ b/autotest/test_gwf_uzf_wc_output.py
@@ -1,0 +1,512 @@
+import os
+import sys
+import numpy as np
+import targets
+
+try:
+    import pymake
+except:
+    msg = 'Error. Pymake package is not available.\n'
+    msg += 'Try installing using the following command:\n'
+    msg += ' pip install https://github.com/modflowpy/pymake/zipball/master'
+    raise Exception(msg)
+
+try:
+    import flopy
+except:
+    msg = 'Error. FloPy package is not available.\n'
+    msg += 'Try installing using the following command:\n'
+    msg += ' pip install flopy'
+    raise Exception(msg)
+
+import flopy.utils.binaryfile as bf
+from framework import testing_framework
+from simulation import Simulation
+
+mf6_exe = os.path.abspath(targets.target_dict['mf6'])
+mfnwt_exe = os.path.abspath(targets.target_dict['mfnwt'])
+
+ex = ['uzf_3lay_wc_chk']
+exdirs = []
+iuz_cell_dict = {}
+cell_iuz_dict = {}
+
+for s in ex:
+    exdirs.append(os.path.join('temp', s))
+
+nlay, nrow, ncol = 3, 1, 10
+nper = 6
+perlen = [10.] * 6
+nstp = [10] + [1] * 5
+tsmult = [1.] * len(perlen)
+
+delr = 1.
+delc = 1.
+strt = -25
+
+nouter, ninner = 100, 300
+hclose, rclose, relax = 1e-9, 1e-3, 0.97
+
+top = 0.
+botm = [-5., -20, -30]
+
+icelltype = 1
+k = 100.0
+k33 = 10
+ss = 1e-5
+sy = 0.3
+
+ghbelv1 = -25.5
+ghbelv2 = -10.5
+ghbcond = 1000.
+nwt_ghb_spdat = {0:[[2, 0, 0, ghbelv1, ghbcond],
+                    [2, 0, ncol - 1, ghbelv1, ghbcond]],
+                 3:[[2, 0, 0, ghbelv2, ghbcond],
+                    [2, 0, ncol - 1, ghbelv2, ghbcond]]}
+
+ghbspd = {0: [[(2, 0, 0), ghbelv1, ghbcond], 
+              [(2, 0, ncol - 1), ghbelv1, ghbcond]],
+          3: [[(2, 0, 0), ghbelv2, ghbcond],
+              [(2, 0, ncol - 1), ghbelv2, ghbcond]]}
+
+# iuzno  cellid landflg ivertcn surfdp vks thtr thts thti eps [bndnm]
+surfdep1 = 1.0
+surfdep2 = 0.001
+vks = 0.5
+eps = 4.
+thti = 0.06
+thtr = 0.05
+thts = 0.35
+iuzfbnd = [[0, 1, 1, 1, 1, 1, 1, 1, 1, 0]]
+uzf_pkdat = [
+    [ 0, (0, 0, 1), 1,  8, surfdep1, vks, thtr, thts, thti, eps, "uzf01"],
+    [ 1, (0, 0, 2), 1,  9, surfdep1, vks, thtr, thts, thti, eps, "uzf02"],
+    [ 2, (0, 0, 3), 1, 10, surfdep1, vks, thtr, thts, thti, eps, "uzf03"],
+    [ 3, (0, 0, 4), 1, 11, surfdep1, vks, thtr, thts, thti, eps, "uzf04"],
+    [ 4, (0, 0, 5), 1, 12, surfdep1, vks, thtr, thts, thti, eps, "uzf05"],
+    [ 5, (0, 0, 6), 1, 13, surfdep1, vks, thtr, thts, thti, eps, "uzf06"],
+    [ 6, (0, 0, 7), 1, 14, surfdep1, vks, thtr, thts, thti, eps, "uzf07"],
+    [ 7, (0, 0, 8), 1, 15, surfdep1, vks, thtr, thts, thti, eps, "uzf08"],
+    [ 8, (1, 0, 1), 0, 16, surfdep2, vks, thtr, thts, thti, eps, "uzf09"],
+    [ 9, (1, 0, 2), 0, 17, surfdep2, vks, thtr, thts, thti, eps, "uzf10"],
+    [10, (1, 0, 3), 0, 18, surfdep2, vks, thtr, thts, thti, eps, "uzf11"],
+    [11, (1, 0, 4), 0, 19, surfdep2, vks, thtr, thts, thti, eps, "uzf12"],
+    [12, (1, 0, 5), 0, 20, surfdep2, vks, thtr, thts, thti, eps, "uzf13"],
+    [13, (1, 0, 6), 0, 21, surfdep2, vks, thtr, thts, thti, eps, "uzf14"],
+    [14, (1, 0, 7), 0, 22, surfdep2, vks, thtr, thts, thti, eps, "uzf15"],
+    [15, (1, 0, 8), 0, 23, surfdep2, vks, thtr, thts, thti, eps, "uzf16"],
+    [16, (2, 0, 1), 0, -1, surfdep2, vks, thtr, thts, thti, eps, "uzf17"],
+    [17, (2, 0, 2), 0, -1, surfdep2, vks, thtr, thts, thti, eps, "uzf18"],
+    [18, (2, 0, 3), 0, -1, surfdep2, vks, thtr, thts, thti, eps, "uzf19"],
+    [19, (2, 0, 4), 0, -1, surfdep2, vks, thtr, thts, thti, eps, "uzf20"],
+    [20, (2, 0, 5), 0, -1, surfdep2, vks, thtr, thts, thti, eps, "uzf21"],
+    [21, (2, 0, 6), 0, -1, surfdep2, vks, thtr, thts, thti, eps, "uzf22"],
+    [22, (2, 0, 7), 0, -1, surfdep2, vks, thtr, thts, thti, eps, "uzf23"],
+    [23, (2, 0, 8), 0, -1, surfdep2, vks, thtr, thts, thti, eps, "uzf24"]
+]
+
+for itm in uzf_pkdat:
+    iuz_cell_dict.update({itm[0]: (itm[1][0], itm[1][1], itm[1][2])})
+    cell_iuz_dict.update({(itm[1][0], itm[1][1], itm[1][2]): itm[0]})
+
+nuztop  = 3
+iuzfopt = 1
+irunflg = 0
+ietflg  = 1
+iuzfcb1 = 10
+iuzfcb2 = 0
+ntrail2 = 25
+nsets2 = 80 
+
+extdp = 3.
+extwc = 0.05
+pet0 = 0.0
+pet1 = 0.001
+pet2 = 0.011
+finf1 = 0.001
+finf2 = 0.05
+finf3 = 0.01
+zero = 0.
+uzf1_finf = {0: finf1, 1: finf1, 2: finf2, 3:finf3, 4:finf1, 5:finf1}
+uzf1_pet = {0: pet0, 1: pet1, 2: pet1, 3: pet1, 4: pet2, 5: pet2}
+uzf_spd = {
+    0:[[ 0, finf1, pet0, extdp, extwc, zero, zero, zero],
+       [ 1, finf1, pet0, extdp, extwc, zero, zero, zero],
+       [ 2, finf1, pet0, extdp, extwc, zero, zero, zero],
+       [ 3, finf1, pet0, extdp, extwc, zero, zero, zero],
+       [ 4, finf1, pet0, extdp, extwc, zero, zero, zero],
+       [ 5, finf1, pet0, extdp, extwc, zero, zero, zero],
+       [ 6, finf1, pet0, extdp, extwc, zero, zero, zero],
+       [ 7, finf1, pet0, extdp, extwc, zero, zero, zero],
+       [ 8, zero,  zero,  zero, extwc, zero, zero, zero],
+       [ 9, zero,  zero,  zero, extwc, zero, zero, zero],
+       [10, zero,  zero,  zero, extwc, zero, zero, zero],
+       [11, zero,  zero,  zero, extwc, zero, zero, zero],
+       [12, zero,  zero,  zero, extwc, zero, zero, zero],
+       [13, zero,  zero,  zero, extwc, zero, zero, zero],
+       [14, zero,  zero,  zero, extwc, zero, zero, zero],
+       [15, zero,  zero,  zero, extwc, zero, zero, zero]],
+    
+    1:[[ 0, finf1, pet1, extdp, extwc, zero, zero, zero],
+       [ 1, finf1, pet1, extdp, extwc, zero, zero, zero],
+       [ 2, finf1, pet1, extdp, extwc, zero, zero, zero],
+       [ 3, finf1, pet1, extdp, extwc, zero, zero, zero],
+       [ 4, finf1, pet1, extdp, extwc, zero, zero, zero],
+       [ 5, finf1, pet1, extdp, extwc, zero, zero, zero],
+       [ 6, finf1, pet1, extdp, extwc, zero, zero, zero],
+       [ 7, finf1, pet1, extdp, extwc, zero, zero, zero],
+       [ 8, zero,  zero,  zero, extwc, zero, zero, zero],
+       [ 9, zero,  zero,  zero, extwc, zero, zero, zero],
+       [10, zero,  zero,  zero, extwc, zero, zero, zero],
+       [11, zero,  zero,  zero, extwc, zero, zero, zero],
+       [12, zero,  zero,  zero, extwc, zero, zero, zero],
+       [13, zero,  zero,  zero, extwc, zero, zero, zero],
+       [14, zero,  zero,  zero, extwc, zero, zero, zero],
+       [15, zero,  zero,  zero, extwc, zero, zero, zero]],
+    
+    2:[[ 0, finf2, pet1, extdp, extwc, zero, zero, zero],
+       [ 1, finf2, pet1, extdp, extwc, zero, zero, zero],
+       [ 2, finf2, pet1, extdp, extwc, zero, zero, zero],
+       [ 3, finf2, pet1, extdp, extwc, zero, zero, zero],
+       [ 4, finf2, pet1, extdp, extwc, zero, zero, zero],
+       [ 5, finf2, pet1, extdp, extwc, zero, zero, zero],
+       [ 6, finf2, pet1, extdp, extwc, zero, zero, zero],
+       [ 7, finf2, pet1, extdp, extwc, zero, zero, zero],
+       [ 8, zero,  zero,  zero, extwc, zero, zero, zero],
+       [ 9, zero,  zero,  zero, extwc, zero, zero, zero],
+       [10, zero,  zero,  zero, extwc, zero, zero, zero],
+       [11, zero,  zero,  zero, extwc, zero, zero, zero],
+       [12, zero,  zero,  zero, extwc, zero, zero, zero],
+       [13, zero,  zero,  zero, extwc, zero, zero, zero],
+       [14, zero,  zero,  zero, extwc, zero, zero, zero],
+       [15, zero,  zero,  zero, extwc, zero, zero, zero]],
+           
+    3:[[ 0, finf3, pet1, extdp, extwc, zero, zero, zero],
+       [ 1, finf3, pet1, extdp, extwc, zero, zero, zero],
+       [ 2, finf3, pet1, extdp, extwc, zero, zero, zero],
+       [ 3, finf3, pet1, extdp, extwc, zero, zero, zero],
+       [ 4, finf3, pet1, extdp, extwc, zero, zero, zero],
+       [ 5, finf3, pet1, extdp, extwc, zero, zero, zero],
+       [ 6, finf3, pet1, extdp, extwc, zero, zero, zero],
+       [ 7, finf3, pet1, extdp, extwc, zero, zero, zero],
+       [ 8, zero,  zero,  zero, extwc, zero, zero, zero],
+       [ 9, zero,  zero,  zero, extwc, zero, zero, zero],
+       [10, zero,  zero,  zero, extwc, zero, zero, zero],
+       [11, zero,  zero,  zero, extwc, zero, zero, zero],
+       [12, zero,  zero,  zero, extwc, zero, zero, zero],
+       [13, zero,  zero,  zero, extwc, zero, zero, zero],
+       [14, zero,  zero,  zero, extwc, zero, zero, zero],
+       [15, zero,  zero,  zero, extwc, zero, zero, zero]],
+           
+    4:[[ 0, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 1, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 2, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 3, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 4, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 5, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 6, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 7, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 8, zero,  zero,  zero, extwc, zero, zero, zero],
+       [ 9, zero,  zero,  zero, extwc, zero, zero, zero],
+       [10, zero,  zero,  zero, extwc, zero, zero, zero],
+       [11, zero,  zero,  zero, extwc, zero, zero, zero],
+       [12, zero,  zero,  zero, extwc, zero, zero, zero],
+       [13, zero,  zero,  zero, extwc, zero, zero, zero],
+       [14, zero,  zero,  zero, extwc, zero, zero, zero],
+       [15, zero,  zero,  zero, extwc, zero, zero, zero]],
+    
+    5:[[ 0, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 1, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 2, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 3, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 4, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 5, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 6, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 7, finf1, pet2, extdp, extwc, zero, zero, zero],
+       [ 8, zero,  zero,  zero, extwc, zero, zero, zero],
+       [ 9, zero,  zero,  zero, extwc, zero, zero, zero],
+       [10, zero,  zero,  zero, extwc, zero, zero, zero],
+       [11, zero,  zero,  zero, extwc, zero, zero, zero],
+       [12, zero,  zero,  zero, extwc, zero, zero, zero],
+       [13, zero,  zero,  zero, extwc, zero, zero, zero],
+       [14, zero,  zero,  zero, extwc, zero, zero, zero],
+       [15, zero,  zero,  zero, extwc, zero, zero, zero]],
+}
+
+
+def get_mf6_model(idx, dir):
+    
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+    
+    name = ex[idx]
+    
+    # build MODFLOW 6 files
+    ws = dir
+    sim = flopy.mf6.MFSimulation(sim_name=name, version='mf6',
+                                 exe_name=mf6_exe,
+                                 sim_ws=ws)
+    
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(sim, time_units='DAYS',
+                                 nper=nper, perioddata=tdis_rc)
+    
+    # create gwf model
+    gwf = flopy.mf6.ModflowGwf(sim, 
+                               modelname=name, 
+                               newtonoptions=True,
+                               save_flows=True)
+    
+    # create iterative model solution and register the gwf model with it
+    ims = flopy.mf6.ModflowIms(sim, print_option='SUMMARY',
+                               complexity='MODERATE',
+                               outer_dvclose=hclose,
+                               outer_maximum=nouter,
+                               under_relaxation='DBD',
+                               inner_maximum=ninner,
+                               inner_dvclose=hclose, rcloserecord=rclose,
+                               linear_acceleration='BICGSTAB',
+                               scaling_method='NONE',
+                               reordering_method='NONE',
+                               relaxation_factor=relax)
+    sim.register_ims_package(ims, [gwf.name])
+    
+    dis = flopy.mf6.ModflowGwfdis(gwf, nlay=nlay, nrow=nrow, ncol=ncol,
+                                  delr=delr, delc=delc,
+                                  top=top, botm=botm)
+    
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
+    
+    # node property flow
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True,
+                                  icelltype=icelltype,
+                                  k=k,
+                                  k33=k33)
+    
+    # aquifer storage
+    sto = flopy.mf6.ModflowGwfsto(gwf, 
+                                  iconvert=1, 
+                                  ss=ss,
+                                  sy=sy,
+                                  transient=True)
+    
+    # ghb files
+    ghb = flopy.mf6.ModflowGwfghb(gwf,
+                                  print_flows=True, 
+                                  stress_period_data=ghbspd)
+    
+    # transient uzf info
+    uzf_obs = {'{}.uzfobs'.format(name): 
+        [('uzf01_dpth=0.5', 'water-content', 'uzf01', 0.5),
+         ('uzf01_dpth=1.5', 'water-content', 'uzf01', 1.5),  # Relies on boundnames
+         ('uzf01_dpth=2.5', 'water-content', 'uzf01', 2.5),
+         ('uzf01_dpth=3.5', 'water-content', 'uzf01', 3.5),
+         ('uzf01_dpth=4.49', 'water-content', 'uzf01', 4.49),
+         ('uzf09_dpth=7.5', 'water-content', 'uzf09', 7.5),
+         ('uzf17_dpth=1.0', 'water-content', 'uzf17', 1.0)]}
+    uzf = flopy.mf6.ModflowGwfuzf(gwf, print_flows=True,
+                                  save_flows=True,
+                                  wc_filerecord="wc.bud",
+                                  simulate_et=True,
+                                  simulate_gwseep=True,
+                                  linear_gwet=True,
+                                  boundnames=True,
+                                  observations=uzf_obs,
+                                  ntrailwaves=ntrail2,
+                                  nwavesets=nsets2,
+                                  nuzfcells=len(uzf_pkdat),
+                                  packagedata=uzf_pkdat,
+                                  perioddata=uzf_spd,
+                                  budget_filerecord='{}.uzf.bud'.format(name),
+                                  filename='{}.uzf'.format(name))
+    
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(gwf,
+                                budget_filerecord='{}.cbc'.format(name),
+                                head_filerecord='{}.hds'.format(name),
+                                headprintrecord=[
+                                    ('COLUMNS', 10, 'WIDTH', 15,
+                                     'DIGITS', 6, 'GENERAL')],
+                                saverecord=[('HEAD', 'ALL'),
+                                            ('BUDGET', 'ALL')],
+                                printrecord=[('HEAD', 'ALL'),
+                                             ('BUDGET', 'ALL')],
+                                filename='{}.oc'.format(name))
+    
+    return sim
+
+def get_mfnwt_model(idx, dir):
+    
+    name = ex[idx]
+    
+    # build MODFLOW-NWT files
+    ws = dir
+    mfnwt_ws = os.path.join(ws, "mfnwt")
+    
+    # Instantiate the MODFLOW model
+    mf = flopy.modflow.Modflow(
+        modelname=name, model_ws=mfnwt_ws, version='mfnwt',
+        exe_name=mfnwt_exe
+    )
+    
+    # Instantiate discretization package
+    # units: itmuni=4 (days), lenuni=2 (m)
+    flopy.modflow.ModflowDis(mf, nlay=nlay, nrow=nrow, ncol=ncol, nper=nper,
+                             delr=delr, delc=delc, top=top, botm=botm, 
+                             perlen=perlen, nstp=nstp, itmuni=4, lenuni=2, 
+                             steady=False)
+    
+    # Instantiate basic package
+    flopy.modflow.ModflowBas(mf, ibound=1, strt=strt)
+    
+    # Instantiate layer property flow package
+    flopy.modflow.ModflowUpw(mf, laytyp=icelltype, layvka=0, hk=k, vka=k33)
+    
+    # Instantiate solver package
+    flopy.modflow.ModflowNwt(mf, headtol=1e-8, fluxtol=1)
+    
+    # Instantiate link mass-transport package (for writing cell-by-cell 
+    # water contents)
+    flopy.modflow.ModflowLmt(mf, output_file_format = 'formatted', 
+                             package_flows=["UZF"])
+    
+    # Instantiate general head boundary package
+    ghb = flopy.modflow.ModflowGhb(mf, stress_period_data = nwt_ghb_spdat)
+    
+    # Instantiate unsaturated-zone flow package
+    flopy.modflow.ModflowUzf1(mf, nuztop=nuztop, iuzfopt=iuzfopt, 
+                              irunflg=irunflg, ietflg=ietflg, ipakcb=iuzfcb1,
+                              iuzfcb2=iuzfcb2, ntrail2=ntrail2, nsets=nsets2,
+                              surfdep=surfdep1, iuzfbnd=iuzfbnd, vks=vks, 
+                              eps=eps, thts=thts, thti=thti, thtr=thtr, 
+                              finf=uzf1_finf, pet=uzf1_pet, extdp=extdp, 
+                              extwc=extwc, nwt_11_fmt=True, specifythti=True, 
+                              specifythtr=True)
+    
+    # Instantiate output control (OC) package
+    spd = {
+        (0, 0): ["save head", "save budget", "print budget"],
+        (1, 0): ["save head", "save budget", "print budget"],
+        (2, 0): ["save head", "save budget", "print budget"],
+        (3, 0): ["save head", "save budget", "print budget"],
+        (4, 0): ["save head", "save budget", "print budget"],
+        (5, 0): ["save head", "save budget", "print budget"],
+    }
+    oc = flopy.modflow.ModflowOc(mf, stress_period_data=spd)
+    
+    return mf
+
+ 
+def build_models():
+    for idx, dir in enumerate(exdirs):
+        # Start by building the MF6 model
+        sim = get_mf6_model(idx, dir)
+        # Construct MF-NWT model for comparing water contents
+        mfnwt = get_mfnwt_model(idx, dir)
+        
+        sim.write_simulation()
+        mfnwt.write_input()
+    return sim, mfnwt
+
+def eval_model(sim, mfnwt):
+    print('evaluating model...')
+    
+    name = ex[0]
+    ws = exdirs[0]
+    sim = flopy.mf6.MFSimulation.load(sim_ws=ws)
+    
+    # Get the MF6 heads
+    fpth = os.path.join(ws, 'uzf_3lay_wc_chk.hds')
+    hobj = flopy.utils.HeadFile(fpth, precision='double')
+    hds = hobj.get_alldata()
+    
+    # Get the MF6 water contents
+    wcpth = os.path.join(ws, 'wc.bud')
+    mf6_wc_obj = bf.HeadFile(wcpth, text='    watercontent')
+    
+    ckstpkper_wc = mf6_wc_obj.get_kstpkper()
+
+    mf6_wc = []
+    for current_kstpkper in ckstpkper_wc:
+        wc_rawdat = mf6_wc_obj.get_data(kstpkper = current_kstpkper)
+        wc_tmp = np.zeros((nlay, nrow, ncol))
+        for i, itm in enumerate(uzf_pkdat):
+            lay = itm[1][0]
+            row = itm[1][1]
+            col = itm[1][2]
+            wc_tmp[lay, row, col] = wc_rawdat[0][0][i]
+            
+        mf6_wc.append(wc_tmp)
+    
+    mf6_wc = np.array(mf6_wc)
+    
+    # Retrieve MF-NWT water contents from formatted linker file
+    mfnwt_wc = []
+    nwtwc = os.path.join(ws, 'mfnwt', 'mt3d_link.ftl')
+    with open(nwtwc, 'r') as f:
+        for line in f:
+            if  'WATER CONTENT   '.lower() in line.lower():
+                line = next(f)
+                wc_tmp = []
+                while not '          10           1           3' in line:
+                    m_arr = line.strip().split()
+                    for i, val in enumerate(m_arr):
+                        wc_tmp.append(float(val))
+                    
+                    line = next(f)
+                
+                wc_tmp = np.array(wc_tmp)
+                wc_tmp = wc_tmp.reshape((nlay, nrow, ncol))
+                mfnwt_wc.append(wc_tmp)
+    
+    mfnwt_wc = np.array(mfnwt_wc)
+
+    # Compare MF6 results with NWT
+    # layer 1
+    assert np.allclose(mf6_wc[:, 0, 0, :], mfnwt_wc[:, 0, 0, :], atol=0.01), 'mf6 water contents different than NWT'
+    # layer 2 (has a mixed condition later in the simulation
+    assert np.allclose(mf6_wc[:, 1, 0, :], mfnwt_wc[:, 1, 0, :], atol=0.01), 'mf6 water contents different than NWT'
+
+    print('Finished running checks')
+
+
+# - No need to change any code below
+def test_mf6model():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build and write the model input
+    mf6, mfnwt = build_models()
+
+    # run the test models
+    mf6.run_simulation()
+    mfnwt.run_model()
+
+    return
+
+
+def main():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    mf6, mfnwt = build_models()
+
+    # run the test models
+    mf6.run_simulation()
+    mfnwt.run_model()
+
+    # compare water contents
+    eval_model(mf6, mfnwt)
+
+    return
+
+
+if __name__ == "__main__":
+    # print message
+    print('standalone run of {}'.format(os.path.basename(__file__)))
+
+    # run main routine
+    main()

--- a/autotest/test_gwf_uzf_wc_output.py
+++ b/autotest/test_gwf_uzf_wc_output.py
@@ -308,7 +308,7 @@ def get_mf6_model(idx, dir):
          ('uzf17_dpth=1.0', 'water-content', 'uzf17', 1.0)]}
     uzf = flopy.mf6.ModflowGwfuzf(gwf, print_flows=True,
                                   save_flows=True,
-                                  wc_filerecord="wc.bud",
+                                  wc_filerecord=name + ".uzfwc.bin",
                                   simulate_et=True,
                                   simulate_gwseep=True,
                                   linear_gwet=True,
@@ -423,8 +423,8 @@ def eval_model(sim, mfnwt):
     hds = hobj.get_alldata()
     
     # Get the MF6 water contents
-    wcpth = os.path.join(ws, 'wc.bud')
-    mf6_wc_obj = bf.HeadFile(wcpth, text='    watercontent')
+    wcpth = os.path.join(ws, ex[0] + '.uzfwc.bin')
+    mf6_wc_obj = bf.HeadFile(wcpth, text='   water-content')
     
     ckstpkper_wc = mf6_wc_obj.get_kstpkper()
 

--- a/autotest/test_gwf_uzf_wc_output.py
+++ b/autotest/test_gwf_uzf_wc_output.py
@@ -505,18 +505,25 @@ def eval_model(sim, mfnwt, include_NWT=False):
 
 # - No need to change any code below
 def test_mf6model():
+    include_NWT = False
     # initialize testing framework
     test = testing_framework()
 
     # build and write the model input
-    mf6, mfnwt = build_models()
+    mf6, mfnwt = build_models(include_NWT=include_NWT)
 
     # run the test models
     mf6.run_simulation()
-    mfnwt.run_model()
+    if include_NWT:
+        mfnwt.run_model()
+    
+    # compare water contents
+    if include_NWT:
+        eval_model(mf6, mfnwt)
+    else:
+        eval_model(mf6, None, include_NWT=include_NWT)
 
     return
-
 
 def main():
     include_NWT = False

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -189,7 +189,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\underline{ADVANCED STRESS PACKAGES}
 	\begin{itemize}
 	        \item The UZF water-content observation by depth was giving an error, because a check was using the wrong index to retrieve the cell top and bottom elevations for the requested observation.  The program was modified to use the correct index, and the output is now as expected.  Note that this bug is not related to the new WC keyword in the OPTIONS block, but rather is related to OBS6 output option.
-	        \item --
+	        \item Amend surfdep error check with landflag.  Deep cells (non-land surface cells) should not require surfdep > 0
 	\end{itemize}
 
 %	\underline{SOLUTION}

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -159,7 +159,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\underline{NEW FUNCTIONALITY}
 	\begin{itemize}
 	        \item --  
-	        \item A new option for printing water contents to a dedicated output file has been added to UZF.  To activate, the keyword WATER_CONTENT is added to the OPTIONS block of UZF, followed by FILEOUT, followed by the user-specified output file name, for example 'water-content.uzf.bin'.  The approach is analogous to the STAGE option within the SFR options block.  Contents of the new file will be written in binary and can be read using flopy's binaryfile utility.  A new test, located in the autotest directory and titled est_gwf_uzf_wc_output.py demonstrates how to read the new binary water content output file.
+	        \item A new option for printing water contents to a dedicated output file has been added to UZF.  To activate, the keyword WATER_CONTENT is added to the OPTIONS block of UZF, followed by FILEOUT, followed by the user-specified output file name, for example ``water-content.uzf.bin''.  The approach is analogous to the STAGE option within the SFR options block.  Contents of the new file will be written in binary and can be read using flopy's binaryfile utility.  A new test, located in the autotest directory and titled test_gwf_uzf_wc_output.py demonstrates how to read the new binary water content output file.
 	        \item The residual balance error for groundwater flow and solute transport is now written to the diagonal position of the flowja array.  The flowja array is optionally written to the binary model budget file according to user settings in the output control file and other package input files.
 	\end{itemize}
 	

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -159,6 +159,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\underline{NEW FUNCTIONALITY}
 	\begin{itemize}
 	        \item --  
+	        \item A new option for printing water contents to a dedicated output file has been added to UZF.  To activate, the keyword WC is added to the OPTIONS block of UZF, followed by FILEOUT, followed by the user-specified output file name, for example 'wc.bin'.  The approach is analogous to the STAGE option within the SFR options block.  Contents of the new file will be written in binary and can be read using flopy's binaryfile utility.  A new test, located in the autotest directory and titled est_gwf_uzf_wc_output.py demonstrates how to read the new binary water content output file.
 	        \item The residual balance error for groundwater flow and solute transport is now written to the diagonal position of the flowja array.  The flowja array is optionally written to the binary model budget file according to user settings in the output control file and other package input files.
 	\end{itemize}
 	
@@ -166,7 +167,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\begin{itemize}
 	        \item Added the following new examples: 
 	        \begin{itemize}
-	          \item --
+	          \item -- A new test compares MODFLOW~6 water contents saved with the new WC keyword in the OPTIONS block of UZF to water contents calculated by MF-NWT and written to the linker file (MT3D-USGS) by the LMT package.  The name of the new test is test_gwf_uzf_wc_output.py
 	          \item --
 	        \end{itemize}
 	\end{itemize}
@@ -187,7 +188,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 
 	\underline{ADVANCED STRESS PACKAGES}
 	\begin{itemize}
-	        \item The UZF water-content observation was giving an error, because a check was using the wrong index to retrieve the cell top and bottom elevations for the requested observation.  The program was modified to use the correct index, and the output is now as expected.
+	        \item The UZF water-content observation by depth was giving an error, because a check was using the wrong index to retrieve the cell top and bottom elevations for the requested observation.  The program was modified to use the correct index, and the output is now as expected.  Note that this bug is not related to the new WC keyword in the OPTIONS block, but rather is related to OBS6 output option.
 	        \item --
 	\end{itemize}
 

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -159,7 +159,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\underline{NEW FUNCTIONALITY}
 	\begin{itemize}
 	        \item --  
-	        \item A new option for printing water contents to a dedicated output file has been added to UZF.  To activate, the keyword WATER_CONTENT is added to the OPTIONS block of UZF, followed by FILEOUT, followed by the user-specified output file name, for example ``water-content.uzf.bin''.  The approach is analogous to the STAGE option within the SFR options block.  Contents of the new file will be written in binary and can be read using flopy's binaryfile utility.  A new test, located in the autotest directory and titled test_gwf_uzf_wc_output.py demonstrates how to read the new binary water content output file.
+	        \item A new option for printing water contents to a dedicated output file has been added to UZF.  To activate, the keyword WATER_CONTENT is added to the OPTIONS block of UZF, followed by FILEOUT, followed by the user-specified output file name, for example ``water-content.uzf.bin''.  The approach is analogous to the STAGE option within the SFR options block.  Contents of the new file will be written in binary and can be read using flopy's binaryfile utility.  A new test, located in the autotest directory and titled test_gwf_uzf_wc_output.py demonstrates how to read the new binary water content output file. Also, this same test compares MODFLOW~6 water contents saved with the new WATER_CONTENT keyword in the OPTIONS block of UZF to water contents calculated by MF-NWT and written to the flow and transport linker file by the LMT package.  
 	        \item The residual balance error for groundwater flow and solute transport is now written to the diagonal position of the flowja array.  The flowja array is optionally written to the binary model budget file according to user settings in the output control file and other package input files.
 	\end{itemize}
 	
@@ -167,7 +167,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\begin{itemize}
 	        \item Added the following new examples: 
 	        \begin{itemize}
-	          \item -- A new test compares MODFLOW~6 water contents saved with the new WATER_CONTENT keyword in the OPTIONS block of UZF to water contents calculated by MF-NWT and written to the linker file (MT3D-USGS) by the LMT package.  The name of the new test is test_gwf_uzf_wc_output.py
+	          \item -- 
 	          \item --
 	        \end{itemize}
 	\end{itemize}

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -159,7 +159,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\underline{NEW FUNCTIONALITY}
 	\begin{itemize}
 	        \item --  
-	        \item A new option for printing water contents to a dedicated output file has been added to UZF.  To activate, the keyword WC is added to the OPTIONS block of UZF, followed by FILEOUT, followed by the user-specified output file name, for example 'wc.bin'.  The approach is analogous to the STAGE option within the SFR options block.  Contents of the new file will be written in binary and can be read using flopy's binaryfile utility.  A new test, located in the autotest directory and titled est_gwf_uzf_wc_output.py demonstrates how to read the new binary water content output file.
+	        \item A new option for printing water contents to a dedicated output file has been added to UZF.  To activate, the keyword WATER_CONTENT is added to the OPTIONS block of UZF, followed by FILEOUT, followed by the user-specified output file name, for example 'water-content.uzf.bin'.  The approach is analogous to the STAGE option within the SFR options block.  Contents of the new file will be written in binary and can be read using flopy's binaryfile utility.  A new test, located in the autotest directory and titled est_gwf_uzf_wc_output.py demonstrates how to read the new binary water content output file.
 	        \item The residual balance error for groundwater flow and solute transport is now written to the diagonal position of the flowja array.  The flowja array is optionally written to the binary model budget file according to user settings in the output control file and other package input files.
 	\end{itemize}
 	
@@ -167,7 +167,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\begin{itemize}
 	        \item Added the following new examples: 
 	        \begin{itemize}
-	          \item -- A new test compares MODFLOW~6 water contents saved with the new WC keyword in the OPTIONS block of UZF to water contents calculated by MF-NWT and written to the linker file (MT3D-USGS) by the LMT package.  The name of the new test is test_gwf_uzf_wc_output.py
+	          \item -- A new test compares MODFLOW~6 water contents saved with the new WATER_CONTENT keyword in the OPTIONS block of UZF to water contents calculated by MF-NWT and written to the linker file (MT3D-USGS) by the LMT package.  The name of the new test is test_gwf_uzf_wc_output.py
 	          \item --
 	        \end{itemize}
 	\end{itemize}

--- a/doc/mf6io/gwf/binaryoutput.tex
+++ b/doc/mf6io/gwf/binaryoutput.tex
@@ -275,7 +275,7 @@ The dependent variable can be saved to a binary file for the LAK, SFR, and MAW P
 GWF/LAK & STAGE & Simulated lake stage  \\
 GWF/SFR & STAGE & Simulated stream reach stage  \\
 GWF/MAW & HEAD & Simulated well head  \\
-GWF/UZF & WATER CONTENT & Simulated unsaturated zone cell water content \\
+GWF/UZF & WATER-CONTENT & Simulated unsaturated zone cell water content \\
 GWT/LKT & CONCENTRATION & Simulated lake concentration  \\
 GWT/SFT & CONCENTRATION & Simulated stream reach concentration  \\
 GWT/MWT & CONCENTRATION & Simulated well concentration  \\

--- a/doc/mf6io/gwf/binaryoutput.tex
+++ b/doc/mf6io/gwf/binaryoutput.tex
@@ -275,6 +275,7 @@ The dependent variable can be saved to a binary file for the LAK, SFR, and MAW P
 GWF/LAK & STAGE & Simulated lake stage  \\
 GWF/SFR & STAGE & Simulated stream reach stage  \\
 GWF/MAW & HEAD & Simulated well head  \\
+GWF/UZF & WATER CONTENT & Simulated unsaturated zone cell water content \\
 GWT/LKT & CONCENTRATION & Simulated lake concentration  \\
 GWT/SFT & CONCENTRATION & Simulated stream reach concentration  \\
 GWT/MWT & CONCENTRATION & Simulated well concentration  \\

--- a/doc/mf6io/mf6ivar/dfn/gwf-uzf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-uzf.dfn
@@ -52,6 +52,39 @@ longname save well flows to budget file
 description REPLACE save_flows {'{#1}': 'UZF'}
 
 block options
+name wc_filerecord
+type record wc fileout wcfile
+shape
+reader urword
+tagged true
+optional true
+longname
+description
+
+block options
+name wc
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname watercontent keyword
+description keyword to specify that record corresponds to unsaturated zone water contents.
+
+block options
+name wcfile
+type string
+preserve_case true
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the binary output file to write water content information.
+
+block options
 name budget_filerecord
 type record budget fileout budgetfile
 shape

--- a/doc/mf6io/mf6ivar/dfn/gwf-uzf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-uzf.dfn
@@ -53,7 +53,7 @@ description REPLACE save_flows {'{#1}': 'UZF'}
 
 block options
 name wc_filerecord
-type record wc fileout wcfile
+type record water_content fileout wcfile
 shape
 reader urword
 tagged true
@@ -62,14 +62,14 @@ longname
 description
 
 block options
-name wc
+name water_content
 type keyword
 shape
 in_record true
 reader urword
 tagged true
 optional false
-longname watercontent keyword
+longname water_content keyword
 description keyword to specify that record corresponds to unsaturated zone water contents.
 
 block options

--- a/src/Model/GroundWaterFlow/gwf3uzf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3uzf8.f90
@@ -44,10 +44,10 @@ module UzfModule
     integer(I4B), pointer :: ipakcsv => null()
     !
     type(BudgetObjectType), pointer                    :: budobj      => null()
-    integer(I4B), pointer                              :: bditems     => null()  !number of budget items
-    integer(I4B), pointer                              :: nbdtxt      => null()  !number of budget text items
+    integer(I4B), pointer                              :: bditems     => null()  !< number of budget items
+    integer(I4B), pointer                              :: nbdtxt      => null()  !< number of budget text items
     character(len=LENBUDTXT), dimension(:), pointer,                            &
-                              contiguous               :: bdtxt       => null()  !budget items written to cbc file
+                              contiguous               :: bdtxt       => null()  !< budget items written to cbc file
     character(len=LENBOUNDNAME), dimension(:), pointer,                         &
                                  contiguous :: uzfname => null()
     !
@@ -59,46 +59,45 @@ module UzfModule
     type(UzfCellGroupType)                             :: uzfobjwork
     !
     ! -- pointer to gwf variables
-    integer(I4B), pointer                                  :: gwfiss      => null()
-    real(DP), dimension(:), pointer, contiguous            :: gwftop      => null()
-    real(DP), dimension(:), pointer, contiguous            :: gwfbot      => null()
-    real(DP), dimension(:), pointer, contiguous            :: gwfarea     => null()
-    real(DP), dimension(:), pointer, contiguous            :: gwfhcond    => null()
+    integer(I4B), pointer                              :: gwfiss      => null()
+    real(DP), dimension(:), pointer, contiguous        :: gwftop      => null()
+    real(DP), dimension(:), pointer, contiguous        :: gwfbot      => null()
+    real(DP), dimension(:), pointer, contiguous        :: gwfarea     => null()
+    real(DP), dimension(:), pointer, contiguous        :: gwfhcond    => null()
     !
     ! -- uzf data
-    integer(I4B), pointer                                   :: ntrail       => null()
-    integer(I4B), pointer                                   :: nsets        => null()
-    integer(I4B), pointer                                   :: nwav         => null()
-    integer(I4B), pointer                                   :: nodes        => null()
-    integer(I4B), pointer                                   :: nper         => null()
-    integer(I4B), pointer                                   :: nstp         => null()
-    integer(I4B), pointer                                   :: readflag     => null()
-    integer(I4B), pointer                                   :: outunitbud   => null()
-    integer(I4B), pointer                                   :: ietflag      => null()
-    integer(I4B), pointer                                   :: igwetflag    => null()
-    integer(I4B), pointer                                   :: iseepflag    => null()
-    integer(I4B), pointer                                   :: imaxcellcnt  => null()
-    integer(I4B), pointer                                   :: iuzf2uzf     => null()
+    integer(I4B), pointer                               :: ntrail       => null()
+    integer(I4B), pointer                               :: nsets        => null()
+    integer(I4B), pointer                               :: nwav         => null()
+    integer(I4B), pointer                               :: nodes        => null()
+    integer(I4B), pointer                               :: nper         => null()
+    integer(I4B), pointer                               :: nstp         => null()
+    integer(I4B), pointer                               :: readflag     => null()
+    integer(I4B), pointer                               :: outunitbud   => null()
+    integer(I4B), pointer                               :: ietflag      => null()  !< et flag, 0 is off, 1 or 2 are different types
+    integer(I4B), pointer                               :: igwetflag    => null()
+    integer(I4B), pointer                               :: iseepflag    => null()
+    integer(I4B), pointer                               :: imaxcellcnt  => null()
+    integer(I4B), pointer                               :: iuzf2uzf     => null()
     ! -- integer vectors
-    integer(I4B), dimension(:), pointer, contiguous         :: igwfnode     => null()
-    integer(I4B), dimension(:), pointer, contiguous         :: ia           => null()
-    integer(I4B), dimension(:), pointer, contiguous         :: ja           => null()
+    integer(I4B), dimension(:), pointer, contiguous     :: igwfnode     => null()
+    integer(I4B), dimension(:), pointer, contiguous     :: ia => null()
+    integer(I4B), dimension(:), pointer, contiguous     :: ja => null()
     ! -- double precision output vectors
-    real(DP), dimension(:), pointer, contiguous             :: appliedinf   => null()
-    real(DP), dimension(:), pointer, contiguous             :: rejinf       => null()
-    real(DP), dimension(:), pointer, contiguous             :: rejinf0      => null()
-    real(DP), dimension(:), pointer, contiguous             :: rejinftomvr  => null()
-    real(DP), dimension(:), pointer, contiguous             :: infiltration => null()
-    real(DP), dimension(:), pointer, contiguous             :: recharge     => null()
-    real(DP), dimension(:), pointer, contiguous             :: gwet         => null()
-    real(DP), dimension(:), pointer, contiguous             :: uzet         => null()
-    real(DP), dimension(:), pointer, contiguous             :: gwd          => null()
-    real(DP), dimension(:), pointer, contiguous             :: gwd0         => null()
-    real(DP), dimension(:), pointer, contiguous             :: gwdtomvr     => null()
-    real(DP), dimension(:), pointer, contiguous             :: rch          => null()
-    real(DP), dimension(:), pointer, contiguous             :: rch0         => null()
-    real(DP), dimension(:), pointer, contiguous             :: qsto         => null()
-    real(DP), dimension(:), pointer, contiguous             :: dbuff        => null()
+    real(DP), dimension(:), pointer, contiguous         :: appliedinf   => null()
+    real(DP), dimension(:), pointer, contiguous         :: rejinf       => null()
+    real(DP), dimension(:), pointer, contiguous         :: rejinf0      => null()
+    real(DP), dimension(:), pointer, contiguous         :: rejinftomvr  => null()
+    real(DP), dimension(:), pointer, contiguous         :: infiltration => null()
+    real(DP), dimension(:), pointer, contiguous         :: gwet         => null()
+    real(DP), dimension(:), pointer, contiguous         :: uzet         => null()
+    real(DP), dimension(:), pointer, contiguous         :: gwd          => null()
+    real(DP), dimension(:), pointer, contiguous         :: gwd0         => null()
+    real(DP), dimension(:), pointer, contiguous         :: gwdtomvr     => null()
+    real(DP), dimension(:), pointer, contiguous         :: rch          => null()
+    real(DP), dimension(:), pointer, contiguous         :: rch0         => null()
+    real(DP), dimension(:), pointer, contiguous         :: qsto         => null()
+    real(DP), dimension(:), pointer, contiguous         :: watercontent => null()
     !
     ! -- timeseries aware variables
     real(DP), dimension(:), pointer, contiguous :: sinf => null()
@@ -118,11 +117,6 @@ module UzfModule
     !
     ! budget variables
     real(DP), pointer                          :: totfluxtot  => null()
-    real(DP), pointer                          :: infilsum    => null()
-    real(DP), pointer                          :: rechsum     => null()
-    real(DP), pointer                          :: delstorsum  => null()
-    real(DP), pointer                          :: uzetsum     => null()
-    real(DP), pointer                          :: vfluxsum    => null()
     integer(I4B), pointer                      :: issflag     => null()
     integer(I4B), pointer                      :: issflagold  => null()
     integer(I4B), pointer                      :: istocb      => null()
@@ -131,11 +125,6 @@ module UzfModule
     integer(I4B), pointer :: cbcauxitems => NULL()
     character(len=16), dimension(:), pointer, contiguous :: cauxcbc => NULL()
     real(DP), dimension(:), pointer, contiguous :: qauxcbc => null()
-    !
-    ! -- observations
-    real(DP), dimension(:), pointer, contiguous            :: obs_theta   => null()
-    real(DP), dimension(:), pointer, contiguous            :: obs_depth   => null()
-    integer(I4B), dimension(:), pointer, contiguous        :: obs_num     => null()
 
   contains
 
@@ -271,14 +260,6 @@ contains
       call this%uzfobj%sethead(i, hgwf)
     end do
     !
-    ! allocate space to store moisture content observations
-    n = this%obs%npakobs
-    if ( n > 0 ) then
-      call mem_reallocate(this%obs_theta, n, 'OBS_THETA', this%memoryPath)
-      call mem_reallocate(this%obs_depth, n, 'OBS_DEPTH', this%memoryPath)
-      call mem_reallocate(this%obs_num, n, 'OBS_NUM', this%memoryPath)
-    end if
-    !
     ! -- setup pakmvrobj
     if (this%imover /= 0) then
       allocate(this%pakmvrobj)
@@ -314,7 +295,6 @@ contains
     call mem_allocate(this%rejinf0, this%nodes, 'REJINF0', this%memoryPath)
     call mem_allocate(this%rejinftomvr, this%nodes, 'REJINFTOMVR', this%memoryPath)
     call mem_allocate(this%infiltration, this%nodes, 'INFILTRATION', this%memoryPath)
-    call mem_allocate(this%recharge, this%nodes, 'RECHARGE', this%memoryPath)
     call mem_allocate(this%gwet, this%nodes, 'GWET', this%memoryPath)
     call mem_allocate(this%uzet, this%nodes, 'UZET', this%memoryPath)
     call mem_allocate(this%gwd, this%nodes, 'GWD', this%memoryPath)
@@ -342,7 +322,6 @@ contains
     ! -- initialize
     do i = 1, this%nodes
       this%appliedinf(i) = DZERO
-      this%recharge(i) = DZERO
       this%rejinf(i) = DZERO
       this%rejinf0(i) = DZERO
       this%rejinftomvr(i) = DZERO
@@ -385,15 +364,16 @@ contains
     this%bdtxt(4) = '        UZF-GWET'
     this%bdtxt(5) = '  UZF-GWD TO-MVR'
     !
-    ! -- allocate and initialize dbuff
+    ! -- allocate and initialize watercontent array
     if (this%iwcontout > 0) then
-      call mem_allocate(this%dbuff, this%nodes, 'DBUFF', this%memoryPath)
+      call mem_allocate(this%watercontent, this%nodes, 'WATERCONTENT', this%memoryPath)
       do i = 1, this%nodes
-        this%dbuff(i) = DZERO
+        this%watercontent(i) = DZERO
       end do
     else
-      call mem_allocate(this%dbuff, 0, 'DBUFF', this%memoryPath)
-    end if    !
+      call mem_allocate(this%watercontent, 0, 'WATERCONTENT', this%memoryPath)
+    end if   
+    !
     ! -- allocate character array for aux budget text
     allocate(this%cauxcbc(this%cbcauxitems))
     allocate(this%uzfname(this%nodes))
@@ -403,11 +383,6 @@ contains
     do i = 1, this%cbcauxitems
       this%qauxcbc(i) = DZERO
     end do
-    !
-    ! -- Allocate obs members
-    call mem_allocate(this%obs_theta, 0, 'OBS_THETA', this%memoryPath)
-    call mem_allocate(this%obs_depth, 0, 'OBS_DEPTH', this%memoryPath)
-    call mem_allocate(this%obs_num, 0, 'OBS_NUM', this%memoryPath)
     !
     ! -- return
     return
@@ -1118,8 +1093,9 @@ contains
       call this%pakmvrobj%fc()
     endif
     !
-    ! -- Solve UZF
-    call this%uzf_solve()
+    ! -- Solve UZF; set reset_state to true so that waves are reset back to
+    !    initial position for each outer iteration
+    call this%uzf_solve(reset_state=.true.)
     !
     ! -- Copy package rhs and hcof into solution rhs and amat
     do i = 1, this%nodes
@@ -1360,7 +1336,6 @@ contains
   subroutine uzf_cq(this, x, flowja, iadv)
 ! **************************************************************************
 ! uzf_cq -- Calculate flows
-  ! -- todo: this is not finished yet.  Need to unweave bd into cq and bdsav!
 ! **************************************************************************
 !
 !    SPECIFICATIONS:
@@ -1376,154 +1351,46 @@ contains
     real(DP), dimension(:), contiguous, intent(inout) :: flowja
     integer(I4B), optional, intent(in) :: iadv
     ! -- local
-    class(ObserveType),   pointer :: obsrv => null()
     integer(I4B) :: i
-    integer(I4B) :: n, m, ivertflag, ierr
-    real(DP) :: rfinf
-    real(DP) :: rin,rout,rsto,ret,retgw,rgwseep,rvflux
-    real(DP) :: hgwf,hgwflm1,rrech
-    real(DP) :: trhsgwet,thcofgwet,derivgwet
-    real(DP) :: qfrommvr, qformvr, qgwformvr
-    real(DP) :: qfinf
-    real(DP) :: qrejinf
-    real(DP) :: qrejinftomvr
+    integer(I4B) :: n
     real(DP) :: qout
     real(DP) :: qfact
     real(DP) :: qtomvr
-    real(DP) :: sqtomvr
     real(DP) :: q
-    real(DP) :: rfrommvr
-    real(DP) :: qseep
-    real(DP) :: qseeptomvr
-    real(DP) :: qgwet
-    real(DP) :: cvv
-    integer(I4B) :: numobs
     ! -- for observations
-    integer(I4B) :: j
     ! -- formats
     character(len=*), parameter :: fmttkk = &
       "(1X,/1X,A,'   PERIOD ',I0,'   STEP ',I0)"
 ! ------------------------------------------------------------------------------
     !
-    ! -- initialize accumulators
-    ierr = 0
-    rfinf = DZERO
-    rin = DZERO
-    rout = DZERO
-    rrech = DZERO
-    rsto = DZERO
-    ret = DZERO
-    retgw = DZERO
-    rgwseep = DZERO
-    rvflux = DZERO
-    qfinf = DZERO
-    qfrommvr = DZERO
-    qtomvr = DZERO
-    qrejinf = DZERO
-    qrejinftomvr = DZERO
-    sqtomvr = DZERO
-    rfrommvr = DZERO
-    qseep = DZERO
-    qseeptomvr = DZERO
-    qgwet = DZERO
-    this%uzfobj%pet = this%uzfobj%petmax
+    ! -- Make uzf solution using final solution
+    call this%uzf_solve(reset_state=.false.)
+    !
+    ! -- call base functionality in bnd_cq.  This will calculate uzf-gwf flows
+    !    and put them into this%simvals and this%simvtomvr
+    call this%BndType%bnd_cq(x, flowja, iadv=1)
     !
     ! -- Go through and process each UZF cell
     do i = 1, this%nodes
       !
       ! -- Initialize variables
       n = this%nodelist(i)
-      ivertflag = this%uzfobj%ivertcon(i)
       !
       ! -- Skip if cell is not active
       if (this%ibound(n) < 1) cycle
       !
-      ! -- Water mover added to infiltration
-      qfrommvr = DZERO
-      qformvr = DZERO
-      if(this%imover == 1) then
-        qfrommvr = this%pakmvrobj%get_qfrommvr(i)
-        rfrommvr = rfrommvr + qfrommvr
-      endif
-      !
-      hgwf = this%xnew(n)
-      !
-      m = n
-      hgwflm1 = hgwf
-      !
-      ! -- for now set cvv = DZERO
-      ! cvv = this%gwfhcond(m)
-      cvv = DZERO
-      !
-      ! -- Get obs information, check if there is obs in uzf cell
-      numobs = 0
-      do j = 1, this%obs%npakobs
-        obsrv => this%obs%pakobs(j)%obsrv
-        if ( obsrv%intPak1 == i ) then
-          numobs = numobs + 1
-          this%obs_num(numobs) = j
-          this%obs_depth(j) = obsrv%dblPak1
-        end if
-      end do
-      !
-      ! -- Call budget routine of the uzf kinematic object
-      ! todo: this will require additional work for ATS because waves are moved forward
-      !       without a way to restore the state
-      call this%uzfobj%budget(ivertflag,i,this%totfluxtot,                     &
-                              rfinf,rin,rout,rsto,ret,retgw,rgwseep,rvflux,    &
-                              this%ietflag,this%iseepflag,this%issflag,hgwf,   &
-                              hgwflm1,cvv,numobs,this%obs_num,                 &
-                              this%obs_depth,this%obs_theta,qfrommvr,qformvr,  &
-                              qgwformvr,ierr)
-      if ( ierr > 0 ) then
-        if ( ierr == 1 ) &
-          errmsg = 'UZF variable NWAVESETS needs to be increased.'
-        call store_error(errmsg)
-        call ustop()
-      end if 
-
-      !
-      ! -- Calculate gwet
-      if (this%igwetflag > 0) then
-        call this%uzfobj%setgwpet(i)
-        derivgwet = DZERO
-        call this%uzfobj%simgwet(this%igwetflag, i, hgwf, trhsgwet, thcofgwet, &
-                                 derivgwet)
-        retgw = retgw + this%uzfobj%gwet(i)
-      end if
-      !
-      ! -- distribute PET to deeper cells
-        if (this%ietflag > 0) then
-          if (this%uzfobj%ivertcon(i) > 0) then
-            call this%uzfobj%setbelowpet(i, ivertflag)
-          end if
-        end if
-      !
-      ! -- Calculate flows for cbc output and observations
-      if (hgwf > this%uzfobj%celbot(i)) then
-        this%recharge(i) = this%uzfobj%totflux(i) * this%uzfobj%uzfarea(i) / delt
-      else
-        if (ivertflag == 0) then
-          this%recharge(i) = this%uzfobj%surflux(i) * this%uzfobj%uzfarea(i)
-        else
-          this%recharge(i) = this%uzfobj%surflux(ivertflag) * this%uzfobj%uzfarea(i)
-        end if
-      end if
-
-      this%rch(i) = this%uzfobj%totflux(i) * this%uzfobj%uzfarea(i) / delt
-
+      ! -- infiltration terms
       this%appliedinf(i) = this%uzfobj%sinf(i) * this%uzfobj%uzfarea(i)
       this%infiltration(i) = this%uzfobj%surflux(i) * this%uzfobj%uzfarea(i)
-
-      this%rejinf(i) = this%uzfobj%finf_rej(i) * this%uzfobj%uzfarea(i)
-
+      !
+      ! -- qtomvr
       qout = this%rejinf(i) + this%uzfobj%surfseep(i)
       qtomvr = DZERO
       if (this%imover == 1) then
         qtomvr = this%pakmvrobj%get_qtomvr(i)
-        sqtomvr = sqtomvr + qtomvr
       end if
-
+      !
+      ! -- rejected infiltration
       qfact = DZERO
       if (qout > DZERO) then
         qfact = this%rejinf(i) / qout
@@ -1540,7 +1407,8 @@ contains
         q = DZERO
       end if
       this%rejinf(i) = q
-
+      !
+      ! -- calculate groundwater discharge and what goes to mover
       this%gwd(i) = this%uzfobj%surfseep(i)
       qfact = DZERO
       if (qout > DZERO) then
@@ -1558,37 +1426,19 @@ contains
         q = DZERO
       end if
       this%gwd(i) = q
-
-      qfinf = qfinf + this%appliedinf(i)
-      qrejinf = qrejinf + this%rejinf(i)
-      qrejinftomvr = qrejinftomvr + this%rejinftomvr(i)
-
-      qseep = qseep + this%gwd(i)
-      qseeptomvr = qseeptomvr + this%gwdtomvr(i)
-
+      !
+      ! -- set mean water contents for cells
+      !    analogous to what NWT writes to the linker file for MT3D
+      this%watercontent(i) = this%uzfobj%get_water_content(i)
+      !
+      ! -- calculate and store remaining budget terms
       this%gwet(i) = this%uzfobj%gwet(i)
       this%uzet(i) = this%uzfobj%etact(i) * this%uzfobj%uzfarea(i) / delt
       this%qsto(i) = this%uzfobj%delstor(i) / delt
-
-      ! -- accumulate groundwater et
-      qgwet = qgwet + this%gwet(i)
-      
-      !todo: need to accumulate into flowja
-
       !
       ! -- End of UZF cell loop
       !
     end do
-    !
-    ! add cumulative flows to UZF budget
-    this%infilsum = rin * delt
-    this%rechsum = rout * delt
-    rrech = rout
-    this%delstorsum = rsto * delt
-    this%uzetsum = ret * delt
-    this%vfluxsum = rvflux
-    !
-    !
     !
     ! -- fill the budget object
     call this%uzf_fill_budobj()
@@ -1662,7 +1512,7 @@ contains
     title = trim(adjustl(this%bdtxt(itxt))) // ' PACKAGE (' // trim(this%packName) //     &
             ') FLOW RATES'
     call save_print_model_flows(icbcfl, ibudfl, icbcun, this%iprflow, &
-    this%outputtab, this%nbound, this%nodelist, -this%rch, &
+    this%outputtab, this%nbound, this%nodelist, this%rch, &
     this%ibound, title, this%bdtxt(itxt), this%ipakcb, this%dis, this%naux, &
     this%name_model, this%name_model, this%name_model, this%packName, &
     this%auxname, this%auxvar, this%iout, this%inamedbound, this%boundname)
@@ -1739,17 +1589,6 @@ contains
     integer(I4B), intent(in) :: idvsave
     integer(I4B), intent(in) :: idvprint
     integer(I4B) :: ibinun
-    integer(I4B) :: n
-    integer(I4B) :: i
-    real(DP) :: top
-    real(DP) :: bot
-    real(DP) :: carea
-    real(DP) :: wc
-    real(DP) :: uzwatvol
-    real(DP) :: theta_r
-    real(DP) :: thk
-    real(DP) :: v
-    real(DP) :: hgwf
     !
     ! -- set unit number for binary dependent variable output
     ibinun = 0
@@ -1758,26 +1597,11 @@ contains
     end if
     if(idvsave == 0) ibinun = 0
     !
-    ! -- write uzf binary moisture-content output 
+    ! -- write uzf binary moisture-content output
     if (ibinun > 0) then
-      do n = 1, this%nodes
-        i = this%nodelist(n)
-        hgwf = this%xnew(i)
-        top = this%uzfobj%celtop(n) 
-        bot = this%uzfobj%celbot(n)
-        carea = this%uzfobj%uzfarea(n)
-        if ( hgwf > bot ) bot = hgwf
-        thk = top - bot
-        v = thk * carea
-        theta_r = this%uzfobj%THTR(n)
-        uzwatvol = (this%uzfobj%uzstor(n) + theta_r * thk) * carea
-        wc =  uzwatvol / v
-        this%dbuff(n) = wc
-      end do
-      call ulasav(this%dbuff, '   WATER-CONTENT', kstp, kper, pertim, totim,   &
-                  this%nodes, 1, 1, ibinun)
-    end if
-    !
+      call ulasav(this%watercontent, '   WATER-CONTENT', kstp, kper, pertim, &
+                  totim, this%nodes, 1, 1, ibinun)
+    end if 
   end subroutine uzf_ot_dv
   
   subroutine uzf_ot_bdsummary(this, kstp, kper, iout)
@@ -1825,7 +1649,7 @@ contains
     return
   end subroutine uzf_ot
 
-  subroutine uzf_solve(this)
+  subroutine uzf_solve(this, reset_state)
 ! ******************************************************************************
 ! uzf_solve -- Formulate the HCOF and RHS terms
 ! ******************************************************************************
@@ -1834,14 +1658,16 @@ contains
 ! ------------------------------------------------------------------------------
     ! -- modules
     use TdisModule, only : delt
+    logical, intent(in) :: reset_state         !< flag indicating that waves should be reset after solution
     ! -- dummy
     class(UzfType) :: this
     ! -- locals
     integer(I4B) :: i, ivertflag
     integer(I4B) :: n, m, ierr
     real(DP) :: trhs1, thcof1, trhs2, thcof2
-    real(DP) :: hgwf, hgwflm1, cvv, uzderiv, derivgwet
-    real(DP) :: qfrommvr, qformvr
+    real(DP) :: hgwf, uzderiv, derivgwet
+    real(DP) :: qfrommvr
+    real(DP) :: qformvr
 ! ------------------------------------------------------------------------------
     !
     ! -- Initialize
@@ -1850,15 +1676,21 @@ contains
     !
     ! -- Calculate hcof and rhs for each UZF entry
     do i = 1, this%nodes
+      !
+      ! -- Initialize hcof/rhs terms
+      this%hcof(i) = DZERO
+      this%rhs(i) = DZERO
       thcof1 = DZERO
       thcof2 = DZERO
       trhs1 = DZERO
       trhs2 = DZERO
       uzderiv = DZERO
       derivgwet = DZERO
+      !
+      ! -- Initialize variables
+      n = this%nodelist(i)
       ivertflag = this%uzfobj%ivertcon(i)
       !
-      n = this%nodelist(i)
       if ( this%ibound(n) > 0 ) then
         !
         ! -- Water mover added to infiltration
@@ -1868,22 +1700,16 @@ contains
           qfrommvr = this%pakmvrobj%get_qfrommvr(i)
         endif
         !
-        ! -- zero out hcof and rhs
-        this%hcof(i) = DZERO
-        this%rhs(i) = DZERO
-        !
         hgwf = this%xnew(n)
-        !
         m = n
-        hgwflm1 = hgwf
-        cvv = DZERO
         !
         ! -- solve for current uzf cell
-        call this%uzfobj%formulate(this%uzfobjwork, ivertflag, i,              &
-                                    this%totfluxtot, this%ietflag,             &
-                                    this%issflag,this%iseepflag,               &
-                                    trhs1,thcof1,hgwf,hgwflm1,cvv,uzderiv,     &
-                                    qfrommvr,qformvr,ierr,ivertflag)
+        call this%uzfobj%solve(this%uzfobjwork, ivertflag, i,                  &
+                               this%totfluxtot, this%ietflag,                  &
+                               this%issflag,this%iseepflag, hgwf,              &
+                               qfrommvr, ierr,                                 &
+                               reset_state=reset_state,                        &
+                               trhs=trhs1, thcof=thcof1, deriv=uzderiv)
         !
         ! -- terminate if an error condition has occurred
         if (ierr > 0) then
@@ -1892,7 +1718,8 @@ contains
             call store_error(errmsg)
             call ustop()
         end if
-        
+        !
+        ! -- Calculate gwet
         if ( this%igwetflag > 0 ) then
           call this%uzfobj%setgwpet(i)
           call this%uzfobj%simgwet(this%igwetflag,i,hgwf,trhs2,thcof2,         &
@@ -1905,7 +1732,8 @@ contains
             call this%uzfobj%setbelowpet(i, ivertflag)
           end if
         end if
-        
+        !
+        ! -- store derivative for Newton addition to equations in _fn()
         this%deriv(i) = uzderiv + derivgwet
         !
         ! -- save current rejected infiltration, groundwater recharge, and
@@ -1920,6 +1748,7 @@ contains
         !
         ! -- add spring discharge and rejected infiltration to mover
         if(this%imover == 1) then
+          qformvr = this%gwd(i) + this%rejinf(i)
           call this%pakmvrobj%accumulate_qformvr(i, qformvr)
         endif
       !
@@ -2565,7 +2394,7 @@ contains
             case ('NET-INFILTRATION')
               v = this%infiltration(n)
             case ('WATER-CONTENT')
-              v = this%obs_theta(i)  ! more than one obs per node
+              v = this%uzfobj%get_water_content_at_depth(n, obsrv%obsDepth)
             case default
               errmsg = 'Unrecognized observation type: ' // trim(obsrv%ObsTypeId)
               call store_error(errmsg)
@@ -2653,12 +2482,13 @@ contains
         !    by a boundname that is assigned to more than one element
         if (obsrv%ObsTypeId == 'WATER-CONTENT') then
           n = obsrv%indxbnds_count
-          if (n > 1) then
+          if (n /= 1) then
             write (errmsg, '(a,3(1x,a))')                                        &
               trim(adjustl(obsrv%ObsTypeId)), 'for observation',                 &
               trim(adjustl(obsrv%Name)),                                         &
               'must be assigned to a UZF cell with a unique boundname.'
             call store_error(errmsg)
+            call ustop()
           end if
           !
           ! -- check WATER-CONTENT depth
@@ -2668,6 +2498,8 @@ contains
           obsrv%dblPak1 = obsdepth
           !
           ! -- determine maximum cell depth
+          ! -- This is presently complicated for landflag = 1 cells and surfdep
+          !    greater than zero.  In this case, celtop is gwftop - surfdep.
           iuzid = obsrv%intPak1
           dmax = this%uzfobj%celtop(iuzid) - this%uzfobj%celbot(iuzid)
           ! -- check that obs depth is valid; call store_error if not
@@ -2782,11 +2614,6 @@ contains
     call mem_allocate(this%nwav, 'NWAV', this%memoryPath)
     call mem_allocate(this%outunitbud, 'OUTUNITBUD', this%memoryPath)
     call mem_allocate(this%totfluxtot, 'TOTFLUXTOT', this%memoryPath)
-    call mem_allocate(this%infilsum, 'INFILSUM', this%memoryPath)
-    call mem_allocate(this%uzetsum, 'UZETSUM', this%memoryPath)
-    call mem_allocate(this%rechsum, 'RECHSUM', this%memoryPath)
-    call mem_allocate(this%vfluxsum, 'VFLUXSUM', this%memoryPath)
-    call mem_allocate(this%delstorsum, 'DELSTORSUM', this%memoryPath)
     call mem_allocate(this%bditems, 'BDITEMS', this%memoryPath)
     call mem_allocate(this%nbdtxt, 'NBDTXT', this%memoryPath)
     call mem_allocate(this%issflag, 'ISSFLAG', this%memoryPath)
@@ -2806,11 +2633,6 @@ contains
     this%iwcontout = 0
     this%ibudgetout = 0
     this%ipakcsv = 0
-    this%infilsum = DZERO
-    this%uzetsum = DZERO
-    this%rechsum = DZERO
-    this%delstorsum = DZERO
-    this%vfluxsum = DZERO
     this%istocb = 0
     this%bditems = 7
     this%nbdtxt = 5
@@ -2878,11 +2700,6 @@ contains
     call mem_deallocate(this%nwav)
     call mem_deallocate(this%outunitbud)
     call mem_deallocate(this%totfluxtot)
-    call mem_deallocate(this%infilsum)
-    call mem_deallocate(this%uzetsum)
-    call mem_deallocate(this%rechsum)
-    call mem_deallocate(this%vfluxsum)
-    call mem_deallocate(this%delstorsum)
     call mem_deallocate(this%bditems)
     call mem_deallocate(this%nbdtxt)
     call mem_deallocate(this%issflag)
@@ -2905,7 +2722,6 @@ contains
     call mem_deallocate(this%rejinf0)
     call mem_deallocate(this%rejinftomvr)
     call mem_deallocate(this%infiltration)
-    call mem_deallocate(this%recharge)
     call mem_deallocate(this%gwet)
     call mem_deallocate(this%uzet)
     call mem_deallocate(this%gwd)
@@ -2916,7 +2732,7 @@ contains
     call mem_deallocate(this%qsto)
     call mem_deallocate(this%deriv)
     call mem_deallocate(this%qauxcbc)
-    call mem_deallocate(this%dbuff)
+    call mem_deallocate(this%watercontent)
     !
     ! -- deallocate integer arrays
     call mem_deallocate(this%ia)
@@ -2931,11 +2747,6 @@ contains
     call mem_deallocate(this%hroot)
     call mem_deallocate(this%rootact)
     call mem_deallocate(this%uauxvar)
-    !
-    ! -- deallocate obs variables
-    call mem_deallocate(this%obs_theta)
-    call mem_deallocate(this%obs_depth)
-    call mem_deallocate(this%obs_num)
     !
     ! -- Parent object
     call this%BndType%bnd_da()

--- a/src/Model/GroundWaterFlow/gwf3uzf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3uzf8.f90
@@ -466,14 +466,14 @@ contains
       !  write(this%iout,'(4x,a)') trim(adjustl(this%text))// &
       !    ' WATERCONTENT WILL BE PRINTED TO LISTING FILE.'
       !  found = .true.
-      case('WC')
+      case('WATER_CONTENT')
         call this%parser%GetStringCaps(keyword)
         if (keyword == 'FILEOUT') then
           call this%parser%GetString(fname)
           this%iwcontout = getunit()
           call openfile(this%iwcontout, this%iout, fname, 'DATA(BINARY)',  &
                        form, access, 'REPLACE', mode_opt=MNORMAL)
-          write(this%iout,fmtuzfbin) 'WATERCONTENT', fname, this%iwcontout
+          write(this%iout,fmtuzfbin) 'WATER-CONTENT', fname, this%iwcontout
           found = .true.
         else
           call store_error('OPTIONAL WATER_CONTENT KEYWORD MUST BE FOLLOWED BY FILEOUT')
@@ -1774,7 +1774,7 @@ contains
         wc =  uzwatvol / v
         this%dbuff(n) = wc
       end do
-      call ulasav(this%dbuff, '    WATERCONTENT', kstp, kper, pertim, totim,   &
+      call ulasav(this%dbuff, '   WATER-CONTENT', kstp, kper, pertim, totim,   &
                   this%nodes, 1, 1, ibinun)
     end if
     !

--- a/src/Model/GroundWaterFlow/gwf3uzf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3uzf8.f90
@@ -2089,7 +2089,7 @@ contains
         !
         ! -- surfdep
         surfdep =  this%parser%GetDouble()
-        if (surfdep <= DZERO) then   !need to check for cell thickness
+        if (surfdep <= DZERO .and. landflag > 0) then   !need to check for cell thickness
           write(errmsg,'(a,1x,i0,1x,a,1x,g0,a)')                                 &
             'SURFDEP for uzf cell', i,                                           &
             'must be greater than 0 (specified value is', surfdep, ').'

--- a/src/Model/GroundWaterFlow/gwf3uzf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3uzf8.f90
@@ -365,14 +365,10 @@ contains
     this%bdtxt(5) = '  UZF-GWD TO-MVR'
     !
     ! -- allocate and initialize watercontent array
-    if (this%iwcontout > 0) then
-      call mem_allocate(this%watercontent, this%nodes, 'WATERCONTENT', this%memoryPath)
-      do i = 1, this%nodes
-        this%watercontent(i) = DZERO
-      end do
-    else
-      call mem_allocate(this%watercontent, 0, 'WATERCONTENT', this%memoryPath)
-    end if   
+    call mem_allocate(this%watercontent, this%nodes, 'WATERCONTENT', this%memoryPath)
+    do i = 1, this%nodes
+      this%watercontent(i) = DZERO
+    end do  
     !
     ! -- allocate character array for aux budget text
     allocate(this%cauxcbc(this%cbcauxitems))
@@ -1429,9 +1425,7 @@ contains
       !
       ! -- set mean water contents for cells
       !    analogous to what NWT writes to the linker file for MT3D
-      if (this%iwcontout /= 0) then
-        this%watercontent(i) = this%uzfobj%get_water_content(i)
-      end if
+      this%watercontent(i) = this%uzfobj%get_water_content(i)
       !
       ! -- calculate and store remaining budget terms
       this%gwet(i) = this%uzfobj%gwet(i)

--- a/src/Model/GroundWaterFlow/gwf3uzf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3uzf8.f90
@@ -1429,7 +1429,9 @@ contains
       !
       ! -- set mean water contents for cells
       !    analogous to what NWT writes to the linker file for MT3D
-      this%watercontent(i) = this%uzfobj%get_water_content(i)
+      if (this%iwcontout) then
+        this%watercontent(i) = this%uzfobj%get_water_content(i)
+      end if
       !
       ! -- calculate and store remaining budget terms
       this%gwet(i) = this%uzfobj%gwet(i)

--- a/src/Model/GroundWaterFlow/gwf3uzf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3uzf8.f90
@@ -1429,7 +1429,7 @@ contains
       !
       ! -- set mean water contents for cells
       !    analogous to what NWT writes to the linker file for MT3D
-      if (this%iwcontout) then
+      if (this%iwcontout /= 0) then
         this%watercontent(i) = this%uzfobj%get_water_content(i)
       end if
       !

--- a/src/Model/ModelUtilities/UzfCellGroup.f90
+++ b/src/Model/ModelUtilities/UzfCellGroup.f90
@@ -2264,7 +2264,6 @@ module UzfCellGroupModule
     real(DP) :: top
     real(DP) :: bot
     real(DP) :: carea
-    real(DP) :: wc
     real(DP) :: uzwatvol
     real(DP) :: theta_r
     real(DP) :: thk

--- a/src/Model/ModelUtilities/UzfCellGroup.f90
+++ b/src/Model/ModelUtilities/UzfCellGroup.f90
@@ -31,7 +31,6 @@ module UzfCellGroupModule
     real(DP), pointer, dimension(:), contiguous :: uzstor => null()
     real(DP), pointer, dimension(:), contiguous :: delstor => null()
     real(DP), pointer, dimension(:), contiguous :: totflux => null()
-    real(DP), pointer, dimension(:), contiguous :: vflow => null()
     integer(I4B), pointer, dimension(:), contiguous :: nwav => null()
     integer(I4B), pointer, dimension(:), contiguous :: ntrail => null()
     real(DP), pointer, dimension(:), contiguous :: sinf => null()
@@ -75,8 +74,7 @@ module UzfCellGroupModule
       procedure :: trailwav
       procedure :: leadwav
       procedure :: advance
-      procedure :: formulate
-      procedure :: budget
+      procedure :: solve
       procedure :: unsat_stor
       procedure :: update_wav
       procedure :: simgwet
@@ -84,12 +82,13 @@ module UzfCellGroupModule
       procedure :: rate_et_z
       procedure :: uzet
       procedure :: uz_rise
-      procedure :: vertcellflow
       procedure :: rejfinf
       procedure :: gwseep
       procedure :: setbelowpet
       procedure :: setgwpet
       procedure :: dealloc
+      procedure :: get_water_content_at_depth
+      procedure :: get_water_content
     end type UzfCellGroupType
 !  
     contains
@@ -137,7 +136,6 @@ module UzfCellGroupModule
       call mem_allocate(this%uzstor, ncells, 'UZSTOR', memory_path)
       call mem_allocate(this%delstor, ncells, 'DELSTOR', memory_path)
       call mem_allocate(this%totflux, ncells, 'TOTFLUX', memory_path)
-      call mem_allocate(this%vflow, ncells, 'VFLOW', memory_path)
       call mem_allocate(this%sinf, ncells, 'SINF', memory_path)
       call mem_allocate(this%finf, ncells, 'FINF', memory_path)
       call mem_allocate(this%finf_rej, ncells, 'FINF_REJ', memory_path)
@@ -184,7 +182,6 @@ module UzfCellGroupModule
       allocate(this%uzstor(ncells))
       allocate(this%delstor(ncells))
       allocate(this%totflux(ncells))
-      allocate(this%vflow(ncells))
       allocate(this%sinf(ncells))
       allocate(this%finf(ncells))
       allocate(this%finf_rej(ncells))
@@ -231,7 +228,6 @@ module UzfCellGroupModule
       this%uzstor(icell) = DZERO
       this%delstor(icell) = DZERO
       this%totflux(icell) = DZERO
-      this%vflow(icell) = DZERO
       this%sinf(icell) = DZERO
       this%finf(icell) = DZERO
       this%finf_rej(icell) = DZERO
@@ -298,7 +294,6 @@ module UzfCellGroupModule
       deallocate(this%uzstor)
       deallocate(this%delstor)
       deallocate(this%totflux)
-      deallocate(this%vflow)
       deallocate(this%sinf)
       deallocate(this%finf)
       deallocate(this%finf_rej)
@@ -344,7 +339,6 @@ module UzfCellGroupModule
       call mem_deallocate(this%uzstor)
       call mem_deallocate(this%delstor)
       call mem_deallocate(this%totflux)
-      call mem_deallocate(this%vflow)
       call mem_deallocate(this%sinf)
       call mem_deallocate(this%finf)
       call mem_deallocate(this%finf_rej)
@@ -679,9 +673,9 @@ module UzfCellGroupModule
     return
   end subroutine advance
 
-  subroutine formulate(this, thiswork, jbelow, icell, totfluxtot, ietflag,    &
-                       issflag, iseepflag, trhs, thcof, hgwf, hgwfml1,        &
-                       cvv, deriv, qfrommvr, qformvr, ierr, ivertflag)
+  subroutine solve(this, thiswork, jbelow, icell, totfluxtot, ietflag,         &
+                   issflag, iseepflag, hgwf, qfrommvr, ierr,                   &
+                   reset_state, trhs, thcof, deriv)
 ! ******************************************************************************
 ! formulate -- formulate the unsaturated flow object, calculate terms for 
 !              gwf equation            
@@ -693,27 +687,35 @@ module UzfCellGroupModule
     use TdisModule, only: delt
     ! -- dummy
     class(UzfCellGroupType) :: this
-    type(UzfCellGroupType) :: thiswork
-    integer(I4B), intent(in) :: jbelow
-    integer(I4B), intent(in) :: icell
-    integer(I4B), intent(in) :: ietflag
-    integer(I4B), intent(in) :: iseepflag
-    integer(I4B), intent(in) :: issflag
-    integer(I4B), intent(in) :: ivertflag
-    integer(I4B), intent(inout) :: ierr
-    real(DP), intent(in) :: hgwf
-    real(DP), intent(in) :: hgwfml1
-    real(DP), intent(in) :: cvv
-    real(DP), intent(in) :: qfrommvr
-    real(DP), intent(inout) :: trhs
-    real(DP), intent(inout) :: thcof
-    real(DP), intent(inout) :: qformvr
-    real(DP), intent(inout) :: totfluxtot
-    real(DP), intent(inout) :: deriv
+    type(UzfCellGroupType) :: thiswork         !< work object for resetting wave state
+    integer(I4B), intent(in) :: jbelow         !< number of underlying uzf object or 0 if none
+    integer(I4B), intent(in) :: icell          !< number of this uzf object
+    real(DP), intent(inout) :: totfluxtot      !< 
+    integer(I4B), intent(in) :: ietflag        !< et is off (0) or based one water content (1) or pressure (2)
+    integer(I4B), intent(in) :: issflag        !< steady state flag
+    integer(I4B), intent(in) :: iseepflag      !< discharge to land is active (1) or not (0)
+    real(DP), intent(in) :: hgwf               !< head for cell icell
+    real(DP), intent(in) :: qfrommvr           !< water inflow from mover
+    integer(I4B), intent(inout) :: ierr        !< flag indicating not enough waves
+    logical, intent(in) :: reset_state         !< flag indicating that waves should be reset after solution
+    real(DP), intent(inout), optional :: trhs  !< total uzf rhs contribution to GWF model
+    real(DP), intent(inout), optional :: thcof !< total uzf hcof contribution to GWF model
+    real(DP), intent(inout), optional :: deriv !< derivate term for contribution to GWF model
     ! -- local
-    real(DP) :: test, scale, seep, finfact, derivfinf
-    real(DP) :: trhsfinf, thcoffinf, trhsseep, thcofseep, deriv1, deriv2
+    real(DP) :: test
+    real(DP) :: scale
+    real(DP) :: seep
+    real(DP) :: finfact
+    real(DP) :: derivfinf
+    real(DP) :: trhsfinf
+    real(DP) :: thcoffinf
+    real(DP) :: trhsseep
+    real(DP) :: thcofseep
+    real(DP) :: deriv1
+    real(DP) :: deriv2
 ! ------------------------------------------------------------------------------
+    !
+    ! -- initialize variables
     totfluxtot = DZERO
     trhsfinf = DZERO
     thcoffinf = DZERO
@@ -721,29 +723,30 @@ module UzfCellGroupModule
     thcofseep = DZERO
     this%finf_rej(icell) = DZERO
     this%surflux(icell) = this%finf(icell) + qfrommvr / this%uzfarea(icell) 
+    this%watab(icell) = hgwf
     this%surfseep(icell) = DZERO
     seep = DZERO
     finfact = DZERO
-    deriv1 = DZERO
-    deriv2 = DZERO
-    derivfinf = DZERO
-    this%watab(icell) = hgwf
     this%etact(icell) = DZERO
     this%surfluxbelow(icell) = DZERO
-    if(ivertflag > 0) then
-      this%finf(jbelow) = DZERO
-    end if
-    !
-    ! -- save wave states for resetting after iteration.
-    this%watab(icell) = hgwf
-    call thiswork%wave_shift(this, 1, icell, 0, 1, this%nwavst(icell), 1)
-    if (this%watab(icell) > this%celtop(icell)) &
-      this%watab(icell) = this%celtop(icell)
-    !
     if (this%ivertcon(icell) > 0) then
+      this%finf(jbelow) = DZERO
       if (this%watab(icell) < this%celbot(icell)) &
         this%watab(icell) = this%celbot(icell)
     end if
+    !
+    ! -- initialize derivative variables
+    deriv1 = DZERO
+    deriv2 = DZERO
+    derivfinf = DZERO
+    !
+    ! -- save wave states for resetting after iteration.
+    if (reset_state) then
+      call thiswork%wave_shift(this, 1, icell, 0, 1, this%nwavst(icell), 1)
+    end if
+    
+    if (this%watab(icell) > this%celtop(icell)) &
+      this%watab(icell) = this%celtop(icell)
     !
     ! -- add water from mover to applied infiltration.
     if (this%surflux(icell) > this%vks(icell)) then
@@ -759,15 +762,14 @@ module UzfCellGroupModule
     ! -- calculate rejected infiltration
     this%finf_rej(icell) =  this%finf(icell) + &
       (qfrommvr / this%uzfarea(icell)) - this%surflux(icell)
+    !
+    ! -- calculate groundwater discharge
     if (iseepflag > 0 .and. this%landflag(icell) == 1) then
-      !
-      ! -- calculate groundwater discharge
       call this%gwseep(icell, deriv2, scale, hgwf, trhsseep, thcofseep, seep)
       this%surfseep(icell) = seep        
     end if
     !
     ! -- route water through unsat zone, calc. storage change and recharge
-    !
     test = this%watab(icell)
     if (this%watabold(icell) - test < -DEM15) test = this%watabold(icell)
     if (this%celtop(icell) - test > DEM15) then
@@ -777,7 +779,8 @@ module UzfCellGroupModule
         call this%uz_rise(icell, totfluxtot)
         this%totflux(icell) = totfluxtot
         if (this%ivertcon(icell) > 0) then
-          call this%addrech(icell, jbelow, hgwf, trhsfinf, thcoffinf, derivfinf, delt, 0)
+          call this%addrech(icell, jbelow, hgwf, trhsfinf, thcoffinf, &
+            derivfinf, delt)
         end if
       else
         this%totflux(icell) = this%surflux(icell) * delt
@@ -785,224 +788,31 @@ module UzfCellGroupModule
       end if
       thcoffinf = DZERO
       trhsfinf = this%totflux(icell) * this%uzfarea(icell) / delt
+      if (.not. reset_state) then
+        call this%update_wav(icell, delt, issflag, 0)
+      end if
     else
       this%totflux(icell) = this%surflux(icell) * delt
       totfluxtot = this%surflux(icell) * delt
+      if (.not. reset_state) then
+        call this%update_wav(icell, delt, issflag, 1)
+      end if
     end if
-    deriv =  deriv1 + deriv2 + derivfinf
-    trhs = trhsfinf + trhsseep
-    thcof = thcoffinf + thcofseep
     !
-    ! -- add spring flow and rejected infiltration to mover
-    qformvr = this%surfseep(icell) + this%finf_rej(icell) * this%uzfarea(icell)
+    ! -- If formulating, then these variables will be present
+    if (present(deriv)) deriv =  deriv1 + deriv2 + derivfinf
+    if (present(trhs))  trhs = trhsfinf + trhsseep
+    if (present(thcof))  thcof = thcoffinf + thcofseep
     !
     ! -- reset waves to previous state for next iteration  
-    call this%wave_shift(thiswork, icell, 1, 0, 1, thiswork%nwavst(1), 1)  
+    if (reset_state) then
+      call this%wave_shift(thiswork, icell, 1, 0, 1, thiswork%nwavst(1), 1)
+    end if
     !
-  end subroutine formulate 
+    return
+  end subroutine solve
 
-  subroutine budget(this, jbelow, icell, totfluxtot, rfinf, rin, rout,         &
-                    rsto, ret, retgw, rgwseep, rvflux, ietflag, iseepflag,     &
-                    issflag, hgwf, hgwfml1, cvv, numobs, obs_num,              &
-                    obs_depth, obs_theta, qfrommvr, qformvr, qgwformvr,        &
-                    ierr)
-! ******************************************************************************
-! budget -- save unsat. conditions at end of time step, calculate budget 
-!           terms            
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-    ! -- modules
-    use TdisModule, only: delt
-    ! -- dummy
-    class(UzfCellGroupType) :: this
-    integer(I4B), intent(in) :: jbelow
-    integer(I4B), intent(in) :: icell
-    integer(I4B), intent(in) :: ietflag
-    integer(I4B), intent(in) :: iseepflag
-    integer(I4B), intent(in) :: issflag
-    integer(I4B), intent(inout) :: ierr
-    integer(I4B), intent(in) :: numobs
-    integer(I4B), dimension(:),intent(in) :: obs_num
-    real(DP),dimension(:),intent(in) :: obs_depth
-    real(DP),dimension(:),intent(inout) :: obs_theta
-    real(DP), intent(in) :: hgwf
-    real(DP), intent(in) :: hgwfml1
-    real(DP), intent(in) :: cvv
-    real(DP), intent(in) :: qfrommvr
-    real(DP), intent(inout) :: rfinf
-    real(DP), intent(inout) :: rin
-    real(DP), intent(inout) :: qformvr
-    real(DP), intent(inout) :: qgwformvr
-    real(DP), intent(inout) :: rout
-    real(DP), intent(inout) :: rsto
-    real(DP), intent(inout) :: ret
-    real(DP), intent(inout) :: retgw
-    real(DP), intent(inout) :: rgwseep
-    real(DP), intent(inout) :: rvflux
-    real(DP), intent(inout) :: totfluxtot
-    ! -- dummy
-    real(DP) :: test, deriv, scale, seep, finfact
-    real(DP) :: f1, f2, d1, d2
-    real(DP) :: trhsfinf, thcoffinf, trhsseep, thcofseep
-    integer(I4B) :: i, j
-! ------------------------------------------------------------------------------
-    !
-    ! -- initialize
-    totfluxtot = DZERO
-    trhsfinf = DZERO
-    thcoffinf = DZERO
-    trhsseep = DZERO
-    thcofseep = DZERO
-    this%finf_rej = DZERO
-    this%surflux(icell) = this%finf(icell) + qfrommvr / this%uzfarea(icell)
-    this%watab(icell) = hgwf
-    this%vflow(icell) = DZERO
-    this%surfseep(icell) = DZERO
-    seep = DZERO
-    finfact = DZERO
-    this%etact(icell) = DZERO
-    this%surfluxbelow(icell) = DZERO
-    if (this%ivertcon(icell) > 0) then
-      this%finf(jbelow) = dzero
-      if (this%watab(icell) < this%celbot(icell)) &
-        this%watab(icell) = this%celbot(icell)
-    end if
-    if (this%watab(icell) > this%celtop(icell)) &
-      this%watab(icell) = this%celtop(icell)
-    if (this%surflux(icell) > this%vks(icell)) then
-      this%surflux(icell) = this%vks(icell)
-    end if
-    !
-    ! -- infiltration excess -- rejected infiltration 
-    if (this%landflag(icell) == 1) then
-      call rejfinf(this, icell, deriv, hgwf, trhsfinf, thcoffinf, finfact)
-      this%surflux(icell) = finfact
-      if (finfact < this%finf(icell)) then
-          this%surflux(icell) = finfact
-      end if
-    end if
-    !
-    ! -- calculate rejected infiltration
-    this%finf_rej(icell) = this%finf(icell) + &
-      (qfrommvr / this%uzfarea(icell)) - this%surflux(icell)
-    !
-    ! -- groundwater discharge
-    if (iseepflag > 0 .and. this%landflag(icell) == 1) then
-      call this%gwseep(icell, deriv, scale, hgwf, trhsseep, thcofseep, seep)
-      this%surfseep(icell) = seep
-      rgwseep = rgwseep + this%surfseep(icell)
-    end if
-    !
-    ! sat. to unsat. zone exchange.
-    !if (this%landflag == 0 .and. issflag == 0) then
-    !  call this%vertcellflow(ipos,ttrhs,hgwf,hgwfml1,cvv)
-    !end if
-    !rvflux = rvflux + this%vflow
-    !
-    ! -- route unsaturated flow, calc. storage change and recharge
-    test = this%watab(icell)
-    if (this%watabold(icell) - test < -DEM15) test = this%watabold(icell)
-    if (this%celtop(icell) - test > DEM15) then
-      if (issflag == 0) then
-        call this%routewaves(totfluxtot, delt, ietflag, icell, ierr) 
-        if (ierr > 0) return
-        call this%uz_rise(icell, totfluxtot)
-        this%totflux(icell) = totfluxtot  
-        if (this%ivertcon(icell) > 0) then
-          call this%addrech(icell, jbelow, hgwf, trhsfinf, thcoffinf, &
-            deriv, delt, 1)
-        end if
-      else 
-        this%totflux(icell) = this%surflux(icell) * delt
-        totfluxtot = this%surflux(icell) * delt  
-      end if
-      thcoffinf = dzero
-      trhsfinf = this%totflux(icell) * this%uzfarea(icell) / delt
-      call this%update_wav(icell, delt, rout, rsto, ret, ietflag, issflag, 0)
-    else
-      call this%update_wav(icell, delt, rout, rsto, ret, ietflag, issflag, 1)
-      totfluxtot = this%surflux(icell) * delt
-      this%totflux(icell) = this%surflux(icell) * delt
-    end if
-    rfinf = rfinf + this%sinf(icell) * this%uzfarea(icell)
-    rin = rin + this%surflux(icell) * this%uzfarea(icell) - &
-      this%surfluxbelow(icell) * this%uzfarea(icell)
-    !
-    ! -- add spring flow and rejected infiltration to mover
-    qformvr = this%finf_rej(icell) * this%uzfarea(icell)
-    qgwformvr = this%surfseep(icell)
-    !
-    ! -- process for observations
-    do i = 1, numobs
-      j = obs_num(i)
-      if (this%watab(icell) < this%celtop(icell)) then
-        if (this%celtop(icell) - obs_depth(j) > this%watab(icell)) then
-          d1 = obs_depth(j) - DEM3
-          d2 = obs_depth(j) + DEM3
-          f1 = this%unsat_stor(icell, d1)
-          f2 = this%unsat_stor(icell, d2)
-          obs_theta(j) = this%thtr(icell) + (f2 - f1) / (d2 - d1)
-        else 
-          obs_theta(j) = this%thts(icell)
-        end if
-      else
-        obs_theta(j) = this%thts(icell)
-      end if
-    end do
-    !
-    ! -- return
-    return
-  end subroutine budget
-                      
-  subroutine vertcellflow(this, icell, trhs, hgwf, hgwfml1, cvv)
-! ******************************************************************************
-! vertcellflow -- calculate exchange from sat. to unsat. zones
-!                 subroutine not used until sat to unsat flow is supported
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------      
-    ! -- modules
-    ! -- dummy
-    class(UzfCellGroupType) :: this
-    integer(I4B), intent(in) :: icell
-    real(DP), intent(in) :: hgwf
-    real(DP), intent(in) :: hgwfml1
-    real(DP), intent(in) :: cvv
-    real(DP), intent(inout) :: trhs
-    ! -- dummy
-    real(DP) :: Qv, maxvflow, h1, h2, test
-! ------------------------------------------------------------------------------
-    this%vflow(icell) = DZERO
-    this%finf(icell) = DZERO
-    trhs = DZERO
-    h1 = hgwfml1
-    h2 = hgwf
-    test = this%watab(icell)
-    if (this%watabold(icell) - test < -DEM30) test = this%watabold(icell)
-    if (this%celtop(icell) - test > DEM30) then
-      !
-      ! calc. downward flow using GWF heads and conductance
-      Qv = cvv * (h1 - h2)
-      if (Qv > DEM30) then
-        this%vflow(icell) = Qv
-        this%surflux(icell) = this%vflow(icell) / this%uzfarea(icell)
-        maxvflow = this%vks(icell) * this%uzfarea(icell)
-        if (this%vflow(icell) - maxvflow > DEM9) then
-          this%surflux(icell) = this%vks(icell)
-          trhs = this%vflow(icell) - maxvflow
-          this%vflow(icell) = maxvflow
-        end if
-      end if  
-    end if
-    !
-    ! -- return
-    return
-  end subroutine vertcellflow
-    
-  subroutine addrech(this, icell, jbelow, hgwf, trhs, thcof, deriv, delt, it)
+  subroutine addrech(this, icell, jbelow, hgwf, trhs, thcof, deriv, delt)
 ! ******************************************************************************
 ! addrech -- add recharge or infiltration to cells
 ! ******************************************************************************
@@ -1014,7 +824,6 @@ module UzfCellGroupModule
     class(UzfCellGroupType) :: this
     integer(I4B), intent(in) :: icell
     integer(I4B), intent(in) :: jbelow
-    integer(I4B), intent(in) :: it
     real(DP), intent(inout) :: trhs
     real(DP), intent(inout) :: thcof
     real(DP), intent(inout) :: deriv
@@ -1980,7 +1789,7 @@ module UzfCellGroupModule
     unsat_stor = fm
   end function unsat_stor
 
-  subroutine update_wav(this, icell, delt, rout, rsto, ret, etflg, iss, itest)
+  subroutine update_wav(this, icell, delt, iss, itest)
 ! ******************************************************************************
 ! update_wav -- update to new state of uz at end of time step
 ! ******************************************************************************
@@ -1991,13 +1800,9 @@ module UzfCellGroupModule
     ! -- dummy
     class (UzfCellGroupType) :: this
     integer(I4B), intent(in) :: icell
-    integer(I4B), intent(in) :: etflg
     integer(I4B), intent(in) :: itest
     integer(I4B), intent(in) :: iss
     real(DP), intent(in) :: delt
-    real(DP), intent(inout) :: rout
-    real(DP), intent(inout) :: rsto
-    real(DP), intent(inout) :: ret
     ! -- local
     real(DP) :: uzstorhold, bot, fm, depthsave, top
     real(DP) :: thick, thtsrinv
@@ -2014,7 +1819,6 @@ module UzfCellGroupModule
       this%delstor(icell) = - this%uzstor(icell)
       this%uzstor(icell) = DZERO
       uzstorhold = DZERO
-      rout = rout + this%totflux(icell) * this%uzfarea(icell) / delt
       return
     end if
     if (iss == 1) then          
@@ -2033,7 +1837,6 @@ module UzfCellGroupModule
       this%nwavst(icell) = 1
       this%uzstor(icell) = thick * (this%thti(icell) - this%thtr(icell)) * this%uzfarea(icell)
       this%delstor(icell) = DZERO
-      rout = rout + this%totflux(icell) * this%uzfarea(icell) / delt
     else
       !
       ! -- water table rises through waves      
@@ -2076,9 +1879,6 @@ module UzfCellGroupModule
         uzstorhold = DZERO
       end if
       this%watabold(icell) = this%watab(icell)
-      rout = rout + this%totflux(icell) * this%uzfarea(icell) / delt
-      rsto = rsto + this%delstor(icell) / delt
-      if (etflg > 0) ret = ret + this%etact(icell) * this%uzfarea(icell) / delt
     end if
   end subroutine update_wav
       
@@ -2426,9 +2226,68 @@ module UzfCellGroupModule
     integer(I4B), intent(in) :: icell
     real(DP), intent(in) :: factor, fktho, h
     ! -- local
-! ----------------------------------------------------------------------
+! ------------------------------------------------------------------------------
     rate_et_z = factor * fktho * (h - this%hroot(icell))
     if (rate_et_z < DZERO) rate_et_z = DZERO
   end function rate_et_z
 
+  function get_water_content_at_depth(this, icell, depth) result(theta_at_depth)
+    class(UzfCellGroupType) :: this
+    integer(I4B), intent(in) :: icell  !< uzf cell containing depth
+    real(DP), intent(in) :: depth      !< depth within the cell
+    real(DP) :: theta_at_depth
+    real(DP) :: d1
+    real(DP) :: d2
+    real(DP) :: f1
+    real(DP) :: f2
+    if (this%watab(icell) < this%celtop(icell)) then
+      if (this%celtop(icell) - depth > this%watab(icell)) then
+        d1 = depth - DEM3
+        d2 = depth + DEM3
+        f1 = this%unsat_stor(icell, d1)
+        f2 = this%unsat_stor(icell, d2)
+        theta_at_depth = this%thtr(icell) + (f2 - f1) / (d2 - d1)
+      else 
+        theta_at_depth = this%thts(icell)
+      end if
+    else
+      theta_at_depth = this%thts(icell)
+    end if
+    return
+  end function get_water_content_at_depth
+  
+  function get_water_content(this, icell) result(watercontent)
+    class(UzfCellGroupType) :: this
+    integer(I4B), intent(in) :: icell  !< uzf cell containing depth
+    !
+    real(DP) :: watercontent
+    real(DP) :: top
+    real(DP) :: bot
+    real(DP) :: carea
+    real(DP) :: wc
+    real(DP) :: uzwatvol
+    real(DP) :: theta_r
+    real(DP) :: thk
+    real(DP) :: v
+    real(DP) :: hgwf
+    !
+    ! -- calculate mean uzf moisture-content for the UZF object 
+    !i = this%nodelist(icell)
+    hgwf = this%watab(icell)  ! this%xnew(i)
+    top = this%celtop(icell) 
+    bot = this%celbot(icell)
+    carea = this%uzfarea(icell)
+    if ( hgwf > bot ) bot = hgwf
+    thk = top - bot
+    v = thk * carea
+    theta_r = this%THTR(icell)
+    uzwatvol = (this%uzstor(icell) + theta_r * thk) * carea
+    if (hgwf < top) then
+      watercontent = uzwatvol / v
+    else
+      watercontent = DZERO
+    endif
+    return
+  end function get_water_content
+                      
 end module UzfCellGroupModule

--- a/src/Utilities/SmoothingFunctions.f90
+++ b/src/Utilities/SmoothingFunctions.f90
@@ -634,7 +634,7 @@ end subroutine sChSmooth
     !
     ! -- set smoothing variable a
     if (present(ta)) then
-      a = a
+      a = ta
     else
       a = DEM8
     end if
@@ -683,7 +683,7 @@ end subroutine sChSmooth
     !
     ! -- set smoothing variable a
     if (present(ta)) then
-      a = a
+      a = ta
     else
       a = DEM8
     end if
@@ -907,5 +907,3 @@ end subroutine sChSmooth
   end function sQuadraticSlopeDerivative 
   
 end module SmoothingModule
-    
-    


### PR DESCRIPTION
- Adds 'wc' keyword to UZF `OPTIONS` block
- New binary output file records mean water contents for every UZF object
- Includes new autotest that compares MODFLOW6/UZF6 output to MFNWT/UZF1 output recorded in the MT3D linker file (written by LMT package)
- Updates UZF definition file (.dfn) for supporting new binary output file with flopy
- Records these updates in the releaseNotes.tex file