### PR TITLE
refactor(dis): allow user to specify tolerance in top/bot check for disu

### DIFF
--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -159,8 +159,8 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\underline{NEW FUNCTIONALITY}
 	\begin{itemize}
 	        \item --  
-	        \item A new option for printing water contents to a dedicated output file has been added to UZF.  To activate, the keyword WATER_CONTENT is added to the OPTIONS block of UZF, followed by FILEOUT, followed by the user-specified output file name, for example ``water-content.uzf.bin''.  The approach is analogous to the STAGE option within the SFR options block.  Contents of the new file will be written in binary and can be read using flopy's binaryfile utility.  A new test, located in the autotest directory and titled test_gwf_uzf_wc_output.py demonstrates how to read the new binary water content output file. Also, this same test compares MODFLOW~6 water contents saved with the new WATER_CONTENT keyword in the OPTIONS block of UZF to water contents calculated by MF-NWT and written to the flow and transport linker file by the LMT package.  
-	        \item The residual balance error for groundwater flow and solute transport is now written to the diagonal position of the flowja array.  The flowja array is optionally written to the binary model budget file according to user settings in the output control file and other package input files.
+	        \item A new option for printing water contents to a dedicated output file has been added to UZF.  To activate, the keyword WATER\_CONTENT is added to the OPTIONS block of UZF, followed by FILEOUT, followed by the user-specified output file name, for example ``water-content.uzf.bin''.  The approach is analogous to the STAGE option within the SFR options block.  Contents of the new file will be written in binary and can be read using flopy's binaryfile utility.  
+	        \item The residual balance error for groundwater flow and solute transport is now written to the diagonal position of the flowja array, which is marked with the text description ``FLOW-JA-FACE''.  The flowja array is optionally written to the binary model budget file according to user settings in the output control file and other package input files.
 	\end{itemize}
 	
 	\underline{EXAMPLES}
@@ -177,6 +177,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\begin{itemize}
 	        \item The convergence failure message message written to GWF and GWT listing files (FAILED TO MEET SOLVER CONVERGENCE CRITERIA) is now written after the budget summary tables.  In previous releases this convergence failure message was written prior to printing heads and concentrations, which often resulted in this message being unnoticed by users.
 	        \item The order of output written to the GWF and GWT listing files for a time step was reorganized in a consistent manner with model and package flows coming first, followed by dependent variables, and then concluding with budget summary tables.
+	        \item The DISU Package checks to make sure that the top of a cell is not higher than the bottom of an overlying cell.  A new option was added to the DISU Package to allow the user to specify the vertical offset tolerance used in this check.
 	\end{itemize}
 
 %	\underline{STRESS PACKAGES}

--- a/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-disu.dfn
@@ -40,6 +40,15 @@ optional true
 longname rotation angle
 description counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 
+block options
+name vertical_offset_tolerance
+type double precision
+reader urword
+optional true
+default_value 0.0
+longname vertical length dimension for top and bottom checking
+description checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used.
+
 # --------------------- gwf disu dimensions ---------------------
 
 block dimensions

--- a/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
@@ -21,6 +21,7 @@ name xorigin
 type double precision
 reader urword
 optional true
+default_value 0.0
 longname x-position origin of the model grid coordinate system
 description x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 
@@ -39,6 +40,14 @@ reader urword
 optional true
 longname rotation angle
 description counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
+
+block options
+name vertical_offset_tolerance
+type double precision
+reader urword
+optional true
+longname vertical length dimension for top and bottom checking
+description checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used.
 
 # --------------------- gwt disu dimensions ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-disu.dfn
@@ -21,7 +21,6 @@ name xorigin
 type double precision
 reader urword
 optional true
-default_value 0.0
 longname x-position origin of the model grid coordinate system
 description x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.
 
@@ -46,6 +45,7 @@ name vertical_offset_tolerance
 type double precision
 reader urword
 optional true
+default_value 0.0
 longname vertical length dimension for top and bottom checking
 description checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used.
 
@@ -101,6 +101,15 @@ reader readarray
 longname cell surface area
 description is the cell surface area (in plan view).
 
+block griddata
+name idomain
+type integer
+shape (nodes)
+reader readarray
+layered false
+optional true
+longname idomain existence array
+description is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.
 
 # --------------------- gwt disu connectiondata ---------------------
 
@@ -118,8 +127,9 @@ type integer
 shape (nja)
 reader readarray
 longname grid connectivity
-description is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWF cells and their connections to the other GWF cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code.
+description is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWT cells and their connections to the other GWT cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code.
 numeric_index true
+jagged_array iac
 
 block connectiondata
 name ihc
@@ -128,6 +138,7 @@ shape (nja)
 reader readarray
 longname connection type
 description is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection.
+jagged_array iac
 
 block connectiondata
 name cl12
@@ -136,6 +147,7 @@ shape (nja)
 reader readarray
 longname connection lengths
 description is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell.
+jagged_array iac
 
 block connectiondata
 name hwva
@@ -144,6 +156,7 @@ shape (nja)
 reader readarray
 longname connection lengths
 description is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection.
+jagged_array iac
 
 block connectiondata
 name angldegx
@@ -153,6 +166,7 @@ shape (nja)
 reader readarray
 longname angle of face normal to connection
 description is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\_SPECIFIC\_DISCHARGE option is specifed in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians.
+jagged_array iac
 
 # --------------------- gwt disu vertices ---------------------
 


### PR DESCRIPTION
* Close #674
* Add new VERTICAL_OFFSET_TOLERANCE option to DISU options block
*  Cell thickness was being checked for all idomain values; now check is only performed for cells with idomain = 1