### PR TITLE
Messaging facility has a state that requires initialization.

### DIFF
--- a/src/Utilities/Message.f90
+++ b/src/Utilities/Message.f90
@@ -25,6 +25,7 @@ module MessageModule
     
     contains
   
+    procedure :: init_message
     procedure :: count_message
     procedure :: set_max_message
     procedure :: store_message
@@ -34,6 +35,19 @@ module MessageModule
   end type MessageType
   
   contains
+
+    !> @brief Always initialize the message object,
+    !! (allocation of message array occurs on-the-fly)
+    !<
+    subroutine init_message(this)
+      class(MessageType) :: this
+      
+      this%nmessage = 0
+      this%max_message = 1000
+      this%max_exceeded = 0
+      this%inc_message = 100
+
+    end subroutine init_message
   
     function count_message(this) result(nmessage)
     ! ******************************************************************************

--- a/src/Utilities/Sim.f90
+++ b/src/Utilities/Sim.f90
@@ -21,6 +21,7 @@ module SimModule
   public :: ustop
   public :: converge_reset
   public :: converge_check
+  public :: initial_message
   public :: final_message
   public :: store_warning
   public :: deprecation_warning
@@ -456,6 +457,23 @@ subroutine converge_reset()
     ! -- Return
     return
   end subroutine converge_check
+
+  !> @brief Prints the header and initializes messaging  
+  !<
+  subroutine initial_message()    
+    use VersionModule, only: write_listfile_header
+    !
+    ! -- initialize message lists
+    call sim_errors%init_message()
+    call sim_uniterrors%init_message()
+    call sim_warnings%init_message()
+    call sim_notes%init_message()
+    !
+    ! -- Write banner to screen (unit stdout)
+    call write_listfile_header(istdout, write_kind_info=.false., &
+                               write_sys_command=.false.)
+    !
+  end subroutine initial_message
 
   subroutine final_message()
 ! ******************************************************************************

--- a/src/mf6core.f90
+++ b/src/mf6core.f90
@@ -162,16 +162,14 @@ contains
   end subroutine Mf6Finalize
   
   subroutine printInfo()
-    use SimVariablesModule, only: istdout
-    use VersionModule, only: write_listfile_header
+    use SimModule, only: initial_message
     use TimerModule, only: start_time
     !
-    ! -- Write banner to screen (unit stdout) and start timer
-    call write_listfile_header(istdout, write_kind_info=.false., &
-                               write_sys_command=.false.)
+    ! -- print initial message
+    call initial_message()
     !
     ! -- get start time
-    call start_time()
+    call start_time()    
     return
   end subroutine printInfo
   


### PR DESCRIPTION
Running two simulations, one after the other, with the same dll was causing exceptions. This should fix it. (NB: we didn't have that at hand before the API)

(cherry picked from commit 0fec1a772c8dd82d5c45a9d387bdff2c6c6a6e92)