### PR TITLE
refactor(fmi): use residual in flowja instead of recalculating

### DIFF
--- a/autotest/test_gwt_fmi01.py
+++ b/autotest/test_gwt_fmi01.py
@@ -155,7 +155,9 @@ def get_model(idx, dir):
         ]
     )
     print(flowja)
-    flowja = np.array([0.0, 0.01, 0.0, 0.0, -0.01, 0.0, 0.01])
+    # create unbalanced flowja to check flow_imbalance_correction
+    # note that residual must be stored in diagonal position
+    flowja = np.array([0.01, 0.01, -0.01, 0.0, -0.01, 0.01, 0.01])
 
     dt = np.dtype(
         [


### PR DESCRIPTION
* With recent BD refactoring, the residual is now stored in the diagonal position of the GWF flowja array.  The previous code that was added to FMI to calculate the flow residual can now be eliminated.  This may offer performance benefits and should not have any effect on the simulation results.