### PR TITLE
fix(oc): output control correctly determines end of period

### DIFF
--- a/autotest/get_build_exes.py
+++ b/autotest/get_build_exes.py
@@ -83,7 +83,7 @@ def rebuild_mf6_release():
     download_pth = os.path.join("temp")
     target_dict = pymake.usgs_program_data.get_target(pm.target)
 
-    pm.download_target(pm.target, download_path=download_pth)
+    pm.download_target(pm.target, download_path=download_pth, verify=False)
 
     # Set MODFLOW 6 to compile develop version of the release
     srcpth = os.path.join(

--- a/autotest/test_gwf_multimvr.py
+++ b/autotest/test_gwf_multimvr.py
@@ -56,7 +56,7 @@ x = [round(x, 3) for x in np.linspace(50.0, 45.0, ncolp)]
 topp = np.repeat(x, nrowp).reshape((15, 15)).T
 z = [round(z, 3) for z in np.linspace(50.0, 0.0, nlayp + 1)]
 botmp = [topp - z[len(z) - 2], topp - z[len(z) - 3], topp - z[0]]
-idomainp = np.ones((nlayp, nrowp, ncolp), dtype=np.int)
+idomainp = np.ones((nlayp, nrowp, ncolp), dtype=np.int32)
 # Zero out where the child grid will reside
 idomainp[0:2, 6:11, 2:8] = 0
 

--- a/src/Model/GroundWaterFlow/gwf3oc8.f90
+++ b/src/Model/GroundWaterFlow/gwf3oc8.f90
@@ -1,15 +1,20 @@
 module GwfOcModule
 
-  use BaseDisModule,       only: DisBaseType
-  use KindModule,          only: DP, I4B
-  use ConstantsModule,     only: LENMODELNAME
-  use OutputControlModule, only: OutputControlType
-  use OutputControlData,   only: OutputControlDataType, ocd_cr
+  use BaseDisModule,             only: DisBaseType
+  use KindModule,                only: DP, I4B
+  use ConstantsModule,           only: LENMODELNAME
+  use OutputControlModule,       only: OutputControlType
+  use OutputControlDataModule,   only: OutputControlDataType, ocd_cr
 
   implicit none
   private
   public GwfOcType, oc_cr
 
+  !> @ brief Output control for GWF
+  !!
+  !!  Concrete implementation of OutputControlType for the
+  !!  GWF Model
+  !<
   type, extends(OutputControlType) :: GwfOcType
   contains
     procedure :: oc_ar
@@ -17,19 +22,18 @@ module GwfOcModule
   
   contains
 
+  !> @ brief Create GwfOcType
+  !!
+  !!  Create by allocating a new GwfOcType object and initializing
+  !!  member variables.
+  !!
+  !<
   subroutine oc_cr(ocobj, name_model, inunit, iout)
-! ******************************************************************************
-! oc_cr -- Create a new oc object
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- dummy
-    type(GwfOcType), pointer :: ocobj
-    character(len=*), intent(in) :: name_model
-    integer(I4B), intent(in) :: inunit
-    integer(I4B), intent(in) :: iout
-! ------------------------------------------------------------------------------
+    type(GwfOcType), pointer :: ocobj             !< GwfOcType object
+    character(len=*), intent(in) :: name_model    !< name of the model
+    integer(I4B), intent(in) :: inunit            !< unit number for input
+    integer(I4B), intent(in) :: iout              !< unit number for output
     !
     ! -- Create the object
     allocate(ocobj)
@@ -48,23 +52,21 @@ module GwfOcModule
     return
   end subroutine oc_cr
 
+  !> @ brief Allocate and read GwfOcType
+  !!
+  !!  Setup head and budget as output control variables.
+  !!
+  !<
   subroutine oc_ar(this, head, dis, dnodata)
-! ******************************************************************************
-! oc_ar -- allocate and read
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- dummy
-    class(GwfOcType) :: this
-    real(DP), dimension(:), pointer, contiguous, intent(in) :: head
-    class(DisBaseType), pointer, intent(in) :: dis
-    real(DP), intent(in) :: dnodata
+    class(GwfOcType) :: this                                         !< GwtOcType object
+    real(DP), dimension(:), pointer, contiguous, intent(in) :: head  !< model head
+    class(DisBaseType), pointer, intent(in) :: dis                   !< model discretization package
+    real(DP), intent(in) :: dnodata                                  !< no data value
     ! -- local
     integer(I4B) :: i, nocdobj, inodata
     type(OutputControlDataType), pointer   :: ocdobjptr
     real(DP), dimension(:), pointer, contiguous :: nullvec => null()
-! ------------------------------------------------------------------------------
     !
     ! -- Initialize variables
     inodata = 0

--- a/src/Model/GroundWaterFlow/gwf3uzf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3uzf8.f90
@@ -70,8 +70,6 @@ module UzfModule
     integer(I4B), pointer                               :: nsets        => null()
     integer(I4B), pointer                               :: nwav         => null()
     integer(I4B), pointer                               :: nodes        => null()
-    integer(I4B), pointer                               :: nper         => null()
-    integer(I4B), pointer                               :: nstp         => null()
     integer(I4B), pointer                               :: readflag     => null()
     integer(I4B), pointer                               :: outunitbud   => null()
     integer(I4B), pointer                               :: ietflag      => null()  !< et flag, 0 is off, 1 or 2 are different types

--- a/src/Model/GroundWaterTransport/gwt1ist1.f90
+++ b/src/Model/GroundWaterTransport/gwt1ist1.f90
@@ -13,14 +13,15 @@
 !<
 module GwtIstModule
 
-  use KindModule,             only: DP, I4B
-  use ConstantsModule,        only: DONE, DZERO, LENFTYPE, LENPACKAGENAME,     &
-                                    LENBUDTXT, DHNOFLO
-  use BndModule,              only: BndType
-  use BudgetModule,           only: BudgetType
-  use GwtFmiModule,           only: GwtFmiType
-  use GwtMstModule,           only: GwtMstType, get_zero_order_decay
-  use OutputControlData,      only: OutputControlDataType
+  use KindModule,                   only: DP, I4B
+  use ConstantsModule,              only: DONE, DZERO, LENFTYPE,               &
+                                          LENPACKAGENAME,                      &
+                                          LENBUDTXT, DHNOFLO
+  use BndModule,                    only: BndType
+  use BudgetModule,                 only: BudgetType
+  use GwtFmiModule,                 only: GwtFmiType
+  use GwtMstModule,                 only: GwtMstType, get_zero_order_decay
+  use OutputControlDataModule,      only: OutputControlDataType
   !
   implicit none
   !
@@ -588,7 +589,7 @@ module GwtIstModule
   !<
   subroutine ist_ot_dv(this, idvsave, idvprint)
     ! -- modules
-    use TdisModule, only: kstp, kper, nstp
+    use TdisModule, only: kstp, endofperiod
       ! -- dummy variables
     class(GwtIstType) :: this              !< BndType object
     integer(I4B), intent(in) :: idvsave    !< flag and unit number for dependent-variable output
@@ -604,13 +605,13 @@ module GwtIstModule
     ibinun = 1
     if(idvsave == 0) ibinun = 0
     if (ibinun /= 0) then
-      call this%ocd%ocd_ot(ipflg, kstp, nstp(kper), this%iout,                 &
+      call this%ocd%ocd_ot(ipflg, kstp, endofperiod, this%iout,                &
                            iprint_opt=0, isav_opt=ibinun)
     endif
     !
     ! -- Print immobile domain concentrations to listing file
     if (idvprint /= 0) then
-      call this%ocd%ocd_ot(ipflg, kstp, nstp(kper), this%iout,                 &
+      call this%ocd%ocd_ot(ipflg, kstp, endofperiod, this%iout,                &
                            iprint_opt=idvprint, isav_opt=0)
     endif
   end subroutine ist_ot_dv
@@ -695,7 +696,7 @@ module GwtIstModule
   subroutine allocate_scalars(this)
     ! -- modules
     use MemoryManagerModule, only: mem_allocate, mem_setptr
-    use OutputControlData, only: ocd_cr
+    use OutputControlDataModule, only: ocd_cr
     ! -- dummy
     class(GwtIstType) :: this  !< GwtIstType object
     ! -- local

--- a/src/Model/GroundWaterTransport/gwt1oc1.f90
+++ b/src/Model/GroundWaterTransport/gwt1oc1.f90
@@ -1,15 +1,20 @@
 module GwtOcModule
 
-  use BaseDisModule,       only: DisBaseType
-  use KindModule,          only: DP, I4B
-  use ConstantsModule,     only: LENMODELNAME
-  use OutputControlModule, only: OutputControlType
-  use OutputControlData,   only: OutputControlDataType, ocd_cr
+  use BaseDisModule,             only: DisBaseType
+  use KindModule,                only: DP, I4B
+  use ConstantsModule,           only: LENMODELNAME
+  use OutputControlModule,       only: OutputControlType
+  use OutputControlDataModule,   only: OutputControlDataType, ocd_cr
 
   implicit none
   private
   public GwtOcType, oc_cr
 
+  !> @ brief Output control for GWT
+  !!
+  !!  Concrete implementation of OutputControlType for the
+  !!  GWT Model
+  !<
   type, extends(OutputControlType) :: GwtOcType
   contains
     procedure :: oc_ar
@@ -17,19 +22,18 @@ module GwtOcModule
   
   contains
 
+  !> @ brief Create GwtOcType
+  !!
+  !!  Create by allocating a new GwtOcType object and initializing
+  !!  member variables.
+  !!
+  !<
   subroutine oc_cr(ocobj, name_model, inunit, iout)
-! ******************************************************************************
-! oc_cr -- Create a new oc object
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- dummy
-    type(GwtOcType), pointer :: ocobj
-    character(len=*), intent(in) :: name_model
-    integer(I4B), intent(in) :: inunit
-    integer(I4B), intent(in) :: iout
-! ------------------------------------------------------------------------------
+    type(GwtOcType), pointer :: ocobj            !< GwtOcType object
+    character(len=*), intent(in) :: name_model   !< name of the model
+    integer(I4B), intent(in) :: inunit           !< unit number for input
+    integer(I4B), intent(in) :: iout             !< unit number for output
     !
     ! -- Create the object
     allocate(ocobj)
@@ -48,23 +52,21 @@ module GwtOcModule
     return
   end subroutine oc_cr
 
-  subroutine oc_ar(this, head, dis, dnodata)
-! ******************************************************************************
-! oc_ar -- allocate and read
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
+  !> @ brief Allocate and read GwtOcType
+  !!
+  !!  Setup concentration and budget as output control variables.
+  !!
+  !<
+  subroutine oc_ar(this, conc, dis, dnodata)
     ! -- dummy
-    class(GwtOcType) :: this
-    real(DP), dimension(:), pointer, contiguous, intent(in) :: head
-    class(DisBaseType), pointer, intent(in) :: dis
-    real(DP), intent(in) :: dnodata
+    class(GwtOcType) :: this                                          !< GwtOcType object
+    real(DP), dimension(:), pointer, contiguous, intent(in) :: conc   !< model concentration
+    class(DisBaseType), pointer, intent(in) :: dis                    !< model discretization package
+    real(DP), intent(in) :: dnodata                                   !< no data value
     ! -- local
     integer(I4B) :: i, nocdobj, inodata
     type(OutputControlDataType), pointer   :: ocdobjptr
     real(DP), dimension(:), pointer, contiguous :: nullvec => null()
-! ------------------------------------------------------------------------------
     !
     ! -- Initialize variables
     inodata = 0
@@ -78,7 +80,7 @@ module GwtOcModule
                                 'COLUMNS 10 WIDTH 11 DIGITS 4 GENERAL ',       &
                                 this%iout, dnodata)
       case (2)
-        call ocdobjptr%init_dbl('CONCENTRATION', head, dis, 'PRINT LAST ',     &
+        call ocdobjptr%init_dbl('CONCENTRATION', conc, dis, 'PRINT LAST ',     &
                                 'COLUMNS 10 WIDTH 11 DIGITS 4 GENERAL ',       &
                                 this%iout, dnodata)
       end select

--- a/src/Utilities/OutputControl/OutputControl.f90
+++ b/src/Utilities/OutputControl/OutputControl.f90
@@ -1,14 +1,26 @@
+!> @brief This module contains the OutputControlModule
+!!
+!! This module defines the OutputControlType.  This type
+!! is overriden by GWF and GWT to create an Output Control
+!! package for the model.
+!!
+!<
 module OutputControlModule
 
-  use KindModule, only: DP, I4B
-  use ConstantsModule,    only: LENMODELNAME, LENMEMPATH
-  use OutputControlData, only: OutputControlDataType, ocd_cr
-  use BlockParserModule, only: BlockParserType
+  use KindModule,              only: DP, I4B
+  use ConstantsModule,         only: LENMODELNAME, LENMEMPATH
+  use SimVariablesModule,      only: errmsg
+  use OutputControlDataModule, only: OutputControlDataType, ocd_cr
+  use BlockParserModule,       only: BlockParserType
 
   implicit none
   private
   public OutputControlType, oc_cr
 
+  !> @ brief OutputControlType
+  !!
+  !!  Generalized output control package
+  !<
   type OutputControlType  
     character(len=LENMEMPATH)                           :: memoryPath                       !< path to data stored in the memory manager
     character(len=LENMODELNAME), pointer                :: name_model => null()             !< name of the model
@@ -33,19 +45,18 @@ module OutputControlModule
 
   contains
 
+  !> @ brief Create OutputControlType
+  !!
+  !!  Create by allocating a new OutputControlType object and initializing
+  !!  member variables.
+  !!
+  !<
   subroutine oc_cr(ocobj, name_model, inunit, iout)
-! ******************************************************************************
-! oc_cr -- Create a new oc object
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- dummy
-    type(OutputControlType), pointer :: ocobj
-    character(len=*), intent(in) :: name_model
-    integer(I4B), intent(in) :: inunit
-    integer(I4B), intent(in) :: iout
-! ------------------------------------------------------------------------------
+    type(OutputControlType), pointer :: ocobj   !< OutputControlType object
+    character(len=*), intent(in) :: name_model  !< name of the model
+    integer(I4B), intent(in) :: inunit          !< unit number for input
+    integer(I4B), intent(in) :: iout            !< unit number for output
     !
     ! -- Create the object
     allocate(ocobj)
@@ -64,34 +75,31 @@ module OutputControlModule
     return
   end subroutine oc_cr
 
+  !> @ brief Define OutputControlType
+  !!
+  !!  Placeholder routine for the moment.
+  !!
+  !<
   subroutine oc_df(this)
-! ******************************************************************************
-! oc_df -- define the Oc Object
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- dummy
-    class(OutputControlType) :: this
-! ------------------------------------------------------------------------------
+    class(OutputControlType) :: this  !< OutputControlType object
     !
     ! -- Return
     return
   end subroutine oc_df
 
+  !> @ brief Read and prepare OutputControlType
+  !!
+  !!  Read a period data block.
+  !!
+  !<
   subroutine oc_rp(this)
-! ******************************************************************************
-! Read and prepare output control for this stress period
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use TdisModule,              only: kper, nper
     use ConstantsModule,         only: LINELENGTH
     use SimModule, only: store_error, store_error_unit, count_errors
     ! -- dummy
-    class(OutputControlType) :: this
+    class(OutputControlType) :: this  !< OutputControlType object
     ! -- local
     integer(I4B) :: ierr, ival, ipos
     logical :: isfound, found, endOfBlock
@@ -113,7 +121,6 @@ module OutputControlModule
       "(1x,'CURRENT STRESS PERIOD GREATER THAN PERIOD IN OUTPUT CONTROL.')"
     character(len=*), parameter :: fmtpererr2 =                                 &
       "(1x,'CURRENT STRESS PERIOD: ',I0,' SPECIFIED STRESS PERIOD: ',I0)"
-! ------------------------------------------------------------------------------
     !
     ! -- Read next block header if kper greater than last one read
     if (this%iperoc < kper) then
@@ -222,22 +229,21 @@ module OutputControlModule
     return
   end subroutine oc_rp
 
+  !> @ brief Output method for OutputControlType
+  !!
+  !!  Go through each output control data type and output, which will print
+  !!  and/or save data based on user-specified controls.
+  !!
+  !<
   subroutine oc_ot(this, ipflg)
-! ******************************************************************************
-! oc_ot -- output information
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
-    use TdisModule, only: kstp, kper, nstp
+    use TdisModule, only: kstp, endofperiod
     ! -- dummy
-    class(OutputControlType) :: this
-    integer(I4B), intent(inout) :: ipflg
+    class(OutputControlType) :: this      !< OutputControlType object
+    integer(I4B), intent(inout) :: ipflg  !< flag indicating if data was printed
     ! -- local
     integer(I4B) :: ipos
     type(OutputControlDataType), pointer   :: ocdobjptr
-! ------------------------------------------------------------------------------
     !
     ! -- Clear printout flag(ipflg).  This flag indicates that an array was
     !    printed to the listing file.
@@ -245,27 +251,25 @@ module OutputControlModule
     !
     do ipos = 1, size(this%ocdobj)
       ocdobjptr => this%ocdobj(ipos)
-      call ocdobjptr%ocd_ot(ipflg, kstp, nstp(kper), this%iout)
+      call ocdobjptr%ocd_ot(ipflg, kstp, endofperiod, this%iout)
     enddo
     !
     ! -- Return
     return
   end subroutine oc_ot
 
+  !> @ brief Deallocate method for OutputControlType
+  !!
+  !!  Deallocate member variables.
+  !!
+  !<
   subroutine oc_da(this)
-! ******************************************************************************
-! oc_da -- deallocate variables
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
     ! -- dummy
-    class(OutputControlType) :: this
+    class(OutputControlType) :: this  !< OutputControlType object
     ! -- local
     integer(I4B) :: i
-! ------------------------------------------------------------------------------
     !
     do i = 1, size(this%ocdobj)
       call this%ocdobj(i)%ocd_da()
@@ -282,20 +286,18 @@ module OutputControlModule
     return
   end subroutine oc_da
 
+  !> @ brief Allocate scalars method for OutputControlType
+  !!
+  !!  Allocate and initialize member variables.
+  !!
+  !<
   subroutine allocate_scalars(this, name_model)
-! ******************************************************************************
-! allocate_scalars -- Allocate scalars
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use MemoryManagerModule, only: mem_allocate
     use MemoryHelperModule, only: create_mem_path
     ! -- dummy
-    class(OutputControlType) :: this
-    character(len=*), intent(in) :: name_model
-! ------------------------------------------------------------------------------
+    class(OutputControlType) :: this            !< OutputControlType object
+    character(len=*), intent(in) :: name_model  !< name of model
     !
     this%memoryPath = create_mem_path(name_model, 'OC')
     !
@@ -315,26 +317,24 @@ module OutputControlModule
     return
   end subroutine allocate_scalars
 
+  !> @ brief Read options for OutputControlType
+  !!
+  !!  Read options block and set member variables.
+  !!
+  !<
   subroutine read_options(this)
-! ******************************************************************************
-! read_options -- read oc options block
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use ConstantsModule, only: LINELENGTH
     use SimModule, only: store_error, store_error_unit
     ! -- dummy
-    class(OutputControlType) :: this
+    class(OutputControlType) :: this  !< OutputControlType object
     ! -- local
-    character(len=LINELENGTH) :: errmsg, keyword
+    character(len=LINELENGTH) :: keyword
     character(len=:), allocatable :: line
     integer(I4B) :: ierr
     integer(I4B) :: ipos
     logical :: isfound, found, endOfBlock
     type(OutputControlDataType), pointer   :: ocdobjptr
-! ------------------------------------------------------------------------------
     !
     ! -- get options block
     call this%parser%GetBlock('OPTIONS', isfound, ierr, &
@@ -370,23 +370,21 @@ module OutputControlModule
     return
   end subroutine read_options
 
+  !> @ brief Save data to file
+  !!
+  !!  Go through data and save if requested by user.
+  !!
+  !<
   logical function oc_save(this, cname)
-! ******************************************************************************
-! oc_save -- determine if it is time to save cname
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
-    use TdisModule, only: kstp, kper, nstp
+    use TdisModule, only: kstp, endofperiod
     ! -- dummy
-    class(OutputControlType) :: this
-    character(len=*), intent(in) :: cname
+    class(OutputControlType) :: this       !< OutputControlType object
+    character(len=*), intent(in) :: cname  !< character string for data name
     ! -- local
     integer(I4B) :: ipos
     logical :: found
     class(OutputControlDataType), pointer :: ocdobjptr
-! ------------------------------------------------------------------------------
     !
     oc_save = .false.
     found = .false.
@@ -398,30 +396,28 @@ module OutputControlModule
       endif
     enddo
     if(found) then
-      oc_save = ocdobjptr%psmobj%kstp_to_save(kstp, nstp(kper))
+      oc_save = ocdobjptr%psmobj%kstp_to_save(kstp, endofperiod)
     endif
     !
     ! -- Return
     return
   end function oc_save
 
+  !> @ brief Determine if time to print
+  !!
+  !!  Determine if it is time to print the data corresponding to cname.
+  !!
+  !<
   logical function oc_print(this, cname)
-! ******************************************************************************
-! oc_print -- determine if it is time to print cname
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
-    use TdisModule, only: kstp, kper, nstp
+    use TdisModule, only: kstp, endofperiod
     ! -- dummy
-    class(OutputControlType) :: this
-    character(len=*), intent(in) :: cname
+    class(OutputControlType) :: this       !< OutputControlType object
+    character(len=*), intent(in) :: cname  !< character string for data name
     ! -- local
     integer(I4B) :: ipos
     logical :: found
     class(OutputControlDataType), pointer :: ocdobjptr
-! ------------------------------------------------------------------------------
     !
     oc_print = .false.
     found = .false.
@@ -433,31 +429,29 @@ module OutputControlModule
       endif
     enddo
     if(found) then
-      oc_print = ocdobjptr%psmobj%kstp_to_print(kstp, nstp(kper))
+      oc_print = ocdobjptr%psmobj%kstp_to_print(kstp, endofperiod)
     endif
     !
     ! -- Return
     return
   end function oc_print
 
+  !> @ brief Determine unit number for saving
+  !!
+  !!  Determine the unit number for saving cname.
+  !!
+  !<
   function oc_save_unit(this, cname)
-! ******************************************************************************
-! oc_save_unit -- determine unit number for saving
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     ! -- return
     integer(I4B) :: oc_save_unit
     ! -- dummy
-    class(OutputControlType) :: this
-    character(len=*), intent(in) :: cname
+    class(OutputControlType) :: this       !< OutputControlType object
+    character(len=*), intent(in) :: cname  !< character string for data name
     ! -- local
     integer(I4B) :: ipos
     logical :: found
     class(OutputControlDataType), pointer :: ocdobjptr
-! ------------------------------------------------------------------------------
     !
     oc_save_unit = 0
     found = .false.
@@ -476,24 +470,22 @@ module OutputControlModule
     return
   end function oc_save_unit
 
+  !> @ brief Set the print flag
+  !!
+  !!  Set the print flag based on convergence and simulation parameters.
+  !!
+  !<
   function set_print_flag(this, cname, icnvg, endofperiod) result(iprint_flag)
-! ******************************************************************************
-! set_print_flag -- determine if cname should be printed
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use SimVariablesModule, only: isimcontinue
     ! -- return
     integer(I4B) :: iprint_flag
     ! -- dummy
-    class(OutputControlType) :: this
-    character(len=*), intent(in) :: cname
-    integer(I4B), intent(in) :: icnvg
-    logical, intent(in) :: endofperiod
+    class(OutputControlType) :: this       !< OutputControlType object
+    character(len=*), intent(in) :: cname  !< character string for data name
+    integer(I4B), intent(in) :: icnvg      !< convergence flag
+    logical, intent(in) :: endofperiod     !< end of period logical flag
     ! -- local
-! ------------------------------------------------------------------------------
     !
     ! -- default is to not print
     iprint_flag = 0

--- a/src/Utilities/OutputControl/OutputControlData.f90
+++ b/src/Utilities/OutputControl/OutputControlData.f90
@@ -1,27 +1,40 @@
-module OutputControlData
+!> @brief This module contains the OutputControlDataModule
+!!
+!! This module defines the OutputControlDataType.  This type
+!! can be assigned to different model variables, such as head
+!! or concentration.  The variables are then printed and/or
+!! saved in a consistent manner.
+!!
+!<
+module OutputControlDataModule
   
   use BaseDisModule,          only: DisBaseType
   use InputOutputModule,      only: print_format
-  use KindModule,             only: DP, I4B
+  use KindModule,             only: DP, I4B, LGP
   use PrintSaveManagerModule, only: PrintSaveManagerType
   
   implicit none
   private
   public OutputControlDataType, ocd_cr
   
+  !> @ brief OutputControlDataType
+  !!
+  !!  Object for storing information and determining whether or
+  !!  not model data should be printed to a list file or saved to disk.
+  !<
   type OutputControlDataType
-    character(len=16), pointer              :: cname    => null()
-    character(len=60), pointer              :: cdatafmp => null()
-    integer(I4B), pointer                   :: idataun  => null()
-    character(len=1), pointer               :: editdesc => null()
-    integer(I4B), pointer                   :: nvaluesp => null()
-    integer(I4B), pointer                   :: nwidthp  => null()
-    real(DP), pointer                       :: dnodata  => null()
-    integer(I4B), pointer                   :: inodata  => null()
-    real(DP), dimension(:), pointer, contiguous         :: dblvec   => null()
-    integer(I4B), dimension(:), pointer, contiguous     :: intvec   => null()
-    class(DisBaseType), pointer             :: dis      => null()
-    type(PrintSaveManagerType), pointer     :: psmobj   => null()
+    character(len=16), pointer                       :: cname    => null()      !< name of variable, such as HEAD
+    character(len=60), pointer                       :: cdatafmp => null()      !< fortran format for printing
+    integer(I4B), pointer                            :: idataun  => null()      !< fortran unit number for binary output
+    character(len=1), pointer                        :: editdesc => null()      !< fortran format type (I, G, F, S, E)
+    integer(I4B), pointer                            :: nvaluesp => null()      !< number of values per line for printing
+    integer(I4B), pointer                            :: nwidthp  => null()      !< width of the number for printing
+    real(DP), pointer                                :: dnodata  => null()      !< no data value
+    integer(I4B), pointer                            :: inodata  => null()      !< integer no data value
+    real(DP), dimension(:), pointer, contiguous      :: dblvec   => null()      !< pointer to double precision data array
+    integer(I4B), dimension(:), pointer, contiguous  :: intvec   => null()      !< pointer to integer data array
+    class(DisBaseType), pointer                      :: dis      => null()      !< pointer to discretization package
+    type(PrintSaveManagerType), pointer              :: psmobj   => null()      !< print/save manager object
   contains
     procedure :: allocate_scalars
     procedure :: init_int
@@ -34,16 +47,14 @@ module OutputControlData
   
   contains
   
+  !> @ brief Create OutputControlDataType
+  !!
+  !!  Create by allocating a new OutputControlDataType object
+  !!
+  !<
   subroutine ocd_cr(ocdobj)
-! ******************************************************************************
-! ocd_cr -- Create a new ocd object
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- dummy
-    type(OutputControlDataType), pointer :: ocdobj
-! ------------------------------------------------------------------------------
+    type(OutputControlDataType), pointer :: ocdobj  !< OutputControlDataType object
     !
     ! -- Create the object
     allocate(ocdobj)
@@ -55,26 +66,24 @@ module OutputControlData
     return
   end subroutine ocd_cr
   
+  !> @ brief Check OutputControlDataType object
+  !!
+  !!  Perform a consistency check
+  !!
+  !<
   subroutine ocd_rp_check(this, inunit)
-! ******************************************************************************
-! ocd_rp_check -- Check to make sure settings are consistent
-! ******************************************************************************
-!
-!    Specifications:
-! ------------------------------------------------------------------------------
     ! -- modules
     use ConstantsModule, only: LINELENGTH
     use SimModule, only: store_error, count_errors, store_error_unit
     ! -- dummy
-    class(OutputControlDataType) :: this
-    integer(I4B), intent(in) :: inunit
+    class(OutputControlDataType) :: this  !< OutputControlDataType object
+    integer(I4B), intent(in) :: inunit    !< Unit number for input
     ! -- locals
     character(len=LINELENGTH) :: errmsg
     ! -- formats
     character(len=*), parameter :: fmtocsaveerr =                              &
       "(1X,'REQUESTING TO SAVE ',A,' BUT ',A,' SAVE FILE NOT SPECIFIED. ',     &
        &A,' SAVE FILE MUST BE SPECIFIED IN OUTPUT CONTROL OPTIONS.')"
-! ------------------------------------------------------------------------------
     !
     ! -- Check to make sure save file was specified
     if(this%psmobj%save_detected) then
@@ -94,25 +103,24 @@ module OutputControlData
     return
   end subroutine ocd_rp_check
 
-  subroutine ocd_ot(this, ipflg, kstp, nstp, iout, iprint_opt, isav_opt)
-! ******************************************************************************
-! ocd_ot -- record information
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
+  !> @ brief Output data
+  !!
+  !!  Depending on the settings, print the data to a listing file and/or
+  !!  save the data to a binary file.
+  !!
+  !<
+  subroutine ocd_ot(this, ipflg, kstp, endofperiod, iout, iprint_opt, isav_opt)
     ! -- dummy
-    class(OutputControlDataType) :: this
-    integer(I4B), intent(inout) :: ipflg
-    integer(I4B), intent(in) :: kstp
-    integer(I4B), intent(in) :: nstp
-    integer(I4B), intent(in) :: iout
-    integer(I4B), optional, intent(in) :: iprint_opt
-    integer(I4B), optional, intent(in) :: isav_opt
+    class(OutputControlDataType) :: this               !< OutputControlDataType object
+    integer(I4B), intent(inout) :: ipflg               !< Flag indicating if something was printed
+    integer(I4B), intent(in) :: kstp                   !< Current time step
+    logical(LGP), intent(in) :: endofperiod            !< End of period logical flag
+    integer(I4B), intent(in) :: iout                   !< Unit number for output
+    integer(I4B), optional, intent(in) :: iprint_opt   !< Optional print flag override
+    integer(I4B), optional, intent(in) :: isav_opt     !< Optional save flag override
     ! -- local
     integer(I4B) :: iprint
     integer(I4B) :: idataun
-! ------------------------------------------------------------------------------
     !
     ! -- initialize
     iprint = 0
@@ -127,7 +135,7 @@ module OutputControlData
         ipflg = 1
       endif
     else
-      if(this%psmobj%kstp_to_print(kstp, nstp)) then
+      if(this%psmobj%kstp_to_print(kstp, endofperiod)) then
         iprint = 1
         ipflg = 1
       endif
@@ -139,13 +147,13 @@ module OutputControlData
         idataun = this%idataun
       endif
     else
-      if(this%psmobj%kstp_to_save(kstp, nstp)) idataun = this%idataun
+      if(this%psmobj%kstp_to_save(kstp, endofperiod)) idataun = this%idataun
     endif
     !
     ! -- Record double precision array
     if(associated(this%dblvec))                                                &
-    call this%dis%record_array(this%dblvec, iout, iprint, idataun,         &
-                               this%cname, this%cdatafmp, this%nvaluesp,   &
+    call this%dis%record_array(this%dblvec, iout, iprint, idataun,             &
+                               this%cname, this%cdatafmp, this%nvaluesp,       &
                                this%nwidthp, this%editdesc, this%dnodata)
     !
     ! -- Record integer array (not supported yet)
@@ -158,18 +166,16 @@ module OutputControlData
     return
   end subroutine ocd_ot
   
+  !> @ brief Deallocate OutputControlDataType
+  !!
+  !!  Deallocate members of this type
+  !!
+  !<
   subroutine ocd_da(this)
-! ******************************************************************************
-! ocd_da --deallocate
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use ConstantsModule, only: DZERO
     ! -- dummy
     class(OutputControlDataType) :: this
-! ------------------------------------------------------------------------------
     !
     ! -- deallocate 
     deallocate(this%cname)
@@ -186,24 +192,22 @@ module OutputControlData
     return
   end subroutine ocd_da  
   
+  !> @ brief Initialize this OutputControlDataType as double precision data
+  !!
+  !!  Initialize this object as a double precision data type
+  !!
+  !<
   subroutine init_dbl(this, cname, dblvec, dis, cdefpsm, cdeffmp, iout,    &
                       dnodata)
-! ******************************************************************************
-! init_int -- Initialize integer variable
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- dummy
-    class(OutputControlDataType) :: this
-    character(len=*), intent(in) :: cname
-    real(DP), dimension(:), pointer, contiguous, intent(in) :: dblvec
-    class(DisBaseType), pointer, intent(in) :: dis
-    character(len=*), intent(in) :: cdefpsm
-    character(len=*), intent(in) :: cdeffmp
-    integer(I4B), intent(in) :: iout
-    real(DP), intent(in) :: dnodata
-! ------------------------------------------------------------------------------
+    class(OutputControlDataType) :: this                                  !< OutputControlDataType object
+    character(len=*), intent(in) :: cname                                 !< Name of variable
+    real(DP), dimension(:), pointer, contiguous, intent(in) :: dblvec     !< Data array that will be managed by this object
+    class(DisBaseType), pointer, intent(in) :: dis                        !< Discretization package
+    character(len=*), intent(in) :: cdefpsm                               !< String for defining the print/save manager
+    character(len=*), intent(in) :: cdeffmp                               !< String for print format
+    integer(I4B), intent(in) :: iout                                      !< Unit number for output
+    real(DP), intent(in) :: dnodata                                       !< No data value
     !
     this%cname = cname
     this%dblvec => dblvec
@@ -218,24 +222,22 @@ module OutputControlData
     return
   end subroutine init_dbl
   
+  !> @ brief Initialize this OutputControlDataType as integer data
+  !!
+  !!  Initialize this object as an integer data type
+  !!
+  !<
   subroutine init_int(this, cname, intvec, dis, cdefpsm, cdeffmp, iout,    &
                       inodata)
-! ******************************************************************************
-! init_int -- Initialize integer variable
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- dummy
-    class(OutputControlDataType) :: this
-    character(len=*), intent(in) :: cname
-    integer(I4B), dimension(:), pointer, contiguous, intent(in) :: intvec
-    class(DisBaseType), pointer, intent(in) :: dis
-    character(len=*), intent(in) :: cdefpsm
-    character(len=*), intent(in) :: cdeffmp
-    integer(I4B), intent(in) :: iout
-    integer(I4B), intent(in) :: inodata
-! ------------------------------------------------------------------------------
+    class(OutputControlDataType) :: this                                    !< OutputControlDataType object
+    character(len=*), intent(in) :: cname                                   !< Name of variable
+    integer(I4B), dimension(:), pointer, contiguous, intent(in) :: intvec   !< Data array that will be managed by this object
+    class(DisBaseType), pointer, intent(in) :: dis                          !< Discretization package
+    character(len=*), intent(in) :: cdefpsm                                 !< String for defining the print/save manager
+    character(len=*), intent(in) :: cdeffmp                                 !< String for print format
+    integer(I4B), intent(in) :: iout                                        !< Unit number for output
+    integer(I4B), intent(in) :: inodata                                     !< No data value
     !
     this%cname = cname
     this%intvec => intvec
@@ -251,18 +253,16 @@ module OutputControlData
     return
   end subroutine init_int  
   
+  !> @ brief Allocate OutputControlDataType members
+  !!
+  !!  Allocate and initialize member variables
+  !!
+  !<
   subroutine allocate_scalars(this)
-! ******************************************************************************
-! allocate_scalars -- Allocate scalars
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use ConstantsModule, only: DZERO
     ! -- dummy
-    class(OutputControlDataType) :: this
-! ------------------------------------------------------------------------------
+    class(OutputControlDataType) :: this  !< OutputControlDataType object
     !
     allocate(this%cname)
     allocate(this%cdatafmp)
@@ -287,23 +287,22 @@ module OutputControlData
     return
   end subroutine allocate_scalars  
   
+  !> @ brief Set options for this object based on an input string
+  !!
+  !!  Set FILEOUT and PRINT_FORMAT options for this object.
+  !!
+  !<
   subroutine set_option(this, linein, inunit, iout)
-! ******************************************************************************
-! allocate_scalars -- Allocate scalars
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use ConstantsModule, only: MNORMAL 
     use OpenSpecModule, only: access, form
     use InputOutputModule, only: urword, getunit, openfile
     use SimModule, only: store_error, store_error_unit, count_errors
     ! -- dummy
-    class(OutputControlDataType) :: this
-    character(len=*), intent(in) :: linein
-    integer(I4B), intent(in) :: inunit
-    integer(I4B), intent(in) :: iout
+    class(OutputControlDataType) :: this     !< OutputControlDataType object
+    character(len=*), intent(in) :: linein   !< Character string with options
+    integer(I4B), intent(in) :: inunit       !< Unit number for input
+    integer(I4B), intent(in) :: iout         !< Unit number for output
     ! -- local
     character(len=len(linein)) :: line
     integer(I4B) :: lloc, istart, istop, ival
@@ -312,7 +311,6 @@ module OutputControlData
     character(len=*),parameter :: fmtocsave = &
       "(4X,A,' INFORMATION WILL BE WRITTEN TO:',                                 &
        &/,6X,'UNIT NUMBER: ', I0,/,6X, 'FILE NAME: ', A)"
-! ------------------------------------------------------------------------------
     !
     line(:) = linein(:)
     lloc = 1
@@ -339,4 +337,4 @@ module OutputControlData
     return
   end subroutine set_option  
   
-end module OutputControlData
+end module OutputControlDataModule

--- a/src/Utilities/OutputControl/PrintSaveManager.f90
+++ b/src/Utilities/OutputControl/PrintSaveManager.f90
@@ -1,40 +1,49 @@
-!    This module defines the PrintSaveManagerType, which can be used
-!    to determine when something should be printed and/or saved. The
-!    object should be initiated with the following call:
-!      call psm_obj%init()
-!
-!    The set method will configure the members based on the following
-!    keywords when set is called as follows:
-!      call psm_obj%set(nstp, line)
-!    where line may be in the following form:
-!      PRINT ALL
-!      PRINT STEPS 1 4 5 6
-!      PRINT FIRST
-!      PRINT LAST
-!      PRINT FREQUENCY 4
-!      SAVE ALL
-!      SAVE STEPS 1 4 5 6
-!      SAVE FIRST
-!      SAVE LAST
-!      SAVE FREQUENCY 4
-!
-!    Based on the keywords, the object can be called with
-!      psm_obj%time_to_print(kstp, kper)
-!      psm_obj%time_to_save(kstp, kper)
-!    to return a logical flag indicating whether or not it
-!    it is time to print or time to save
-
+!> @brief This module contains the PrintSaveManagerModule
+!!
+!! This module defines the PrintSaveManagerType, which can be used
+!! to determine when something should be printed and/or saved. The
+!! object should be initiated with the following call:
+!!   call psm_obj%init()
+!!
+!! The set method will configure the members based on the following
+!! keywords when set is called as follows:
+!!   call psm_obj%set(nstp, line)
+!! where line may be in the following form:
+!!   PRINT ALL
+!!   PRINT STEPS 1 4 5 6
+!!   PRINT FIRST
+!!   PRINT LAST
+!!   PRINT FREQUENCY 4
+!!   SAVE ALL
+!!   SAVE STEPS 1 4 5 6
+!!   SAVE FIRST
+!!   SAVE LAST
+!!   SAVE FREQUENCY 4
+!!
+!! Based on the keywords, the object can be called with
+!!   psm_obj%time_to_print(kstp, kper)
+!!   psm_obj%time_to_save(kstp, kper)
+!! to return a logical flag indicating whether or not it
+!! it is time to print or time to save
+!!
+!<
 module PrintSaveManagerModule
   
-  use KindModule, only: DP, I4B
+  use KindModule, only: DP, I4B, LGP
   use ArrayHandlersModule, only: expandarray
   use SimVariablesModule, only: errmsg
   use SimModule,           only: store_error
   use InputOutputModule,   only: urword
+  
   implicit none
   private
   public :: PrintSaveManagerType
   
+  !> @ brief PrintSaveManagerType
+  !!
+  !!  Object for storing information and determining whether or
+  !!  not data should be printed to a list file or saved to disk.
+  !<
   type :: PrintSaveManagerType
     integer(I4B), allocatable, dimension(:) :: kstp_list_print
     integer(I4B), allocatable, dimension(:) :: kstp_list_save
@@ -57,16 +66,14 @@ module PrintSaveManagerModule
   
   contains
   
+  !> @ brief Initialize PrintSaveManager
+  !!
+  !!  Initializes variables of a PrintSaveManagerType
+  !!
+  !<
   subroutine init(this)
-! ******************************************************************************
-! init
-! ******************************************************************************
-!
-!    Specifications:
-! ------------------------------------------------------------------------------
     ! -- dummy
-    class(PrintSaveManagerType) :: this
-! ------------------------------------------------------------------------------
+    class(PrintSaveManagerType) :: this  !< psm object to initialize
     !
     ! -- Initialize members to their defaults
     if(allocated(this%kstp_list_print)) deallocate(this%kstp_list_print)
@@ -88,17 +95,17 @@ module PrintSaveManagerModule
     return
   end subroutine init
   
+  !> @ brief Read and prepare for PrintSaveManager
+  !!
+  !!  Parse information in the line and assign settings for the 
+  !!  PrintSaveManagerType.
+  !!
+  !<
   subroutine rp(this, linein, iout)
-! ******************************************************************************
-! read and prepare
-! ******************************************************************************
-!
-!    Specifications:
-! ------------------------------------------------------------------------------
     ! -- dummy
-    class(PrintSaveManagerType)  :: this
-    character(len=*), intent(in) :: linein
-    integer(I4B), intent(in) :: iout
+    class(PrintSaveManagerType)  :: this     !< psm object
+    character(len=*), intent(in) :: linein   !< character line of information
+    integer(I4B), intent(in) :: iout         !< unit number of output file
     ! -- local
     character(len=len(linein)) :: line
     logical lp, ls
@@ -110,7 +117,6 @@ module PrintSaveManagerModule
       "(6x,'THE FOLLOWING STEPS WILL BE ',A,': ',50(I0,' '))"
     character(len=*), parameter :: fmt_freq = &
       "(6x,'THE FOLLOWING FREQUENCY WILL BE ',A,': ',I0)"
-! ------------------------------------------------------------------------------
     !
     ! -- Set the values based on line
     ! -- Get keyword to use in assignment
@@ -207,26 +213,23 @@ module PrintSaveManagerModule
     return
   end subroutine rp
   
-  logical function kstp_to_print(this, kstp, nstp)
-! ******************************************************************************
-! kstp_to_print
-! ******************************************************************************
-!
-!    Specifications:
-! ------------------------------------------------------------------------------
-    implicit none
+  !> @ brief Determine if it is time to print the data
+  !!
+  !!  Determine if data should be printed based on kstp and endofperiod 
+  !!
+  !<
+  logical function kstp_to_print(this, kstp, endofperiod)
     ! -- dummy
-    class(PrintSaveManagerType) :: this
-    integer(I4B), intent(in) :: kstp
-    integer(I4B), intent(in) :: nstp
+    class(PrintSaveManagerType) :: this          !< psm object
+    integer(I4B), intent(in) :: kstp             !< current time step
+    logical(LGP), intent(in) :: endofperiod      !< flag indicating end of stress period
     ! -- local
     integer(I4B) :: i, n
-! ------------------------------------------------------------------------------
     !
     kstp_to_print = .false.
     if(this%print_all) kstp_to_print = .true.
     if(kstp == 1 .and. this%print_first) kstp_to_print = .true.
-    if(kstp == nstp .and. this%print_last) kstp_to_print = .true.
+    if(endofperiod .and. this%print_last) kstp_to_print = .true.
     if(this%ifreq_print > 0) then
       if(mod(kstp, this%ifreq_print) == 0) kstp_to_print = .true.
     endif
@@ -244,26 +247,23 @@ module PrintSaveManagerModule
     return
   end function kstp_to_print
   
-  logical function kstp_to_save(this, kstp, nstp)
-! ******************************************************************************
-! kstp_to_save
-! ******************************************************************************
-!
-!    Specifications:
-! ------------------------------------------------------------------------------
-    implicit none
+  !> @ brief Determine if it is time to save the data
+  !!
+  !!  Determine if data should be saved based on kstp and endofperiod 
+  !!
+  !<
+  logical function kstp_to_save(this, kstp, endofperiod)
     ! -- dummy
-    class(PrintSaveManagerType) :: this
-    integer(I4B), intent(in) :: kstp
-    integer(I4B), intent(in) :: nstp
+    class(PrintSaveManagerType) :: this          !< psm object
+    integer(I4B), intent(in) :: kstp             !< current time step
+    logical(LGP), intent(in) :: endofperiod      !< flag indicating end of stress period
     ! -- local
     integer(I4B) :: i, n
-! ------------------------------------------------------------------------------
     !
     kstp_to_save = .false.
     if(this%save_all) kstp_to_save = .true.
     if(kstp == 1 .and. this%save_first) kstp_to_save = .true.
-    if(kstp == nstp .and. this%save_last) kstp_to_save = .true.
+    if(endofperiod .and. this%save_last) kstp_to_save = .true.
     if(this%ifreq_save > 0) then
       if(mod(kstp, this%ifreq_save) == 0) kstp_to_save = .true.
     endif


### PR DESCRIPTION
* Output control was not correctly determining if it was the end of a stress period for ATS simulations
* Output control now uses tdis%endofperiod to determine if last time step of stress period instead of kstp == nstp(kper)
* Close #764 
* Update to doxygen comments for output control modules
* Remove two unused UZF variables