### PR TITLE
Combined TVK and TVS feature additions (time-varying hydraulic conductivities, specific storage and specific yield)

### DIFF
--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -80,6 +80,9 @@
 		<File RelativePath="..\src\Model\GroundWaterFlow\gwf3riv8.f90"/>
 		<File RelativePath="..\src\Model\GroundWaterFlow\gwf3sfr8.f90"/>
 		<File RelativePath="..\src\Model\GroundWaterFlow\gwf3sto8.f90"/>
+		<File RelativePath="..\src\Model\GroundWaterFlow\gwf3tvbase8.f90"/>
+		<File RelativePath="..\src\Model\GroundWaterFlow\gwf3tvk8.f90"/>
+		<File RelativePath="..\src\Model\GroundWaterFlow\gwf3tvs8.f90"/>
 		<File RelativePath="..\src\Model\GroundWaterFlow\gwf3uzf8.f90"/>
 		<File RelativePath="..\src\Model\GroundWaterFlow\gwf3wel8.f90"/></Filter>
 		<Filter Name="GroundWaterTransport">

--- a/src/Model/GroundWaterFlow/gwf3.f90
+++ b/src/Model/GroundWaterFlow/gwf3.f90
@@ -481,6 +481,7 @@ module GwfModule
     if (.not. readnewdata) return
     !
     ! -- Read and prepare
+    if(this%innpf > 0) call this%npf%npf_rp()
     if(this%inbuy > 0) call this%buy%buy_rp()
     if(this%inhfb > 0) call this%hfb%hfb_rp()
     if(this%inoc > 0)  call this%oc%oc_rp()

--- a/src/Model/GroundWaterFlow/gwf3sto8.f90
+++ b/src/Model/GroundWaterFlow/gwf3sto8.f90
@@ -19,6 +19,8 @@ module GwfStoModule
   use NumericalPackageModule, only: NumericalPackageType
   use BlockParserModule, only: BlockParserType
   use GwfStorageUtilsModule, only: SsCapacity, SyCapacity
+  use InputOutputModule, only: GetUnit, openfile
+  use TvsModule, only: TvsType, tvs_cr
 
   implicit none
   public :: GwfStoType, sto_cr
@@ -39,6 +41,11 @@ module GwfStoModule
     real(DP), dimension(:), pointer, contiguous      :: strgsy => null()         !< vector of specific yield rates
     integer(I4B), dimension(:), pointer, contiguous  :: ibound => null()         !< pointer to model ibound
     real(DP), pointer                                :: satomega => null()       !< newton-raphson saturation omega
+    integer(I4B), pointer                                :: integratechanges => null() !< indicates if mid-simulation ss and sy changes should be integrated via an additional matrix formulation term
+    integer(I4B), pointer                                :: intvs => null()            !< TVS (time-varying storage) unit number (0 if unused)
+    type(TvsType), pointer                               :: tvs => null()              !< TVS object
+    real(DP), dimension(:), pointer, contiguous, private :: oldss => null()            !< previous time step specific storage
+    real(DP), dimension(:), pointer, contiguous, private :: oldsy => null()            !< previous time step specific yield
   contains
     procedure :: sto_ar
     procedure :: sto_rp
@@ -54,6 +61,7 @@ module GwfStoModule
     !procedure, private :: register_handlers
     procedure, private :: read_options
     procedure, private :: read_data
+    procedure, private :: save_old_ss_sy
   end type
 
 contains
@@ -131,6 +139,11 @@ contains
     ! -- read the data block
     call this%read_data()
     !
+    ! -- TVS
+    if (this%intvs /= 0) then
+      call this%tvs%ar(this%dis)
+    end if
+    !
     ! -- return
     return
   end subroutine sto_ar
@@ -159,6 +172,12 @@ contains
     ! -- data
     data css(0)/'       TRANSIENT'/
     data css(1)/'    STEADY-STATE'/
+! ------------------------------------------------------------------------------
+    !
+    ! -- Store ss and sy values from end of last stress period if needed
+    if(this%integratechanges /= 0) then
+      call this%save_old_ss_sy()
+    end if
     !
     ! -- get stress period data
     if (this%ionper < kper) then
@@ -218,6 +237,11 @@ contains
     write (this%iout, '(//1X,A,I0,A,A,/)') &
       'STRESS PERIOD ', kper, ' IS ', trim(adjustl(css(this%iss)))
     !
+    ! -- TVS
+    if (this%intvs /= 0) then
+      call this%tvs%rp()
+    end if
+    !
     ! -- return
     return
   end subroutine sto_rp
@@ -228,10 +252,20 @@ contains
   !!
   !<
   subroutine sto_ad(this)
+    ! -- modules
+    use TdisModule, only: kstp
     ! -- dummy variables
     class(GwfStoType) :: this  !< GwfStoType object
     !
-    ! -- Subroutine does not do anything at the moment
+    ! -- Store ss and sy values from end of last time step if needed
+    if(this%integratechanges /= 0 .and. kstp > 1) then
+      call this%save_old_ss_sy()
+    end if
+    !
+    ! -- TVS
+    if(this%intvs /= 0) then
+      call this%tvs%ad()
+    endif
     !
     ! -- return
     return
@@ -262,6 +296,10 @@ contains
     real(DP) :: sc2
     real(DP) :: rho1
     real(DP) :: rho2
+    real(DP) :: sc1old
+    real(DP) :: sc2old
+    real(DP) :: rho1old
+    real(DP) :: rho2old
     real(DP) :: tp
     real(DP) :: bt
     real(DP) :: tthk
@@ -312,21 +350,30 @@ contains
       !
       ! -- set saturation used for ss
       ss_sat1 = snnew
-      ssh0 = hold(n)
-      ssh1 = DZERO
+      ssh0 = hold(n) - tp
+      ssh1 = tp
       if (this%iconf_ss /= 0) then
         if (snold < DONE) then
-          ssh0 = tp
+          ssh0 = DZERO
         end if
         if (snnew < DONE) then
           ss_sat1 = DZERO
-          ssh1 = tp
+          ssh1 = DZERO
         end if
       end if
       !
       ! -- storage coefficients
       sc1 = SsCapacity(this%istor_coef, tp, bt, this%dis%area(n), this%ss(n))
       rho1 = sc1*tled
+      !
+      if(this%integratechanges /= 0) then
+        ! -- Integration of storage changes (e.g. when using TVS): separate the old (start of time step) and new (end of time step) storage capacities
+        sc1old = SsCapacity(this%istor_coef, tp, bt, this%dis%area(n), this%oldss(n))
+        rho1old = sc1old * tled
+      else
+        ! -- No integration of storage changes: old and new values are identical => normal MF6 storage formulation
+        rho1old = rho1
+      end if
       !
       ! -- initialize matrix terms
       aterm = -rho1 * ss_sat1
@@ -339,15 +386,15 @@ contains
           if (this%iconf_ss == 0) then
             zold = bt + DHALF * tthk * snold
             znew = bt + DHALF * tthk * snnew
-            rhsterm = -rho1 * (snold * (hold(n) - zold) + snnew * znew)
+            rhsterm = -rho1old * snold * (hold(n) - zold) - rho1 * snnew * znew
           else
-            rhsterm = -rho1 * ssh0 + rho1 * ssh1
+            rhsterm = -rho1old * ssh0 + rho1 * ssh1
           end if
         else
-          rhsterm = -rho1 * snold * hold(n)
+          rhsterm = -rho1old * snold * hold(n)
         end if
       else
-        rhsterm = -rho1 * snold * hold(n)
+        rhsterm = -rho1old * snold * hold(n)
       end if
       !
       ! -- add specific storage terms to amat and rhs
@@ -362,18 +409,27 @@ contains
         sc2 = SyCapacity(this%dis%area(n), this%sy(n))
         rho2 = sc2 * tled
         !
+        if(this%integratechanges /= 0) then
+          ! -- Integration of storage changes (e.g. when using TVS): separate the old (start of time step) and new (end of time step) storage capacities
+          sc2old = SyCapacity(this%dis%area(n), this%oldsy(n))
+          rho2old = sc2old * tled
+        else
+          ! -- No integration of storage changes: old and new values are identical => normal MF6 storage formulation
+          rho2old = rho2
+        end if
+        !
         ! -- add specific yield terms to amat at rhs
         if (snnew < DONE) then
           if (snnew > DZERO) then
             amat(idxglo(idiag)) = amat(idxglo(idiag)) - rho2
-            rhsterm = rho2 * tthk * snold
+            rhsterm = rho2old * tthk * snold
             rhsterm = rhsterm + rho2 * bt
           else
-            rhsterm = -rho2 * tthk * (DZERO - snold)
+            rhsterm = -tthk * (DZERO - rho2old * snold)
           end if
           ! -- known flow from specific yield
         else
-          rhsterm = -rho2 * tthk * (DONE - snold)
+          rhsterm = -tthk * (rho2 * snnew - rho2old * snold)
         end if
         rhs(n) = rhs(n) - rhsterm
       end if
@@ -413,7 +469,6 @@ contains
     real(DP) :: bt
     real(DP) :: tthk
     real(DP) :: h
-    real(DP) :: snold
     real(DP) :: snnew
     real(DP) :: derv
     real(DP) :: rterm
@@ -437,7 +492,6 @@ contains
       h = hnew(n)
       !
       ! -- aquifer saturation
-      snold = sQuadraticSaturation(tp, bt, hold(n))
       snnew = sQuadraticSaturation(tp, bt, h)
       !
       ! -- storage coefficients
@@ -456,7 +510,7 @@ contains
         ! -- newton terms for specific storage
         if (this%iconf_ss == 0) then
           if (this%iorig_ss == 0) then
-            drterm = -rho1 * derv * (h - bt) + rho1 * tthk * snnew * derv 
+            drterm = -rho1 * derv * (h - bt) + rho1 * tthk * snnew * derv
           else
             drterm = -(rho1 * derv * h)
           end if
@@ -506,6 +560,10 @@ contains
     real(DP) :: sc2
     real(DP) :: rho1
     real(DP) :: rho2
+    real(DP) :: sc1old
+    real(DP) :: sc2old
+    real(DP) :: rho1old
+    real(DP) :: rho2old
     real(DP) :: tp
     real(DP) :: bt
     real(DP) :: tthk
@@ -542,20 +600,29 @@ contains
           snnew = sQuadraticSaturation(tp, bt, hnew(n), this%satomega)
         end if
         !
-        ! -- set saturation used for ss
-        ssh0 = hold(n)
-        ssh1 = hnew(n)
+        ! -- calculate heads above full saturation used for confined-only ss
+        ssh0 = hold(n) - tp
+        ssh1 = hnew(n) - tp
         if (this%iconf_ss /= 0) then
           if (snold < DONE) then
-            ssh0 = tp
+            ssh0 = DZERO
           end if
           if (snnew < DONE) then
-            ssh1 = tp
+            ssh1 = DZERO
           end if
         end if
         ! -- primary storage coefficient
         sc1 = SsCapacity(this%istor_coef, tp, bt, this%dis%area(n), this%ss(n))
         rho1 = sc1*tled
+        !
+        if(this%integratechanges /= 0) then
+          ! -- Integration of storage changes (e.g. when using TVS): separate the old (start of time step) and new (end of time step) storage capacities
+          sc1old = SsCapacity(this%istor_coef, tp, bt, this%dis%area(n), this%oldss(n))
+          rho1old = sc1old * tled
+        else
+          ! -- No integration of storage changes: old and new values are identical => normal MF6 storage formulation
+          rho1old = rho1
+        end if
         !
         ! -- specific storage
         if (this%iconvert(n) /= 0) then
@@ -563,15 +630,15 @@ contains
             if (this%iconf_ss == 0) then
               zold = bt + DHALF * tthk * snold
               znew = bt + DHALF * tthk * snnew
-              rate = rho1 * (snold * (hold(n) - zold) - snnew * (hnew(n) - znew))
+              rate = rho1old * snold * (hold(n) - zold) - rho1 * snnew * (hnew(n) - znew)
             else
-              rate = rho1 * (ssh0 - ssh1)
+              rate = rho1old * ssh0 - rho1 * ssh1
             end if
           else
-            rate = rho1 * snold * hold(n) - rho1 * snnew * hnew(n)
+            rate = rho1old * snold * hold(n) - rho1 * snnew * hnew(n)
           end if
         else
-          rate = rho1 * hold(n) - rho1 * hnew(n)
+          rate = rho1old * hold(n) - rho1 * hnew(n)
         end if
         !
         ! -- save rate
@@ -589,8 +656,17 @@ contains
           sc2 = SyCapacity(this%dis%area(n), this%sy(n))
           rho2 = sc2 * tled
           !
+          if(this%integratechanges /= 0) then
+            ! -- Integration of storage changes (e.g. when using TVS): separate the old (start of time step) and new (end of time step) storage capacities
+            sc2old = SyCapacity(this%dis%area(n), this%oldsy(n))
+            rho2old = sc2old * tled
+          else
+            ! -- No integration of storage changes: old and new values are identical => normal MF6 storage formulation
+            rho2old = rho2
+          end if
+          !
           ! -- contribution from specific yield
-          rate = rho2 * tthk * snold - rho2 * tthk * snnew
+          rate = rho2old * tthk * snold - rho2 * tthk * snnew
         end if
         this%strgsy(n) = rate
         !
@@ -697,6 +773,12 @@ contains
     ! -- dummy variables
     class(GwfStoType) :: this  !< GwfStoType object
     !
+    ! -- TVS
+    if (this%intvs /= 0) then
+      call this%tvs%da()
+      deallocate(this%tvs)
+    end if
+    !
     ! -- Deallocate arrays if package is active
     if (this%inunit > 0) then
       call mem_deallocate(this%iconvert)
@@ -704,6 +786,14 @@ contains
       call mem_deallocate(this%sy)
       call mem_deallocate(this%strgss)
       call mem_deallocate(this%strgsy)
+      !
+      ! -- Deallocate lazily-allocated arrays if used
+      if(associated(this%oldss)) then
+        deallocate(this%oldss)
+      end if
+      if(associated(this%oldsy)) then
+        deallocate(this%oldsy)
+      end if
     end if
     !
     ! -- Deallocate scalars
@@ -712,6 +802,8 @@ contains
     call mem_deallocate(this%iorig_ss)
     call mem_deallocate(this%iusesy)
     call mem_deallocate(this%satomega)
+    call mem_deallocate(this%integratechanges)
+    call mem_deallocate(this%intvs)
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
@@ -741,6 +833,8 @@ contains
     call mem_allocate(this%iorig_ss, 'IORIG_SS', this%memoryPath)
     call mem_allocate(this%iusesy, 'IUSESY', this%memoryPath)
     call mem_allocate(this%satomega, 'SATOMEGA', this%memoryPath)
+    call mem_allocate(this%integratechanges, 'INTEGRATECHANGES', this%memoryPath)
+    call mem_allocate(this%intvs, 'INTVS', this%memoryPath)
     !
     ! -- initialize scalars
     this%istor_coef = 0
@@ -748,6 +842,8 @@ contains
     this%iorig_ss = 0
     this%iusesy = 0
     this%satomega = DZERO
+    this%integratechanges = 0
+    this%intvs = 0
     !
     ! -- return
     return
@@ -799,7 +895,7 @@ contains
     ! -- dummy variables
     class(GwfStoType) :: this  !< GwfStoType object
     ! -- local variables
-    character(len=LINELENGTH) :: keyword
+    character(len=LINELENGTH) :: keyword, fname
     integer(I4B) :: ierr
     logical :: isfound, endOfBlock
     ! -- formats
@@ -840,6 +936,22 @@ contains
           this%iconf_ss = 1
           this%iorig_ss = 0
           write (this%iout, fmtconfss)
+        case ('TVS')
+          if (this%intvs /= 0) then
+            errmsg = 'Multiple TVS keywords detected in OPTIONS block. ' // &
+                     'Only one TVS entry allowed.'
+            call store_error(errmsg, terminate=.TRUE.)
+          end if
+          call this%parser%GetStringCaps(keyword)
+          if(trim(adjustl(keyword)) /= 'FILEIN') then
+            errmsg = 'TVS keyword must be followed by "FILEIN" ' //          &
+                     'then by filename.'
+            call store_error(errmsg, terminate=.TRUE.)
+          endif
+          call this%parser%GetString(fname)
+          this%intvs = GetUnit()
+          call openfile(this%intvs, this%iout, fname, 'TVS')
+          call tvs_cr(this%tvs, this%name_model, this%intvs, this%iout)
         !
         ! -- right now these are options that are only available in the
         !    development version and are not included in the documentation.
@@ -1004,4 +1116,40 @@ contains
     return
   end subroutine read_data
 
+  !> @ brief Save old storage values
+  !!
+  !!  Save ss and sy values from the previous time step for use with storage
+  !!  integration when integratechanges is non-zero.
+  !!
+  !<
+  subroutine save_old_ss_sy(this)
+    ! -- dummy variables
+    class(GwfStoType) :: this  !< GwfStoType object
+    ! -- local variables
+    integer(I4B) :: n
+    !
+    ! -- Lazily allocate arrays
+    if(.not. associated(this%oldss)) then
+      allocate(this%oldss(this%dis%nodes))
+    end if
+    if(this%iusesy == 1 .and. .not. associated(this%oldsy)) then
+      allocate(this%oldsy(this%dis%nodes))
+    end if
+    !
+    ! -- Save current specific storage
+    do n = 1, this%dis%nodes
+      this%oldss(n) = this%ss(n)
+    end do
+    !
+    ! -- Save current specific yield, if used
+    if(this%iusesy == 1) then
+      do n = 1, this%dis%nodes
+        this%oldsy(n) = this%sy(n)
+      end do
+    end if
+    !
+    ! -- Return
+    return
+  end subroutine save_old_ss_sy
+    
 end module GwfStoModule

--- a/src/Model/GroundWaterFlow/gwf3tvbase8.f90
+++ b/src/Model/GroundWaterFlow/gwf3tvbase8.f90
@@ -1,0 +1,404 @@
+module TvBaseModule
+  use BaseDisModule, only: DisBaseType
+  use ConstantsModule, only: LINELENGTH, MAXCHARLEN, DZERO
+  use KindModule, only: I4B, DP
+  use NumericalPackageModule, only: NumericalPackageType
+  use SimModule, only: count_errors, store_error, ustop
+  use SimVariablesModule, only: errmsg
+  use TdisModule, only: kper, nper, kstp
+  use TimeSeriesLinkModule, only: TimeSeriesLinkType
+  use TimeSeriesManagerModule, only: TimeSeriesManagerType, tsmanager_cr, read_value_or_time_series_adv
+
+  implicit none
+
+  private
+
+  public :: TvBaseType
+  public :: tvbase_da
+
+  ! -- Abstract base class implementing common time-varying property functionality for TVK and TVS
+  type, abstract, extends(NumericalPackageType) :: TvBaseType
+    type(TimeSeriesManagerType), pointer, private :: tsmanager => null()
+  contains
+    procedure :: init
+    procedure :: ar
+    procedure :: rp
+    procedure :: ad
+    procedure :: da => tvbase_da
+    procedure, private :: tvbase_allocate_scalars
+    procedure, private :: read_options
+    procedure(ar_set_pointers), deferred :: ar_set_pointers
+    procedure(read_option), deferred :: read_option
+    procedure(get_pointer_to_value), deferred :: get_pointer_to_value
+    procedure(set_changed_at), deferred :: set_changed_at
+    procedure(reset_change_flags), deferred :: reset_change_flags
+    procedure(validate_change), deferred :: validate_change
+  end type TvBaseType
+
+  abstract interface
+
+    subroutine ar_set_pointers(this)
+      import TvBaseType
+      !
+      class(TvBaseType) :: this
+    end subroutine
+
+    function read_option(this, keyword) result(success)
+      import TvBaseType
+      !
+      class(TvBaseType) :: this
+      character(len=*), intent(in) :: keyword
+      !
+      logical :: success
+    end function
+
+    function get_pointer_to_value(this, n, varName) result(bndElem)
+      use KindModule, only: I4B, DP
+      import TvBaseType
+      !
+      class(TvBaseType) :: this
+      integer(I4B), intent(in) :: n
+      character(len=*), intent(in) :: varName
+      !
+      real(DP), pointer :: bndElem
+    end function
+
+    subroutine set_changed_at(this, kper, kstp)
+      use KindModule, only: I4B
+      import TvBaseType
+      !
+      class(TvBaseType) :: this
+      integer(I4B), intent(in) :: kper
+      integer(I4B), intent(in) :: kstp
+    end subroutine
+
+    subroutine reset_change_flags(this)
+      import TvBaseType
+      !
+      class(TvBaseType) :: this
+    end subroutine
+
+    subroutine validate_change(this, n, varName)
+      use KindModule, only: I4B
+      import TvBaseType
+      !
+      class(TvBaseType) :: this
+      integer(I4B), intent(in) :: n
+      character(len=*), intent(in) :: varName
+    end subroutine
+
+  end interface
+
+contains
+
+  subroutine init(this, name_model, pakname, ftype, inunit, iout)
+! ******************************************************************************
+! init -- Initialise the TvBaseType object
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvBaseType) :: this
+    character(len=*), intent(in) :: name_model
+    character(len=*), intent(in) :: pakname
+    character(len=*), intent(in) :: ftype
+    integer(I4B), intent(in) :: inunit
+    integer(I4B), intent(in) :: iout
+! ------------------------------------------------------------------------------
+    !
+    call this%set_names(1, name_model, pakname, ftype)
+    call this%tvbase_allocate_scalars()
+    this%inunit = inunit
+    this%iout = iout
+    call this%parser%Initialize(this%inunit, this%iout)
+    !
+    return
+  end subroutine init
+
+  subroutine tvbase_allocate_scalars(this)
+! ******************************************************************************
+! tvbase_allocate_scalars -- Allocate scalar members
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvBaseType) :: this
+! ------------------------------------------------------------------------------
+    !
+    ! -- Call standard NumericalPackageType allocate scalars
+    call this%NumericalPackageType%allocate_scalars()
+    !
+    ! -- Allocate time series manager
+    allocate(this%tsmanager)
+    !
+    return
+  end subroutine tvbase_allocate_scalars
+
+  subroutine ar(this, dis)
+! ******************************************************************************
+! ar -- Allocate and read
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvBaseType) :: this
+    class(DisBaseType), pointer, intent(in) :: dis
+! ------------------------------------------------------------------------------
+    !
+    ! -- Set pointers to other package variables and announce package
+    this%dis => dis
+    call this%ar_set_pointers()
+    !
+    ! -- Create time series manager
+    call tsmanager_cr(this%tsmanager, this%iout, removeTsLinksOnCompletion = .true., extendTsToEndOfSimulation = .true.)
+    !
+    ! -- Read options
+    call this%read_options()
+    !
+    ! -- Now that time series will have been read, need to call the df routine to define the manager
+    call this%tsmanager%tsmanager_df()
+    !
+    ! -- Terminate if any errors were encountered
+    if(count_errors() > 0) then
+      call this%parser%StoreErrorUnit()
+      call ustop()
+    end if
+    !
+    return
+  end subroutine ar
+
+  subroutine read_options(this)
+! ******************************************************************************
+! read_options -- Read OPTIONS block of TVK file
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvBaseType) :: this
+    !
+    character(len=LINELENGTH) :: keyword
+    character(len=MAXCHARLEN) :: fname
+    logical :: isfound
+    logical :: endOfBlock
+    integer(I4B) :: ierr
+    !
+    character(len=*), parameter :: fmtts = &
+      "(4x, 'TIME-SERIES DATA WILL BE READ FROM FILE: ', a)"
+! ------------------------------------------------------------------------------
+    !
+    ! -- Get options block
+    call this%parser%GetBlock('OPTIONS', isfound, ierr, blockRequired=.false., supportOpenClose=.true.)
+    !
+    ! -- Parse options block if detected
+    if(isfound) then
+      write(this%iout, '(1x,a)') 'PROCESSING ' // trim(adjustl(this%packName)) // ' OPTIONS'
+      do
+        call this%parser%GetNextLine(endOfBlock)
+        if(endOfBlock) then
+          exit
+        end if
+        call this%parser%GetStringCaps(keyword)
+        select case (keyword)
+          case ('TS6')
+            !
+            ! -- Add a time series file
+            call this%parser%GetStringCaps(keyword)
+            if(trim(adjustl(keyword)) /= 'FILEIN') then
+              errmsg = 'TS6 keyword must be followed by "FILEIN" then by filename.'
+              call store_error(errmsg)
+              call this%parser%StoreErrorUnit()
+              call ustop()
+            end if
+            call this%parser%GetString(fname)
+            write(this%iout, fmtts) trim(fname)
+            call this%tsmanager%add_tsfile(fname, this%inunit)
+          case default
+            !
+            ! -- Defer to subtype to read the option; if the subtype can't handle it, report an error
+            if(.not. this%read_option(keyword)) then
+              write(errmsg, '(a,3(1x,a),a)') 'Unknown', trim(adjustl(this%packName)), "option '", trim(keyword), "'."
+              call store_error(errmsg)
+            end if
+        end select
+      end do
+      write(this%iout, '(1x,a)') 'END OF ' // trim(adjustl(this%packName)) // ' OPTIONS'
+    end if
+    !
+    return
+  end subroutine read_options
+
+  subroutine rp(this)
+! ******************************************************************************
+! rp -- Read and prepare
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvBaseType) :: this
+    !
+    character(len=LINELENGTH) :: line, cellid, varName, text
+    logical :: isfound, endOfBlock, haveChanges
+    integer(I4B) :: ierr, node
+    real(DP), pointer :: bndElem => null()
+    !
+    character(len=*),parameter :: fmtblkerr =                                   &
+      "('Looking for BEGIN PERIOD iper.  Found ', a, ' instead.')"
+    character(len=*),parameter :: fmtvalchg =                                   &
+      "(a, ' package: Setting ', a, ' value for cell ', a, ' at start of stress period ', i0, ' = ', g12.5)"
+! ------------------------------------------------------------------------------
+    !
+    if(this%inunit == 0) return
+    !
+    ! -- Get stress period data
+    if(this%ionper < kper) then
+      !
+      ! -- Get PERIOD block
+      call this%parser%GetBlock('PERIOD', isfound, ierr, &
+                                supportOpenClose=.true.)
+      if(isfound) then
+        !
+        ! -- Read ionper and check for increasing period numbers
+        call this%read_check_ionper()
+      else
+        !
+        ! -- PERIOD block not found
+        if(ierr < 0) then
+          ! -- End of file found; data applies for remainder of simulation.
+          this%ionper = nper + 1
+        else
+          ! -- Found invalid block
+          call this%parser%GetCurrentLine(line)
+          write(errmsg, fmtblkerr) adjustl(trim(line))
+          call store_error(errmsg)
+        end if
+      end if
+    end if
+    !
+    ! -- Read data if ionper == kper
+    if(this%ionper == kper) then
+      !
+      ! -- Reset per-node property change flags
+      call this%reset_change_flags()
+      !
+      haveChanges = .false.
+      do
+        call this%parser%GetNextLine(endOfBlock)
+        if(endOfBlock) then
+          exit
+        end if
+        !
+        ! -- Read cell ID
+        call this%parser%GetCellid(this%dis%ndim, cellid)
+        node = this%dis%noder_from_cellid(cellid, this%parser%iuactive, this%iout)
+        !
+        ! -- Validate cell ID
+        if(node < 1 .or. node > this%dis%nodes) then
+          write(errmsg, '(a,2(1x,a))') 'CELLID', cellid, 'is not in the active model domain.'
+          call store_error(errmsg)
+          cycle
+        end if
+        !
+        ! -- Read variable name
+        call this%parser%GetStringCaps(varName)
+        !
+        ! -- Get a pointer to the property value given by varName for the node with the specified cell ID
+        bndElem => this%get_pointer_to_value(node, varName)
+        if(.not. associated(bndElem)) then
+          write(errmsg, '(a,3(1x,a),a)') 'Unknown', trim(adjustl(this%packName)), "variable '", trim(varName), "'."
+          call store_error(errmsg)
+          cycle
+        end if
+        !
+        ! -- Read and apply value or time series link
+        call this%parser%GetString(text)
+        call read_value_or_time_series_adv(text, node, 0, bndElem, this%packName, 'BND', this%tsmanager, this%iprpak, varName)
+        !
+        ! -- Report value change
+        write(this%iout, fmtvalchg) trim(adjustl(this%packName)), trim(varName), trim(cellid), kper, bndElem
+        !
+        ! -- Validate the new property value
+        call this%validate_change(node, varName)
+        haveChanges = .true.
+      end do
+      !
+      ! -- Record that any changes were made at the first time step of the stress period
+      if(haveChanges) then
+        call this%set_changed_at(kper, 1)
+      end if
+    end if
+    !
+    ! -- Terminate if errors were encountered in the PERIOD block
+    if(count_errors() > 0) then
+      call this%parser%StoreErrorUnit()
+      call ustop()
+    end if
+    !
+    return
+  end subroutine rp
+
+  subroutine ad(this)
+! ******************************************************************************
+! ad -- Advance
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvBaseType) :: this
+    !
+    integer(I4B) :: i, n, numlinks
+    type(TimeSeriesLinkType), pointer :: tsLink
+! ------------------------------------------------------------------------------
+    !
+    ! -- Advance the time series manager - this will apply any time series changes to property values
+    call this%tsmanager%ad()
+    !
+    ! -- If there are no time series property changes, there is nothing else to be done
+    numlinks = this%tsmanager%CountLinks('BND')
+    if(numlinks <= 0) then
+      return
+    end if
+    !
+    ! -- Record that changes were made at the current time step (as we have at least one active time series link)
+    call this%set_changed_at(kper, kstp)
+    !
+    ! -- Reset node K change flags at all time steps except the first of each period (the first is done in rp(), to allow non-time series changes)
+    if(kstp /= 1) then
+      call this%reset_change_flags()
+    end if
+    !
+    ! -- Validate all new property values
+    do i = 1, numlinks
+      tsLink => this%tsmanager%GetLink('BND', i)
+      n = tsLink%iRow
+      call this%validate_change(n, tsLink%Text)
+    end do
+    !
+    ! -- Terminate if there were errors
+    if(count_errors() > 0) then
+      call this%parser%StoreErrorUnit()
+      call ustop()
+    end if
+    !
+    return
+  end subroutine ad
+
+  subroutine tvbase_da(this)
+! ******************************************************************************
+! tvbase_da -- Deallocate variables
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvBaseType) :: this
+! ------------------------------------------------------------------------------
+    !
+    ! -- Deallocate time series manager
+    deallocate(this%tsmanager)
+    !
+    ! -- Deallocate parent
+    call this%NumericalPackageType%da()
+    !
+    return
+  end subroutine tvbase_da
+
+end module TvBaseModule

--- a/src/Model/GroundWaterFlow/gwf3tvk8.f90
+++ b/src/Model/GroundWaterFlow/gwf3tvk8.f90
@@ -1,0 +1,255 @@
+module TvkModule
+  use BaseDisModule, only: DisBaseType
+  use ConstantsModule, only: LINELENGTH, LENMEMPATH, DZERO
+  use KindModule, only: I4B, DP
+  use MemoryManagerModule, only: mem_setptr
+  use MemoryHelperModule, only: create_mem_path
+  use SimModule, only: store_error
+  use SimVariablesModule, only: errmsg
+  use TvBaseModule, only: TvBaseType, tvbase_da
+
+  implicit none
+
+  private
+
+  public :: TvkType
+  public :: tvk_cr
+
+  type, extends(TvBaseType) :: TvkType
+    integer(I4B), pointer :: ik22overk => null()                             ! NPF flag that k22 is specified as anisotropy ratio
+    integer(I4B), pointer :: ik33overk => null()                             ! NPF flag that k33 is specified as anisotropy ratio
+    real(DP), dimension(:), pointer, contiguous :: k11 => null()             ! NPF hydraulic conductivity; if anisotropic, then this is Kx prior to rotation
+    real(DP), dimension(:), pointer, contiguous :: k22 => null()             ! NPF hydraulic conductivity; if specified then this is Ky prior to rotation
+    real(DP), dimension(:), pointer, contiguous :: k33 => null()             ! NPF hydraulic conductivity; if specified then this is Kz prior to rotation
+    integer(I4B), pointer :: kchangeper => null()                            ! NPF last stress period in which any node K (or K22, or K33) values were changed (0 if unchanged from start of simulation)
+    integer(I4B), pointer :: kchangestp => null()                            ! NPF last time step in which any node K (or K22, or K33) values were changed (0 if unchanged from start of simulation)
+    integer(I4B), dimension(:), pointer, contiguous :: nodekchange => null() ! NPF grid array of flags indicating for each node whether its K (or K22, or K33) value changed (1) at (kchangeper, kchangestp) or not (0)
+  contains
+    procedure :: da => tvk_da
+    procedure :: ar_set_pointers => tvk_ar_set_pointers
+    procedure :: read_option => tvk_read_option
+    procedure :: get_pointer_to_value => tvk_get_pointer_to_value
+    procedure :: set_changed_at => tvk_set_changed_at
+    procedure :: reset_change_flags => tvk_reset_change_flags
+    procedure :: validate_change => tvk_validate_change
+  end type TvkType
+
+contains
+
+  subroutine tvk_cr(tvk, name_model, inunit, iout)
+! ******************************************************************************
+! tvk_cr -- Create a new TvkType object
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    type(TvkType), pointer, intent(out) :: tvk
+    character(len=*), intent(in) :: name_model
+    integer(I4B), intent(in) :: inunit
+    integer(I4B), intent(in) :: iout
+! ------------------------------------------------------------------------------
+    !
+    allocate(tvk)
+    call tvk%init(name_model, 'TVK', 'TVK', inunit, iout)
+    !
+    return
+  end subroutine tvk_cr
+
+  subroutine tvk_ar_set_pointers(this)
+! ******************************************************************************
+! tvk_ar_set_pointers -- Announce package and set pointers to variables
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvkType) :: this
+    !
+    character(len=LENMEMPATH) :: npfMemoryPath
+    !
+    character(len=*), parameter :: fmttvk =                                    &
+      "(1x,/1x,'TVK -- TIME-VARYING K PACKAGE, VERSION 1, 08/18/2021',         &
+     &' INPUT READ FROM UNIT ', i0, //)"
+! ------------------------------------------------------------------------------
+    !
+    ! -- Print a message identifying the TVK package
+    write(this%iout, fmttvk) this%inunit
+    !
+    ! -- Set pointers to other package variables
+    ! -- NPF
+    npfMemoryPath = create_mem_path(this%name_model, 'NPF')
+    call mem_setptr(this%ik22overk, 'IK22OVERK', npfMemoryPath)
+    call mem_setptr(this%ik33overk, 'IK33OVERK', npfMemoryPath)
+    call mem_setptr(this%k11, 'K11', npfMemoryPath)
+    call mem_setptr(this%k22, 'K22', npfMemoryPath)
+    call mem_setptr(this%k33, 'K33', npfMemoryPath)
+    call mem_setptr(this%kchangeper, 'KCHANGEPER', npfMemoryPath)
+    call mem_setptr(this%kchangestp, 'KCHANGESTP', npfMemoryPath)
+    call mem_setptr(this%nodekchange, 'NODEKCHANGE', npfMemoryPath)
+    !
+    return
+  end subroutine tvk_ar_set_pointers
+
+  function tvk_read_option(this, keyword) result(success)
+! ******************************************************************************
+! tvk_read_option -- Read a TVK-specific setting from the OPTIONS block
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvkType) :: this
+    character(len=*), intent(in) :: keyword
+    !
+    logical :: success
+! ------------------------------------------------------------------------------
+    !
+    ! -- There are no TVK-specific options, so just return false
+    success = .false.
+    !
+    return
+  end function tvk_read_option
+
+  function tvk_get_pointer_to_value(this, n, varName) result(bndElem)
+! ******************************************************************************
+! tvk_get_pointer_to_value -- Return a pointer to the property value for node n
+!                             and the given variable name
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvkType) :: this
+    integer(I4B), intent(in) :: n
+    character(len=*), intent(in) :: varName
+    !
+    real(DP), pointer :: bndElem
+! ------------------------------------------------------------------------------
+    !
+    select case (varName)
+      case ('K')
+        bndElem => this%k11(n)
+      case ('K22')
+        bndElem => this%k22(n)
+      case ('K33')
+        bndElem => this%k33(n)
+      case default
+        bndElem => null()
+    end select
+    !
+    return
+  end function tvk_get_pointer_to_value
+
+  subroutine tvk_set_changed_at(this, kper, kstp)
+! ******************************************************************************
+! tvk_set_changed_at -- Mark property changes as having occurred at (kper, kstp)
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvkType) :: this
+    integer(I4B), intent(in) :: kper
+    integer(I4B), intent(in) :: kstp
+! ------------------------------------------------------------------------------
+    !
+    this%kchangeper = kper
+    this%kchangestp = kstp
+    !
+    return
+  end subroutine tvk_set_changed_at
+
+  subroutine tvk_reset_change_flags(this)
+! ******************************************************************************
+! tvk_reset_change_flags -- Clear all per-node change flags
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvkType) :: this
+    !
+    integer(I4B) :: i
+! ------------------------------------------------------------------------------
+    !
+    ! -- Clear NPF's nodekchange array
+    do i = 1, this%dis%nodes
+      this%nodekchange(i) = 0
+    end do
+    !
+    return
+  end subroutine tvk_reset_change_flags
+
+  subroutine tvk_validate_change(this, n, varName)
+! ******************************************************************************
+! tvk_validate_change -- Multiply out K22 and K33 factors (if the corresponding
+!                        NPF options are active), mark change and check value
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvkType) :: this
+    integer(I4B), intent(in) :: n
+    character(len=*), intent(in) :: varName
+    !
+    character(len=LINELENGTH) :: cellstr
+    !
+    character(len=*), parameter :: fmtkerr =                                   &
+      "(1x, a, ' changed hydraulic property ',a,' is <= 0 for cell ',a, ' ', 1pg15.6)"
+! ------------------------------------------------------------------------------
+    !
+    ! -- Mark the node as being changed this time step
+    this%nodekchange(n) = 1
+    !
+    ! -- Check the changed value is ok
+    if(varName == 'K') then
+      if(this%k11(n) <= DZERO) then
+        call this%dis%noder_to_string(n, cellstr)
+        write(errmsg, fmtkerr) trim(adjustl(this%packName)), 'K', trim(cellstr), this%k11(n)
+        call store_error(errmsg)
+      end if
+    elseif(varName == 'K22') then
+      if(this%ik22overk == 1) then
+        this%k22(n) = this%k22(n) * this%k11(n)
+      end if
+      if(this%k22(n) <= DZERO) then
+        call this%dis%noder_to_string(n, cellstr)
+        write(errmsg, fmtkerr) trim(adjustl(this%packName)), 'K22', trim(cellstr), this%k22(n)
+        call store_error(errmsg)
+      end if
+    elseif(varName == 'K33') then
+      if(this%ik33overk == 1) then
+        this%k33(n) = this%k33(n) * this%k33(n)
+      end if
+      if(this%k33(n) <= DZERO) then
+        call this%dis%noder_to_string(n, cellstr)
+        write(errmsg, fmtkerr) trim(adjustl(this%packName)), 'K33', trim(cellstr), this%k33(n)
+        call store_error(errmsg)
+      end if
+    end if
+    !
+    return
+  end subroutine tvk_validate_change
+
+  subroutine tvk_da(this)
+! ******************************************************************************
+! tvk_da -- Deallocate variables
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvkType) :: this
+! ------------------------------------------------------------------------------
+    !
+    ! -- Nullify pointers to other package variables
+    nullify(this%ik22overk)
+    nullify(this%ik33overk)
+    nullify(this%k11)
+    nullify(this%k22)
+    nullify(this%k33)
+    nullify(this%kchangeper)
+    nullify(this%kchangestp)
+    nullify(this%nodekchange)
+    !
+    ! -- Deallocate parent
+    call tvbase_da(this)
+    !
+    return
+  end subroutine tvk_da
+
+end module TvkModule

--- a/src/Model/GroundWaterFlow/gwf3tvs8.f90
+++ b/src/Model/GroundWaterFlow/gwf3tvs8.f90
@@ -1,0 +1,240 @@
+module TvsModule
+  use BaseDisModule, only: DisBaseType
+  use ConstantsModule, only: LINELENGTH, LENMEMPATH, DZERO
+  use KindModule, only: I4B, DP
+  use MemoryManagerModule, only: mem_setptr
+  use MemoryHelperModule, only: create_mem_path
+  use SimModule, only: store_error
+  use SimVariablesModule, only: errmsg
+  use TvBaseModule, only: TvBaseType, tvbase_da
+
+  implicit none
+
+  private
+
+  public :: TvsType
+  public :: tvs_cr
+
+  type, extends(TvBaseType) :: TvsType
+    integer(I4B), pointer :: integratechanges => null()           ! STO flag indicating if ss is read as storativity
+    integer(I4B), pointer :: iusesy => null()                     ! STO flag set if any cell is convertible (0, 1)
+    real(DP), dimension(:), pointer, contiguous :: ss => null()   ! STO specific storage
+    real(DP), dimension(:), pointer, contiguous :: sy => null()   ! STO specific yield
+  contains
+    procedure :: da => tvs_da
+    procedure :: ar_set_pointers => tvs_ar_set_pointers
+    procedure :: read_option => tvs_read_option
+    procedure :: get_pointer_to_value => tvs_get_pointer_to_value
+    procedure :: set_changed_at => tvs_set_changed_at
+    procedure :: reset_change_flags => tvs_reset_change_flags
+    procedure :: validate_change => tvs_validate_change
+  end type TvsType
+
+contains
+
+  subroutine tvs_cr(tvs, name_model, inunit, iout)
+! ******************************************************************************
+! tvs_cr -- Create a new TvsType object
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    type(TvsType), pointer, intent(out) :: tvs
+    character(len=*), intent(in) :: name_model
+    integer(I4B), intent(in) :: inunit
+    integer(I4B), intent(in) :: iout
+! ------------------------------------------------------------------------------
+    !
+    allocate(tvs)
+    call tvs%init(name_model, 'TVS', 'TVS', inunit, iout)
+    !
+    return
+  end subroutine tvs_cr
+
+  subroutine tvs_ar_set_pointers(this)
+! ******************************************************************************
+! tvs_ar_set_pointers -- Announce package and set pointers to variables
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvsType) :: this
+    !
+    character(len=LENMEMPATH) :: stoMemoryPath
+    !
+    character(len=*), parameter :: fmttvs =                                    &
+      "(1x,/1x,'TVS -- TIME-VARYING S PACKAGE, VERSION 1, 08/18/2021',         &
+     &' INPUT READ FROM UNIT ', i0, //)"
+! ------------------------------------------------------------------------------
+    !
+    ! -- Print a message identifying the TVS package
+    write(this%iout, fmttvs) this%inunit
+    !
+    ! -- Set pointers to other package variables
+    ! -- STO
+    stoMemoryPath = create_mem_path(this%name_model, 'STO')
+    call mem_setptr(this%integratechanges, 'INTEGRATECHANGES', stoMemoryPath)
+    call mem_setptr(this%iusesy, 'IUSESY', stoMemoryPath)
+    call mem_setptr(this%ss, 'SS', stoMemoryPath)
+    call mem_setptr(this%sy, 'SY', stoMemoryPath)
+    !
+    ! -- Instruct STO to integrate storage changes by default, since TVS is active
+    this%integratechanges = 1
+    !
+    return
+  end subroutine tvs_ar_set_pointers
+
+  function tvs_read_option(this, keyword) result(success)
+! ******************************************************************************
+! tvs_read_option -- Read a TVS-specific setting from the OPTIONS block
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvsType) :: this
+    character(len=*), intent(in) :: keyword
+    !
+    logical :: success
+    !
+    character(len=*), parameter :: fmtdsci =                                   &
+      "(4X,'DISABLE_STORAGE_CHANGE_INTEGRATION OPTION:',/,                     &
+      &1X,'Storage derivative terms will not be added to STO matrix formulation')"
+! ------------------------------------------------------------------------------
+    !
+    select case (keyword)
+      case ('DISABLE_STORAGE_CHANGE_INTEGRATION')
+        success = .true.
+        this%integratechanges = 0
+        write(this%iout, fmtdsci)
+      case default
+        success = .false.
+    end select
+    !
+    return
+  end function tvs_read_option
+
+  function tvs_get_pointer_to_value(this, n, varName) result(bndElem)
+! ******************************************************************************
+! tvs_get_pointer_to_value -- Return a pointer to the property value for node n
+!                             and the given variable name
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvsType) :: this
+    integer(I4B), intent(in) :: n
+    character(len=*), intent(in) :: varName
+    !
+    real(DP), pointer :: bndElem
+! ------------------------------------------------------------------------------
+    !
+    select case (varName)
+      case ('SS')
+        bndElem => this%ss(n)
+      case ('SY')
+        bndElem => this%sy(n)
+      case default
+        bndElem => null()
+    end select
+    !
+    return
+  end function tvs_get_pointer_to_value
+
+  subroutine tvs_set_changed_at(this, kper, kstp)
+! ******************************************************************************
+! tvs_set_changed_at -- Mark property changes as having occurred at (kper, kstp)
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvsType) :: this
+    integer(I4B), intent(in) :: kper
+    integer(I4B), intent(in) :: kstp
+! ------------------------------------------------------------------------------
+    !
+    ! -- No need to record TVS/STO changes, as no other packages cache ss or sy values
+    !
+    return
+  end subroutine tvs_set_changed_at
+
+  subroutine tvs_reset_change_flags(this)
+! ******************************************************************************
+! tvs_reset_change_flags -- Clear all per-node change flags
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvsType) :: this
+! ------------------------------------------------------------------------------
+    !
+    ! -- No need to record TVS/STO changes, as no other packages cache ss or sy values
+    !
+    return
+  end subroutine tvs_reset_change_flags
+
+  subroutine tvs_validate_change(this, n, varName)
+! ******************************************************************************
+! tvs_validate_change -- Multiply by area and thickness as necessary to get
+!                        storage capacity, and check value is non-negative
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvsType) :: this
+    integer(I4B), intent(in) :: n
+    character(len=*), intent(in) :: varName
+    !
+    character(len=LINELENGTH) :: cellstr
+    real(DP) :: thick
+    !
+    character(len=*), parameter :: fmtserr =                                   &
+      "(1x, a, ' changed storage property ',a,' is < 0 for cell ',a, ' ', 1pg15.6)"
+    character(len=*), parameter :: fmtsyerr =                                  &
+      "(1x, a, ' cannot change ',a,' for cell ',a, ' because SY is unused in this model (all ICONVERT flags are 0).')"
+! ------------------------------------------------------------------------------
+    !
+    ! -- Check the changed value is ok and convert to storage capacity
+    if(varName == 'SS') then
+      if(this%ss(n) < DZERO) then
+        call this%dis%noder_to_string(n, cellstr)
+        write(errmsg, fmtserr) trim(adjustl(this%packName)), 'SS', trim(cellstr), this%ss(n)
+        call store_error(errmsg)
+      endif
+    elseif(varName == 'SY') then
+      if(this%iusesy /= 1) then
+        call this%dis%noder_to_string(n, cellstr)
+        write(errmsg, fmtsyerr) trim(adjustl(this%packName)), 'SY', trim(cellstr)
+        call store_error(errmsg)
+      elseif(this%sy(n) < DZERO) then
+        call this%dis%noder_to_string(n, cellstr)
+        write(errmsg, fmtserr) trim(adjustl(this%packName)), 'SY', trim(cellstr), this%sy(n)
+        call store_error(errmsg)
+      endif
+    end if
+    !
+    return
+  end subroutine tvs_validate_change
+
+  subroutine tvs_da(this)
+! ******************************************************************************
+! tvs_da -- Deallocate variables
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    class(TvsType) :: this
+! ------------------------------------------------------------------------------
+    !
+    ! -- Nullify pointers to other package variables
+    nullify(this%integratechanges)
+    nullify(this%iusesy)
+    nullify(this%ss)
+    nullify(this%sy)
+    !
+    ! -- Deallocate parent
+    call tvbase_da(this)
+    !
+    return
+  end subroutine tvs_da
+
+end module TvsModule


### PR DESCRIPTION
@langevin-usgs As requested, this PR on develop replaces the earlier separate TVK and TVS PRs on feat-tvk and feat-tvs.

TVK
Add time-varying K support to NPF, as TVK sub-package available through additional file include in NPF OPTIONS block.
Add nodekchange, kchangeper and kchangestp variables to NPF type to allow other affected packages to query for K changes in ad routines. No changes to affected packages have been included in this PR (affected packages: GWF-GWF exchange, HFB, LAK, MAW).

TVS
Add time-varying SS and SY support to STO, as TVS sub-package available through additional file include in STO OPTIONS block.
Generalize STO formulate and budget routines to correctly integrate changes in stored water volume due to changes in SS and/or SY, when new STO type variable integratechanges is non-zero. This is applied by default when TVS is active in a model, and not applied otherwise unless the integratechanges variable is manually set non-zero (e.g. via BMI).
