### PR TITLE
TVK and TVS tests

### DIFF
--- a/autotest/test_gwf_npf_tvk02.py
+++ b/autotest/test_gwf_npf_tvk02.py
@@ -1,0 +1,272 @@
+import os
+import sys
+import numpy as np
+
+try:
+    import pymake
+except:
+    msg = "Error. Pymake package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install https://github.com/modflowpy/pymake/zipball/master"
+    raise Exception(msg)
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+from framework import testing_framework
+from simulation import Simulation
+
+ex = [
+    "tvk02",
+]
+exdirs = []
+for s in ex:
+    exdirs.append(os.path.join("temp", s))
+ddir = "data"
+
+
+def get_model(idx, dir):
+    nlay, nrow, ncol = 1, 1, 3
+    perlen = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    nper = len(perlen)
+    nstp = nper * [1]
+    tsmult = nper * [1.0]
+    delr = 1.0
+    delc = 1.0
+    top = 1.0
+    laytyp = 0
+    botm = [-1.0]
+    strt = [0.0, 1.0, 1.0]
+    hk = 1.0
+    cellid1 = (0, 0, 0)
+    cellid3 = (0, 0, 2)
+
+    nouter, ninner = 100, 300
+    hclose, rclose, relax = 1e-6, 1e-6, 1.0
+
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+    name = ex[idx]
+
+    # build MODFLOW 6 files
+    ws = dir
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
+    )
+
+    # create gwf model
+    gwfname = "gwf_" + name
+    gwf = flopy.mf6.MFModel(
+        sim,
+        model_type="gwf6",
+        modelname=gwfname,
+        model_nam_file="{}.nam".format(gwfname),
+    )
+    gwf.name_file.save_flows = False
+
+    # create iterative model solution and register the gwf model with it
+    imsgwf = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="CG",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename="{}.ims".format(gwfname),
+    )
+    sim.register_ims_package(imsgwf, [gwf.name])
+
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        idomain=np.ones((nlay, nrow, ncol), dtype=int),
+        filename="{}.dis".format(gwfname),
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(
+        gwf, strt=strt, filename="{}.ic".format(gwfname)
+    )
+
+    # node property flow
+    tvk_filename = f"{gwfname}.npf.tvk"
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf,
+        icelltype=laytyp,
+        k=hk,
+        k33=hk,
+        tvk_filerecord=[tvk_filename]
+    )
+
+    # TVK
+    tvkspd = {}
+
+    # TVK SP1: No changes. Check initial solution, h2 == 0.5.
+
+    # TVK SP2: Increase K1. Check h2 == 0.4.
+    kper = 2
+    spd = []
+    spd.append([cellid1, "K", 3.0])
+    tvkspd[kper - 1] = spd
+
+    # TVK SP3: Decrease K1. Check h2 == 0.75.
+    kper = 3
+    spd = []
+    spd.append([cellid1, "K", 0.2])
+    tvkspd[kper - 1] = spd
+
+    # TVK SP4: Revert K1 and increase K3. Check h2 == 0.6.
+    kper = 4
+    spd = []
+    spd.append([cellid1, "K", 1.0])
+    spd.append([cellid3, "K", 3.0])
+    tvkspd[kper - 1] = spd
+
+    # TVK SP5: Decrease K3. Check h2 == 0.25.
+    kper = 5
+    spd = []
+    spd.append([cellid3, "K", 0.2])
+    tvkspd[kper - 1] = spd
+
+    # TVK SP6: No changes. Check that solution remains as per SP5, h2 == 0.25.
+
+    # TVK SP7: Revert K3. Check that solution returns to original, h2 == 0.5.
+    kper = 7
+    spd = []
+    spd.append([cellid3, "K", 1.0])
+    tvkspd[kper - 1] = spd
+    
+    tvk = flopy.mf6.ModflowUtltvk(gwf, perioddata=tvkspd, filename=tvk_filename)
+
+    # chd files
+    chdspd = []
+    chdspd.append([cellid1, 0.0])
+    chdspd.append([cellid3, 1.0])
+    chd = flopy.mf6.ModflowGwfchd(
+        gwf,
+        stress_period_data=chdspd,
+        save_flows=False,
+        print_flows=True,
+        pname="CHD-1",
+    )
+
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord="{}.hds".format(gwfname),
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "LAST")],
+        printrecord=[("HEAD", "LAST")],
+    )
+
+    return sim
+
+
+def build_models():
+    for idx, dir in enumerate(exdirs):
+        sim = get_model(idx, dir)
+        sim.write_simulation()
+    return
+
+
+def eval_model(sim):
+    print("evaluating model...")
+
+    name = ex[sim.idxsim]
+    gwfname = "gwf_" + name
+
+    # head
+    fpth = os.path.join(sim.simpath, "{}.hds".format(gwfname))
+    try:
+        hobj = flopy.utils.HeadFile(fpth, precision="double")
+        head = hobj.get_alldata()
+    except:
+        assert False, 'could not load data from "{}"'.format(fpth)
+
+    # Check against manually calculated results
+    expected_results = []
+    expected_results.append(0.5)    # TVK SP1: No changes. Check initial solution.
+    expected_results.append(0.4)    # TVK SP2: Increase K1.
+    expected_results.append(0.75)   # TVK SP3: Decrease K1.
+    expected_results.append(0.6)    # TVK SP4: Revert K1 and increase K3.
+    expected_results.append(0.25)   # TVK SP5: Decrease K3.
+    expected_results.append(0.25)   # TVK SP6: No changes. Check that solution remains as per SP5.
+    expected_results.append(0.5)    # TVK SP7: Revert K3. Check that solution returns to original.
+    nper = len(expected_results)
+    ex_lay = 1
+    ex_row = 1
+    ex_col = 2
+
+    for kper, expected_result in enumerate(expected_results):
+        h = head[kper, ex_lay - 1, ex_row - 1, ex_col - 1]
+        
+        print(kper, h, expected_result)
+
+        errmsg = f"Expected head {expected_result} in period {kper} but found {h}"
+        assert np.isclose(h, expected_result)
+
+    # comment when done testing
+    # assert False
+
+    return
+
+
+# - No need to change any code below
+def test_mf6model():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    build_models()
+
+    # run the test models
+    for idx, dir in enumerate(exdirs):
+        yield test.run_mf6, Simulation(dir, exfunc=eval_model, idxsim=idx)
+
+    return
+
+
+def main():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    build_models()
+
+    # run the test models
+    for idx, dir in enumerate(exdirs):
+        sim = Simulation(dir, exfunc=eval_model, idxsim=idx)
+        test.run_mf6(sim)
+
+    return
+
+
+if __name__ == "__main__":
+    # print message
+    print("standalone run of {}".format(os.path.basename(__file__)))
+
+    # run main routine
+    main()

--- a/autotest/test_gwf_npf_tvk03.py
+++ b/autotest/test_gwf_npf_tvk03.py
@@ -1,0 +1,272 @@
+import os
+import sys
+import numpy as np
+
+try:
+    import pymake
+except:
+    msg = "Error. Pymake package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install https://github.com/modflowpy/pymake/zipball/master"
+    raise Exception(msg)
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+from framework import testing_framework
+from simulation import Simulation
+
+ex = [
+    "tvk03",
+]
+exdirs = []
+for s in ex:
+    exdirs.append(os.path.join("temp", s))
+ddir = "data"
+
+
+def get_model(idx, dir):
+    nlay, nrow, ncol = 3, 1, 1
+    perlen = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    nper = len(perlen)
+    nstp = nper * [1]
+    tsmult = nper * [1.0]
+    delr = 1.0
+    delc = 1.0
+    top = 0.0
+    laytyp = 0
+    botm = [-1.0, -2.0, -3.0]
+    strt = [1.0, 1.0, 0.0]
+    hk = 1.0
+    cellid1 = (0, 0, 0)
+    cellid3 = (2, 0, 0)
+
+    nouter, ninner = 100, 300
+    hclose, rclose, relax = 1e-6, 1e-6, 1.0
+
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+    name = ex[idx]
+
+    # build MODFLOW 6 files
+    ws = dir
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
+    )
+
+    # create gwf model
+    gwfname = "gwf_" + name
+    gwf = flopy.mf6.MFModel(
+        sim,
+        model_type="gwf6",
+        modelname=gwfname,
+        model_nam_file="{}.nam".format(gwfname),
+    )
+    gwf.name_file.save_flows = False
+
+    # create iterative model solution and register the gwf model with it
+    imsgwf = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="CG",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename="{}.ims".format(gwfname),
+    )
+    sim.register_ims_package(imsgwf, [gwf.name])
+
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        idomain=np.ones((nlay, nrow, ncol), dtype=int),
+        filename="{}.dis".format(gwfname),
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(
+        gwf, strt=strt, filename="{}.ic".format(gwfname)
+    )
+
+    # node property flow
+    tvk_filename = f"{gwfname}.npf.tvk"
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf,
+        icelltype=laytyp,
+        k=hk,
+        k33=hk,
+        tvk_filerecord=[tvk_filename]
+    )
+
+    # TVK
+    tvkspd = {}
+
+    # TVK SP1: No changes. Check initial solution, h2 == 0.5.
+
+    # TVK SP2: Increase K3. Check h2 == 0.4.
+    kper = 2
+    spd = []
+    spd.append([cellid3, "K33", 3.0])
+    tvkspd[kper - 1] = spd
+
+    # TVK SP3: Decrease K3. Check h2 == 0.75.
+    kper = 3
+    spd = []
+    spd.append([cellid3, "K33", 0.2])
+    tvkspd[kper - 1] = spd
+
+    # TVK SP4: Revert K3 and increase K1. Check h2 == 0.6.
+    kper = 4
+    spd = []
+    spd.append([cellid3, "K33", 1.0])
+    spd.append([cellid1, "K33", 3.0])
+    tvkspd[kper - 1] = spd
+
+    # TVK SP5: Decrease K1. Check h2 == 0.25.
+    kper = 5
+    spd = []
+    spd.append([cellid1, "K33", 0.2])
+    tvkspd[kper - 1] = spd
+
+    # TVK SP6: No changes. Check that solution remains as per SP5, h2 == 0.25.
+
+    # TVK SP7: Revert K1. Check that solution returns to original, h2 == 0.5.
+    kper = 7
+    spd = []
+    spd.append([cellid1, "K33", 1.0])
+    tvkspd[kper - 1] = spd
+
+    tvk = flopy.mf6.ModflowUtltvk(gwf, perioddata=tvkspd, filename=tvk_filename)
+
+    # chd files
+    chdspd = []
+    chdspd.append([cellid1, 1.0])
+    chdspd.append([cellid3, 0.0])
+    chd = flopy.mf6.ModflowGwfchd(
+        gwf,
+        stress_period_data=chdspd,
+        save_flows=False,
+        print_flows=True,
+        pname="CHD-1",
+    )
+
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord="{}.hds".format(gwfname),
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "LAST")],
+        printrecord=[("HEAD", "LAST")],
+    )
+
+    return sim
+
+
+def build_models():
+    for idx, dir in enumerate(exdirs):
+        sim = get_model(idx, dir)
+        sim.write_simulation()
+    return
+
+
+def eval_model(sim):
+    print("evaluating model...")
+
+    name = ex[sim.idxsim]
+    gwfname = "gwf_" + name
+
+    # head
+    fpth = os.path.join(sim.simpath, "{}.hds".format(gwfname))
+    try:
+        hobj = flopy.utils.HeadFile(fpth, precision="double")
+        head = hobj.get_alldata()
+    except:
+        assert False, 'could not load data from "{}"'.format(fpth)
+
+    # Check against manually calculated results
+    expected_results = []
+    expected_results.append(0.5)    # TVK SP1: No changes. Check initial solution.
+    expected_results.append(0.4)    # TVK SP2: Increase K3.
+    expected_results.append(0.75)   # TVK SP3: Decrease K3.
+    expected_results.append(0.6)    # TVK SP4: Revert K3 and increase K1.
+    expected_results.append(0.25)   # TVK SP5: Decrease K1.
+    expected_results.append(0.25)   # TVK SP6: No changes. Check that solution remains as per SP5.
+    expected_results.append(0.5)    # TVK SP7: Revert K1. Check that solution returns to original.
+    nper = len(expected_results)
+    ex_lay = 2
+    ex_row = 1
+    ex_col = 1
+
+    for kper, expected_result in enumerate(expected_results):
+        h = head[kper, ex_lay - 1, ex_row - 1, ex_col - 1]
+        
+        print(kper, h, expected_result)
+
+        errmsg = f"Expected head {expected_result} in period {kper} but found {h}"
+        assert np.isclose(h, expected_result)
+
+    # comment when done testing
+    # assert False
+
+    return
+
+
+# - No need to change any code below
+def test_mf6model():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    build_models()
+
+    # run the test models
+    for idx, dir in enumerate(exdirs):
+        yield test.run_mf6, Simulation(dir, exfunc=eval_model, idxsim=idx)
+
+    return
+
+
+def main():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    build_models()
+
+    # run the test models
+    for idx, dir in enumerate(exdirs):
+        sim = Simulation(dir, exfunc=eval_model, idxsim=idx)
+        test.run_mf6(sim)
+
+    return
+
+
+if __name__ == "__main__":
+    # print message
+    print("standalone run of {}".format(os.path.basename(__file__)))
+
+    # run main routine
+    main()

--- a/autotest/test_gwf_sto_tvs01.py
+++ b/autotest/test_gwf_sto_tvs01.py
@@ -1,0 +1,274 @@
+import os
+import sys
+import numpy as np
+
+try:
+    import pymake
+except:
+    msg = "Error. Pymake package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install https://github.com/modflowpy/pymake/zipball/master"
+    raise Exception(msg)
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+from framework import testing_framework
+from simulation import Simulation
+
+ex = [
+    "tvs01",
+]
+exdirs = []
+for s in ex:
+    exdirs.append(os.path.join("temp", s))
+ddir = "data"
+
+
+def get_model(idx, dir):
+    nlay, nrow, ncol = 1, 1, 1
+    perlen = [1.0, 1.0, 1.0, 1.0, 1.0]
+    nper = len(perlen)
+    nstp = nper * [1]
+    tsmult = nper * [1.0]
+    delr = 1.0
+    delc = 1.0
+    top = 1.0
+    laytyp = 1
+    botm = [0.0]
+    strt = [0.8]
+    hk = 1.0
+    ss = 1e-6
+    sy = 0.01
+    cellid1 = (0, 0, 0)
+
+    nouter, ninner = 1000, 100
+    hclose, rclose, relax = 1e-9, 1e-12, 0.0
+
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+        
+    transient = {}
+    for i in range(nper):
+        transient[i] = True
+
+    name = ex[idx]
+
+    # build MODFLOW 6 files
+    ws = dir
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
+    )
+
+    # create gwf model
+    gwfname = "gwf_" + name
+    gwf = flopy.mf6.MFModel(
+        sim,
+        model_type="gwf6",
+        modelname=gwfname,
+        model_nam_file="{}.nam".format(gwfname),
+    )
+    gwf.name_file.save_flows = False
+    gwf.name_file.newtonoptions="NEWTON UNDER_RELAXATION"
+
+    # create iterative model solution and register the gwf model with it
+    imsgwf = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="DBD",
+        under_relaxation_theta=0.7,
+        under_relaxation_kappa=0.07,
+        under_relaxation_gamma=0.1,
+        under_relaxation_momentum=0.0,
+        backtracking_number=200,
+        backtracking_tolerance=1.1,
+        backtracking_reduction_factor=0.2,
+        backtracking_residual_limit=1.0,
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename="{}.ims".format(gwfname),
+    )
+    sim.register_ims_package(imsgwf, [gwf.name])
+
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        idomain=np.ones((nlay, nrow, ncol), dtype=int),
+        filename="{}.dis".format(gwfname),
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(
+        gwf, strt=strt, filename="{}.ic".format(gwfname)
+    )
+
+    # node property flow
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf,
+        icelltype=laytyp,
+        k=hk,
+        k33=hk
+    )
+
+    # storage
+    tvs_filename = f"{gwfname}.sto.tvs"
+    sto = flopy.mf6.ModflowGwfsto(
+        gwf,
+        save_flows=False,
+        iconvert=laytyp,
+        ss=ss,
+        sy=sy,
+        transient=transient,
+        tvs_filerecord=[tvs_filename]
+    )
+
+    # TVS
+    tvsspd = {}
+
+    # TVS SP1: No changes. Check h1 == 0.8.
+
+    # TVS SP2: Decrease SY1. Check h1 == 3000.823.
+    kper = 2
+    spd = []
+    spd.append([cellid1, "SY", 0.005])
+    tvsspd[kper - 1] = spd
+
+    # TVS SP3: Increase SS1. Check h1 == 300.5323.
+    kper = 3
+    spd = []
+    spd.append([cellid1, "SS", 1e-5])
+    tvsspd[kper - 1] = spd
+
+    # TVS SP4: Increase SY1. Check h1 == 0.4 approx. (0.399976)
+    kper = 4
+    spd = []
+    spd.append([cellid1, "SY", 0.02])
+    tvsspd[kper - 1] = spd
+
+    # TVS SP5: Revert SS1 and SY1. Check h1 == 0.8.
+    kper = 5
+    spd = []
+    spd.append([cellid1, "SS", 1e-6])
+    spd.append([cellid1, "SY", 0.01])
+    tvsspd[kper - 1] = spd
+    
+    tvs = flopy.mf6.ModflowUtltvs(gwf, perioddata=tvsspd, filename=tvs_filename)
+
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord="{}.hds".format(gwfname),
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "LAST")],
+        printrecord=[("HEAD", "LAST")],
+    )
+
+    return sim
+
+
+def build_models():
+    for idx, dir in enumerate(exdirs):
+        sim = get_model(idx, dir)
+        sim.write_simulation()
+    return
+
+
+def eval_model(sim):
+    print("evaluating model...")
+
+    name = ex[sim.idxsim]
+    gwfname = "gwf_" + name
+
+    # head
+    fpth = os.path.join(sim.simpath, "{}.hds".format(gwfname))
+    try:
+        hobj = flopy.utils.HeadFile(fpth, precision="double")
+        head = hobj.get_alldata()
+    except:
+        assert False, 'could not load data from "{}"'.format(fpth)
+
+    # Check against manually calculated results
+    expected_results = []
+    expected_results.append(0.8)        # TVS SP1: No changes. Check initial solution.
+    expected_results.append(3000.823)   # TVS SP2: Decrease SY1.
+    expected_results.append(300.5323)   # TVS SP3: Increase SS1.
+    expected_results.append(0.399976)   # TVS SP4: Increase SY1.
+    expected_results.append(0.8)        # TVS SP5: Revert SS1 and SY1. Check that solution returns to original.
+    nper = len(expected_results)
+    ex_lay = 1
+    ex_row = 1
+    ex_col = 1
+
+    for kper, expected_result in enumerate(expected_results):
+        h = head[kper, ex_lay - 1, ex_row - 1, ex_col - 1]
+        
+        print(kper, h, expected_result)
+
+        errmsg = f"Expected head {expected_result} in period {kper} but found {h}"
+        assert np.isclose(h, expected_result)
+
+    # comment when done testing
+    # assert False
+
+    return
+
+
+# - No need to change any code below
+def test_mf6model():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    build_models()
+
+    # run the test models
+    for idx, dir in enumerate(exdirs):
+        yield test.run_mf6, Simulation(dir, exfunc=eval_model, idxsim=idx)
+
+    return
+
+
+def main():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    build_models()
+
+    # run the test models
+    for idx, dir in enumerate(exdirs):
+        sim = Simulation(dir, exfunc=eval_model, idxsim=idx)
+        test.run_mf6(sim)
+
+    return
+
+
+if __name__ == "__main__":
+    # print message
+    print("standalone run of {}".format(os.path.basename(__file__)))
+
+    # run main routine
+    main()

--- a/src/Model/GroundWaterFlow/gwf3sto8.f90
+++ b/src/Model/GroundWaterFlow/gwf3sto8.f90
@@ -735,11 +735,11 @@ contains
       call mem_deallocate(this%strgsy)
       !
       ! -- deallocate TVS arrays
-      if (this%integratechanges /= 0) then
+      if(associated(this%oldss)) then
         call mem_deallocate(this%oldss)
-        if (this%iusesy /= 0) then
-          call mem_deallocate(this%oldsy)
-        end if
+      end if
+      if(associated(this%oldsy)) then
+        call mem_deallocate(this%oldsy)
       end if
     end if
     !
@@ -818,14 +818,6 @@ contains
     call mem_allocate(this%sy, nodes, 'SY', this%memoryPath)
     call mem_allocate(this%strgss, nodes, 'STRGSS', this%memoryPath)
     call mem_allocate(this%strgsy, nodes, 'STRGSY', this%memoryPath)
-    !
-    ! -- allocate TVS arrays
-    if (this%integratechanges /= 0) then
-      call mem_allocate(this%oldss, nodes, 'OLDSS', this%memoryPath)
-      if (this%iusesy /= 0) then
-        call mem_allocate(this%oldsy, nodes, 'OLDSY', this%memoryPath)
-      end if
-    end if
     !
     ! -- Initialize arrays
     this%iss = 0
@@ -1085,10 +1077,20 @@ contains
   !!
   !<
   subroutine save_old_ss_sy(this)
+    ! -- modules
+    use MemoryManagerModule, only: mem_allocate
     ! -- dummy variables
     class(GwfStoType) :: this  !< GwfStoType object
     ! -- local variables
     integer(I4B) :: n
+    !
+    ! -- Allocate TVS arrays if needed
+    if(.not. associated(this%oldss)) then
+      call mem_allocate(this%oldss, this%dis%nodes, 'OLDSS', this%memoryPath)
+    end if
+    if(this%iusesy == 1 .and. .not. associated(this%oldsy)) then
+      call mem_allocate(this%oldsy, this%dis%nodes, 'OLDSY', this%memoryPath)
+    end if
     !
     ! -- Save current specific storage
     do n = 1, this%dis%nodes


### PR DESCRIPTION
Added three new tests: gwf_npf_tvk02, gwf_npf_tvk03 and gwf_sto_tvs01.

@langevin-usgs Does something further need to be done to add these to the set of CI build tests, or will they be picked up automatically?

@jdhughes-usgs While writing the TVS tests, I noticed that part of the recent refactor was causing TVS to crash, as the memory allocation for OLDSS and OLDSY was moved to occur prior to when the integratechanges flag is set by TVS. I have kept the modification to use mem_allocate and mem_deallocate, but changed where and when it occurs back to using a "lazy" allocation approach, which I believe is a better option here. In addition to supporting the existing order of operations on TVS initialisation, it allows the integratechanges flag potentially to be changed at any point in the simulation and result in the expected behaviour (e.g. via Python script), while ensuring that additional memory for the OLDSS and OLDSY variables is allocated only if needed. My changes also guarantee deallocation when the arrays have been used, which relying solely on the integratechanges flag would miss if the flag is changed to zero mid-simulation.
