### PR TITLE
fix(boundarypackage): do not print rates to list file table if ibound <= 0

### DIFF
--- a/autotest/test_gwf_npf01_75x75.py
+++ b/autotest/test_gwf_npf01_75x75.py
@@ -129,7 +129,7 @@ def get_model(idx, dir):
         iconvert=laytyp[idx],
         ss=ss[idx],
         sy=sy[idx],
-        steady_state={0: True, 2: True},
+        steady_state={0: True, 1: False, 2: True},
         transient={1: True},
     )
 

--- a/autotest/test_gwf_rch03.py
+++ b/autotest/test_gwf_rch03.py
@@ -1,0 +1,221 @@
+"""
+MODFLOW 6 Autotest
+Test to make sure that array based recharge is applied correctly when idomain
+is used with -1, 0, and 1 for top layer.
+"""
+
+import os
+import sys
+import numpy as np
+
+try:
+    import pymake
+except:
+    msg = "Error. Pymake package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install https://github.com/modflowpy/pymake/zipball/master"
+    raise Exception(msg)
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+from framework import testing_framework
+from simulation import Simulation
+
+ex = ["rch03"]
+exdirs = []
+for s in ex:
+    exdirs.append(os.path.join("temp", s))
+
+
+def get_model(idx, dir):
+
+    nlay, nrow, ncol = 2, 4, 5
+    perlen = [1.]
+    nper = len(perlen)
+    nstp = nper * [1]
+    tsmult = nper * [1.0]
+
+    delr = delc = 1.0
+
+    nouter, ninner = 100, 300
+    hclose, rclose, relax = 1e-9, 1e-3, 0.97
+
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+    name = "rch"
+
+    # build MODFLOW 6 files
+    ws = dir
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
+    )
+
+    # set ims csv files
+    csv0 = "{}.outer.ims.csv".format(name)
+    csv1 = "{}.inner.ims.csv".format(name)
+
+    # create iterative model solution and register the gwf model with it
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        print_option="ALL",
+        csv_outer_output_filerecord=csv0,
+        csv_inner_output_filerecord=csv1,
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="DBD",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+    )
+
+    # create gwf model
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
+
+    idomain = [
+        [[0, 0, 0, 0, 0],
+        [0, -1, 1, -1, 0],
+        [0, -1, 1, -1, 0],
+        [0, 0, 0, 0, 0]],
+        [[1, 1, 1, 1, 1],
+         [1, 1, 1, -1, 1],
+         [1, 1, 1, 1, 1],
+         [1, 1, 1, 1, 1],],
+    ]
+    idomain = np.array(idomain, dtype=int)
+
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=100.0,
+        botm=[50.0, 0.0],
+        idomain=idomain,
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=100.)
+
+    # node property flow
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=0, k=1.0)
+
+    # chd
+    chdspd = [[(1, 0, 0), 100.]]
+    chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chdspd)
+
+    recharge = np.arange(nrow * ncol).reshape(nrow, ncol) + 1.
+    irch = [
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 1, 0],
+        [0, 1, 0, 1, 0],
+        [0, 0, 0, 0, 0],
+            ]
+    rch = flopy.mf6.ModflowGwfrcha(gwf, print_flows=True, recharge=recharge,
+                                   irch=irch)
+
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord="{}.cbc".format(name),
+        head_filerecord="{}.hds".format(name),
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        filename="{}.oc".format(name),
+    )
+
+    return sim
+
+
+def build_models():
+    for idx, dir in enumerate(exdirs):
+        sim = get_model(idx, dir)
+        sim.write_simulation()
+    return
+
+
+def eval_model(sim):
+    print("evaluating model...")
+
+    fpth = os.path.join(sim.simpath, "rch.cbc")
+    bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
+    records = bobj.get_data(text="rch")[0]
+
+    errmsg1 = "node not equal to index"
+    errmsg2 = "node2 not equal to recharge"
+    for i, (node, node2, q) in enumerate(records):
+        print(f"Checking: index={i+1}; node={node}; node2={node2}; q={q}")
+
+    answer = [21, 27, 8, 32, 13, 34]
+    errmsg = f"node must be {answer}.  found {records['node']}"
+    assert np.allclose(records['node'], answer), errmsg
+
+    answer = [1, 2, 3, 4, 5, 6]
+    errmsg = f"node2 must be {answer}.  found {records['node2']}"
+    assert np.allclose(records['node2'], answer), errmsg
+
+    answer = [0., 7., 8., 12., 13., 14.]
+    errmsg = f"rech q must be {answer}.  found {records['q']}"
+    assert np.allclose(records['q'], answer), errmsg
+
+    fpth = os.path.join(sim.simpath, "rch.hds")
+    hobj = flopy.utils.HeadFile(fpth, precision="double")
+    heads = hobj.get_alldata()
+
+    return
+
+
+# - No need to change any code below
+def test_mf6model():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    build_models()
+
+    # run the test models
+    for idx, dir in enumerate(exdirs):
+        yield test.run_mf6, Simulation(dir, exfunc=eval_model, idxsim=idx)
+
+    return
+
+
+def main():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    build_models()
+
+    # run the test models
+    for idx, dir in enumerate(exdirs):
+        sim = Simulation(dir, exfunc=eval_model, idxsim=idx)
+        test.run_mf6(sim)
+
+    return
+
+
+if __name__ == "__main__":
+    # print message
+    print("standalone run of {}".format(os.path.basename(__file__)))
+
+    # run main routine
+    main()

--- a/src/Model/ModelUtilities/BoundaryPackage.f90
+++ b/src/Model/ModelUtilities/BoundaryPackage.f90
@@ -1890,30 +1890,34 @@ module BndModule
           ! -- If cell is no-flow or constant-head, then ignore it.
           rrate = DZERO
           if (node > 0) then
-              !
-              ! -- Use simval, which was calculated in cq()
-              rrate = flow(i)
-              !
-              ! -- Print the individual rates if the budget is being printed
-              !    and PRINT_FLOWS was specified (iprflow < 0)
-              if (ibudfl /= 0) then
-                if (iprflow /= 0) then
+            !
+            ! -- Use simval, which was calculated in cq()
+            rrate = flow(i)
+            !
+            ! -- Print the individual rates if the budget is being printed
+            !    and PRINT_FLOWS was specified (iprflow < 0).  Rates are only
+            !    printed only if ibound > 0.  This is different from budget
+            !    output where entries are written to the binary file even if
+            !    ibound <= 0.
+            if (ibudfl /= 0) then
+              if (iprflow /= 0) then
+                if (ibound(node) > 0) then
                   !
                   ! -- set nodestr and write outputtab table
                   nodeu = dis%get_nodeuser(node)
                   call dis%nodeu_to_string(nodeu, nodestr)
-                  call outputtab%print_list_entry(i, trim(adjustl(nodestr)),  &
+                  call outputtab%print_list_entry(i, trim(adjustl(nodestr)),   &
                                                       rrate, bname)
                 end if
               end if
+            end if
             !
             ! -- If saving cell-by-cell flows in list, write flow
             if (ibinun /= 0) then
               n2 = i
               if (present(imap)) n2 = imap(i)
-              call dis%record_mf6_list_entry(ibinun, node, n2, rrate,         &
-                                                  naux, auxvar(:,i),          &
-                                                  olconv2=.FALSE.)
+              call dis%record_mf6_list_entry(ibinun, node, n2, rrate, naux,    &
+                                             auxvar(:,i), olconv2=.FALSE.)
             end if
           end if
           !

--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -439,7 +439,7 @@ contains
     use MemorySetHandlerModule, only: on_memory_set
     ! -- dummy variables
     character(kind=c_char), intent(in) :: c_var_address(*) !< memory address string of the variable
-    type(c_ptr), intent(in) :: c_arr_ptr                    !< pointer to the double precision array
+    type(c_ptr), intent(in) :: c_arr_ptr                    !< pointer to the integer array
     integer :: bmi_status                                   !< BMI status code
     ! -- local variables
     character(len=LENMEMPATH) :: mem_path


### PR DESCRIPTION
* The number of rows in the bound package table printed to the list file was not consistent with the number of rows written to the table.  The table writer was modified so that an entry is not written if ibound is less than or equal to zero.  This is consistent with mf2005.
* Added new recharge test that mixes irch and idomain
* Minor tweaks to mf6bmi.f90 and test_gwf_npf01_75x75.py