### PR TITLE
Enforce "lib" prefix for shared library

### DIFF
--- a/srcbmi/meson.build
+++ b/srcbmi/meson.build
@@ -7,4 +7,4 @@ bmi_sources = files(
     'mf6xmi.f90',
 )
 
-library('mf6', bmi_sources, link_with: mf6_internal_lib)
+library('mf6', bmi_sources, link_with: mf6_internal_lib, name_prefix: 'lib')


### PR DESCRIPTION
This results in "libmf6.dll" instead of "mf6.dll" on Windows with ifort