### PR TITLE
fix(sfr): Correct floating point error in depth calculation

### DIFF
--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -183,7 +183,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 
 	\underline{ADVANCED STRESS PACKAGES}
 	\begin{itemize}
-	        \item--
+	        \item The Streamflow Routing (SFR) Package would die with a floating point error when calculating the stream depth as a function of flow rate, if the flow rate was slightly negative.  Added a conditional check to ensure that the stream depth is calculated as zero if the calculated flow rate is zero or less.
 	\end{itemize}
 
 	\underline{SOLUTION}

--- a/src/Model/GroundWaterFlow/gwf3sfr8.f90
+++ b/src/Model/GroundWaterFlow/gwf3sfr8.f90
@@ -3873,12 +3873,16 @@ module SfrModule
       r = this%rough(n)
       !
       ! -- calculate stream depth at the midpoint
-      if (this%ncrosspts(n) > 1) then
-        call this%sfr_calc_npoint_depth(n, q1, d1)
+      if (q1 > DZERO) then
+        if (this%ncrosspts(n) > 1) then
+          call this%sfr_calc_npoint_depth(n, q1, d1)
+        else
+          w = this%station(this%iacross(n))
+          qconst = this%unitconv * w * sqrt(s) / r
+          d1 = (q1 / qconst)**DP6
+        end if
       else
-        w = this%station(this%iacross(n))
-        qconst = this%unitconv * w * sqrt(s) / r
-        d1 = (q1 / qconst)**DP6
+        d1 = DZERO
       end if
       if (d1 < DEM30) d1 = DZERO ! test removal of this check
       !


### PR DESCRIPTION
* Close #803
* The SFR Package can die with a floating point error when calculating the stream depth as a function of flow if the flow is near zero. The stream depth should be calculated only if the flow is greater than zero, otherwise it should return a depth of zero.