### PR TITLE
fix(listreader): list could not be wider than 300 columns

### DIFF
--- a/autotest/test_gwf_auxvars02.py
+++ b/autotest/test_gwf_auxvars02.py
@@ -1,0 +1,185 @@
+import os
+import pytest
+import sys
+import numpy as np
+
+try:
+    import pymake
+except:
+    msg = "Error. Pymake package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install https://github.com/modflowpy/pymake/zipball/master"
+    raise Exception(msg)
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+from framework import testing_framework
+from simulation import Simulation
+
+ex = ["aux02"]
+exdirs = []
+for s in ex:
+    exdirs.append(os.path.join("temp", s))
+
+def get_model(idx, dir):
+    nlay, nrow, ncol = 1, 10, 10
+    nper = 3
+    perlen = [1.0, 1.0, 1.0]
+    nstp = [10, 10, 10]
+    tsmult = [1.0, 1.0, 1.0]
+
+    lenx = 300.0
+    delr = delc = lenx / float(nrow)
+    strt = 100.0
+
+    nouter, ninner = 100, 300
+    hclose, rclose, relax = 1e-9, 1e-3, 0.97
+
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+    name = ex[idx]
+
+    # build MODFLOW 6 files
+    ws = dir
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
+    )
+
+    # create gwf model
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
+
+    # create iterative model solution and register the gwf model with it
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="DBD",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+    )
+    sim.register_ims_package(ims, [gwf.name])
+
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=90.0,
+        botm=0.0,
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
+
+    # node property flow
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf, save_flows=True, icelltype=1, k=1.0, k33=0.01
+    )
+
+    # chd files
+    chdlist0 = []
+    chdlist0.append([(0, 0, 0), 100.0] + [a for a in range(100)])
+    chdlist0.append([(0, nrow - 1, ncol - 1), 95.0] + [a for a in range(100)])
+
+    chdspdict = {0: chdlist0}
+    chd = flopy.mf6.ModflowGwfchd(
+        gwf,
+        stress_period_data=chdspdict,
+        save_flows=True,
+        auxiliary=[f"aux{i}" for i in range(100)],
+        pname="CHD-1"
+    )
+
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord="{}.bud".format(name),
+        head_filerecord="{}.hds".format(name),
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        filename="{}.oc".format(name),
+    )
+
+    return sim
+
+
+def build_models():
+    for idx, dir in enumerate(exdirs):
+        sim = get_model(idx, dir)
+        sim.write_simulation()
+    return
+
+
+def eval_model(sim):
+    print("evaluating model...")
+
+    # maw budget aux variables
+    fpth = os.path.join(sim.simpath, "aux02.bud")
+    bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
+    records = bobj.get_data(text="CHD")
+    for r in records:
+        for a in range(100):
+            aname = f"AUX{a}"
+            assert np.allclose(r[aname], a)
+
+    return
+
+
+# - No need to change any code below
+@pytest.mark.parametrize(
+    "idx, dir",
+    list(enumerate(exdirs)),
+)
+def test_mf6model(idx, dir):
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    build_models()
+
+    # run the test model
+    test.run_mf6(Simulation(dir, exfunc=eval_model, idxsim=idx))
+
+
+def main():
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the models
+    build_models()
+
+    # run the test model
+    for idx, dir in enumerate(exdirs):
+        sim = Simulation(dir, exfunc=eval_model, idxsim=idx)
+        test.run_mf6(sim)
+
+    return
+
+
+if __name__ == "__main__":
+    # print message
+    print("standalone run of {}".format(os.path.basename(__file__)))
+
+    # run main routine
+    main()

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -172,6 +172,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\underline{BASIC FUNCTIONALITY}
 	\begin{itemize}
 	        \item Fixed a bug that caused the last binary budget and head file information provided by a GWF simulation in a given stress period to be used for all subsequent GWT simulation time steps in that stress period, even if binary budget and head file information was provided for more than one time step in that stress period. In that situation, the GWF time steps must match the GWT time steps one-for-one.
+	        \item Boundary packages, such as WEL, DRN and GHB, for example, read lists of data using a general list reader.  For text input, the list of data would not be read correctly if it was longer than 300 characters wide.  Most lists would normally be less than 300 characters unless a large number of auxiliary variables were specified.  In this case, information beyond 300 characters would not be read.  The list reader was modified to use an unlimited character length so that any number of auxiliary variables can be specified.
 	\end{itemize}
 
 	\underline{STRESS PACKAGES}

--- a/src/Utilities/ListReader.f90
+++ b/src/Utilities/ListReader.f90
@@ -25,7 +25,7 @@ module ListReaderModule
     integer(I4B) :: ntxtrlist = 0                                                ! number of text entries found in rlist
     integer(I4B) :: ntxtauxvar = 0                                               ! number of text entries found in auxvar
     character(len=LENLISTLABEL) :: label = ''                                    ! label for printing list
-    character(len=LINELENGTH) :: line = ''                                       ! line string for reading file
+    character(len=:), allocatable, private :: line                               ! current line
     integer(I4B), dimension(:), pointer, contiguous :: mshape => null()          ! pointer to model shape
     integer(I4B), dimension(:), pointer, contiguous :: nodelist => null()        ! pointer to nodelist
     real(DP), dimension(:, :), pointer, contiguous :: rlist => null()            ! pointer to rlist
@@ -122,7 +122,7 @@ module ListReaderModule
 !    SPECIFICATIONS:
 ! ------------------------------------------------------------------------------
     ! -- modules
-    use InputOutputModule, only: u8rdcom, urword
+    use InputOutputModule, only: u9rdcom, urword
     ! -- dummy
     class(ListReaderType) :: this
     ! -- local
@@ -139,7 +139,7 @@ module ListReaderModule
     this%ibinary = 0
     !
     ! -- Read to the first non-commented line
-    call u8rdcom(this%in, this%iout, this%line, this%ierr)
+    call u9rdcom(this%in, this%iout, this%line, this%ierr)
     this%lloc = 1
     call urword(this%line, this%lloc, this%istart, this%istop, 1, idum, r,     &
                 this%iout, this%in)
@@ -164,7 +164,7 @@ module ListReaderModule
 !    SPECIFICATIONS:
 ! ------------------------------------------------------------------------------
     ! -- modules
-    use InputOutputModule, only: u8rdcom, urword, openfile
+    use InputOutputModule, only: u9rdcom, urword, openfile
     use OpenSpecModule, only: form, access
     use ConstantsModule, only: LINELENGTH
     use SimModule, only: store_error
@@ -236,7 +236,7 @@ module ListReaderModule
     !
     ! -- Read the first line from inlist to be consistent with how the list is
     !    read when it is included in the package input file
-    if(this%ibinary /= 1) call u8rdcom(this%inlist, this%iout, this%line,      &
+    if(this%ibinary /= 1) call u9rdcom(this%inlist, this%iout, this%line,      &
                                        this%ierr)
     !
     ! -- return
@@ -385,7 +385,7 @@ module ListReaderModule
 ! ------------------------------------------------------------------------------
     ! -- modules
     use ConstantsModule, only: LENBOUNDNAME, LINELENGTH, DZERO
-    use InputOutputModule, only: u8rdcom, urword, get_node
+    use InputOutputModule, only: u9rdcom, urword, get_node
     use SimModule, only: store_error, count_errors
     use ArrayHandlersModule, only: ExpandArray
     ! -- dummy
@@ -419,7 +419,7 @@ module ListReaderModule
     readloop: do
       !
       ! -- First line was already read, so don't read again
-      if(ii /= 1) call u8rdcom(this%inlist, 0, this%line, this%ierr)
+      if(ii /= 1) call u9rdcom(this%inlist, 0, this%line, this%ierr)
       !
       ! -- If this is an unknown-length list, then check for END.
       !    If found, then backspace, set nlist, and exit readloop.
@@ -428,7 +428,7 @@ module ListReaderModule
         call urword(this%line, this%lloc, this%istart, this%istop, 1, idum, r, &
                     this%iout, this%inlist)
         if(this%line(this%istart:this%istop) == 'END' .or. this%ierr < 0) then
-          ! If ierr < 0, backspace was already performed in u8rdcom, so only
+          ! If ierr < 0, backspace was already performed in u9rdcom, so only
           ! need to backspace if END was found.
           if (this%ierr == 0) then
             backspace(this%inlist)


### PR DESCRIPTION
* The line variable for the list reader was only 300 characters
* This meant that lists could not be wider than 300 characters
* Values were not correctly for large numbers of aux variables
* This PR uses u9rdcom and an allocatable character string to read unlimited columns