### PR TITLE
Patch ssm

### DIFF
--- a/src/Model/GroundWaterTransport/gwt1ssm1.f90
+++ b/src/Model/GroundWaterTransport/gwt1ssm1.f90
@@ -312,6 +312,9 @@ module GwtSsmModule
         else
           ctmp = this%cnew(n)
           omega = DONE  ! lhs
+          if (ctmp < DZERO) then
+            omega = DZERO ! concentration is negative, so do not remove more mass
+          end if
         end if
       else
         !

--- a/src/Model/GroundWaterTransport/gwt1ssm1.f90
+++ b/src/Model/GroundWaterTransport/gwt1ssm1.f90
@@ -313,7 +313,7 @@ module GwtSsmModule
           ctmp = this%cnew(n)
           omega = DONE  ! lhs
           if (ctmp < DZERO) then
-            omega = DZERO ! concentration is negative, so do not remove more mass
+            omega = DZERO ! concentration is negative, so set mass flux to zero
           end if
         end if
       else


### PR DESCRIPTION
* When the simulated concentration in a cell is negative and an extraction boundary is present, then solute mass is erroneously generated.  This fix sets the mass flux to zero for an extraction boundary if the cell concentration is negative.
* Close #814 