### PR TITLE
Fix failure if bin dir does not exist

### DIFF
--- a/.vscode/build_vscode.py
+++ b/.vscode/build_vscode.py
@@ -32,9 +32,11 @@ if not os.path.isdir(builddir):
 subprocess.run(["meson", "compile", "-C", builddir], check=True)
 
 # Remove all files from bin folder
-for dir_entry in os.scandir(os.path.join(os.getcwd(), "bin")):
-    path = dir_entry.path
-    if os.path.isfile(path):
-        os.remove(path)
+bin_dir = os.path.join(os.getcwd(), "bin")
+if os.path.isdir(bin_dir):
+    for dir_entry in os.scandir(bin_dir):
+        path = dir_entry.path
+        if os.path.isfile(path):
+            os.remove(path)
 
 subprocess.run(["meson", "install", "-C", builddir], check=True)


### PR DESCRIPTION
While working on related tasks I've noticed that the vscode task fails if there is no bin folder