### PR TITLE
fix(run_command): use process.returncode for ierr

### DIFF
--- a/autotest/build_mfio_tex.py
+++ b/autotest/build_mfio_tex.py
@@ -171,14 +171,13 @@ def delete_files(files, pth, allow_failure=False):
 
 
 def run_command(argv, pth, timeout=10):
-    buff = ""
-    ierr = 0
     with subprocess.Popen(
         argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=pth
     ) as process:
         try:
             output, unused_err = process.communicate(timeout=timeout)
             buff = output.decode("utf-8")
+            ierr = process.returncode
         except subprocess.TimeoutExpired:
             process.kill()
             output, unused_err = process.communicate()

--- a/autotest/update_flopy.py
+++ b/autotest/update_flopy.py
@@ -125,13 +125,13 @@ def delete_files(files, pth, allow_failure=False, exclude=None):
 
 
 def run_command(argv, pth, timeout=10):
-    ierr = 0
     with subprocess.Popen(
         argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=pth
     ) as process:
         try:
             output, unused_err = process.communicate(timeout=timeout)
             buff = output.decode("utf-8")
+            ierr = process.returncode
         except subprocess.TimeoutExpired:
             process.kill()
             output, unused_err = process.communicate()

--- a/distribution/mkdist.py
+++ b/distribution/mkdist.py
@@ -393,14 +393,13 @@ def delete_files(files, pth, allow_failure=False):
 
 
 def run_command(argv, pth, timeout=None):
-    buff = ""
-    ierr = 0
     with subprocess.Popen(
         argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=pth
     ) as process:
         try:
             output, unused_err = process.communicate(timeout=timeout)
             buff = output.decode("utf-8")
+            ierr = process.returncode
         except subprocess.TimeoutExpired:
             process.kill()
             output, unused_err = process.communicate()


### PR DESCRIPTION
The Python function `run_command` is used in a few places, and should use the process [returncode](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.returncode) for ierr.

This fixes instances like [this one](https://github.com/modflowpy/flopy/runs/4877208422?check_suite_focus=true#step:10:215) which shows:
```
running...createpackages.py
successfully ran...createpackages.py
```
when really the command was not successful due to an unrelated error in the script.