### PR TITLE
feat(tvk-tvs): add support for TVK/TVS PRINT_INPUT

### DIFF
--- a/autotest/test_gwf_npf_tvk01.py
+++ b/autotest/test_gwf_npf_tvk01.py
@@ -134,7 +134,7 @@ def build_model(idx, dir):
                     spd.append([(k, i, j), "K", hydraulic_conductivity])
         tvkspd[kper] = spd
     tvk = flopy.mf6.ModflowUtltvk(
-        gwf, perioddata=tvkspd, filename=tvk_filename
+        gwf, print_input=True, perioddata=tvkspd, filename=tvk_filename
     )
 
     # chd files

--- a/autotest/test_gwf_npf_tvk02.py
+++ b/autotest/test_gwf_npf_tvk02.py
@@ -157,7 +157,7 @@ def build_model(idx, dir):
     tvkspd[kper - 1] = spd
 
     tvk = flopy.mf6.ModflowUtltvk(
-        gwf, perioddata=tvkspd, filename=tvk_filename
+        gwf, print_input=True, perioddata=tvkspd, filename=tvk_filename
     )
 
     # chd files

--- a/autotest/test_gwf_npf_tvk03.py
+++ b/autotest/test_gwf_npf_tvk03.py
@@ -157,7 +157,7 @@ def build_model(idx, dir):
     tvkspd[kper - 1] = spd
 
     tvk = flopy.mf6.ModflowUtltvk(
-        gwf, perioddata=tvkspd, filename=tvk_filename
+        gwf, print_input=True, perioddata=tvkspd, filename=tvk_filename
     )
 
     # chd files

--- a/autotest/test_gwf_sto_tvs01.py
+++ b/autotest/test_gwf_sto_tvs01.py
@@ -172,7 +172,7 @@ def build_model(idx, dir):
     tvsspd[kper - 1] = spd
 
     tvs = flopy.mf6.ModflowUtltvs(
-        gwf, perioddata=tvsspd, filename=tvs_filename
+        gwf, print_input=True, perioddata=tvsspd, filename=tvs_filename
     )
 
     # output control

--- a/doc/mf6io/mf6ivar/dfn/utl-tvk.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-tvk.dfn
@@ -1,6 +1,14 @@
 # --------------------- gwf tvk options ---------------------
 
 block options
+name print_input
+type keyword
+reader urword
+optional true
+longname print input to listing file
+description keyword to indicate that information for each change to the hydraulic conductivity in a cell will be written to the model listing file.
+
+block options
 name ts_filerecord
 type record ts6 filein ts6_filename
 shape

--- a/doc/mf6io/mf6ivar/dfn/utl-tvs.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-tvs.dfn
@@ -9,6 +9,14 @@ longname deactivate storage change integration
 description keyword that deactivates inclusion of storage derivative terms in the STO package matrix formulation.  In the absence of this keyword (the default), the groundwater storage formulation will be modified to correctly adjust heads based on transient variations in stored water volumes arising from changes to SS and SY properties.
 
 block options
+name print_input
+type keyword
+reader urword
+optional true
+longname print input to listing file
+description keyword to indicate that information for each change to a storage property in a cell will be written to the model listing file.
+
+block options
 name ts_filerecord
 type record ts6 filein ts6_filename
 shape

--- a/src/Model/GroundWaterFlow/gwf3tvbase8.f90
+++ b/src/Model/GroundWaterFlow/gwf3tvbase8.f90
@@ -255,6 +255,9 @@ contains
         end if
         call this%parser%GetStringCaps(keyword)
         select case (keyword)
+          case ('PRINT_INPUT')
+            this%iprpak = 1
+            write(this%iout,'(4x,a)') 'TIME-VARYING INPUT WILL BE PRINTED.'
           case ('TS6')
             !
             ! -- Add a time series file
@@ -383,9 +386,11 @@ contains
                                            varName)
         !
         ! -- Report value change
-        write(this%iout, fmtvalchg) &
-          trim(adjustl(this%packName)), trim(varName), trim(cellid), &
-          kper, bndElem
+        if (this%iprpak /= 0) then
+          write(this%iout, fmtvalchg) &
+            trim(adjustl(this%packName)), trim(varName), trim(cellid), &
+            kper, bndElem
+        end if
         !
         ! -- Validate the new property value
         call this%validate_change(node, varName)


### PR DESCRIPTION
* The TVK and TVS packages wrote all property changes to model listing file
* This list could be enormous for large models with many property changes
* By default writing these lists is now inactive
* These lists can be optionally written now by specifying the PRINT_OPTION option in TVK and/or TVS
* Close #871