### PR TITLE
-Use simvals for gwtgwt exchange flows in all cases

### DIFF
--- a/src/Exchange/GwfGwtExchange.f90
+++ b/src/Exchange/GwfGwtExchange.f90
@@ -376,7 +376,9 @@ module GwfGwtExchangeModule
     class(GwtGwtConnectionType), pointer :: gwtConn !< GWT connection
     class(GwfGwfConnectionType), pointer :: gwfConn !< GWF connection
 
-    gwtConn%exgflowja => gwfConn%exgflowja
+    !gwtConn%exgflowja => gwfConn%exgflowja
+    gwtConn%exgflowja => gwfConn%gwfExchange%simvals
+    if (associated(gwfConn%gwfExchange%model2, gwfConn%owner)) gwtConn%exgflowSign = -1
 
     ! fmi flows are not read from file
     gwtConn%gwtInterfaceModel%fmi%flows_from_file = .false.

--- a/src/Model/Connection/GwtInterfaceModel.f90
+++ b/src/Model/Connection/GwtInterfaceModel.f90
@@ -158,11 +158,11 @@ subroutine gwtifmod_ar(this)
     call this%adv%adv_ar(this%dis, this%ibound)
   end if
   if (this%indsp > 0) then
-    call dspGridData%construct(this%neq)
-    call this%setDspGridData(dspGridData)
-    call this%dsp%dsp_ar(this%ibound, this%porosity, dspGridData)
     this%dsp%idiffc = this%owner%dsp%idiffc
     this%dsp%idisp = this%owner%dsp%idisp
+    call dspGridData%construct(this%neq)
+    call this%setDspGridData(dspGridData)
+    call this%dsp%dsp_ar(this%ibound, this%porosity, dspGridData)    
   end if
   
 end subroutine gwtifmod_ar
@@ -183,12 +183,17 @@ subroutine setDspGridData(this, gridData)
     gwtModel => CastAsGwtModel(modelPtr)
     idx = this%gridConnection%idxToGlobal(i)%index
 
-    gridData%diffc(i) = gwtModel%dsp%diffc(idx)
-    gridData%alh(i) = gwtModel%dsp%alh(idx)
-    gridData%alv(i) = gwtModel%dsp%alv(idx)
-    gridData%ath1(i) = gwtModel%dsp%ath1(idx)
-    gridData%ath2(i) = gwtModel%dsp%ath2(idx)
-    gridData%atv(i) = gwtModel%dsp%atv(idx)
+    if (this%dsp%idiffc > 0) then
+      gridData%diffc(i) = gwtModel%dsp%diffc(idx)
+    end if
+    if (this%dsp%idisp > 0) then
+      gridData%alh(i) = gwtModel%dsp%alh(idx)
+      gridData%alv(i) = gwtModel%dsp%alv(idx)
+      gridData%ath1(i) = gwtModel%dsp%ath1(idx)
+      gridData%ath2(i) = gwtModel%dsp%ath2(idx)
+      gridData%atv(i) = gwtModel%dsp%atv(idx)
+    end if
+
   end do
 
 end subroutine setDspGridData


### PR DESCRIPTION
-Check on idisp and idiffc before copying arrays into GWT interface model