### PR TITLE
fix(xt3d): array access error for highly refined nested gwf or gwt model

### DIFF
--- a/autotest/test_gwf_ifmod_xt3d01.py
+++ b/autotest/test_gwf_ifmod_xt3d01.py
@@ -80,7 +80,7 @@ def get_model(idx, dir):
     row_s, row_e = 3, 5
     col_s, col_e = 3, 5
 
-    ref_fct = 3
+    ref_fct = 5
     nrowc = ref_fct * ((row_e - row_s) + 1)
     ncolc = ref_fct * ((col_e - col_s) + 1)
 

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -207,7 +207,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
 	\underline{BASIC FUNCTIONALITY}
 	\begin{itemize}
-		\item xxx
+		\item Corrected programming error in XT3D functionality that could occur when running coupled flow models or transport models.  The XT3D code would result in a memory access error when a child model with a much larger level of refinement was coupled to a coarser parent model.  The XT3D code was generalized to handle this situation. 
 	%	\item xxx
 	%	\item xxx
 	\end{itemize}

--- a/src/Model/GroundWaterTransport/gwt1ssm1.f90
+++ b/src/Model/GroundWaterTransport/gwt1ssm1.f90
@@ -155,10 +155,12 @@ module GwtSsmModule
     !
     ! -- Check to make sure that there are flow packages
     if (this%fmi%nflowpack == 0) then
-      write(errmsg, '(a)') 'SSM PACKAGE DOES NOT HAVE &
-                            &BOUNDARY FLOWS.  ACTIVATE GWF-GWT EXCHANGE &
-                            &OR TURN ON FMI AND PROVIDE A BUDGET FILE &
-                            &THAT CONTAINS BOUNDARY FLOWS.'
+      write(errmsg, '(a)') 'SSM PACKAGE DOES NOT DETECT ANY BOUNDARY FLOWS &
+                            &THAT REQUIRE SSM TERMS.  ACTIVATE GWF-GWT &
+                            &EXCHANGE OR ACTIVATE FMI PACKAGE AND PROVIDE A &
+                            &BUDGET FILE THAT CONTAINS BOUNDARY FLOWS.  IF NO &
+                            &BOUNDARY FLOWS ARE PRESENT IN CORRESPONDING GWF &
+                            &MODEL THEN THIS SSM PACKAGE SHOULD BE REMOVED.'
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()
     endif


### PR DESCRIPTION
* The xt3d procedure for storing and adding matrix coefficients for extended xt3d connections did not work for lgr configurations in which a highly refined child model was nested inside a coarser parent model.  The logic was improved so that matrix terms added by exchanges were properly handled by the internal calculations used by xt3d.   Prior to this fix, the xt3d logic assumed that any matrix terms added to the local model space of the solution were because of xt3d.  This can no longer be assumed for lgr configurations.