### PR TITLE
refactor(GwfMvr): store mover variables in memory manager

### DIFF
--- a/make/makedefaults
+++ b/make/makedefaults
@@ -1,4 +1,4 @@
-# makedefaults created by pymake (version 1.2.3) for the 'mf6' executable.
+# makedefaults created by pymake (version 1.2.5) for the 'mf6' executable.
 
 # determine OS
 ifeq ($(OS), Windows_NT)

--- a/make/makefile
+++ b/make/makefile
@@ -1,4 +1,4 @@
-# makefile created by pymake (version 1.2.3) for the 'mf6' executable.
+# makefile created by pymake (version 1.2.5) for the 'mf6' executable.
 
 
 include ./makedefaults
@@ -145,6 +145,7 @@ $(OBJDIR)/GwtAdvOptions.o \
 $(OBJDIR)/gwf3tvs8.o \
 $(OBJDIR)/GwfStorageUtils.o \
 $(OBJDIR)/Mover.o \
+$(OBJDIR)/GwfMvrPeriodData.o \
 $(OBJDIR)/GwfBuyInputData.o \
 $(OBJDIR)/gwf3disu8.o \
 $(OBJDIR)/GridSorting.o \

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -123,6 +123,7 @@
 		<File RelativePath="..\src\Model\ModelUtilities\DiscretizationBase.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\DisvGeom.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\GwfBuyInputData.f90"/>
+		<File RelativePath="..\src\Model\ModelUtilities\GwfMvrPeriodData.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\GwfNpfGridData.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\GwfNpfOptions.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\GwfStorageUtils.f90"/>

--- a/src/Model/GroundWaterTransport/gwt1.f90
+++ b/src/Model/GroundWaterTransport/gwt1.f90
@@ -1,7 +1,6 @@
 ! Groundwater Transport (GWT) Model
 ! The following are additional features/checks to add
 !   * Add check that discretization is the same between both models 
-!   * Program GWT-GWT exchange transport (awaiting implementation of interface model)
 !   * Consider implementation of steady-state transport (affects MST, IST)
 !   * Check and handle pore space discrepancy between flow and transport (porosity vs specific yield)
 !   * UZT may not have the required porosity term

--- a/src/Model/ModelUtilities/GwfMvrPeriodData.f90
+++ b/src/Model/ModelUtilities/GwfMvrPeriodData.f90
@@ -1,0 +1,144 @@
+  
+module GwfMvrPeriodDataModule
+  use KindModule,             only: DP, I4B
+  use ConstantsModule,        only: LENMEMPATH, LENMODELNAME, LENPACKAGENAME,  &
+                                    LINELENGTH
+  use SimVariablesModule,     only: errmsg
+  use SimModule,              only: store_error
+  use BlockParserModule,      only: BlockParserType
+  
+  implicit none
+  private
+  public GwfMvrPeriodDataType
+  
+  type GwfMvrPeriodDataType
+    character(len=LENMODELNAME), dimension(:), pointer, contiguous   :: mname1   => null() !< provider model name
+    character(len=LENPACKAGENAME), dimension(:), pointer, contiguous :: pname1   => null() !< provider package name
+    character(len=LENMODELNAME), dimension(:), pointer, contiguous   :: mname2   => null() !< receiver model name
+    character(len=LENPACKAGENAME), dimension(:), pointer, contiguous :: pname2   => null() !< receiver package name
+    integer(I4B), dimension(:), pointer, contiguous                  :: id1      => null() !< provider reach number
+    integer(I4B), dimension(:), pointer, contiguous                  :: id2      => null() !< receiver reach number
+    integer(I4B), dimension(:), pointer, contiguous                  :: imvrtype => null() !< mover type (1, 2, 3, 4) corresponds to mvrtypes
+    real(DP), dimension(:), pointer, contiguous                      :: value    => null() !< factor or rate depending on mvrtype
+  contains
+    procedure :: construct
+    procedure :: read_from_parser
+    procedure :: destroy
+    
+  end type GwfMvrPeriodDataType
+
+  contains
+  
+  subroutine construct(this, maxsize, memoryPath)
+    use MemoryManagerModule, only: mem_allocate
+    class(GwfMvrPeriodDataType) :: this
+    integer(I4B), intent(in) :: maxsize
+    character(len=LENMEMPATH), intent(in) :: memoryPath
+    
+    ! -- character arrays
+    allocate(this%mname1(maxsize))
+    allocate(this%pname1(maxsize))
+    allocate(this%mname2(maxsize))
+    allocate(this%pname2(maxsize))
+    
+    ! -- integer and real
+    call mem_allocate(this%id1, maxsize, 'ID1', memoryPath)
+    call mem_allocate(this%id2, maxsize, 'ID2', memoryPath)
+    call mem_allocate(this%imvrtype, maxsize, 'IMVRTYPE', memoryPath)
+    call mem_allocate(this%value, maxsize, 'VALUE', memoryPath)
+
+    return
+  end subroutine construct
+  
+  subroutine read_from_parser(this, parser, nmvr, modelname)
+    class(GwfMvrPeriodDataType) :: this
+    type(BlockParserType), intent(inout) :: parser
+    integer(I4B), intent(out) :: nmvr
+    character(len=LENMODELNAME), intent(in) :: modelname
+    ! -- local
+    integer(I4B) :: i
+    integer(I4B) :: maxmvr
+    logical :: endOfBlock
+    character(len=LINELENGTH) :: line
+    character(len=12) :: mvrtype_char
+    !
+    ! -- Initialize
+    i = 1
+    maxmvr = size(this%id1)
+    !
+    ! -- Read each mover entry
+    do
+      call parser%GetNextLine(endOfBlock)
+      if (endOfBlock) exit
+      !
+      ! -- Raise error if movers exceeds maxmvr
+      if (i > maxmvr) then
+        call parser%GetCurrentLine(line)
+        write(errmsg,'(4x,a,a)') 'MOVERS EXCEED MAXMVR ON LINE: ', &
+                                  trim(adjustl(line))
+        call store_error(errmsg)
+        call parser%StoreErrorUnit()
+      endif
+      !
+      ! -- modelname, package name, id for provider
+      if (modelname == '') then
+        call parser%GetStringCaps(this%mname1(i))
+      else
+        this%mname1(i) = modelname
+      end if
+      call parser%GetStringCaps(this%pname1(i))
+      this%id1(i) = parser%GetInteger()
+      !
+      ! -- modelname, package name, id for receiver
+      if (modelname == '') then
+        call parser%GetStringCaps(this%mname2(i))
+      else
+        this%mname2(i) = modelname
+      end if
+      call parser%GetStringCaps(this%pname2(i))
+      this%id2(i) = parser%GetInteger()
+      !
+      ! -- Mover type and value
+      call parser%GetStringCaps(mvrtype_char)
+      select case(mvrtype_char)
+        case('FACTOR')
+          this%imvrtype(i) = 1
+        case('EXCESS')
+          this%imvrtype(i) = 2
+        case('THRESHOLD')
+          this%imvrtype(i) = 3
+        case('UPTO')
+          this%imvrtype(i) = 4
+        case default
+          call store_error('INVALID MOVER TYPE: '//trim(mvrtype_char))
+          call parser%StoreErrorUnit()
+      end select
+      this%value(i) = parser%GetDouble()
+      i = i + 1
+    end do
+    nmvr = i - 1
+    return
+  end subroutine read_from_parser
+
+  subroutine destroy(this)
+    use MemoryManagerModule, only: mem_deallocate
+    class(GwfMvrPeriodDataType) :: this
+
+    ! -- character arrays
+    deallocate(this%mname1)
+    deallocate(this%pname1)
+    deallocate(this%mname2)
+    deallocate(this%pname2)
+    
+    ! -- integer and real
+    call mem_deallocate(this%id1)
+    call mem_deallocate(this%id2)
+    call mem_deallocate(this%imvrtype)
+    call mem_deallocate(this%value)
+    
+    return
+  end subroutine destroy
+
+  
+end module GwfMvrPeriodDataModule
+  

--- a/src/Model/ModelUtilities/GwfMvrPeriodData.f90
+++ b/src/Model/ModelUtilities/GwfMvrPeriodData.f90
@@ -1,4 +1,9 @@
-  
+!> @brief This module contains the GwfMvrPeriodDataModule Module
+!!
+!! This module contains the code for storing and reading
+!! stress period data for the GwfMvr Package.
+!!
+!<
 module GwfMvrPeriodDataModule
   use KindModule,             only: DP, I4B
   use ConstantsModule,        only: LENMEMPATH, LENMODELNAME, LENPACKAGENAME,  &
@@ -11,6 +16,12 @@ module GwfMvrPeriodDataModule
   private
   public GwfMvrPeriodDataType
   
+  !> @brief Derived type for GwfMvrPeriodDataType 
+  !!
+  !! This derived type contains information and methods for
+  !! the data read for the GwfMvr Package.
+  !!
+  !<
   type GwfMvrPeriodDataType
     character(len=LENMODELNAME), dimension(:), pointer, contiguous   :: mname1   => null() !< provider model name
     character(len=LENPACKAGENAME), dimension(:), pointer, contiguous :: pname1   => null() !< provider package name
@@ -24,16 +35,22 @@ module GwfMvrPeriodDataModule
     procedure :: construct
     procedure :: read_from_parser
     procedure :: destroy
-    
   end type GwfMvrPeriodDataType
 
   contains
   
+  !> @ brief Construct arrays
+  !!
+  !! Allocate maximum space for mover input.
+  !!
+  !<
   subroutine construct(this, maxsize, memoryPath)
+    ! -- modules
     use MemoryManagerModule, only: mem_allocate
-    class(GwfMvrPeriodDataType) :: this
-    integer(I4B), intent(in) :: maxsize
-    character(len=LENMEMPATH), intent(in) :: memoryPath
+    ! -- dummy
+    class(GwfMvrPeriodDataType) :: this                  !< GwfMvrPeriodDataType
+    integer(I4B), intent(in) :: maxsize                  !< size of arrays
+    character(len=LENMEMPATH), intent(in) :: memoryPath  !< memory manager path
     
     ! -- character arrays
     allocate(this%mname1(maxsize))
@@ -50,11 +67,17 @@ module GwfMvrPeriodDataModule
     return
   end subroutine construct
   
+  !> @ brief Fill the arrays from parser
+  !!
+  !! Use the provided block parser to fill the input arrays.
+  !!
+  !<
   subroutine read_from_parser(this, parser, nmvr, modelname)
-    class(GwfMvrPeriodDataType) :: this
-    type(BlockParserType), intent(inout) :: parser
-    integer(I4B), intent(out) :: nmvr
-    character(len=LENMODELNAME), intent(in) :: modelname
+    ! -- dummy
+    class(GwfMvrPeriodDataType) :: this                    !< GwfMvrPeriodDataType
+    type(BlockParserType), intent(inout) :: parser         !< block parser
+    integer(I4B), intent(out) :: nmvr                      !< number of mover entries read
+    character(len=LENMODELNAME), intent(in) :: modelname   !< name of model or empty string
     ! -- local
     integer(I4B) :: i
     integer(I4B) :: maxmvr
@@ -120,9 +143,16 @@ module GwfMvrPeriodDataModule
     return
   end subroutine read_from_parser
 
+  !> @ brief Destroy memory
+  !!
+  !! Deallocate memory from the memory manager.
+  !!
+  !<
   subroutine destroy(this)
+    ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    class(GwfMvrPeriodDataType) :: this
+    ! -- dummy 
+    class(GwfMvrPeriodDataType) :: this  !< GwfMvrPeriodDataType
 
     ! -- character arrays
     deallocate(this%mname1)

--- a/src/Model/ModelUtilities/Mover.f90
+++ b/src/Model/ModelUtilities/Mover.f90
@@ -1,3 +1,9 @@
+!> @brief This module contains the MvrModule Module
+!!
+!! This module contains the code for the low-level MvrType
+!! object.
+!!
+!<
 module MvrModule
   
   use KindModule, only: DP, I4B
@@ -14,6 +20,12 @@ module MvrModule
   character(len=12), dimension(4) :: mvrtypes =                                &
     [character(len=12) :: 'FACTOR', 'EXCESS', 'THRESHOLD', 'UPTO']
   
+  !> @brief Derived type for MvrType 
+  !!
+  !! This derived type contains information and methods for
+  !! moving water between packages.
+  !!
+  !<
   type MvrType
     character(len=LENMEMPATH)                    :: pckNameSrc = ''              !< provider package name
     character(len=LENMEMPATH)                    :: pckNameTgt = ''              !< receiver package name
@@ -39,6 +51,11 @@ module MvrModule
   
   contains
   
+  !> @ brief Set values from input data
+  !!
+  !! Set values and pointers for mover object.
+  !!
+  !<
   subroutine set_values(this, mname1, pname1, id1, mname2, pname2, &
                         id2, imvrtype, value)
     use MemoryHelperModule, only: create_mem_path
@@ -62,31 +79,27 @@ module MvrModule
     return
   end subroutine set_values
                         
+  !> @ brief Prepare object
+  !!
+  !! Set values and pointers for mover object.
+  !! pckMemPaths is an array of strings which are the memory paths for those 
+  !! packages. They are composed of model names and package names. The mover 
+  !! entries must be in pckMemPaths, or this routine will terminate with an error.
+  !<
   subroutine prepare(this, inunit, pckMemPaths, pakmovers)
-! ******************************************************************************
-! set -- Setup mvr object
-!        If mname == '', then read mname out of line. pckMemPaths is an array
-!        of strings which are the memory paths for those packages. They are composed
-!        of model names and package names. The mover entries must be in pckMemPaths, 
-!        or this routine will terminate with an error.
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use SimModule, only: store_error, store_error_unit, count_errors    
     ! -- dummy
-    class(MvrType) :: this
-    integer(I4B), intent(in) :: inunit
+    class(MvrType) :: this                                                  !< MvrType objec
+    integer(I4B), intent(in) :: inunit                                      !< input file unit number
     character(len=LENMEMPATH),                                                &
-      dimension(:), pointer, contiguous              :: pckMemPaths
-    type(PackageMoverType), dimension(:), pointer, contiguous    :: pakmovers
+      dimension(:), pointer, contiguous  :: pckMemPaths                     !< array of strings
+    type(PackageMoverType), dimension(:), pointer, contiguous :: pakmovers  !< Array of package mover objects
     ! -- local
     real(DP), dimension(:), pointer, contiguous :: temp_ptr => null()
     logical :: found
     integer(I4B) :: i
     integer(I4B) :: ipakloc1, ipakloc2
-! ------------------------------------------------------------------------------
     !
     ! -- Check to make sure provider and receiver are not the same
     if(this%pckNameSrc == this%pckNameTgt .and. this%iRchNrSrc == this%iRchNrTgt) then
@@ -161,19 +174,17 @@ module MvrModule
     return
   end subroutine prepare
   
+  !> @ brief Echo data to list file
+  !!
+  !! Write mover values to output file.
+  !!
+  !<
   subroutine echo(this, iout)
-! ******************************************************************************
-! echo -- Write the mover info that was read from file
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     ! -- dummy
-    class(MvrType) :: this
-    integer(I4B), intent(in) :: iout
+    class(MvrType) :: this             !< MvrType
+    integer(I4B), intent(in) :: iout   !< unit number for output file
     ! -- local
-! ------------------------------------------------------------------------------
     !
     write(iout, '(4x, a, a, a, i0)') 'FROM PACKAGE: ', trim(this%pckNameSrc),  &
       ' FROM ID: ', this%iRchNrSrc
@@ -186,37 +197,32 @@ module MvrModule
     return
   end subroutine echo
   
+  !> @ brief Advance
+  !!
+  !! Advance mover object.  Does nothing now.
+  !!
+  !<
   subroutine advance(this)
-! ******************************************************************************
-! advance -- Advance the mover
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     ! -- dummy
     class(MvrType) :: this
     ! -- local
-! ------------------------------------------------------------------------------
-    !
     !
     ! -- return
     return
   end subroutine advance
   
+  !> @ brief Formulate coefficients
+  !!
+  !! Make mover calculations.
+  !!
+  !<
   subroutine fc(this)
-! ******************************************************************************
-! fc -- formulate coefficients
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     ! -- dummy
-    class(MvrType) :: this
+    class(MvrType) :: this  !< MvrType
     ! -- local
     real(DP) :: qavailable, qtanew, qpactual
-! ------------------------------------------------------------------------------
     !
     ! -- Set qa and this%qavailable equal to available water in package (qtomvr)
     qavailable = this%qformvr_ptr
@@ -246,22 +252,20 @@ module MvrModule
     return
   end subroutine fc
 
+  !> @ brief Flow to receiver
+  !!
+  !! Calculate the rate of water provided to receiver.
+  !!
+  !<
   function qrcalc(this, qa, qta) result(qr)
-! ******************************************************************************
-! qrcalc -- Calculate the rate of water provided to the receiver
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     ! -- return
     real(DP) :: qr
     ! -- dummy
-    class(MvrType) :: this
-    real(DP), intent(in) :: qa
-    real(DP), intent(in) :: qta
+    class(MvrType) :: this      !< MvrType
+    real(DP), intent(in) :: qa  !< actual flow
+    real(DP), intent(in) :: qta !< total available flow
     ! -- local
-! ------------------------------------------------------------------------------
     ! -- Using the mover rules, calculate how much of the available water will
     !    go to the receiver.
     qr = DZERO
@@ -299,22 +303,20 @@ module MvrModule
     return
   end function qrcalc
 
+  !> @ brief Write flow
+  !!
+  !! Write a line of output for this mover object.
+  !!
+  !<
   subroutine writeflow(this, iout)
-! ******************************************************************************
-! writeflow -- Write mover flow information
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     ! -- dummy
-    class(MvrType) :: this
-    integer(I4B), intent(in) :: iout
+    class(MvrType) :: this            !< MvrType
+    integer(I4B), intent(in) :: iout  !< output file unit number
     ! -- local
     character(len=*), parameter :: fmt = &
       "(1x, a, ' ID ', i0, ' AVAILABLE ', 1(1pg15.6), " // &
       "' PROVIDED ', 1(1pg15.6), ' TO ', a, ' ID ', i0)"
-! ------------------------------------------------------------------------------
     !
     write(iout, fmt) trim(this%pckNameSrc), this%iRchNrSrc, this%qavailable,   &
       this%qpactual, trim(this%pckNameTgt), this%iRchNrTgt

--- a/src/meson.build
+++ b/src/meson.build
@@ -78,6 +78,7 @@ modflow_sources = files(
     'Model' / 'ModelUtilities' / 'DiscretizationBase.f90',
     'Model' / 'ModelUtilities' / 'DisvGeom.f90',
     'Model' / 'ModelUtilities' / 'GwfBuyInputData.f90',
+    'Model' / 'ModelUtilities' / 'GwfMvrPeriodData.f90',
     'Model' / 'ModelUtilities' / 'GwfNpfGridData.f90',
     'Model' / 'ModelUtilities' / 'GwfNpfOptions.f90',
     'Model' / 'ModelUtilities' / 'GwfStorageUtils.f90',


### PR DESCRIPTION
* create new GwfMvrPeriodData object for reading and storing mover stress period data
* store mover stress period data as vectors in the memory manager
* revise the low-level mover object to point into the input data