### PR TITLE
refactor(gwt): Create generalized transport base class for gwe

### DIFF
--- a/make/makefile
+++ b/make/makefile
@@ -151,6 +151,7 @@ $(OBJDIR)/gwf3disu8.o \
 $(OBJDIR)/GridSorting.o \
 $(OBJDIR)/DisConnExchange.o \
 $(OBJDIR)/CsrUtils.o \
+$(OBJDIR)/TransportModel.o \
 $(OBJDIR)/NameFile.o \
 $(OBJDIR)/mf6lists.o \
 $(OBJDIR)/gwt1uzt1.o \

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -140,7 +140,8 @@
 		<File RelativePath="..\src\Model\ModelUtilities\Xt3dInterface.f90"/></Filter>
 		<File RelativePath="..\src\Model\BaseModel.f90"/>
 		<File RelativePath="..\src\Model\NumericalModel.f90"/>
-		<File RelativePath="..\src\Model\NumericalPackage.f90"/></Filter>
+		<File RelativePath="..\src\Model\NumericalPackage.f90"/>
+		<File RelativePath="..\src\Model\TransportModel.f90"/></Filter>
 		<Filter Name="Solution">
 		<Filter Name="IMS">
 		<File RelativePath="..\src\Solution\SparseMatrixSolver\ims8base.f90"/>

--- a/src/Model/GroundWaterTransport/gwt1.f90
+++ b/src/Model/GroundWaterTransport/gwt1.f90
@@ -12,6 +12,7 @@ module GwtModule
   use ConstantsModule,             only: LENFTYPE, DZERO, LENPAKLOC
   use VersionModule,               only: write_listfile_header
   use NumericalModelModule,        only: NumericalModelType  
+  use TransportModelModule,        only: TransportModelType
   use BaseModelModule,             only: BaseModelType
   use BndModule,                   only: BndType, AddBndToList, GetBndFromList
   use GwtIcModule,                 only: GwtIcType
@@ -32,7 +33,7 @@ module GwtModule
   public :: GwtModelType
   public :: CastAsGwtModel
 
-  type, extends(NumericalModelType) :: GwtModelType
+  type, extends(TransportModelType) :: GwtModelType
     
     type(GwtIcType),                pointer :: ic      => null()                ! initial conditions package
     type(GwtFmiType),               pointer :: fmi     => null()                ! flow model interface

--- a/src/Model/TransportModel.f90
+++ b/src/Model/TransportModel.f90
@@ -1,0 +1,31 @@
+! Generalized Transport Base Class
+! Base class for solute (mass) and energy (thermal) transport
+!   (The following copied from gwt1.f90)
+!   * Add check that discretization is the same between both models 
+!   * Program GWT-GWT exchange transport (awaiting implementation of interface model)
+!   * Consider implementation of steady-state transport (affects MST, IST)
+!   * Check and handle pore space discrepancy between flow and transport (porosity vs specific yield)
+!   * UZT may not have the required porosity term
+
+module TransportModelModule
+  use KindModule,                  only: DP, I4B
+  use ConstantsModule,             only: LENFTYPE
+  use SimVariablesModule,          only: errmsg
+  use NumericalModelModule,        only: NumericalModelType
+  
+  implicit none
+  
+  private
+  
+  public :: TransportModelType
+  
+  type, extends(NumericalModelType) :: TransportModelType
+
+  contains
+  
+  end type TransportModelType
+  
+
+  
+end module TransportModelModule  
+  

--- a/src/Model/TransportModel.f90
+++ b/src/Model/TransportModel.f90
@@ -1,11 +1,8 @@
-! Generalized Transport Base Class
-! Base class for solute (mass) and energy (thermal) transport
-!   (The following copied from gwt1.f90)
-!   * Add check that discretization is the same between both models 
-!   * Program GWT-GWT exchange transport (awaiting implementation of interface model)
-!   * Consider implementation of steady-state transport (affects MST, IST)
-!   * Check and handle pore space discrepancy between flow and transport (porosity vs specific yield)
-!   * UZT may not have the required porosity term
+!> @brief This module contains the base transport model type
+!!
+!! This module contains the base class for transport models.
+!!
+!<
 
 module TransportModelModule
   use KindModule,                  only: DP, I4B

--- a/src/meson.build
+++ b/src/meson.build
@@ -96,6 +96,7 @@ modflow_sources = files(
     'Model' / 'BaseModel.f90',
     'Model' / 'NumericalModel.f90',
     'Model' / 'NumericalPackage.f90',
+    'Model' / 'TransportModel.f90',
     'Solution' / 'SparseMatrixSolver' / 'ims8base.f90',
     'Solution' / 'SparseMatrixSolver' / 'ims8linear.f90',
     'Solution' / 'SparseMatrixSolver' / 'ims8reordering.f90',


### PR DESCRIPTION
Initial refactor of gwt to use a generalized base class that will support other types of transport models, for example gwe.