### PR TITLE
docs: require Python3.8 per xmipy dependency

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -52,7 +52,7 @@ gfortran can be used to compile MODFLOW 6 and associated utilities and generate 
 ### Python
 
 Install Python, for example via [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual).
-Please make sure that your Python version is 3.7 or higher.
+Please make sure that your Python version is 3.8 or higher.
 Then install all packages necessary to run the tests either by executing [install-python-std.sh](.github/common/install-python-std.sh) via bash directly or by installing the listed packages manually.
 
 ### ifort (optional)


### PR DESCRIPTION
The [developer README](https://github.com/MODFLOW-USGS/modflow6/blob/develop/DEVELOPER.md#python) stipulates Python>=3.7. However [`xmipy`](https://github.com/Deltares/xmipy) uses f-string [self-documenting expressions](https://docs.python.org/3/whatsnew/3.8.html#f-strings-support-for-self-documenting-expressions-and-debugging) (a Python 3.8 feature) [here](https://github.com/Deltares/xmipy/blob/7375186e91b4868c364a9269ba82539a915e8d91/xmipy/xmiwrapper.py#L381). Running tests with Python 3.7 produces syntax errors in the following:

- test_gwf_ifmod_mult_exg.py
- test_gwf_libmf6_evt01.py
- test_gwf_libmf6_ghb01.py
- test_gwf_libmf6_ifmod01.py
- test_gwf_libmf6_ifmod02.py
- test_gwf_libmf6_ifmod03.py
- test_gwf_libmf6_rch01.py
- test_gwf_libmf6_rch02.py
- test_gwf_libmf6_riv01.py
- test_gwf_libmf6_riv02.py
- test_gwf_libmf6_sto01.py

**Reproducing**
1. Create a Python 3.7 environment (e.g., with `venv` or Anaconda)
2. Follow the developer instructions to install dependencies, compile MODFLOW, etc
3. Run `pytest -v`

This yields errors like:
```
../venv/lib/python3.7/site-packages/_pytest/python.py:608: in _importtestmodule
    mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
../venv/lib/python3.7/site-packages/_pytest/pathlib.py:533: in import_path
    importlib.import_module(module_name)
/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1006: in _gcd_import
    ???
<frozen importlib._bootstrap>:983: in _find_and_load
    ???
<frozen importlib._bootstrap>:967: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:677: in _load_unlocked
    ???
../venv/lib/python3.7/site-packages/_pytest/assertion/rewrite.py:168: in exec_module
    exec(co, module.__dict__)
test_gwf_ifmod_mult_exg.py:26: in <module>
    from modflowapi import ModflowApi
../venv/lib/python3.7/site-packages/modflowapi/__init__.py:2: in <module>
    from modflowapi.modflowapi import ModflowApi
../venv/lib/python3.7/site-packages/modflowapi/modflowapi.py:1: in <module>
    from xmipy import XmiWrapper
../venv/lib/python3.7/site-packages/xmipy/__init__.py:3: in <module>
    from xmipy.xmiwrapper import XmiWrapper as XmiWrapper
E     File "<fstring>", line 1
E       (vartype=)
E               ^
E   SyntaxError: invalid syntax
```