### PR TITLE
Add conda `environment.yml`

### DIFF
--- a/.github/common/install-python-std.sh
+++ b/.github/common/install-python-std.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-pip install wheel
-pip install requests appdirs numpy matplotlib pytest pytest-xdist meson!=0.63.0 ninja fprettify
-pip install https://github.com/modflowpy/flopy/zipball/develop
-pip install https://github.com/modflowpy/pymake/zipball/master
-pip install https://github.com/Deltares/xmipy/zipball/develop
-pip install https://github.com/MODFLOW-USGS/modflowapi/zipball/develop

--- a/.github/workflows/ci-check-warnings-gfortran.yml
+++ b/.github/workflows/ci-check-warnings-gfortran.yml
@@ -14,20 +14,16 @@ env:
 jobs:
   check_warnings:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
     
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Python
-        uses: actions/setup-python@v4.0.0
-        with:
-          python-version: 3.9
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
 
       - name: Setup symbolic links on Linux
         run: |
@@ -40,10 +36,6 @@ jobs:
           gfortran --version
           gcc --version
           g++ --version
-
-      - name: Install python packages
-        run: |
-          .github/common/install-python-std.sh
 
       - name: Print python package versions
         run: |
@@ -59,20 +51,16 @@ jobs:
 
   test_night_build_script:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Python
-        uses: actions/setup-python@v4.0.0
-        with:
-          python-version: 3.9
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
 
       - name: Setup symbolic links on Linux
         run: |
@@ -85,10 +73,6 @@ jobs:
           gfortran --version
           gcc --version
           g++ --version
-
-      - name: Install python packages
-        run: |
-          .github/common/install-python-std.sh
 
       - name: Print python package versions
         run: |

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   rtd_build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     env:
       working-directory: .build_rtd_docs
       distribution-directory: distribution
@@ -16,20 +19,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: Setup Python
-        uses: actions/setup-python@v4.0.0
-        with:
-          python-version: 3.9
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
 
       - name: Upgrade pip and install packages for Sphinx
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
         working-directory: ${{env.working-directory}}
-
-      - name: Install additional python packages
-        run: |
-          .github/common/install-python-std.sh
 
       - name: Install TeX Live
         run: |

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -9,18 +9,15 @@ on:
 jobs:
   fortan-format-check:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
       - uses: actions/checkout@v2.3.4
 
-      - name: Setup Python
-        uses: actions/setup-python@v4.0.0
-        with:
-          python-version: 3.9
-
-      - name: Install python packages
-        run: |
-          .github/common/install-python-std.sh
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
 
       - name: Setup symbolic links on Linux
         run: |

--- a/.github/workflows/ci-large-tests.yml
+++ b/.github/workflows/ci-large-tests.yml
@@ -38,17 +38,15 @@ jobs:
         test_script: [ largetests, examples ]
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
 
     if: github.repository_owner == 'MODFLOW-USGS'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Python
-        uses: actions/setup-python@v4.0.0
-        with:
-          python-version: 3.9
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
 
       - name: set FC=ifort environmental variable
         if: matrix.FC == 'ifort'
@@ -76,10 +74,6 @@ jobs:
           sudo ln -fs /usr/bin/gfortran-10 /usr/local/bin/gfortran
           sudo ln -fs /usr/bin/gcc-10 /usr/local/bin/gcc
           sudo ln -fs /usr/bin/g++-10 /usr/local/bin/g++
-
-      - name: Install python packages
-        run: |
-          .github/common/install-python-std.sh
 
       - name: Install additional python packages
         run: |

--- a/.github/workflows/ci-tests-gfortran-latest.yml
+++ b/.github/workflows/ci-tests-gfortran-latest.yml
@@ -20,16 +20,14 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Python
-        uses: actions/setup-python@v4.0.0
-        with:
-          python-version: 3.9
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
 
       - name: Workaround for windows-2022 v20220626.1 gfortran executable run failures
         if: runner.os == 'Windows'
@@ -45,7 +43,6 @@ jobs:
 
       - name: Setup symbolic link to gfortran on macOS
         if: runner.os == 'macOS'
-        shell: bash
         run: |
           sudo ln -fs /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
           sudo ln -fs /usr/local/bin/gcc-11 /usr/local/bin/gcc
@@ -56,10 +53,6 @@ jobs:
           gfortran --version
           gcc --version
           g++ --version
-
-      - name: Install python packages
-        run: |
-          .github/common/install-python-std.sh
 
       - name: Print python package versions
         run: |

--- a/.github/workflows/ci-tests-gfortran-previous.yml
+++ b/.github/workflows/ci-tests-gfortran-previous.yml
@@ -21,16 +21,14 @@ jobs:
         GCC_V: [ 5, 6, 7, 8 ]
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Python
-        uses: actions/setup-python@v4.0.0
-        with:
-          python-version: 3.9
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
 
       - name: Set up gfortran ${{ matrix.GCC_V }}
         run: |
@@ -46,10 +44,6 @@ jobs:
           gfortran --version
           g++ --version
           gcov --version
-
-      - name: Install python packages
-        run: |
-          .github/common/install-python-std.sh
 
       - name: Print python package versions
         run: |

--- a/.github/workflows/ci-tests-ifort.yml
+++ b/.github/workflows/ci-tests-ifort.yml
@@ -38,16 +38,14 @@ jobs:
           - os: windows-latest
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Python
-        uses: actions/setup-python@v4.0.0
-        with:
-          python-version: 3.9
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
 
       - name: cache install ifort on linux
         if: runner.os == 'Linux'
@@ -89,10 +87,6 @@ jobs:
         run: |
           .github/intel-scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_FORTRAN_COMPONENTS
 
-      - name: Install python packages
-        run: |
-          .github/common/install-python-std.sh
-
       - name: Print python package versions
         run: |
           pip list
@@ -131,8 +125,9 @@ jobs:
 
       - name: Build MODFLOW 6 (Windows)
         if: runner.os == 'Windows'
-        shell: cmd
+        shell: cmd /C CALL {0}
         run: |
+          call micromamba activate modflow6
           call ".github/intel-scripts/build_windows.bat"
           meson setup builddir -Ddebug=false --prefix=%CD% --libdir=bin
           meson install -C builddir
@@ -151,6 +146,5 @@ jobs:
 
       - name: exclude unused files from cache on windows
         if: runner.os == 'Windows' && steps.cache-install-windows.outputs.cache-hit != 'true'
-        shell: bash
         run: |
           .github/intel-scripts/cache_exclude_windows.sh

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -29,17 +29,6 @@ installation in a WSL environment.
 
 Required and optional dependencies for MODFLOW 6 are discussed in [DEVELOPER.md](../DEVELOPER.md)
 
-The Modern Fortran extension requires a Fortran compiler and language server.  To install
-the [fortls](https://github.com/gnikit/fortls) fortran language server run:
-
-```bash
-pip install -U fortls
-```
-
-The Modern Fortran formatting capability requires `fprettify`, which can be installed in a similar way
-using `pip` or `conda`.
-
-
 ### Settings
 
 Add [settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settingsjson) to the
@@ -52,17 +41,19 @@ In general, to determine the path of an installed tool in your environment run:
 - cmd: `where <toolname>`, e.g. `where python`
 - PowerShell: `Get-Command <toolname>` e.g. `Get-Command fprettify`
 
-The setting "python.defaultInterpreterPath" describes the path of your Python executable:
-```json
-{
-    "python.defaultInterpreterPath": "/path/to/python",
-}
+1. Activate the conda environment:
+
+```bash
+conda activate modflow6
 ```
 
-The setting "fortran.fortls.path" describes the path of your fortls executable:
+2. Determine the path of `fortls` and `fprettify`
+
+3. Set the setting "fortran.fortls.path" and "fortran.formatting.path":
 ```json
 {
-    "fortran.fortls.path": "/path/to/fortls"
+    "fortran.fortls.path": "/path/to/fortls",
+    "fortran.formatting.path": "/path/to/fprettify",
 }
 ```
 
@@ -70,10 +61,11 @@ The fortran formatter can be integrated with VSCode using the following settings
 
 ```json
 {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "fortran-lang.linter-gfortran",
+    "[fortran]": {
+        "editor.formatOnSave": true,
+    },
     "fortran.formatting.formatter": "fprettify",
-    "fortran.formatting.fprettifyArgs": ["-c", "C:\\<full path to modflow6>\\distribution\\.fprettify.yaml"],
+    "fortran.formatting.fprettifyArgs": ["-c", "/path/to/modflow6/.fprettify.yaml"],
 }
 ```
 

--- a/.vscode/run_python.cmd
+++ b/.vscode/run_python.cmd
@@ -1,9 +1,10 @@
 @echo off
 
-if "%4" == "ifort" (
+if "%3" == "ifort" (
  call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
 )
 
+call conda activate modflow6
 
 rem run python script
-%1 %2 %3 %4 %5 %6 %7
+python %1 %2 %3 %4 %5 %6

--- a/.vscode/run_python.sh
+++ b/.vscode/run_python.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-if [[ "$4" == "ifort" ]];
+if [[ "$3" == "ifort" ]];
 then
     source /opt/intel/oneapi/setvars.sh
 fi
 
+eval "$(conda shell.bash hook)"
+conda activate modflow6
+
 # run python script
-$1 $2 $3 $4 $5 $6 $7
+python $1 $2 $3 $4 $5 $6

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,6 @@
             "windows": {
                 "command": "${workspaceFolder}/.vscode/run_python.cmd",
                 "args": [
-                    "${config:python.defaultInterpreterPath}",
                     "${workspaceFolder}/.vscode/build_vscode.py",
                     "--compiler",
                     "ifort",
@@ -20,7 +19,6 @@
                 "problemMatcher": "$msCompile"
             },
             "args": [
-                "${config:python.defaultInterpreterPath}",
                 "${workspaceFolder}/.vscode/build_vscode.py",
                 "--compiler",
                 "ifort",
@@ -39,7 +37,6 @@
             "windows": {
                 "command": "${workspaceFolder}/.vscode/run_python.cmd",
                 "args": [
-                    "${config:python.defaultInterpreterPath}",
                     "${workspaceFolder}/.vscode/build_vscode.py",
                     "--compiler",
                     "ifort",
@@ -49,7 +46,6 @@
                 ],
             },
             "args": [
-                "${config:python.defaultInterpreterPath}",
                 "${workspaceFolder}/.vscode/build_vscode.py",
                 "--compiler",
                 "ifort",
@@ -68,7 +64,6 @@
             "windows": {
                 "command": "${workspaceFolder}/.vscode/run_python.cmd",
                 "args": [
-                    "${config:python.defaultInterpreterPath}",
                     "${workspaceFolder}/.vscode/build_vscode.py",
                     "--compiler",
                     "gfortran",
@@ -79,7 +74,6 @@
                 "problemMatcher": "$msCompile"
             },
             "args": [
-                "${config:python.defaultInterpreterPath}",
                 "${workspaceFolder}/.vscode/build_vscode.py",
                 "--compiler",
                 "gfortran",
@@ -98,7 +92,6 @@
             "windows": {
                 "command": "${workspaceFolder}/.vscode/run_python.cmd",
                 "args": [
-                    "${config:python.defaultInterpreterPath}",
                     "${workspaceFolder}/.vscode/build_vscode.py",
                     "--compiler",
                     "gfortran",
@@ -108,7 +101,6 @@
                 ],
             },
             "args": [
-                "${config:python.defaultInterpreterPath}",
                 "${workspaceFolder}/.vscode/build_vscode.py",
                 "--compiler",
                 "gfortran",
@@ -127,7 +119,6 @@
             "windows": {
                 "command": "${workspaceFolder}/.vscode/run_python.cmd",
                 "args": [
-                    "${config:python.defaultInterpreterPath}",
                     "${workspaceFolder}/.vscode/build_vscode.py",
                     "--compiler",
                     "ifort",
@@ -138,7 +129,6 @@
                 "problemMatcher": "$msCompile"
             },
             "args": [
-                "${config:python.defaultInterpreterPath}",
                 "${workspaceFolder}/.vscode/build_vscode.py",
                 "--compiler",
                 "ifort",
@@ -157,7 +147,6 @@
             "windows": {
                 "command": "${workspaceFolder}/.vscode/run_python.cmd",
                 "args": [
-                    "${config:python.defaultInterpreterPath}",
                     "${workspaceFolder}/.vscode/build_vscode.py",
                     "--compiler",
                     "ifort",
@@ -167,7 +156,6 @@
                 ],
             },
             "args": [
-                "${config:python.defaultInterpreterPath}",
                 "${workspaceFolder}/.vscode/build_vscode.py",
                 "--compiler",
                 "ifort",
@@ -186,7 +174,6 @@
             "windows": {
                 "command": "${workspaceFolder}/.vscode/run_python.cmd",
                 "args": [
-                    "${config:python.defaultInterpreterPath}",
                     "${workspaceFolder}/.vscode/build_vscode.py",
                     "--compiler",
                     "gfortran",
@@ -197,7 +184,6 @@
                 "problemMatcher": "$msCompile"
             },
             "args": [
-                "${config:python.defaultInterpreterPath}",
                 "${workspaceFolder}/.vscode/build_vscode.py",
                 "--compiler",
                 "gfortran",
@@ -216,7 +202,6 @@
             "windows": {
                 "command": "${workspaceFolder}/.vscode/run_python.cmd",
                 "args": [
-                    "${config:python.defaultInterpreterPath}",
                     "${workspaceFolder}/.vscode/build_vscode.py",
                     "--compiler",
                     "gfortran",
@@ -226,7 +211,6 @@
                 ],
             },
             "args": [
-                "${config:python.defaultInterpreterPath}",
                 "${workspaceFolder}/.vscode/build_vscode.py",
                 "--compiler",
                 "gfortran",

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -52,8 +52,10 @@ gfortran can be used to compile MODFLOW 6 and associated utilities and generate 
 ### Python
 
 Install Python, for example via [miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/products/individual).
-Please make sure that your Python version is 3.8 or higher.
-Then install all packages necessary to run the tests either by executing [install-python-std.sh](.github/common/install-python-std.sh) via bash directly or by installing the listed packages manually.
+Then create a new environment by executing the following at the root of this repository
+```
+conda env create --force -f environment.yml
+```
 
 ### ifort (optional)
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+name: modflow6
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - appdirs 
+  - fprettify
+  - numpy
+  - matplotlib
+  - meson!=0.63.0
+  - ninja
+  - pip
+  - pip:
+      - git+https://github.com/modflowpy/flopy.git
+      - git+https://github.com/modflowpy/pymake.git
+      - git+https://github.com/Deltares/xmipy.git
+      - git+https://github.com/MODFLOW-USGS/modflowapi.git
+  - pytest
+  - pytest-xdist
+  - requests


### PR DESCRIPTION
This PR adds an `environment.yml` which should make it easier to keep docs and CI in sync.
It also changes the behavior of the vscode tasks.
It expects an environment called `modflow6` created with the following command.
```
conda env create --force -f environment.yml
```

You might also want to change your `"fortran.fortls.path"` setting to the `fortls` in your `modflow6` environment.

Ideally, you would use this environment for your daily development work as well and adapt it if our dependencies change.

@jmccreight, @mjr-deltares, @langevin-usgs, @jdhughes-usgs, @mjreno 