### PR TITLE
ci: fix Intel OneAPI build on Windows

### DIFF
--- a/.github/common/install-python-std.sh
+++ b/.github/common/install-python-std.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 pip install wheel
-pip install requests appdirs numpy matplotlib pytest pytest-xdist meson ninja
+pip install requests appdirs numpy matplotlib pytest pytest-xdist meson!=0.63.0 ninja
 pip install https://github.com/modflowpy/flopy/zipball/develop
 pip install https://github.com/modflowpy/pymake/zipball/master
 pip install https://github.com/Deltares/xmipy/zipball/develop

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,8 @@ endif
 if fc_id == 'intel-cl'
   # windows
   compile_args += ['/fpe:0',              # Activate all floating point exceptions
+                   '/heap-arrays:0',
+                   '/traceback',
                    '/fpp',                # Activate preprocessing
                    '/Qdiag-disable:7416', # f2008 warning
                    '/Qdiag-disable:7025', # f2008 warning
@@ -74,9 +76,11 @@ if fc_id == 'intel-cl'
 elif fc_id == 'intel'
   # linux and macOS
   compile_args += ['-fpe0',              # Activate all floating point exceptions
-                  '-diag-disable:7416',  # f2008 warning
-                  '-diag-disable:7025',  # f2008 warning
-                  '-diag-disable:5268',  # Line too long
+                   '-no-heap-arrays',
+                   '-traceback',
+                   '-diag-disable:7416',  # f2008 warning
+                   '-diag-disable:7025',  # f2008 warning
+                   '-diag-disable:5268',  # Line too long
                   ]
   link_args += '-static-intel'
 endif


### PR DESCRIPTION
The issue is caused by the latest meson release. Exclude meson version 0.63.0.