### PR TITLE
docs(formatting): add fortran source formatting to documentation

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -30,7 +30,7 @@ installation in a WSL environment.
 
 ### Dependencies
 
-Required and optional dependencies for modflow6 are discussed in [DEVELOPER.md](../DEVELOPER.md)
+Required and optional dependencies for MODFLOW 6 are discussed in [DEVELOPER.md](../DEVELOPER.md)
 
 The Modern Fortran extension requires a Fortran compiler and language server.  To install
 the [fortls](https://github.com/gnikit/fortls) fortran language server run:
@@ -83,7 +83,7 @@ Setting the formatter up in this way will cause a source file to reformat with e
 
 ### Running VSCode
 
-Open the top level `modflow6` repository directoy on your system when starting VSCode. The program will
+Open the top level `modflow6` repository directory on your system when starting VSCode. The program will
 then look for the `modflow6/.vscode` directory to discover settings relevant to your session.
 
 A nice alternative on any system is to start VSCode from the shell. For example, in a bash or git bash

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -22,49 +22,100 @@ Install the following VSCode extensions:
 - Modern Fortran:
   https://marketplace.visualstudio.com/items?itemName=krvajalm.linter-gfortran
 
-Now, configure the VSCode files for the modflow6 directory.
-Open the `modflow6` directory in VSCode.
-Make sure that the setting "python.defaultInterpreterPath" points toward your Python executable.
+- vscode-modern-fortran-formatter:
+  https://marketplace.visualstudio.com/items?itemName=yukiuuh.vscode-modern-fortran-formatter
 
+- Remote - WSL:
+  https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl
+
+Remote - WSL is only needed if you want to use a windows vscode installation in a WSL environment.
+
+### Dependencies
+
+Required and optional dependencies for modflow6 are discussed in [DEVELOPER.md](../DEVELOPER.md)
+
+The Modern Fortran extension requires a Fortran compiler and language server.  To install
+the [fortls](https://github.com/gnikit/fortls) fortran language server run:
+
+```bash
+pip install -U fortls
+```
+
+The vscode-modern-fortran-formatter requires `fprettify`, which can be installed in a similar way
+using pip or conda.
+
+
+### Settings
+
+Add [settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settingsjson) to the
+`modflow6/.vscode` directory if not already there. The following settings can be considered a
+starting place as the contents of this file are dictated both by desired VSCode behavior and
+environmental factors:
+
+In general, to determine the path of an installed tool in your environment run:
+- bash: `which <toolname>`, e.g. `which fortls`
+- cmd: `where <toolname>`, e.g. `where python`
+- PowerShell: `Get-Command <toolname>` e.g. `Get-Command fprettify`
+
+The setting "python.defaultInterpreterPath" points toward your Python executable:
 ```json
 {
     "python.defaultInterpreterPath": "/path/to/python",
 }
 ```
 
-In order to compile run:
-
-* Press `Ctrl + Shift + P` in VSCode.
-* Type `Tasks`.
-* Select `Run Task` (press Enter).
-* Select the suitable task for your situation.
-
-
-### Language Server
-
-1. Install the fortran language server via:
-
-```bash
-pip install -U fortls
-```
-
-2. Find out where the executable is
-
-- bash: `which fortls`
-- cmd: `where fortls`
-- PowerShell: `Get-Command fortls`
-
-3. Add the setting "fortran.fortls.path" to `.vscode/settings.json` and set its value to the result of step 2.
-In case this file does not exist yet, create a new one.
-
-
+The setting "fortran.fortls.path" points toward your fortls executable:
 ```json
 {
     "fortran.fortls.path": "/path/to/fortls"
 }
 ```
 
+The fortran formatter can be integrated with vscode using the following settings:
 
+```json
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "yukiuuh.vscode-modern-fortran-formatter",
+    "modernFortranFormatter.fprettifyArgs": "-c C:\\<full path to modflow6>\\distribution\\.fprettify.yaml"
+}
+```
+
+...or, in a WSL environment:
+
+```json
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "yukiuuh.vscode-modern-fortran-formatter",
+    "modernFortranFormatter.fprettifyArgs": "-c /<full path to modflow6>/distribution/.fprettify.yaml",
+}
+```
+
+Setting the formatter up in this way will cause a source file to reformat with each explicit save.
+
+### Running VSCode
+
+Open the top level `modflow6` repository directoy on your system when starting VSCode. The program will
+then look for the `modflow6/.vscode` directory to discover settings relevant to your session.
+
+A nice alternative on any system is to start VSCode from the shell. For example, in a bash or git bash
+shell (windows), change to the `modflow6` directory and execute the command:
+
+```bash
+code .
+```
+
+Note the dot. Starting in this way, VSCode will open as desired, inheriting and discovering
+expected runtime settings in the correct directory location.
+
+### Compiling
+
+In order to compile Fortran source run:
+
+* Press `Ctrl + Shift + P` in VSCode.
+* Type `Tasks`.
+* Select `Run Task` (press Enter).
+* Select the suitable task for your situation.
 
 ### Debugging
 

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -25,10 +25,8 @@ Install the following VSCode extensions:
 - vscode-modern-fortran-formatter:
   https://marketplace.visualstudio.com/items?itemName=yukiuuh.vscode-modern-fortran-formatter
 
-- Remote - WSL:
-  https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl
-
-Remote - WSL is only needed if you want to use a windows vscode installation in a WSL environment.
+Note: The Remote - WSL extension may be required if you want to use a windows VSCode
+installation in a WSL environment.
 
 ### Dependencies
 
@@ -57,37 +55,27 @@ In general, to determine the path of an installed tool in your environment run:
 - cmd: `where <toolname>`, e.g. `where python`
 - PowerShell: `Get-Command <toolname>` e.g. `Get-Command fprettify`
 
-The setting "python.defaultInterpreterPath" points toward your Python executable:
+The setting "python.defaultInterpreterPath" describes the path of your Python executable:
 ```json
 {
     "python.defaultInterpreterPath": "/path/to/python",
 }
 ```
 
-The setting "fortran.fortls.path" points toward your fortls executable:
+The setting "fortran.fortls.path" describes the path of your fortls executable:
 ```json
 {
     "fortran.fortls.path": "/path/to/fortls"
 }
 ```
 
-The fortran formatter can be integrated with vscode using the following settings:
+The fortran formatter can be integrated with VSCode using the following settings:
 
 ```json
 {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "yukiuuh.vscode-modern-fortran-formatter",
     "modernFortranFormatter.fprettifyArgs": "-c C:\\<full path to modflow6>\\distribution\\.fprettify.yaml"
-}
-```
-
-...or, in a WSL environment:
-
-```json
-{
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "yukiuuh.vscode-modern-fortran-formatter",
-    "modernFortranFormatter.fprettifyArgs": "-c /<full path to modflow6>/distribution/.fprettify.yaml",
 }
 ```
 

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -22,9 +22,6 @@ Install the following VSCode extensions:
 - Modern Fortran:
   https://marketplace.visualstudio.com/items?itemName=krvajalm.linter-gfortran
 
-- vscode-modern-fortran-formatter:
-  https://marketplace.visualstudio.com/items?itemName=yukiuuh.vscode-modern-fortran-formatter
-
 Note: The Remote - WSL extension may be required if you want to use a windows VSCode
 installation in a WSL environment.
 
@@ -39,8 +36,8 @@ the [fortls](https://github.com/gnikit/fortls) fortran language server run:
 pip install -U fortls
 ```
 
-The vscode-modern-fortran-formatter requires `fprettify`, which can be installed in a similar way
-using pip or conda.
+The Modern Fortran formatting capability requires `fprettify`, which can be installed in a similar way
+using `pip` or `conda`.
 
 
 ### Settings
@@ -74,8 +71,9 @@ The fortran formatter can be integrated with VSCode using the following settings
 ```json
 {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "yukiuuh.vscode-modern-fortran-formatter",
-    "modernFortranFormatter.fprettifyArgs": "-c C:\\<full path to modflow6>\\distribution\\.fprettify.yaml"
+    "editor.defaultFormatter": "fortran-lang.linter-gfortran",
+    "fortran.formatting.formatter": "fprettify",
+    "fortran.formatting.fprettifyArgs": ["-c", "C:\\<full path to modflow6>\\distribution\\.fprettify.yaml"],
 }
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Contributions to MODFLOW 6 are welcome from the community. As a contributor, her
  - [Feature Requests](#feature)
  - [Submission Guidelines](#submit)
  - [Coding Rules](#rules)
+ - [Format Rules](#format)
  - [Commit Message Guidelines](#commit)
 
 ## <a name="coc"></a> Code of Conduct
@@ -135,6 +136,34 @@ from the main (upstream) repository:
 To ensure consistency throughout the source code, keep these rules in mind as you are working:
 
 * All features or bug fixes **must be tested** by one or more specs (unit-tests and/or integration/regression-tests).
+* All Fortran souce code submissions must adhere to modflow6 [Format Rules](#format)
+
+## <a name="format"></a> Format Rules
+
+Fortran souce code format rules are met by running the
+[fprettify formatter](https://github.com/pseewald/fprettify) while specifying the [modflow6
+fprettify configuration](https://github.com/MODFLOW-USGS/modflow6/blob/develop/distribution/.fprettify.yaml).
+The tool can be run from the command line or integrated into a Visual Studio or
+[VSCode environment](https://github.com/MODFLOW-USGS/modflow6/blob/develop/.vscode/README.md).
+
+The format configuration file reflects the current minimum standard for Fortran source
+formatting.  The main goal, however, is consistent and readable Fortran source code and as such
+some considerations are relevant beyond running the tool:
+
+* When modifying a file, in general follow already well established patterns in the file.
+* When adding a file, look to already well established patterns in related files.
+
+The formatting tool at times shifts code in unexpected ways so such patterns should be checked after running.
+
+An example run of the command line tool: `fprettify -c ./distribution/.fprettify.yaml ./utils/zonebudget/src/zbud6.f90`
+
+When run in this way, the tool will modify the file in place and generate no output if successful. The
+tool will write stderr warnings when unable to complete formatting. In general, these warnings (e.g.
+for excess line length) must be manually fixed before attempting to rerun the tool.
+
+Certain Fortran source files are excluded from the formatting standard, for example external Fortran
+source found under the `modflow6/src/Utilities/Libraries` path. There will be a mechanism to exclude such
+files from CI format checking.
 
 ## <a name="commit"></a> Commit Message Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,29 +141,25 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 ## <a name="format"></a> Format Rules
 
 Fortran souce code format rules are met by running the
-[fprettify formatter](https://github.com/pseewald/fprettify) while specifying the [modflow6
+[fprettify formatter](https://github.com/pseewald/fprettify) while specifying the [MODFLOW 6
 fprettify configuration](https://github.com/MODFLOW-USGS/modflow6/blob/develop/distribution/.fprettify.yaml).
-The tool can be run from the command line or integrated into a Visual Studio or
-[VSCode environment](https://github.com/MODFLOW-USGS/modflow6/blob/develop/.vscode/README.md).
+The tool can be run from the command line or integrated into a
+[VSCode](https://github.com/MODFLOW-USGS/modflow6/blob/develop/.vscode/README.md) or Visual Studio environment.
 
 The format configuration file reflects the current minimum standard for Fortran source
 formatting.  The main goal, however, is consistent and readable Fortran source code and as such
-some considerations are relevant beyond running the tool:
+pay particular attention to consistency within and across files.  As the formatting tool may at
+times shift code in unexpected ways, check for formatting consistency after running.
 
-* When modifying a file, in general follow already well established patterns in the file.
-* When adding a file, look to already well established patterns in related files.
-
-The formatting tool at times shifts code in unexpected ways so such patterns should be checked after running.
-
-An example run of the command line tool: `fprettify -c ./distribution/.fprettify.yaml ./utils/zonebudget/src/zbud6.f90`
+An example run of the command line tool from the MODFLOW 6 root directory:
+`fprettify -c ./distribution/.fprettify.yaml ./utils/zonebudget/src/zbud6.f90`
 
 When run in this way, the tool will modify the file in place and generate no output if successful. The
 tool will write stderr warnings when unable to complete formatting. In general, these warnings (e.g.
 for excess line length) must be manually fixed before attempting to rerun the tool.
 
-Certain Fortran source files are excluded from the formatting standard, for example external Fortran
-source found under the `modflow6/src/Utilities/Libraries` path. There will be a mechanism to exclude such
-files from CI format checking.
+Fortran source files can be excluded from the formatting standard if necessary, as is the case
+for Fortran source found under the `modflow6/src/Utilities/Libraries` path.
 
 ## <a name="commit"></a> Commit Message Guidelines
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -68,7 +68,7 @@ These programs can be installed from various sources, including by conda, macpor
 
 ### fprettify
 
-[fprettify](https://github.com/pseewald/fprettify) can be used to format Fortran source code and in combination with the [MODFLOW 6 fprettify configuration](https://github.com/MODFLOW-USGS/modflow6/blob/develop/distribution/.fprettify.yaml) establishes a contribution standard for properly formatted MODFLOW 6 Fortran source. This tool can be installed with pip or conda and used from the command line or integrated with a [VSCode](https://github.com/MODFLOW-USGS/modflow6/blob/develop/.vscode/README.md) or Visual Studio development environment. See [contribution guidelines](https://github.com/MODFLOW-USGS/modflow6/blob/develop/CONTRIBUTING.md) for additional information.
+[fprettify](https://github.com/pseewald/fprettify) can be used to format Fortran source code and in combination with the [MODFLOW 6 fprettify configuration](https://github.com/MODFLOW-USGS/modflow6/blob/develop/distribution/.fprettify.yaml) establishes a contribution standard for properly formatted MODFLOW 6 Fortran source. This tool can be installed with `pip` or `conda` and used from the command line or integrated with a [VSCode](https://github.com/MODFLOW-USGS/modflow6/blob/develop/.vscode/README.md) or Visual Studio development environment. See [contribution guidelines](https://github.com/MODFLOW-USGS/modflow6/blob/develop/CONTRIBUTING.md) for additional information.
 
 ## Getting the Sources
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -66,9 +66,9 @@ Documentation describing how to set the intel envrionment variables can be found
 [Doxygen](https://www.doxygen.nl/index.html) is used to generate the [MODFLOW 6 source code documentation](https://modflow-usgs.github.io/modflow6/). [Graphviz](https://graphviz.org/) is used by doxygen to produce source code diagrams. [LaTeX](https://www.latex-project.org/) is used to generate the MODFLOW 6 release notes and Input/Output documents (docs/mf6io/mf6io.nightlybuild).
 These programs can be installed from various sources, including by conda, macports, or from individual sources such as https://www.tug.org/. Details about USGS LaTeX libraries can be seen in addition to linux installs in the CI workflow for the docs (`.github/workflows/ci-docs.yml`).
 
-### fprettify (optional)
+### fprettify
 
-[fprettify](https://github.com/pseewald/fprettify) can be used to format Fortran source code and in combination with the [modflow6 fprettify configuration](https://github.com/MODFLOW-USGS/modflow6/blob/develop/distribution/.fprettify.yaml) establishes a contribution standard for properly formatted modflow6 Fortran source. This tool can be installed with pip or conda and used from the command line or integrated with a VSCode or Visual Studio development environment. See the [contribution guidelines](https://github.com/MODFLOW-USGS/modflow6/blob/develop/CONTRIBUTING.md) and [vscode README](https://github.com/MODFLOW-USGS/modflow6/blob/develop/.vscode/README.md) for additional information.
+[fprettify](https://github.com/pseewald/fprettify) can be used to format Fortran source code and in combination with the [MODFLOW 6 fprettify configuration](https://github.com/MODFLOW-USGS/modflow6/blob/develop/distribution/.fprettify.yaml) establishes a contribution standard for properly formatted MODFLOW 6 Fortran source. This tool can be installed with pip or conda and used from the command line or integrated with a [VSCode](https://github.com/MODFLOW-USGS/modflow6/blob/develop/.vscode/README.md) or Visual Studio development environment. See [contribution guidelines](https://github.com/MODFLOW-USGS/modflow6/blob/develop/CONTRIBUTING.md) for additional information.
 
 ## Getting the Sources
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -66,6 +66,10 @@ Documentation describing how to set the intel envrionment variables can be found
 [Doxygen](https://www.doxygen.nl/index.html) is used to generate the [MODFLOW 6 source code documentation](https://modflow-usgs.github.io/modflow6/). [Graphviz](https://graphviz.org/) is used by doxygen to produce source code diagrams. [LaTeX](https://www.latex-project.org/) is used to generate the MODFLOW 6 release notes and Input/Output documents (docs/mf6io/mf6io.nightlybuild).
 These programs can be installed from various sources, including by conda, macports, or from individual sources such as https://www.tug.org/. Details about USGS LaTeX libraries can be seen in addition to linux installs in the CI workflow for the docs (`.github/workflows/ci-docs.yml`).
 
+### fprettify (optional)
+
+[fprettify](https://github.com/pseewald/fprettify) can be used to format Fortran source code and in combination with the [modflow6 fprettify configuration](https://github.com/MODFLOW-USGS/modflow6/blob/develop/distribution/.fprettify.yaml) establishes a contribution standard for properly formatted modflow6 Fortran source. This tool can be installed with pip or conda and used from the command line or integrated with a VSCode or Visual Studio development environment. See the [contribution guidelines](https://github.com/MODFLOW-USGS/modflow6/blob/develop/CONTRIBUTING.md) and [vscode README](https://github.com/MODFLOW-USGS/modflow6/blob/develop/.vscode/README.md) for additional information.
+
 ## Getting the Sources
 
 Fork and clone the MODFLOW 6 repository:


### PR DESCRIPTION
* reorganize vscode README and include fprettify integration
* update DEVELOPER and CONTRIBUTING docs to describe tools and standard