### PR TITLE
DEVELOPER.md: Visual Studio for ifort

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -66,8 +66,8 @@ Documentation describing how to set the intel environment variables can be found
 
 #### Windows
 
-- Visual Studio 2017 or 2019 with the appropriate redistributable libraries must be installed for ifort to compile on Windows.
-- ifort does not work yet with the latest Visual Studio (2022). Older versions can be found here: https://visualstudio.microsoft.com/vs/older-downloads/
+- Visual Studio with the appropriate redistributable libraries must be installed for ifort to compile on Windows.
+- Install Visual Studio, which can be found [here](https://visualstudio.microsoft.com/). Note: the latest version of Visual Studio, 2022, requires a sufficiently new version of the Intel OneAPI as well.
 - The redistributable libraries can installed via ticking the "Desktop Development with C++" checkbox in the Visual Studio Installer in the Workloads tab. 
 
 ### Doxygen & LaTeX (optional)

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -61,7 +61,14 @@ conda env create --force -f environment.yml
 
 Intel fortran can be used to compile MODFLOW 6 and associated utilities and generate distributable files (if not using gfortran).
 Download the Intel oneAPI HPC Toolkit: https://software.intel.com/content/www/us/en/develop/tools/oneapi/hpc-toolkit/download.html
-Documentation describing how to set the intel envrionment variables can be found [here](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup.html).
+
+Documentation describing how to set the intel environment variables can be found [here](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup.html).
+
+#### Windows
+
+- Visual Studio 2017 or 2019 with the appropriate redistributable libraries must be installed for ifort to compile on Windows.
+- ifort does not work yet with the latest Visual Studio (2022). Older versions can be found here: https://visualstudio.microsoft.com/vs/older-downloads/
+- The redistributable libraries can installed via ticking the "Desktop Development with C++" checkbox in the Visual Studio Installer in the Workloads tab. 
 
 ### Doxygen & LaTeX (optional)
 


### PR DESCRIPTION
I removed the Visual Studio installation on my Windows laptop (because I'm using VSCode), and then I found out ifort wouldn't compile anymore. I reinstalled Visual Studio, but still got a confusing error: "visual studio 2017 or 2019 is not found in c:\program files (x86)\microsoft visual studio\<2017 or 2019>\<edition>, please set vs2017installdir or vs2019installdir".

This is resolved by installing the C++ Desktop Development components. Apparently, the ifort compilers rely on some of the C++ parts.
I'm quite confident some parts aren't required (E.g. Test Adapter for Boost.Test), but I haven't done the research to find which parts are required and not. At the least, just checking the "Desktop Development with C++" checkbox does the trick.