### PR TITLE
refactor(autotest): clean up autotest, rework tests and integrate wit…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ UserPrefs.xml
 
 tmp_simulations/
 autotest/temp/
+autotest/results/
 autotest/tempbin/
 autotest/*.html
 autotest/notebooks/

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -1,0 +1,57 @@
+import pytest
+from pathlib import Path
+from shutil import copytree, rmtree, which
+import re
+
+try:
+    from modflow_devtools import (
+        MFTestContext,
+    )
+
+    modflow6_devbin = "../bin"
+
+    def pytest_sessionstart(session):
+        # setup devtools if not already done
+        MFTestContext(testbin=modflow6_devbin)
+
+    @pytest.fixture(scope="session")
+    def mf6testctx(request):
+        return MFTestContext(testbin=modflow6_devbin)
+
+except:
+
+    @pytest.fixture(scope="session")
+    def mf6testctx(request):
+        return None
+
+
+@pytest.fixture(scope="function")
+def tmpdir(tmpdir_factory, request) -> Path:
+    node = (
+        request.node.name.replace("/", "_")
+        .replace("\\", "_")
+        .replace(":", "_")
+    )
+    temp = Path(tmpdir_factory.mktemp(node))
+    yield Path(temp)
+
+    keep = request.config.getoption("--keep")
+    if keep:
+        tokens = re.split("\[|\]", temp.name)
+        if len(tokens) == 1:
+            copytree(temp, Path(keep) / tokens[0], dirs_exist_ok=True)
+        else:
+            copytree(
+                temp,
+                Path(keep) / tokens[0] / tokens[1].split("-", 1)[1],
+                dirs_exist_ok=True,
+            )
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--keep",
+        action="store",
+        default=None,
+        help="Save test outputs in named directory path",
+    )

--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -1,0 +1,11 @@
+# content of pytest.ini
+[pytest]
+python_files = 
+    test_*.py
+markers =
+    gwf: modflow6 groundwater flow test.
+    gwt: modflow6 groundwater transport test.
+    gwf_ats: modflow6 groundwater flow adaptive time step utility test.
+    gwf_aux: modflow6 groundwater flow auxiliary variable test.
+    gwf_lak: modflow6 groundwater flow lake package test.
+    gwf_maw: modflow6 groundwater flow multi-aquifer well package test.

--- a/autotest/test_gwf_ats01.py
+++ b/autotest/test_gwf_ats01.py
@@ -9,14 +9,6 @@ import numpy as np
 import pytest
 
 try:
-    import pymake
-except:
-    msg = "Error. Pymake package is not available.\n"
-    msg += "Try installing using the following command:\n"
-    msg += " pip install https://github.com/modflowpy/pymake/zipball/master"
-    raise Exception(msg)
-
-try:
     import flopy
 except:
     msg = "Error. FloPy package is not available.\n"
@@ -24,14 +16,16 @@ except:
     msg += " pip install flopy"
     raise Exception(msg)
 
-from framework import testing_framework
-from simulation import Simulation
+try:
+    from modflow_devtools import (
+        testing_framework,
+        Simulation,
+    )
+except:
+    from framework import testing_framework
+    from simulation import Simulation
 
-ex = ["gwf_ats01a"]
-exdirs = []
-for s in ex:
-    exdirs.append(os.path.join("temp", s))
-ddir = "data"
+runs = ["gwf_ats01a"]
 nlay, nrow, ncol = 1, 1, 2
 
 # set dt0, dtmin, dtmax, dtadj, dtfailadj
@@ -61,7 +55,7 @@ def build_model(idx, dir):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = runs[idx]
 
     # build MODFLOW 6 files
     ws = dir
@@ -198,7 +192,7 @@ def build_model(idx, dir):
 def eval_flow(sim):
     print("evaluating flow...")
 
-    name = ex[sim.idxsim]
+    name = runs[sim.idxsim]
     gwfname = name
 
     # This will fail if budget numbers cannot be read
@@ -230,19 +224,21 @@ def eval_flow(sim):
 
 
 # - No need to change any code below
+@pytest.mark.gwf
+@pytest.mark.gwf_ats
 @pytest.mark.parametrize(
-    "idx, dir",
-    list(enumerate(exdirs)),
+    "idx, run",
+    list(enumerate(runs)),
 )
-def test_mf6model(idx, dir):
+def test_gwf_ats01(idx, run, tmpdir):
     # initialize testing framework
     test = testing_framework()
 
     # build the model
-    test.build_mf6_models(build_model, idx, dir)
+    test.build_mf6_models(build_model, idx, str(tmpdir))
 
     # run the test model
-    test.run_mf6(Simulation(dir, exfunc=eval_flow, idxsim=idx))
+    test.run_mf6(Simulation(str(tmpdir), exfunc=eval_flow, idxsim=idx))
 
 
 def main():
@@ -250,9 +246,14 @@ def main():
     test = testing_framework()
 
     # run the test model
-    for idx, dir in enumerate(exdirs):
-        test.build_mf6_models(build_model, idx, dir)
-        sim = Simulation(dir, exfunc=eval_flow, idxsim=idx)
+    for idx, run in enumerate(runs):
+        simdir = os.path.join(
+            "results",
+            os.path.splitext(os.path.basename(__file__))[0].split("_", 1)[1],
+            run,
+        )
+        test.build_mf6_models(build_model, idx, simdir)
+        sim = Simulation(simdir, exfunc=eval_flow, idxsim=idx)
         test.run_mf6(sim)
 
 

--- a/autotest/test_gwf_ats03.py
+++ b/autotest/test_gwf_ats03.py
@@ -16,14 +16,6 @@ import numpy as np
 import pytest
 
 try:
-    import pymake
-except:
-    msg = "Error. Pymake package is not available.\n"
-    msg += "Try installing using the following command:\n"
-    msg += " pip install https://github.com/modflowpy/pymake/zipball/master"
-    raise Exception(msg)
-
-try:
     import flopy
 except:
     msg = "Error. FloPy package is not available.\n"
@@ -31,14 +23,16 @@ except:
     msg += " pip install flopy"
     raise Exception(msg)
 
-from framework import testing_framework
-from simulation import Simulation
+try:
+    from modflow_devtools import (
+        testing_framework,
+        Simulation,
+    )
+except:
+    from framework import testing_framework
+    from simulation import Simulation
 
-ex = ["gwf_ats03a"]
-exdirs = []
-for s in ex:
-    exdirs.append(os.path.join("temp", s))
-ddir = "data"
+runs = ["gwf_ats03a"]
 nlay, nrow, ncol = 1, 1, 10
 
 
@@ -61,7 +55,7 @@ def build_model(idx, dir):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = runs[idx]
 
     # build MODFLOW 6 files
     ws = dir
@@ -214,7 +208,7 @@ def build_model(idx, dir):
 def eval_flow(sim):
     print("evaluating flow...")
 
-    name = ex[sim.idxsim]
+    name = runs[sim.idxsim]
     gwfname = name
 
     # ensure obs2 (a constant head time series) drops linearly from 100 to 50
@@ -231,19 +225,21 @@ def eval_flow(sim):
 
 
 # - No need to change any code below
+@pytest.mark.gwf
+@pytest.mark.gwf_ats
 @pytest.mark.parametrize(
-    "idx, dir",
-    list(enumerate(exdirs)),
+    "idx, run",
+    list(enumerate(runs)),
 )
-def test_mf6model(idx, dir):
+def test_gwf_ats03(idx, run, tmpdir):
     # initialize testing framework
     test = testing_framework()
 
     # build the model
-    test.build_mf6_models(build_model, idx, dir)
+    test.build_mf6_models(build_model, idx, str(tmpdir))
 
     # run the test model
-    test.run_mf6(Simulation(dir, exfunc=eval_flow, idxsim=idx))
+    test.run_mf6(Simulation(str(tmpdir), exfunc=eval_flow, idxsim=idx))
 
 
 def main():
@@ -251,9 +247,14 @@ def main():
     test = testing_framework()
 
     # run the test model
-    for idx, dir in enumerate(exdirs):
-        test.build_mf6_models(build_model, idx, dir)
-        sim = Simulation(dir, exfunc=eval_flow, idxsim=idx)
+    for idx, run in enumerate(runs):
+        simdir = os.path.join(
+            "results",
+            os.path.splitext(os.path.basename(__file__))[0].split("_", 1)[1],
+            run,
+        )
+        test.build_mf6_models(build_model, idx, simdir)
+        sim = Simulation(simdir, exfunc=eval_flow, idxsim=idx)
         test.run_mf6(sim)
 
 

--- a/autotest/test_gwf_maw01.py
+++ b/autotest/test_gwf_maw01.py
@@ -4,14 +4,6 @@ import numpy as np
 import pytest
 
 try:
-    import pymake
-except:
-    msg = "Error. Pymake package is not available.\n"
-    msg += "Try installing using the following command:\n"
-    msg += " pip install https://github.com/modflowpy/pymake/zipball/master"
-    raise Exception(msg)
-
-try:
     import flopy
 except:
     msg = "Error. FloPy package is not available.\n"
@@ -19,15 +11,17 @@ except:
     msg += " pip install flopy"
     raise Exception(msg)
 
-from framework import testing_framework
-from simulation import Simulation
+try:
+    from modflow_devtools import (
+        testing_framework,
+        Simulation,
+    )
+except:
+    from framework import testing_framework
+    from simulation import Simulation
 
-ex = ["maw01", "maw01nwt", "maw01nwtur"]
+runs = ["maw01", "maw01nwt", "maw01nwtur"]
 newtonoptions = [None, "NEWTON", "NEWTON UNDER_RELAXATION"]
-exdirs = []
-for s in ex:
-    exdirs.append(os.path.join("temp", s))
-ddir = "data"
 
 
 def build_model(idx, dir):
@@ -52,13 +46,14 @@ def build_model(idx, dir):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = runs[idx]
 
     # build MODFLOW 6 files
     ws = dir
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
+
     # create tdis package
     tdis = flopy.mf6.ModflowTdis(
         sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
@@ -215,19 +210,21 @@ def eval_maw(sim):
 
 
 # - No need to change any code below
+@pytest.mark.gwf
+@pytest.mark.gwf_maw
 @pytest.mark.parametrize(
-    "idx, dir",
-    list(enumerate(exdirs)),
+    "idx, run",
+    list(enumerate(runs)),
 )
-def test_mf6model(idx, dir):
+def test_gwf_maw01(idx, run, tmpdir):
     # initialize testing framework
     test = testing_framework()
 
     # build the models
-    test.build_mf6_models(build_model, idx, dir)
+    test.build_mf6_models(build_model, idx, str(tmpdir))
 
     # run the test model
-    test.run_mf6(Simulation(dir, exfunc=eval_maw, idxsim=idx))
+    test.run_mf6(Simulation(str(tmpdir), exfunc=eval_maw, idxsim=idx))
 
 
 def main():
@@ -236,9 +233,15 @@ def main():
 
     # build the models
     # run the test model
-    for idx, dir in enumerate(exdirs):
-        test.build_mf6_models(build_model, idx, dir)
-        sim = Simulation(dir, exfunc=eval_maw, idxsim=idx)
+    for idx, run in enumerate(runs):
+        simdir = os.path.join(
+            "results",
+            os.path.splitext(os.path.basename(__file__))[0].split("_", 1)[1],
+            run,
+        )
+        simdir = os.path.join("results", "gwf_maw01", run)
+        test.build_mf6_models(build_model, idx, simdir)
+        sim = Simulation(simdir, exfunc=eval_maw, idxsim=idx)
         test.run_mf6(sim)
 
     return

--- a/autotest/test_gwf_maw05.py
+++ b/autotest/test_gwf_maw05.py
@@ -17,14 +17,17 @@ except:
     msg += " pip install flopy"
     raise Exception(msg)
 
-from framework import testing_framework
-from simulation import Simulation
+try:
+    from modflow_devtools import (
+        testing_framework,
+        Simulation,
+    )
+except:
+    from framework import testing_framework
+    from simulation import Simulation
 
-ex = ["maw_05a", "maw_05b", "maw_05c"]
+runs = ["maw_05a", "maw_05b", "maw_05c"]
 mawstrt = [4.0, 3.5, 2.5]  # add 3.0
-exdirs = []
-for s in ex:
-    exdirs.append(os.path.join("temp", s))
 
 
 def build_model(idx, dir):
@@ -54,7 +57,7 @@ def build_model(idx, dir):
     nouter, ninner = 700, 10
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = runs[idx]
 
     # build MODFLOW 6 files
     ws = dir
@@ -193,7 +196,7 @@ def eval_results(sim):
     print("evaluating results...")
 
     # calculate volume of water and make sure it is conserved
-    name = ex[sim.idxsim]
+    name = runs[sim.idxsim]
     gwfname = "gwf_" + name
     fname = gwfname + ".maw.bin"
     fname = os.path.join(sim.simpath, fname)
@@ -256,19 +259,21 @@ def eval_results(sim):
 
 
 # - No need to change any code below
+@pytest.mark.gwf
+@pytest.mark.gwf_maw
 @pytest.mark.parametrize(
-    "idx, dir",
-    list(enumerate(exdirs)),
+    "idx, run",
+    list(enumerate(runs)),
 )
-def test_mf6model(idx, dir):
+def test_gwf_maw05(idx, run, tmpdir):
     # initialize testing framework
     test = testing_framework()
 
     # build the model
-    test.build_mf6_models(build_model, idx, dir)
+    test.build_mf6_models(build_model, idx, str(tmpdir))
 
     # run the test model
-    test.run_mf6(Simulation(dir, exfunc=eval_results, idxsim=idx))
+    test.run_mf6(Simulation(str(tmpdir), exfunc=eval_results, idxsim=idx))
 
 
 def main():
@@ -276,9 +281,14 @@ def main():
     test = testing_framework()
 
     # run the test model
-    for idx, dir in enumerate(exdirs):
-        test.build_mf6_models(build_model, idx, dir)
-        sim = Simulation(dir, exfunc=eval_results, idxsim=idx)
+    for idx, run in enumerate(runs):
+        simdir = os.path.join(
+            "results",
+            os.path.splitext(os.path.basename(__file__))[0].split("_", 1)[1],
+            run,
+        )
+        test.build_mf6_models(build_model, idx, simdir)
+        sim = Simulation(simdir, exfunc=eval_results, idxsim=idx)
         test.run_mf6(sim)
 
 

--- a/autotest/test_gwf_maw06.py
+++ b/autotest/test_gwf_maw06.py
@@ -15,13 +15,16 @@ except:
     msg += " pip install flopy"
     raise Exception(msg)
 
-from framework import testing_framework
-from simulation import Simulation
+try:
+    from modflow_devtools import (
+        testing_framework,
+        Simulation,
+    )
+except:
+    from framework import testing_framework
+    from simulation import Simulation
 
-ex = ["maw_06a", "maw_06b"]
-exdirs = []
-for s in ex:
-    exdirs.append(os.path.join("temp", s))
+runs = ["maw_06a", "maw_06b"]
 
 nlay = 2
 nrow = 1
@@ -71,7 +74,7 @@ def build_model(idx, dir):
     nouter, ninner = 700, 200
     hclose, rclose, relax = 1e-9, 1e-9, 1.0
 
-    name = ex[idx]
+    name = runs[idx]
 
     # build MODFLOW 6 files
     ws = dir
@@ -212,7 +215,7 @@ def eval_results(sim):
     print("evaluating results...")
 
     # calculate volume of water and make sure it is conserved
-    name = ex[sim.idxsim]
+    name = runs[sim.idxsim]
     gwfname = "gwf_" + name
     fname = gwfname + ".maw.bin"
     fname = os.path.join(sim.simpath, fname)
@@ -293,19 +296,21 @@ def eval_results(sim):
 
 
 # - No need to change any code below
+@pytest.mark.gwf
+@pytest.mark.gwf_maw
 @pytest.mark.parametrize(
-    "idx, dir",
-    list(enumerate(exdirs)),
+    "idx, run",
+    list(enumerate(runs)),
 )
-def test_mf6model(idx, dir):
+def test_gwf_maw06(idx, run, tmpdir):
     # initialize testing framework
     test = testing_framework()
 
     # build the model
-    test.build_mf6_models(build_model, idx, dir)
+    test.build_mf6_models(build_model, idx, str(tmpdir))
 
     # run the test model
-    test.run_mf6(Simulation(dir, exfunc=eval_results, idxsim=idx))
+    test.run_mf6(Simulation(str(tmpdir), exfunc=eval_results, idxsim=idx))
 
 
 def main():
@@ -313,9 +318,14 @@ def main():
     test = testing_framework()
 
     # run the test model
-    for idx, dir in enumerate(exdirs):
-        test.build_mf6_models(build_model, idx, dir)
-        sim = Simulation(dir, exfunc=eval_results, idxsim=idx)
+    for idx, run in enumerate(runs):
+        simdir = os.path.join(
+            "results",
+            os.path.splitext(os.path.basename(__file__))[0].split("_", 1)[1],
+            run,
+        )
+        test.build_mf6_models(build_model, idx, simdir)
+        sim = Simulation(simdir, exfunc=eval_results, idxsim=idx)
         test.run_mf6(sim)
 
 

--- a/autotest/test_gwf_maw10.py
+++ b/autotest/test_gwf_maw10.py
@@ -14,14 +14,6 @@ import numpy as np
 import pytest
 
 try:
-    import pymake
-except:
-    msg = "Error. Pymake package is not available.\n"
-    msg += "Try installing using the following command:\n"
-    msg += " pip install https://github.com/modflowpy/pymake/zipball/master"
-    raise Exception(msg)
-
-try:
     import flopy
 except:
     msg = "Error. FloPy package is not available.\n"
@@ -29,13 +21,16 @@ except:
     msg += " pip install flopy"
     raise Exception(msg)
 
-from framework import testing_framework
-from simulation import Simulation
+try:
+    from modflow_devtools import (
+        testing_framework,
+        Simulation,
+    )
+except:
+    from framework import testing_framework
+    from simulation import Simulation
 
-ex = ["maw10a", "maw10b", "maw10c", "maw10d"]
-exdirs = []
-for s in ex:
-    exdirs.append(os.path.join("temp", s))
+runs = ["maw10a", "maw10b", "maw10c", "maw10d"]
 
 # maw settings for runs a, b, c and d
 mawsetting_a = {
@@ -103,7 +98,7 @@ def build_model(idx, dir):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = runs[idx]
 
     # build MODFLOW 6 files
     ws = dir
@@ -239,7 +234,7 @@ def eval_mawred(sim):
 
     # MODFLOW 6 maw results
     idx = sim.idxsim
-    name = ex[idx]
+    name = runs[idx]
     fpthobs = os.path.join(sim.simpath, f"{name}.maw.obs.csv")
     fpthmfr = os.path.join(sim.simpath, f"{name}.maw-reduction.csv")
     try:
@@ -290,19 +285,21 @@ def eval_mawred(sim):
 
 
 # - No need to change any code below
+@pytest.mark.gwf
+@pytest.mark.gwf_maw
 @pytest.mark.parametrize(
-    "idx, dir",
-    list(enumerate(exdirs)),
+    "idx, run",
+    list(enumerate(runs)),
 )
-def test_mf6model(idx, dir):
+def test_gwf_maw10(idx, run, tmpdir):
     # initialize testing framework
     test = testing_framework()
 
     # build the models
-    test.build_mf6_models(build_model, idx, dir)
+    test.build_mf6_models(build_model, idx, str(tmpdir))
 
     # run the test model
-    test.run_mf6(Simulation(dir, exfunc=eval_mawred, idxsim=idx))
+    test.run_mf6(Simulation(str(tmpdir), exfunc=eval_mawred, idxsim=idx))
 
 
 def main():
@@ -311,9 +308,14 @@ def main():
 
     # build the models
     # run the test model
-    for idx, dir in enumerate(exdirs):
-        test.build_mf6_models(build_model, idx, dir)
-        sim = Simulation(dir, exfunc=eval_mawred, idxsim=idx)
+    for idx, run in enumerate(runs):
+        simdir = os.path.join(
+            "results",
+            os.path.splitext(os.path.basename(__file__))[0].split("_", 1)[1],
+            run,
+        )
+        test.build_mf6_models(build_model, idx, simdir)
+        sim = Simulation(simdir, exfunc=eval_mawred, idxsim=idx)
         test.run_mf6(sim)
 
     return


### PR DESCRIPTION
…h modflow-devtools

* in progress: updates to gwf maw and ats test
* use devtools if available
* use tmpdir fixture and organize outputs when kept
* add markers for running subsets of tests based on type, package, etc