### PR TITLE
docs(gwf-buy.dfn): variable description refers to block that does not exist

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwf-buy.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-buy.dfn
@@ -79,7 +79,7 @@ type integer
 reader urword
 optional false
 longname number of species used in density equation of state
-description number of species used in density equation of state.  This value must be one or greater.  The value must be one if concentrations are specified using the CONCENTRATION keyword in the PERIOD block below.
+description number of species used in density equation of state.  This value must be one or greater if the BUY package is activated.  
 
 
 # --------------------- gwf buy packagedata ---------------------

--- a/doc/mf6io/mf6ivar/dfn/gwf-buy.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-buy.dfn
@@ -140,6 +140,6 @@ in_record true
 tagged false
 shape
 reader urword
-longname modelname
+longname auxspeciesname
 description name of an auxiliary variable in a GWF stress package that will be used for this species to calculate a density value.  If a density value is needed by the Buoyancy Package then it will use the concentration values in this AUXSPECIESNAME column in the density equation of state.  For advanced stress packages (LAK, SFR, MAW, and UZF) that have an associated advanced transport package (LKT, SFT, MWT, and UZT), the FLOW\_PACKAGE\_AUXILIARY\_NAME option in the advanced transport package can be used to transfer simulated concentrations into the flow package auxiliary variable.  In this manner, the Buoyancy Package can calculate density values for lakes, streams, multi-aquifer wells, and unsaturated zone flow cells using simulated concentrations.
 


### PR DESCRIPTION
To hopefully avoid confusion on my part, I had a look in `gwf3buy8.f90` and it does not appear to look for a PERIOD block, so I think this reference in the `nrhospecies` description might be leftover from previous code development.