### PR TITLE
fix(gwtgwt): allow exchange to work without XT3D active for dispersion

### DIFF
--- a/autotest/test_gwt_adv01_gwtgwt.py
+++ b/autotest/test_gwt_adv01_gwtgwt.py
@@ -303,7 +303,7 @@ def build_model(idx, dir):
         exgtype="GWT6-GWT6",
         gwfmodelname1=gwf1.name,
         gwfmodelname2=gwf2.name,
-        advscheme=scheme[idx],
+        adv_scheme=scheme[idx],
         nexg=len(gwfgwf_data),
         exgmnamea=gwt1.name,
         exgmnameb=gwt2.name,

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -241,12 +241,12 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	%	\item xxx
 	%\end{itemize}
 
-	%\underline{EXCHANGES}
-	%\begin{itemize}
-	%	\item Fixed a bug that occurred when flow and transport models were run simultaneously and auxiliary variable(s), for example CONCENTRATION, and mover were both active in the OPTIONS block of a boundary package (e.g., WEL). When running the flow and transport problems separately, no issues occurred.  The issue only seemed to be a problem when running flow and transport simultaneously because an indexing variable would get out of sync in SSM that reported an error message to the screen and prematurely exited MF6.  Two new autotests added: the first runs GWF & GWT independently while the second runs them simultaneously and would trigger the condition that this bug report aims to fix.
+	\underline{EXCHANGES}
+	\begin{itemize}
+		\item The GWT-GWT Exchange did not work when the XT3D\_OFF option was specified.  Fixed the program so that the XT3D dispersion terms can be shut off for a GWT-GWT Exchange.  GWT-GWT Exchange keywords were renamed from ADVSCHEME, XT3D\_OFF, and XT3D\_RHS to ADV\_SCHEME, DSP\_XT3D\_OFF, and DSP\_XT3D\_OFF, respectively, to more clearly indicate how the keywords relate to the underlying processes.  
 	%	\item xxx
 	%	\item xxx
-	%\end{itemize}
+	\end{itemize}
 
 	
 \end{itemize}

--- a/doc/mf6io/mf6ivar/dfn/exg-gwtgwt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/exg-gwtgwt.dfn
@@ -60,7 +60,7 @@ longname keyword to save GWFGWF flows
 description keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.
 
 block options
-name advscheme
+name adv_scheme
 type string
 valid upstream central tvd
 reader urword
@@ -69,22 +69,22 @@ longname advective scheme
 description scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.
 
 block options
-name xt3d_off
+name dsp_xt3d_off
 type keyword
 shape
 reader urword
 optional true
 longname deactivate xt3d
-description deactivate the xt3d method and use the faster and less accurate approximation for this exchange.
+description deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange.
 
 block options
-name xt3d_rhs
+name dsp_xt3d_rhs
 type keyword
 shape
 reader urword
 optional true
 longname xt3d on right-hand side
-description add xt3d terms to right-hand side, when possible, for this exchange.
+description add xt3d dispersion terms to right-hand side, when possible, for this exchange.
 
 block options
 name filein

--- a/src/Exchange/GwtGwtExchange.f90
+++ b/src/Exchange/GwtGwtExchange.f90
@@ -907,17 +907,17 @@ contains
       errmsg = 'ADVSCHEME is no longer a valid keyword.  Use ADV_SCHEME &
         &instead.'
       call store_error(errmsg)
-      call this%parser%StoreErrorUnit()      
+      call this%parser%StoreErrorUnit()
     case ('XT3D_OFF')
       errmsg = 'XT3D_OFF is no longer a valid keyword.  Use DSP_XT3D_OFF &
         &instead.'
       call store_error(errmsg)
-      call this%parser%StoreErrorUnit()      
+      call this%parser%StoreErrorUnit()
     case ('XT3D_RHS')
       errmsg = 'XT3D_RHS is no longer a valid keyword.  Use DSP_XT3D_RHS &
         &instead.'
       call store_error(errmsg)
-      call this%parser%StoreErrorUnit()      
+      call this%parser%StoreErrorUnit()
     case default
       parsed = .false.
     end select
@@ -1246,7 +1246,7 @@ contains
     ! if support is added in the future for simpler flow calcuation,
     ! then set useIM as follows
     !useIM = (this%ixt3d > 0)
-    
+
     ! For now set useIM to .true. since the interface model approach
     ! must currently be used for any GWT-GWT exchange.
     useIM = .true.

--- a/src/Exchange/GwtGwtExchange.f90
+++ b/src/Exchange/GwtGwtExchange.f90
@@ -881,8 +881,7 @@ contains
       inobs = GetUnit()
       call openfile(inobs, iout, this%obs%inputFilename, 'OBS')
       this%obs%inUnitObs = inobs
-    case ('ADVSCHEME')
-      !cdl todo: change to ADV_SCHEME?
+    case ('ADV_SCHEME')
       call this%parser%GetStringCaps(subkey)
       select case (subkey)
       case ('UPSTREAM')
@@ -898,14 +897,27 @@ contains
       end select
       write (iout, '(4x,a,a)') &
         'CELL AVERAGING METHOD HAS BEEN SET TO: ', trim(subkey)
-    case ('XT3D_OFF')
-      !cdl todo: change to DSP_XT3D_OFF?
+    case ('DSP_XT3D_OFF')
       this%ixt3d = 0
       write (iout, '(4x,a)') 'XT3D FORMULATION HAS BEEN SHUT OFF.'
-    case ('XT3D_RHS')
-      !cdl todo: change to DSP_XT3D_RHS?
+    case ('DSP_XT3D_RHS')
       this%ixt3d = 2
       write (iout, '(4x,a)') 'XT3D RIGHT-HAND SIDE FORMULATION IS SELECTED.'
+    case ('ADVSCHEME')
+      errmsg = 'ADVSCHEME is no longer a valid keyword.  Use ADV_SCHEME &
+        &instead.'
+      call store_error(errmsg)
+      call this%parser%StoreErrorUnit()      
+    case ('XT3D_OFF')
+      errmsg = 'XT3D_OFF is no longer a valid keyword.  Use DSP_XT3D_OFF &
+        &instead.'
+      call store_error(errmsg)
+      call this%parser%StoreErrorUnit()      
+    case ('XT3D_RHS')
+      errmsg = 'XT3D_RHS is no longer a valid keyword.  Use DSP_XT3D_RHS &
+        &instead.'
+      call store_error(errmsg)
+      call this%parser%StoreErrorUnit()      
     case default
       parsed = .false.
     end select
@@ -1220,12 +1232,24 @@ contains
   end function gwt_gwt_connects_model
 
   !> @brief Should interface model be used for this exchange
+  !!
+  !! For now this always returns true, since we do not support
+  !! a classic-style two-point flux approximation for GWT-GWT.
+  !! If we ever add logic to support a simpler non-interface
+  !! model flux calculation, then logic should be added here to
+  !! set the return accordingly.
   !<
   function use_interface_model(this) result(useIM)
     class(GwtExchangeType) :: this !<  GwtExchangeType
     logical(LGP) :: useIM !< true when interface model should be used
 
-    useIM = (this%ixt3d > 0)
+    ! if support is added in the future for simpler flow calcuation,
+    ! then set useIM as follows
+    !useIM = (this%ixt3d > 0)
+    
+    ! For now set useIM to .true. since the interface model approach
+    ! must currently be used for any GWT-GWT exchange.
+    useIM = .true.
 
   end function
 


### PR DESCRIPTION
The main point of this PR is to always use the interface model, even if xt3d is not used for dispersion.

In this PR I've changed several keywords in options block of the GWT-GWT Exchange file. 

ADVSCHEME => ADV_SCHEME
XT3D_OFF => DSP_XT3D_OFF
XT3D_RHS => DSP_XT3D_RHS

It seems desirable to mark these options with the underlying packages to which they belong.  The downside is that this will break any models that used these keywords.  I doubt they have been used much (since the XT3D_OFF keyword didn't work correctly), but it does break some things.  This is why we have a CI failure at the moment.  Maybe we support ADVSCHEME (only in the Fortran code) and ADV_SCHEME for one release to avoid the headaches associated with keyword renaming?