### PR TITLE
ci(z03): prevent regression on gwtgwt example since keyword changed

### DIFF
--- a/autotest/test_z03_examples.py
+++ b/autotest/test_z03_examples.py
@@ -135,7 +135,7 @@ def set_make_comparison(test):
         "ex-gwf-sfr-p01": ("6.2.1",),
         "ex-gwf-lgr": ("6.2.2",),
         "ex-gwt-rotate": ("6.2.2",),
-        "ex-gwtgwt-mt3dms-p10": ("6.2.2",),
+        "ex-gwt-gwtgwt-mt3dms-p10": ("6.3.0",),
     }
     make_comparison = True
     if test in compare_tests.keys():

--- a/distribution/evaluate_run_times.py
+++ b/distribution/evaluate_run_times.py
@@ -288,14 +288,16 @@ def run_model(app, app0, example, fmd, silent=True, pool=False):
         elt = get_elapsed_time(buff)
         line += f" {elt} |"
     else:
-        print(buff)
+        print(f"Failure for current app with example: {test}")
+        for b in buff:
+            print(b)
         line += " -- |"
 
     if success0:
         elt0 = get_elapsed_time(buff0)
         line += f" {elt0} |"
     else:
-        print(buff0)
+        print(f"Failure for previous app with example: {test}")
         line += " -- |"
 
     if success and success0:

--- a/distribution/evaluate_run_times.py
+++ b/distribution/evaluate_run_times.py
@@ -288,12 +288,14 @@ def run_model(app, app0, example, fmd, silent=True, pool=False):
         elt = get_elapsed_time(buff)
         line += f" {elt} |"
     else:
+        print(buff)
         line += " -- |"
 
     if success0:
         elt0 = get_elapsed_time(buff0)
         line += f" {elt0} |"
     else:
+        print(buff0)
         line += " -- |"
 
     if success and success0:


### PR DESCRIPTION
Skip regression test for ex-gwtgwt-mt3dms-p10 because PR #1008 changed the gwtgwt keywords.  The name for this test was also based on an earlier name (ex-gwtgwt-mt3dms-p10), which is slightly different from the current test name (ex-gwt-gwtgwt-mt3dms-p10).  