### PR TITLE
fix(gwf-npf.f90): leave k22 and k33 allocated if tvk active

### DIFF
--- a/autotest/test_gwf_npf_tvk04.py
+++ b/autotest/test_gwf_npf_tvk04.py
@@ -156,14 +156,14 @@ def build_model(idx, dir):
     ghbspd = []
     ghbcond = time_varying_k[1] * delz * delc / (0.5 * delr)
     for i in range(nrow):
-        ghbspd.append([(nlay-1, i, ncol-1), top, ghbcond])
+        ghbspd.append([(nlay - 1, i, ncol - 1), top, ghbcond])
 
     ghb = flopy.mf6.ModflowGwfghb(
         gwf,
         stress_period_data=ghbspd,
         save_flows=False,
         print_flows=True,
-        pname="GHB-1"
+        pname="GHB-1",
     )
 
     # output control
@@ -203,7 +203,9 @@ def eval_model(sim):
 
     # comment when done testing
     print(f"Total outflow in stress period 1 is {str(sp_x[0][8])}")
-    print(f"Total outflow in stress period 2 after increasing K33 is {str(sp_x[1][8])}")
+    print(
+        f"Total outflow in stress period 2 after increasing K33 is {str(sp_x[1][8])}"
+    )
     errmsg = f"Expect higher flow rate in period 2 compared to period 1, but found equal or higher flow rate in period 1"
     assert 2.0 * sp_x[0][8] < sp_x[1][8], errmsg
 

--- a/autotest/test_gwf_npf_tvk04.py
+++ b/autotest/test_gwf_npf_tvk04.py
@@ -1,0 +1,245 @@
+import os
+import sys
+
+import numpy as np
+import pytest
+
+try:
+    import pymake
+except:
+    msg = "Error. Pymake package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install https://github.com/modflowpy/pymake/zipball/master"
+    raise Exception(msg)
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+from framework import testing_framework
+from simulation import Simulation
+
+ex = [
+    "tvk04",
+]
+exdirs = []
+for s in ex:
+    exdirs.append(os.path.join("temp", s))
+ddir = "data"
+
+time_varying_k = [1.0, 10.0]
+
+
+def build_model(idx, dir):
+    nlay, nrow, ncol = 3, 3, 3
+    perlen = [100.0, 100.0]
+    nper = len(perlen)
+    nstp = nper * [1]
+    tsmult = nper * [1.0]
+    delr = 1.0
+    delc = 1.0
+    delz = 1.0
+    top = 1.0
+    laytyp = 0
+    botm = [0.0, -1.0, -2.0]
+    strt = 1.0
+    hk = 0.1
+
+    nouter, ninner = 100, 300
+    hclose, rclose, relax = 1e-6, 1e-6, 1.0
+
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+    name = ex[idx]
+
+    # build MODFLOW 6 files
+    ws = dir
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
+    )
+
+    # create gwf model
+    gwfname = "gwf_" + name
+    gwf = flopy.mf6.MFModel(
+        sim,
+        model_type="gwf6",
+        modelname=gwfname,
+        model_nam_file=f"{gwfname}.nam",
+    )
+    gwf.name_file.save_flows = True
+
+    # create iterative model solution and register the gwf model with it
+    imsgwf = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="NONE",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="CG",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename=f"{gwfname}.ims",
+    )
+    sim.register_ims_package(imsgwf, [gwf.name])
+
+    dis = flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+        idomain=np.ones((nlay, nrow, ncol), dtype=int),
+        filename=f"{gwfname}.dis",
+    )
+
+    # initial conditions
+    ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{gwfname}.ic")
+
+    # node property flow
+    tvk_filename = f"{gwfname}.npf.tvk"
+    npf = flopy.mf6.ModflowGwfnpf(
+        gwf,
+        save_specific_discharge=True,
+        icelltype=laytyp,
+        k=hk,
+        k22=hk,
+    )
+
+    # tvk
+    # k33 not originally specified in NPF, but specifying an
+    # alternate value in the 2nd stress period to test MF6
+    tvkspd = {}
+    kper = 1
+    hydraulic_conductivity = time_varying_k[kper]
+    spd = []
+    for k in range(nlay):
+        for i in range(nrow):
+            for j in range(ncol):
+                spd.append([(k, i, j), "K33", hydraulic_conductivity])
+    tvkspd[kper] = spd
+
+    tvk = flopy.mf6.ModflowUtltvk(
+        npf, print_input=True, perioddata=tvkspd, filename=tvk_filename
+    )
+
+    # chd files
+    chdspd = []
+    for i in range(nrow):
+        chdspd.append([(0, i, 0), top + 1])
+
+    chd = flopy.mf6.ModflowGwfchd(
+        gwf,
+        stress_period_data=chdspd,
+        save_flows=False,
+        print_flows=True,
+        pname="CHD-1",
+    )
+
+    # ghb files
+    ghbspd = []
+    ghbcond = time_varying_k[1] * delz * delc / (0.5 * delr)
+    for i in range(nrow):
+        ghbspd.append([(0, i, ncol-1), top, ghbcond])
+
+    ghb = flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data=ghbspd,
+        save_flows=False,
+        print_flows=True,
+        pname="GHB-1"
+    )
+
+    # output control
+    oc = flopy.mf6.ModflowGwfoc(
+        gwf,
+        budget_filerecord=f"{gwfname}.cbc",
+        head_filerecord=f"{gwfname}.hds",
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
+        printrecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
+    )
+
+    return sim, None
+
+
+def eval_model(sim):
+    print("evaluating model...")
+
+    name = ex[sim.idxsim]
+
+    # budget
+    try:
+        fname = f"gwf_{name}.lst"
+        ws = sim.simpath
+        fname = os.path.join(ws, fname)
+        lst = flopy.utils.Mf6ListBudget(
+            fname, budgetkey="VOLUME BUDGET FOR ENTIRE MODEL"
+        )
+        lstra = lst.get_incremental()
+    except:
+        assert False, f'could not load data from "{fname}"'
+
+    # This is the answer to this problem.
+    sp_x = []
+    for kper, bud in enumerate(lstra):
+        sp_x.append(bud)
+
+    # comment when done testing
+    print(f"Total outflow in stress period 1 is {str(sp_x[0][8])}")
+    print(f"Total outflow in stress period 2 after increasing K33 is {str(sp_x[1][8])}")
+    errmsg = f"Expect higher flow rate in period 2 compared to period 1, but found equal or higher flow rate in period 1"
+    assert 1.5 * sp_x[0][8] < sp_x[1][8], errmsg
+
+    return
+
+
+# - No need to change any code below
+@pytest.mark.parametrize(
+    "idx, dir",
+    list(enumerate(exdirs)),
+)
+def test_mf6model(idx, dir):
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the model
+    test.build_mf6_models(build_model, idx, dir)
+
+    # run the test model
+    test.run_mf6(Simulation(dir, exfunc=eval_model, idxsim=idx))
+
+
+def main():
+    # initialize testing framework
+    test = testing_framework()
+
+    # run the test model
+    for idx, dir in enumerate(exdirs):
+        test.build_mf6_models(build_model, idx, dir)
+        sim = Simulation(dir, exfunc=eval_model, idxsim=idx)
+        test.run_mf6(sim)
+
+
+if __name__ == "__main__":
+    # print message
+    print(f"standalone run of {os.path.basename(__file__)}")
+
+    # run main routine
+    main()

--- a/autotest/test_gwf_npf_tvk05.py
+++ b/autotest/test_gwf_npf_tvk05.py
@@ -128,7 +128,7 @@ def build_model(idx, dir):
     # problem
     tvkspd = {}
     kper = 1
-    k33 = 1000.
+    k33 = 1000.0
     spd = []
     for k in range(nlay):
         for i in range(nrow):
@@ -157,14 +157,14 @@ def build_model(idx, dir):
     ghbspd = []
     ghbcond = hk * delz * delc / (0.5 * delr)
     for i in range(nrow):
-        ghbspd.append([(0, i, ncol-1), top, ghbcond])
+        ghbspd.append([(0, i, ncol - 1), top, ghbcond])
 
     ghb = flopy.mf6.ModflowGwfghb(
         gwf,
         stress_period_data=ghbspd,
         save_flows=False,
         print_flows=True,
-        pname="GHB-1"
+        pname="GHB-1",
     )
 
     # output control
@@ -204,7 +204,9 @@ def eval_model(sim):
 
     # comment when done testing
     print(f"Total outflow in stress period 1 is {str(sp_x[0][8])}")
-    print(f"Total outflow in stress period 2 after increasing K33 should have no effect on final solution")
+    print(
+        f"Total outflow in stress period 2 after increasing K33 should have no effect on final solution"
+    )
     errmsg = f"Period 2 budget should be exactly the same as period 1"
     assert sp_x[0][8] == sp_x[1][8], errmsg
 

--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -212,6 +212,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 		\item Terminate with error if METHOD or METHODS not specified in time series input files.  Prior to this change, the program would continue without an interpolated value for one or more time series records.
 		\item When a GWF Model and a corresponding GWT model are solved in the same simulation, the GWF Model must be solved before the corresponding GWT model.  The GWF Model must also be solved by a different IMS than the GWT Model.  There was not a check for this in previous versions and if these conditions were not met, the solution would often not converge or it would give erroneous results.
 		\item The DISV Package would not raise an error if a model cell was defined as a line.  The program was modified to check for the case where the calculated cell area is equal to zero.  If the calculated cell area is equal to zero, the program terminates with an error.
+		\item The TVK Package is free to modify K22, K33, or both even though neither may have been specified in NPF when the simulation was initialized.  NPF does not allocate space for K22 or K33 when omitted from the NPF input file, but instead points K22 and K33 to K11. As a result, specification of K22 or K33 in TVK (in this circumstance) will overwrite values of K11.  NPF now allocates space for K22 and K33 if TVK is present in the simulation. This allows TVK to modify K22 or K33 as needed without stomping on K11.
 	\end{itemize}
 
 	\underline{INTERNAL FLOW PACKAGES}

--- a/src/Model/GroundWaterFlow/gwf3npf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8.f90
@@ -146,7 +146,7 @@ contains
 ! ------------------------------------------------------------------------------
     ! -- modules
     ! -- dummy
-    type(GwfNpftype), pointer :: npfobj
+    type(GwfNpfType), pointer :: npfobj
     character(len=*), intent(in) :: name_model
     integer(I4B), intent(in) :: inunit
     integer(I4B), intent(in) :: iout
@@ -187,7 +187,7 @@ contains
     use SimModule, only: store_error
     use Xt3dModule, only: xt3d_cr
     ! -- dummy
-    class(GwfNpftype) :: this !< instance of the NPF package
+    class(GwfNpfType) :: this !< instance of the NPF package
     class(DisBaseType), pointer, intent(inout) :: dis !< the pointer to the discretization
     type(Xt3dType), pointer :: xt3d !< the pointer to the XT3D 'package'
     integer(I4B), intent(in) :: ingnc !< ghostnodes enabled? (>0 means yes)
@@ -243,7 +243,7 @@ contains
     use SparseModule, only: sparsematrix
     use MemoryManagerModule, only: mem_allocate
     ! -- dummy
-    class(GwfNpftype) :: this
+    class(GwfNpfType) :: this
     integer(I4B), intent(in) :: moffset
     type(sparsematrix), intent(inout) :: sparse
     ! -- local
@@ -266,7 +266,7 @@ contains
     ! -- modules
     use MemoryManagerModule, only: mem_allocate
     ! -- dummy
-    class(GwfNpftype) :: this
+    class(GwfNpfType) :: this
     integer(I4B), intent(in) :: moffset
     integer(I4B), dimension(:), intent(in) :: iasln
     integer(I4B), dimension(:), intent(in) :: jasln
@@ -293,7 +293,7 @@ contains
 !    SPECIFICATIONS:
 ! ------------------------------------------------------------------------------
     ! -- dummy
-    class(GwfNpftype) :: this !< instance of the NPF package
+    class(GwfNpfType) :: this !< instance of the NPF package
     type(GwfIcType), pointer, intent(in) :: ic !< initial conditions
     integer(I4B), dimension(:), pointer, contiguous, intent(inout) :: ibound !< model ibound array
     real(DP), dimension(:), pointer, contiguous, intent(inout) :: hnew !< pointer to model head array
@@ -1024,7 +1024,7 @@ contains
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
     ! -- dummy
-    class(GwfNpftype) :: this
+    class(GwfNpfType) :: this
 ! ------------------------------------------------------------------------------
     !
     ! -- TVK
@@ -1109,7 +1109,7 @@ contains
     use MemoryManagerModule, only: mem_allocate, mem_setptr
     use MemoryHelperModule, only: create_mem_path
     ! -- dummy
-    class(GwfNpftype) :: this
+    class(GwfNpfType) :: this
 ! ------------------------------------------------------------------------------
     !
     ! -- allocate scalars in NumericalPackageType
@@ -1208,7 +1208,7 @@ contains
     ! -- modules
     use MemoryManagerModule, only: mem_allocate
     ! -- dummy
-    class(GwfNpftype) :: this
+    class(GwfNpfType) :: this
     integer(I4B), intent(in) :: ncells
     integer(I4B), intent(in) :: njas
     ! -- local
@@ -1285,7 +1285,7 @@ contains
     use SimModule, only: store_error, count_errors
     implicit none
     ! -- dummy
-    class(GwfNpftype) :: this
+    class(GwfNpfType) :: this
     ! -- local
     character(len=LINELENGTH) :: errmsg, keyword, fname
     integer(I4B) :: ierr
@@ -1504,7 +1504,7 @@ contains
   end subroutine read_options
 
   subroutine set_options(this, options)
-    class(GwfNpftype) :: this
+    class(GwfNpfType) :: this
     type(GwfNpfOptionsType), intent(in) :: options
 
     this%icellavg = options%icellavg
@@ -1530,7 +1530,7 @@ contains
     use SimModule, only: store_error
     use ConstantsModule, only: LINELENGTH
     ! -- dummy
-    class(GwfNpftype) :: this
+    class(GwfNpfType) :: this
     ! -- local
     integer(I4B) :: ival
     character(len=LINELENGTH) :: keyword, errmsg
@@ -1620,7 +1620,7 @@ contains
     use SimModule, only: store_error, count_errors
     use ConstantsModule, only: LINELENGTH
     ! -- dummy
-    class(GwfNpftype) :: this
+    class(GwfNpfType) :: this
     ! -- local
     character(len=LINELENGTH) :: errmsg
 ! ------------------------------------------------------------------------------
@@ -1689,7 +1689,7 @@ contains
                                    mem_reassignptr
     use SimModule, only: store_error, count_errors
     ! -- dummy
-    class(GwfNpftype) :: this
+    class(GwfNpfType) :: this
     ! -- local
     character(len=LINELENGTH) :: errmsg
     integer(I4B) :: n, ierr
@@ -1754,6 +1754,15 @@ contains
     ! -- set ik33 flag
     if (lname(3)) then
       this%ik33 = 1
+    else if (.not. lname(3) .and. this%intvk > 0) then
+      this%ik33 = 1
+      if (this%ik33overk /= 0) then
+        write (errmsg, '(a)') 'K33OVERK option specified but K33 not specified.'
+        call store_error(errmsg)
+      end if
+      write (this%iout, '(1x, a)') 'K33 not provided but TVK is active. &
+          &Setting K33 = K to support possible TVK adjustments.'
+      call this%dis%fill_grid_array(this%k11, this%k33)
     else
       if (this%ik33overk /= 0) then
         write (errmsg, '(a)') 'K33OVERK option specified but K33 not specified.'
@@ -1767,6 +1776,15 @@ contains
     ! -- set ik22 flag
     if (lname(4)) then
       this%ik22 = 1
+    else if (.not. lname(4) .and. this%intvk > 0) then
+      this%ik22 = 1
+      if (this%ik22overk /= 0) then
+        write (errmsg, '(a)') 'K22OVERK option specified but K22 not specified.'
+        call store_error(errmsg)
+      end if
+      write (this%iout, '(1x, a)') 'K22 not provided but TVK is active. &
+          &Setting K22 = K to support possible TVK adjustments.'
+      call this%dis%fill_grid_array(this%k11, this%k22)
     else
       if (this%ik22overk /= 0) then
         write (errmsg, '(a)') 'K22OVERK option specified but K22 not specified.'

--- a/src/Model/GroundWaterFlow/gwf3npf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8.f90
@@ -1752,17 +1752,13 @@ contains
     end if
     !
     ! -- set ik33 flag
-    if (lname(3)) then
-      this%ik33 = 1
-    else if (.not. lname(3) .and. this%intvk > 0) then
-      this%ik33 = 1
-      if (this%ik33overk /= 0) then
-        write (errmsg, '(a)') 'K33OVERK option specified but K33 not specified.'
-        call store_error(errmsg)
+    if (lname(3) .or. this%intvk > 0) then
+      if (this%intvk > 0 .and. this%ik33 == 0) then
+        write (this%iout, '(1x, a)') 'K33 not provided but TVK is active. &
+            &Setting K33 = K to support possible TVK adjustments.'
+        call this%dis%fill_grid_array(this%k11, this%k33)
       end if
-      write (this%iout, '(1x, a)') 'K33 not provided but TVK is active. &
-          &Setting K33 = K to support possible TVK adjustments.'
-      call this%dis%fill_grid_array(this%k11, this%k33)
+      this%ik33 = 1
     else
       if (this%ik33overk /= 0) then
         write (errmsg, '(a)') 'K33OVERK option specified but K33 not specified.'
@@ -1774,17 +1770,13 @@ contains
     end if
     !
     ! -- set ik22 flag
-    if (lname(4)) then
-      this%ik22 = 1
-    else if (.not. lname(4) .and. this%intvk > 0) then
-      this%ik22 = 1
-      if (this%ik22overk /= 0) then
-        write (errmsg, '(a)') 'K22OVERK option specified but K22 not specified.'
-        call store_error(errmsg)
+    if (lname(4) .or. this%intvk > 0) then
+      if (this%intvk > 0 .and. this%ik22 == 0) then
+        write (this%iout, '(1x, a)') 'K22 not provided but TVK is active. &
+            &Setting K22 = K to support possible TVK adjustments.'
+        call this%dis%fill_grid_array(this%k11, this%k22)
       end if
-      write (this%iout, '(1x, a)') 'K22 not provided but TVK is active. &
-          &Setting K22 = K to support possible TVK adjustments.'
-      call this%dis%fill_grid_array(this%k11, this%k22)
+      this%ik22 = 1
     else
       if (this%ik22overk /= 0) then
         write (errmsg, '(a)') 'K22OVERK option specified but K22 not specified.'


### PR DESCRIPTION
Includes new test that does not specify K33 in NPF; however, TVK then modifies K33 in the second stress period which would previously stomp on K11.

Fixes #1000