### PR TITLE
fix(gwt): LKT fix for outlet flows

### DIFF
--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -212,6 +212,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 		\item Terminate with error if METHOD or METHODS not specified in time series input files.  Prior to this change, the program would continue without an interpolated value for one or more time series records.
 		\item When a GWF Model and a corresponding GWT model are solved in the same simulation, the GWF Model must be solved before the corresponding GWT model.  The GWF Model must also be solved by a different IMS than the GWT Model.  There was not a check for this in previous versions and if these conditions were not met, the solution would often not converge or it would give erroneous results.
 		\item The DISV Package would not raise an error if a model cell was defined as a line.  The program was modified to check for the case where the calculated cell area is equal to zero.  If the calculated cell area is equal to zero, the program terminates with an error.
+		\item When the LAK Package was used with a combination of outlets that routed water to another lake and outlets that did not, then the budget information stored for the LAK Package had uninitialized records for LAK to LAK flows.  These uninitialized records were used by the LKT Package and possibly other programs.  The LAK to LAK budget information was modified to include only valid records.   
 	\end{itemize}
 
 	\underline{INTERNAL FLOW PACKAGES}

--- a/src/Model/GroundWaterFlow/gwf3lak8.f90
+++ b/src/Model/GroundWaterFlow/gwf3lak8.f90
@@ -5864,11 +5864,12 @@ contains
                                      ibudcsv=this%ibudcsv)
     idx = 0
     !
-    ! -- Go through and set up each budget term
+    ! -- Go through and set up each budget term. nlen is the number
+    !    of outlets that discharge into another lake
     if (nlen > 0) then
       text = '    FLOW-JA-FACE'
       idx = idx + 1
-      maxlist = 2 * this%noutlets
+      maxlist = 2 * nlen
       naux = 0
       call this%budobj%budterm(idx)%initialize(text, &
                                                this%name_model, &

--- a/src/Model/GroundWaterTransport/gwt1ist1.f90
+++ b/src/Model/GroundWaterTransport/gwt1ist1.f90
@@ -55,7 +55,7 @@ module GwtIstModule
     integer(I4B), pointer :: ibudgetout => null() !< binary budget output file
     integer(I4B), pointer :: ibudcsv => null() !< unit number for csv budget output file
     integer(I4B), pointer :: idcy => null() !< order of decay rate (0:none, 1:first, 2:zero)
-    integer(I4B), pointer :: isrb => null() !< sorption active flag (0:off, 1:on)
+    integer(I4B), pointer :: isrb => null() !< sorption active flag (0:off, 1:on); only linear is supported in ist
     integer(I4B), pointer :: kiter => null() !< picard iteration counter
     real(DP), dimension(:), pointer, contiguous :: cim => null() !< concentration for immobile domain
     real(DP), dimension(:), pointer, contiguous :: cimnew => null() !< immobile concentration at end of current time step
@@ -198,12 +198,15 @@ contains
     ! -- Perform a check to ensure that sorption and decay are set
     !    consistently between the MST and IST packages.
     if (this%idcy /= this%mst%idcy) then
-      call store_error('DECAY MUST BE ACTIVATED CONSISTENTLY BETWEEN THE &
-        &MST AND IST PACKAGES.  TURN DECAY ON OR OFF FOR BOTH PACKAGES.')
+      call store_error('DECAY must be activated consistently between the &
+        &MST and IST Packages.  Activate or deactivate DECAY for both &
+        &Packages.')
     end if
     if (this%isrb /= this%mst%isrb) then
-      call store_error('SORPTION MUST BE ACTIVATED CONSISTENTLY BETWEEN THE &
-        &MST AND IST PACKAGES.  TURN SORPTION ON OR OFF FOR BOTH PACKAGES.')
+      call store_error('Sorption is active for the IST Package but it is not &
+        &compatible with the sorption option selected for the MST Package.  &
+        &If sorption is active for the IST Package, then SORPTION LINEAR must &
+        &be specified in the options block of the MST Package.')
     end if
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()


### PR DESCRIPTION
* When the LAK Package was used with a combination of outlets that routed water to another lake and outlets that did not, then the budget information stored for the LAK Package had uninitialized records for LAK to LAK flows.  These uninitialized records were used by the LKT Package and possibly other programs.  The LAK to LAK budget information was modified to include only valid records.
* Close #1006
* Close #1007