### PR TITLE
fix(lak): withdrawal and budget errors

### DIFF
--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -231,8 +231,10 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\underline{ADVANCED STRESS PACKAGES}
 	\begin{itemize}
 		\item When the LAK Package was used with a combination of outlets that routed water to another lake and outlets that did not, then the budget information stored for the LAK Package had uninitialized records for LAK to LAK flows.  These uninitialized records were used by the LKT Package and possibly other programs.  The LAK to LAK budget information was modified to include only valid records.
+		\item When a WITHDRAWAL value was specified for lakes, only the withdrawal value for the last lake would be reported in budget files, lake budget tables, and in lake withdrawal observations.  This error would also be propagated to the GWT Lake Transport (LKT) Package, if active.  This error would only show up for models with more than one lake and if the lake withdrawal term was included.
+		\item When lakes were assigned with the STATUS CONSTANT setting to prescribe the lake stage, the CONSTANT term used in the lake budget table was tabulated using an incorrect sign for aquifer leakage.  This error would result in inaccurate budget tables.  The program modified to use the correct leakage values for calculating the CONSTANT term.
 		\item There were several problems in the observation utility for the Streamflow Transport (SFT), Lake Transport (LKT), Multi-Aquifer Well Transport (MWT), and Unsaturated Zone Transport (UZT) Packages.  These issues were corrected as well as the descriptions for the observations in the user input and output guide.
-		\item The BUDGETCSV option for the advanced stress packages would intermittently cause an error due to a variable not being set properly.  The BUDGETCSV option was fixed to work properly.
+		\item The BUDGETCSV option for the advanced stress packages would intermittently cause an error due to a variable not being set properly.  The BUDGETCSV option did not work at all for the GWT advanced packages.  The BUDGETCSV option was fixed to work properly.
 	%	\item xxx
 	%	\item xxx
 	\end{itemize}

--- a/doc/mf6io/mf6ivar/dfn/gwf-lak.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-lak.dfn
@@ -448,7 +448,7 @@ description character string that defines the lake-GWF connection type for the l
 
 block connectiondata
 name bedleak
-type double precision
+type string
 shape
 tagged false
 in_record true

--- a/doc/mf6io/mf6ivar/dfn/gwf-sto.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sto.dfn
@@ -22,7 +22,7 @@ type keyword
 reader urword
 optional true
 longname keyword to indicate specific storage only applied under confined conditions
-description keyword to indicate that specific storage is only calculated when a cell is under confined conditions (head greater than or equal to the top of the cell). This option is identical to the approach used to calculate storage changes under confined conditions in MODFLOW-2005.
+description keyword to indicate that compressible storage is only calculated for a convertible cell (ICONVERT>0) when the cell is under confined conditions (head greater than or equal to the top of the cell). This option has no effect on cells that are marked as being always confined (ICONVERT=0).  This option is identical to the approach used to calculate storage changes under confined conditions in MODFLOW-2005.
 
 block options
 name tvs_filerecord

--- a/src/Model/GroundWaterFlow/gwf3lak8.f90
+++ b/src/Model/GroundWaterFlow/gwf3lak8.f90
@@ -4294,8 +4294,11 @@ contains
       if (this%iboundpak(n) == 0) cycle
       rrate = DZERO
       do j = this%idxlakeconn(n), this%idxlakeconn(n + 1) - 1
-        rrate = this%simvals(j)
-        this%qleak(j) = -rrate
+        ! simvals is from aquifer perspective, and so it is positive
+        ! for flow into the aquifer.  Need to switch sign for lake
+        ! perspective.
+        rrate = -this%simvals(j)
+        this%qleak(j) = rrate
         call this%lak_accumulate_chterm(n, rrate, chratin, chratout)
       end do
     end do
@@ -5478,9 +5481,9 @@ contains
         !
         ! -- limit withdrawals to lake inflows and lake storage
         call this%lak_calculate_withdrawal(n, this%flwiter(n), wr)
-        this%withr = wr
+        this%withr(n) = wr
         call this%lak_calculate_withdrawal(n, this%flwiter1(n), wr)
-        this%withr1 = wr
+        this%withr1(n) = wr
         !
         ! -- limit evaporation to lake inflows and lake storage
         call this%lak_calculate_evaporation(n, hlak, this%flwiter(n), ev)

--- a/src/Model/GroundWaterTransport/gwt1apt1.f90
+++ b/src/Model/GroundWaterTransport/gwt1apt1.f90
@@ -2154,7 +2154,7 @@ contains
     ! -- set up budobj
     call budgetobject_cr(this%budobj, this%packName)
     call this%budobj%budgetobject_df(this%ncv, nbudterm, 0, 0, &
-                                     bddim_opt='M')
+                                     bddim_opt='M', ibudcsv=this%ibudcsv)
     idx = 0
     !
     ! -- Go through and set up each budget term
@@ -2376,7 +2376,7 @@ contains
       if (this%iboundpak(n1) /= 0) then
         igwfnode = this%flowbudptr%budterm(this%idxbudgwf)%id2(j)
         q = this%hcof(j) * x(igwfnode) - this%rhs(j)
-        q = -q ! flip sign so relative to lake
+        q = -q ! flip sign so relative to advanced package feature
       end if
       call this%budobj%budterm(idx)%update_term(n1, igwfnode, q)
       call this%apt_accumulate_ccterm(n1, q, ccratin, ccratout)


### PR DESCRIPTION
* Close #1043
* When a WITHDRAWAL value was specified for lakes, only the withdrawal value for the last lake would be reported in budget files, lake budget tables, and in lake withdrawal observations.  This error would also be propagated to the GWT Lake Transport (LKT) Package, if active.  This error would only show up for models with more than one lake and if the lake withdrawal term was included.
* When lakes were assigned with the STATUS CONSTANT setting to prescribe the lake stage, the CONSTANT term used in the lake budget table was tabulated using an incorrect sign for aquifer leakage.  This error would result in inaccurate budget tables.  The program modified to use the correct leakage values for calculating the CONSTANT term.
* The BUDGETCSV option was activated to work for the GWT advanced packages; although the keyword option was read, the file remained empty.
* A new test was added for LAK and LKT
* The bedleak entry in gwf-lak.dfn support was specified as DOUBLE PRECISION even though NONE could be specified.  This meant that lake packages could not be loaded by flopy if bedleak was specified as NONE.
* The description for the SS_CONFINED_ONLY option in the GWF Storage Package was improved.
* The release notes were updated to reflect these changes.