### PR TITLE
docs(releasenotes): hotfix to escape underscore in release notes

### DIFF
--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -224,7 +224,7 @@ This section describes changes introduced into MODFLOW~6 for the current release
 	\underline{STRESS PACKAGES}
 	\begin{itemize}
 		\item The Evapotranspiration (EVT) Package was modified to include a new error check if the segmented evapotranspiration capability is active.  If the number of ET segments is greater than 1, then the user must specify values for PXDP (as well as PETM).  For a cell, PXDP is a one-dimensional array of size NSEG - 1.  Values in this array must be greater than zero and less than one.  Furthermore, the values in PXDP must increase monotonically.  The program now checks for these conditions and terminates with an error if these conditions are not met.  The segmented ET capability can used be used for list-based EVT Package input.  Provided that the PXDP conditions are met, this new error check should have no effect on simulation results.
-		\item The Evapotranspiration (EVT) Package would throw an index error when SURF_RATE_SPECIFIED was specified in the OPTIONS block and NSEG was set equal to 1.  The code now supports this combination of input options.
+		\item The Evapotranspiration (EVT) Package would throw an index error when SURF\_RATE\_SPECIFIED was specified in the OPTIONS block and NSEG was set equal to 1.  The code now supports this combination of input options.
 	%	\item xxx
 	%	\item xxx
 	\end{itemize}

--- a/src/Model/GroundWaterFlow/gwf3npf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8.f90
@@ -954,7 +954,7 @@ contains
     end if
     !
     ! -- Calculate specific discharge at cell centers and write, if requested
-    if (this%icalcspdis /= 0) then
+    if (this%isavspdis /= 0) then
       if (ibinun /= 0) call this%sav_spdis(ibinun)
     end if
     !


### PR DESCRIPTION
* release notes was updated in #1047 and broke nightly build
* minor change to npf