### PR TITLE
rfct(dis): add xc, yc to DIS as cell center coordinates

### DIFF
--- a/src/Model/Connection/GridConnection.f90
+++ b/src/Model/Connection/GridConnection.f90
@@ -12,6 +12,7 @@ module GridConnectionModule
   use ConnectionsModule
   use SparseModule, only: sparsematrix
   use InterfaceMapModule
+  use BaseDisModule, only: dis_transform_xy
   implicit none
   private
 
@@ -1034,7 +1035,7 @@ contains
     ! local
     integer(I4B) :: icell, nrOfCells, idx
     type(NumericalModelType), pointer :: model
-    real(DP) :: x, y, xglo, yglo
+    real(DP) :: xglo, yglo
 
     ! the following is similar to dis_df
     nrOfCells = this%nrOfCells
@@ -1064,13 +1065,17 @@ contains
     do icell = 1, nrOfCells
       idx = this%idxToGlobal(icell)%index
       model => this%idxToGlobal(icell)%model
-      call model%dis%get_cellxy(idx, x, y)
 
       ! we are merging grids with possibly (likely) different origins,
-      ! transform:
-      call model%dis%transform_xy(x, y, xglo, yglo)
+      ! transform to global coordinates:
+      call dis_transform_xy(model%dis%xc(idx), model%dis%yc(idx), &
+                            model%dis%xorigin, model%dis%yorigin, &
+                            model%dis%angrot, xglo, yglo)
+
       disu%cellxy(1, icell) = xglo
+      disu%xc(icell) = xglo
       disu%cellxy(2, icell) = yglo
+      disu%yc(icell) = yglo
     end do
 
     ! if vertices will be needed, it will look like this:

--- a/src/Model/Connection/GridSorting.f90
+++ b/src/Model/Connection/GridSorting.f90
@@ -3,6 +3,7 @@ module GridSorting
   use ConstantsModule, only: DHALF
   use CellWithNbrsModule, only: GlobalCellType
   use GenericUtilitiesModule, only: is_same
+  use BaseDisModule, only: dis_transform_xy
   implicit none
   private
 
@@ -38,13 +39,23 @@ contains
       gcm => idxToGlobal(array(m))
 
       ! convert coordinates
-      call gcn%model%dis%get_cellxy(gcn%index, xnloc, ynloc)
-      call gcn%model%dis%transform_xy(xnloc, ynloc, xn, yn)
+      xnloc = gcn%model%dis%xc(gcn%index)
+      ynloc = gcn%model%dis%yc(gcn%index)
+      call dis_transform_xy(xnloc, ynloc, &
+                            gcn%model%dis%xorigin, &
+                            gcn%model%dis%yorigin, &
+                            gcn%model%dis%angrot, &
+                            xn, yn)
       zn = DHALF * (gcn%model%dis%top(gcn%index) + &
                     gcn%model%dis%bot(gcn%index))
 
-      call gcm%model%dis%get_cellxy(gcm%index, xmloc, ymloc)
-      call gcm%model%dis%transform_xy(xmloc, ymloc, xm, ym)
+      xmloc = gcm%model%dis%xc(gcm%index)
+      ymloc = gcm%model%dis%yc(gcm%index)
+      call dis_transform_xy(xmloc, ymloc, &
+                            gcm%model%dis%xorigin, &
+                            gcm%model%dis%yorigin, &
+                            gcm%model%dis%angrot, &
+                            xm, ym)
       zm = DHALF * (gcm%model%dis%top(gcm%index) + &
                     gcm%model%dis%bot(gcm%index))
 

--- a/src/Model/GroundWaterFlow/gwf3disu8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disu8.f90
@@ -249,7 +249,7 @@ contains
         this%xc(noder) = this%cellxy(1, node)
         this%yc(noder) = this%cellxy(2, node)
       end do
-    else          
+    else
       call mem_reallocate(this%xc, 0, 'XC', this%memoryPath)
       call mem_reallocate(this%yc, 0, 'YC', this%memoryPath)
     end if

--- a/src/Model/GroundWaterFlow/gwf3disu8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disu8.f90
@@ -42,7 +42,6 @@ module GwfDisuModule
   contains
     procedure :: dis_df => disu_df
     procedure :: dis_da => disu_da
-    procedure :: get_cellxy => get_cellxy_disu
     procedure :: get_dis_type => get_dis_type
     procedure :: disu_ck
     procedure :: grid_finalize
@@ -239,6 +238,8 @@ contains
       this%top(noder) = this%top1d(node)
       this%bot(noder) = this%bot1d(node)
       this%area(noder) = this%area1d(node)
+      this%xc(noder) = this%cellxy(1, node)
+      this%yc(noder) = this%cellxy(2, node)
     end do
     !
     ! -- create and fill the connections object
@@ -1333,9 +1334,11 @@ contains
       call store_error(errmsg, terminate=.TRUE.)
     end if
     !
-    ! -- Find xy coords
-    call this%get_cellxy(noden, xn, yn)
-    call this%get_cellxy(nodem, xm, ym)
+    ! -- get xy center coords
+    xn = this%xc(noden)
+    yn = this%yc(noden)
+    xm = this%xc(nodem)
+    ym = this%yc(nodem)
     !
     ! -- Set vector components based on ihc
     if (ihc == 0) then
@@ -1363,30 +1366,6 @@ contains
     ! -- return
     return
   end subroutine connection_vector
-
-  subroutine get_cellxy_disu(this, node, xcell, ycell)
-! ******************************************************************************
-! get_cellxy_disu -- assign xcell and ycell
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-    class(GwfDisuType), intent(in) :: this
-    integer(I4B), intent(in) :: node ! the reduced node number
-    real(DP), intent(out) :: xcell, ycell ! the x,y for the cell
-    ! -- local
-    integer(I4B) :: nu
-! ------------------------------------------------------------------------------
-    !
-    ! -- Convert to user node number (because that's how cell centers are
-    !    stored) and then set xcell and ycell
-    nu = this%get_nodeuser(node)
-    xcell = this%cellxy(1, nu)
-    ycell = this%cellxy(2, nu)
-    !
-    ! -- return
-    return
-  end subroutine get_cellxy_disu
 
   ! return discretization type
   subroutine get_dis_type(this, dis_type)

--- a/src/Model/GroundWaterFlow/gwf3disu8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disu8.f90
@@ -161,7 +161,7 @@ contains
 !    SPECIFICATIONS:
 ! ------------------------------------------------------------------------------
     ! -- modules
-    use MemoryManagerModule, only: mem_allocate
+    use MemoryManagerModule, only: mem_allocate, mem_reallocate
     ! -- dummy
     class(GwfDisuType) :: this
     ! -- locals
@@ -238,9 +238,21 @@ contains
       this%top(noder) = this%top1d(node)
       this%bot(noder) = this%bot1d(node)
       this%area(noder) = this%area1d(node)
-      this%xc(noder) = this%cellxy(1, node)
-      this%yc(noder) = this%cellxy(2, node)
     end do
+    !
+    ! -- fill cell center coordinates
+    if (this%nvert > 0) then
+      do node = 1, this%nodesuser
+        noder = node
+        if (this%nodes < this%nodesuser) noder = this%nodereduced(node)
+        if (noder <= 0) cycle
+        this%xc(noder) = this%cellxy(1, node)
+        this%yc(noder) = this%cellxy(2, node)
+      end do
+    else          
+      call mem_reallocate(this%xc, 0, 'XC', this%memoryPath)
+      call mem_reallocate(this%yc, 0, 'YC', this%memoryPath)
+    end if
     !
     ! -- create and fill the connections object
     nrsize = 0

--- a/src/Model/GroundWaterFlow/gwf3disv8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disv8.f90
@@ -571,8 +571,8 @@ contains
         end if
         this%top(noder) = top
         this%bot(noder) = this%bot3d(j, 1, k)
-        this%xc(noder) = this%cellxy(1, node)
-        this%yc(noder) = this%cellxy(2, node)
+        this%xc(noder) = this%cellxy(1, j)
+        this%yc(noder) = this%cellxy(2, j)
       end do
     end do
     !

--- a/src/Model/GroundWaterFlow/gwf3disv8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disv8.f90
@@ -30,7 +30,6 @@ module GwfDisvModule
   contains
     procedure :: dis_df => disv_df
     procedure :: dis_da => disv_da
-    procedure :: get_cellxy => get_cellxy_disv
     procedure :: get_dis_type => get_dis_type
     procedure, public :: record_array
     procedure, public :: read_layer_array
@@ -556,7 +555,8 @@ contains
       end do
     end if
     !
-    ! -- Move top2d and bot3d into top and bot, and calculate area
+    ! -- Move top2d and bot3d into top and bot
+    !    and set x and y center coordinates
     node = 0
     do k = 1, this%nlay
       do j = 1, this%ncpl
@@ -571,6 +571,8 @@ contains
         end if
         this%top(noder) = top
         this%bot(noder) = this%bot3d(j, 1, k)
+        this%xc(noder) = this%cellxy(1, node)
+        this%yc(noder) = this%cellxy(2, node)
       end do
     end do
     !
@@ -1309,23 +1311,6 @@ contains
     ! -- return
     return
   end subroutine connection_vector
-
-  ! return x,y coordinate for a node
-  subroutine get_cellxy_disv(this, node, xcell, ycell)
-    use InputOutputModule, only: get_jk
-    class(GwfDisvType), intent(in) :: this
-    integer(I4B), intent(in) :: node ! the reduced node number
-    real(DP), intent(out) :: xcell, ycell ! the x,y for the cell
-    ! local
-    integer(I4B) :: nodeuser, ncell2d, k
-
-    nodeuser = this%get_nodeuser(node)
-    call get_jk(nodeuser, this%ncpl, this%nlay, ncell2d, k)
-
-    xcell = this%cellxy(1, ncell2d)
-    ycell = this%cellxy(2, ncell2d)
-
-  end subroutine get_cellxy_disv
 
   ! return discretization type
   subroutine get_dis_type(this, dis_type)


### PR DESCRIPTION
prep. refactoring for the interface model:
- introduced cell center coordinate arrays for all DIS, getting rid of get_cellxy subroutine
- transform_xy is now stateless