### PR TITLE
fix(maw): patch-up relatively minor typo

### DIFF
--- a/src/Model/GroundWaterFlow/gwf3maw8.f90
+++ b/src/Model/GroundWaterFlow/gwf3maw8.f90
@@ -674,7 +674,7 @@ contains
         else
           write (errmsg, '(a,1x,i0,1x,a)') &
             'CONDEQN for well', n, &
-            "must be 'CONDUCTANCE', 'THIEM', 'MEAN', or 'SKIN'."
+            "must be 'CUMULATIVE', 'THIEM', 'MEAN', or 'SKIN'."
         end if
         wellieqn(n) = ieqn
         !


### PR DESCRIPTION
not a big deal, but output message written to .lst might be confusing to a new user.  Based on what's in mf6io.pdf, the four allowed options are `THEIM`, `SKIN`, `CUMULATIVE`, and `MEAN`.

![condeqn](https://user-images.githubusercontent.com/3236576/194672822-46a07653-68ac-4dd7-b902-9a1ae38e5fb0.png)
