### PR TITLE
fix(ci): revise distribution scripts and workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,25 +153,21 @@ jobs:
 
       - name: Update flopy
         working-directory: modflow6/autotest
-        run: |
-          python update_flopy.py
-      
+        run: python update_flopy.py
+
       - name: Get executables
         working-directory: modflow6/autotest
-        run: |
-          pytest -v --durations 0 get_exes.py
+        run: pytest -v --durations 0 get_exes.py
 
       - name: Test programs
         working-directory: modflow6/autotest
-        run: |
-          pytest -v -n auto --durations 0
+        run: pytest -v -n auto --durations 0
 
       - name: Test scripts
         working-directory: modflow6/distribution
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          pytest -v --durations 0
+        run: pytest -v --durations 0
 
   test_gfortran_previous:
     name: Test gfortran (${{ matrix.GCC_V }}, ${{ matrix.os }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
             ostag: linux
           - os: macos-12
             ostag: mac
-          - os: windows-2022
-            ostag: win64
+          # - os: windows-2022
+          #   ostag: win64
     defaults:
       run:
         shell: bash -l {0}
@@ -39,7 +39,7 @@ jobs:
           path: modflow6/bin
 
       - name: Setup Micromamba
-        if: ${{ !(contains(github.ref_name, 'rc')) || steps.cache-bin.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache-bin.outputs.cache-hit != 'true' }}
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: modflow6/environment.yml
@@ -47,11 +47,11 @@ jobs:
           cache-env: true
 
       - name: Setup Intel Fortran
-        if: ${{ !(contains(github.ref_name, 'rc')) || steps.cache-bin.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache-bin.outputs.cache-hit != 'true' }}
         uses: modflowpy/install-intelfortran-action@v1
 
       - name: Fix Micromamba path (Windows)
-        if: ${{ runner.os == 'Windows' && (!(contains(github.ref_name, 'rc')) || steps.cache-bin.outputs.cache-hit != 'true') }}
+        if: ${{ runner.os == 'Windows' && steps.cache-bin.outputs.cache-hit != 'true' }}
         shell: pwsh
         run: |
           # https://github.com/modflowpy/install-intelfortran-action#conda-scripts
@@ -59,7 +59,7 @@ jobs:
           echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Update version
-        if: ${{ !(contains(github.ref_name, 'rc')) || steps.cache-bin.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache-bin.outputs.cache-hit != 'true' }}
         working-directory: modflow6/distribution
         run: |
           ref="${{ github.ref_name }}"
@@ -75,7 +75,7 @@ jobs:
           cat ../src/Utilities/version.f90
 
       - name: Build binaries
-        if: ${{ runner.os != 'Windows' && (!(contains(github.ref_name, 'rc')) || steps.cache-bin.outputs.cache-hit != 'true') }}
+        if: ${{ runner.os != 'Windows' && steps.cache-bin.outputs.cache-hit != 'true' }}
         working-directory: modflow6
         run: |
           meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
@@ -83,7 +83,7 @@ jobs:
           meson test --verbose --no-rebuild -C builddir
 
       - name: Build binaries (Windows)
-        if: ${{ runner.os == 'Windows' && (!(contains(github.ref_name, 'rc')) || steps.cache-bin.outputs.cache-hit != 'true') }}
+        if: ${{ runner.os == 'Windows' && steps.cache-bin.outputs.cache-hit != 'true' }}
         working-directory: modflow6
         shell: pwsh
         run: |
@@ -227,8 +227,8 @@ jobs:
             ostag: linux
           - os: macos-12
             ostag: mac
-          - os: windows-2022
-            ostag: win64
+          # - os: windows-2022
+          #   ostag: win64
     defaults:
       run:
         shell: bash -l {0}
@@ -303,11 +303,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            # fix MSVC linker path on Windows
-            export PATH="/C/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.33.31629/bin/Hostx64/x64":$PATH
-          fi
-          
           # build dist folder
           python modflow6/distribution/build_dist.py -o "$DISTNAME" -e modflow6-examples
 
@@ -519,19 +514,27 @@ jobs:
           '
           gh release create "$version" ../mf*/mf*.zip ../release_notes/release.pdf --target master --title "$title" --notes "$notes" --draft --latest
 
+      - uses: oprypin/find-latest-tag@v1
+        id: latest_tag
+        with:
+          repository: MODFLOW-USGS/modflow6
+          releases-only: true
+
       - name: Reinitialize develop branch
         working-directory: modflow6
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           # create reset branch from master
-          reset_branch="post-release-$RELEASE_VERSION-reset"
+          reset_branch="post-release-${{ steps.latest_tag.outputs.tag }}-reset"
           git checkout master
           git switch -c $reset_branch
           
-          # bump minor version and reset IDEVELOPMODE to 1
-          python distribution/update_version.py --bump-minor
-          version=$(python distribution/update_version.py --get)
+          # increment minor version from latest official release and reset IDEVELOPMODE to 1
+          major_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f1)
+          minor_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f2)
+          version="$major_version.$((minor_version + 1)).0"
+          python distribution/update_version.py -v "$version"
           
           # commit and push to reset branch
           git config core.sharedRepository true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,15 @@ on:
     branches:
       - master
       - v*
+  release:
+    types:
+      - published
 env:
   FC: ifort
 jobs:
   build:
     name: Build binaries (${{ matrix.os }})
-    if: ${{ github.event_name != 'push' || github.ref_name != 'master' }}
+    if: ${{ github.event_name == 'push' && github.ref_name != 'master' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -19,8 +22,8 @@ jobs:
             ostag: linux
           - os: macos-12
             ostag: mac
-          # - os: windows-2022
-          #   ostag: win64
+          - os: windows-2022
+            ostag: win64
     defaults:
       run:
         shell: bash -l {0}
@@ -99,7 +102,7 @@ jobs:
 
   docs:
     name: Build docs
-    if: ${{ github.event_name != 'push' || github.ref_name != 'master' }}
+    if: ${{ github.event_name == 'push' && github.ref_name != 'master' }}
     needs: build
     runs-on: ubuntu-22.04
     defaults:
@@ -216,7 +219,7 @@ jobs:
 
   dist:
     name: Build distribution (${{ matrix.os }})
-    if: ${{ github.event_name != 'push' || github.ref_name != 'master' }}
+    if: ${{ github.event_name == 'push' && github.ref_name != 'master' }}
     needs: docs
     runs-on: ${{ matrix.os }}
     strategy:
@@ -227,8 +230,8 @@ jobs:
             ostag: linux
           - os: macos-12
             ostag: mac
-          # - os: windows-2022
-          #   ostag: win64
+          - os: windows-2022
+            ostag: win64
     defaults:
       run:
         shell: bash -l {0}
@@ -401,8 +404,8 @@ jobs:
           path: ${{ env.DISTNAME }}/doc/release.pdf
 
   pr:
-    name: Create release PR
-    if: ${{ github.event_name == 'push' && !(contains(github.ref_name, 'rc')) }}
+    name: Draft release PR
+    if: ${{ github.event_name == 'push' && github.ref_name != 'master' && !(contains(github.ref_name, 'rc')) }}
     needs: dist
     runs-on: ubuntu-22.04
     permissions:
@@ -441,7 +444,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "ci(release): update version to $ver"
+          git commit -m "ci(release): update version to $ver release mode"
           git push origin "$ref"
 
       - name: Create pull request
@@ -460,7 +463,7 @@ jobs:
           gh pr create -B "master" -H "$ref" --title "Release $ver" --draft --body "$body"
 
   release:
-    name: Release and reset
+    name: Draft release
     if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
     runs-on: ubuntu-22.04
     defaults:
@@ -495,7 +498,7 @@ jobs:
       #       mf*/mf*.zip
       #       release_notes/release.pdf
 
-      - name: Create release
+      - name: Draft release
         working-directory: modflow6
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -514,40 +517,63 @@ jobs:
           '
           gh release create "$version" ../mf*/mf*.zip ../release_notes/release.pdf --target master --title "$title" --notes "$notes" --draft --latest
 
-      - uses: oprypin/find-latest-tag@v1
+  reset:
+    name: Draft reset PR
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+
+      - name: Checkout modflow6
+        uses: actions/checkout@v3
+        with:
+          path: modflow6
+
+      - name: Setup Micromamba
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: modflow6/environment.yml
+          cache-downloads: true
+          cache-env: true
+
+      - name: Get release tag
+        uses: oprypin/find-latest-tag@v1
         id: latest_tag
         with:
-          repository: MODFLOW-USGS/modflow6
+          repository: ${{ github.repository }}
           releases-only: true
 
-      - name: Reinitialize develop branch
+      - name: Create pull request
         working-directory: modflow6
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           # create reset branch from master
           reset_branch="post-release-${{ steps.latest_tag.outputs.tag }}-reset"
+          git fetch origin
           git checkout master
           git switch -c $reset_branch
-          
+
           # increment minor version from latest official release and reset IDEVELOPMODE to 1
           major_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f1)
           minor_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f2)
           version="$major_version.$((minor_version + 1)).0"
           python distribution/update_version.py -v "$version"
-          
+
           # commit and push to reset branch
           git config core.sharedRepository true
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "ci(release): reinitialize develop for next release"
+          git commit -m "ci(release): update version to $version development mode"
           git push -u origin $reset_branch
-          
+
           # create PR into develop
           body='
           # Reinitialize for development
-          
-          Updates the `develop` branch from `master` following an approved release. Bumps the minor version number, resets version files, and sets `IDEVELOPMODE` back to `1`.
+
+          Updates the `develop` branch from `master` following an approved release. Bumps the minor version number and resets `IDEVELOPMODE` back to `1`.
           '
-          gh pr create -B "develop" -H "$reset_branch" --title "Reinitialize develop to $version" --draft --body "$body"
+          gh pr create -B "develop" -H "$reset_branch" --title "Reinitialize develop branch" --draft --body "$body"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
             ostag: linux
           - os: macos-12
             ostag: mac
-          # - os: windows-2022
-          #   ostag: win64
+          - os: windows-2022
+            ostag: win64
     defaults:
       run:
         shell: bash -l {0}
@@ -65,17 +65,16 @@ jobs:
         if: ${{ steps.cache-bin.outputs.cache-hit != 'true' }}
         working-directory: modflow6/distribution
         run: |
+          # extract version from ref name
           ref="${{ github.ref_name }}"
           ver="${ref%"rc"}"
-          # if tag doesn't end with 'rc' the release is approved
-          if [ "$ref" == "$ver" ]; then
+          
+          # update version files
+          if [[ "$ver" == *"rc"* ]]; then
             python update_version.py -v "${ver#"v"}" --approve
           else
             python update_version.py -v "${ver#"v"}" 
           fi
-          
-          # check src/Utilities/version.f90 IDEVELOPMODE setting
-          cat ../src/Utilities/version.f90
 
       - name: Build binaries
         if: ${{ runner.os != 'Windows' && steps.cache-bin.outputs.cache-hit != 'true' }}
@@ -122,15 +121,12 @@ jobs:
       - name: Install extra Python packages
         if: steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc
-        run: |
-          pip install -r requirements.pip.txt
+        run: pip install -r requirements.pip.txt
 
       - name: Build example models
         if: steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc
-        run: |
-          python ci_build_files.py
-          ls -lh ../examples/
+        run: python ci_build_files.py
 
       - name: Update flopy
         working-directory: modflow6/autotest
@@ -142,13 +138,13 @@ jobs:
 
       - name: Test programs
         working-directory: modflow6/autotest
-        run: pytest -v -n auto --durations 0
+        run: pytest -v -n auto -m "not developmode" --durations 0
 
       - name: Test scripts
         working-directory: modflow6/distribution
+        run: pytest -v --durations 0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: pytest -v --durations 0
 
   docs:
     name: Build docs
@@ -174,7 +170,11 @@ jobs:
       - name: Install TeX Live
         run: |
           sudo apt-get update
-          sudo apt install texlive-latex-extra texlive-science texlive-font-utils texlive-fonts-recommended texlive-fonts-extra
+          sudo apt install texlive-science \
+            texlive-latex-extra \
+            texlive-font-utils \
+            texlive-fonts-recommended \
+            texlive-fonts-extra
 
       - name: Checkout usgslatex
         uses: actions/checkout@v3
@@ -184,8 +184,7 @@ jobs:
 
       - name: Install USGS LaTeX style files and Univers font
         working-directory: usgslatex/usgsLaTeX
-        run: |
-          sudo ./install.sh --all-users
+        run: sudo ./install.sh --all-users
 
       - name: Setup Micromamba
         uses: mamba-org/provision-with-micromamba@main
@@ -211,23 +210,29 @@ jobs:
 
       - name: Build example models
         working-directory: modflow6-examples/etc
-        run: |
-          pytest -v -n auto ci_build_files.py
-          ls -lh ../examples/ 
+        run: pytest -v -n auto ci_build_files.py
 
       - name: Update version
         working-directory: modflow6/distribution
         run: |
+          # extract version from ref name
           ref="${{ github.ref_name }}"
           ver="${ref%"rc"}"
-          # if tag doesn't end with 'rc' the release is approved
-          if [ "$ref" == "$ver" ]; then
+          
+          # update version files
+          if [[ "$ver" == *"rc"* ]]; then
             python update_version.py -v "${ver#"v"}" --approve
           else
             python update_version.py -v "${ver#"v"}" 
           fi
           
-          echo "DISTNAME=mf${ref#"v"}" >> $GITHUB_ENV
+          # set dist name, format is 'mf<major.minor.patch>_<ostag>'
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            distname="mf${ref#"v"}"
+          else
+            distname="mf${ref#"v"}_${{ matrix.ostag }}"
+          fi
+          echo "DISTNAME=$distname" >> $GITHUB_ENV
 
       - name: Create directory structure
         run: |
@@ -280,8 +285,8 @@ jobs:
             ostag: linux
           - os: macos-12
             ostag: mac
-          # - os: windows-2022
-          #   ostag: win64
+          - os: windows-2022
+            ostag: win64
     defaults:
       run:
         shell: bash -l {0}
@@ -317,34 +322,33 @@ jobs:
 
       - name: Install extra Python packages
         working-directory: modflow6-examples/etc
-        run: |
-          pip install -r requirements.pip.txt
+        run: pip install -r requirements.pip.txt
 
       - name: Build example models
         working-directory: modflow6-examples/etc
-        run: |
-          pytest -v -n auto ci_build_files.py
-          ls -lh ../examples/ 
-      
+        run: pytest -v -n auto ci_build_files.py
+
       - name: Update version
         working-directory: modflow6/distribution
         run: |
+          # extract version from ref name
           ref="${{ github.ref_name }}"
           ver="${ref%"rc"}"
-          # if tag doesn't end with 'rc' the release is approved
-          if [ "$ref" == "$ver" ]; then
+          
+          # update version files
+          if [[ "$ver" == *"rc"* ]]; then
             python update_version.py -v "${ver#"v"}" --approve
           else
             python update_version.py -v "${ver#"v"}" 
           fi
           
+          # set dist name, format is 'mf<major.minor.patch>_<ostag>'
           if [ "${{ runner.os }}" == "Windows" ]; then
-            dist_name="mf${ref#"v"}"
+            distname="mf${ref#"v"}"
           else
-            dist_name="mf${ref#"v"}_${{ matrix.ostag }}"
+            distname="mf${ref#"v"}_${{ matrix.ostag }}"
           fi
-          
-          echo "DISTNAME=$dist_name" >> $GITHUB_ENV
+          echo "DISTNAME=$distname" >> $GITHUB_ENV
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -353,8 +357,7 @@ jobs:
 
       - name: Select artifacts for OS
         run: |
-          # move binaries for current OS to top level bin
-          # directory and remove executables for other OS
+          # move binaries for current OS to top level bin dir
           mv "$DISTNAME/bin-${{ runner.os }}" "$DISTNAME/bin"
           rm -rf "$DISTNAME/bin-*"
 
@@ -420,30 +423,6 @@ jobs:
           name: ${{ env.DISTNAME }}
           path: ${{ env.DISTNAME }}.zip
 
-      # actions/upload-artifact doesn't preserve execute permissions
-      # - name: Upload distribution (Windows)
-      #   if: runner.os == 'Windows'
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: ${{ env.DISTNAME }}
-      #     path: |
-      #       ${{ env.DISTNAME }}/bin
-      #       ${{ env.DISTNAME }}/src
-      #       ${{ env.DISTNAME }}/srcbmi
-      #       ${{ env.DISTNAME }}/doc
-      #       ${{ env.DISTNAME }}/examples
-      #       ${{ env.DISTNAME }}/make
-      #       ${{ env.DISTNAME }}/msvs
-      #       ${{ env.DISTNAME }}/utils
-      #       ${{ env.DISTNAME }}/code.json
-      #       ${{ env.DISTNAME }}/meson.build
-      #       !${{ env.DISTNAME }}/utils/idmloader
-      #       !${{ env.DISTNAME }}/bin/libmf6.lib
-      #       !${{ env.DISTNAME }}/**/pymake
-      #       !${{ env.DISTNAME }}/**/.DS_Store
-      #       !${{ env.DISTNAME }}/**/obj_temp
-      #       !${{ env.DISTNAME }}/**/mod_temp
-
       - name: Upload release notes
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v3
@@ -453,6 +432,7 @@ jobs:
 
   pr:
     name: Draft release PR
+    # only runs if branch name doesn't end with 'rc' (i.e. release is approved)
     if: ${{ github.event_name == 'push' && github.ref_name != 'master' && !(contains(github.ref_name, 'rc')) }}
     needs: dist
     runs-on: ubuntu-22.04
@@ -475,16 +455,18 @@ jobs:
       - name: Update version
         working-directory: distribution
         run: |
-          # update version files
+          # extract version from branch name
           ref="${{ github.ref_name }}"
           ver="${ref#"v"}"
+          
+          # update version files
           if [[ "$ver" == *"rc"* ]]; then
             python update_version.py -v "$ver" 
           else
             python update_version.py -v "$ver" --approve
           fi
           
-          # update formatting
+          # lint version.f90
           fprettify -c ../.fprettify.yaml ../src/Utilities/version.f90
           
           # commit and push
@@ -504,14 +486,15 @@ jobs:
           body='
           # MODFLOW '$ver' release
           
-          To approve this release, merge this pull request into `master`. This will trigger a final CI job to: 
-          1) create a tagged GitHub release and upload assets (OS-specific distributions and release notes)
-          2) open a PR updating `develop` from `master`, resetting version files, and setting `IDEVELOPMODE=1`
+          This release can be approved by merging this PR into `master`. Doing so triggers a final job, to: 
+          1) create and tag a draft GitHub release, then upload assets (OS distributions and release notes)
+          2) open a PR to update `develop` from `master`, resetting version files and setting `IDEVELOPMODE=1`
           '
           gh pr create -B "master" -H "$ref" --title "Release $ver" --draft --body "$body"
 
   release:
     name: Draft release
+    # runs only after release PR is merged to master
     if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
     runs-on: ubuntu-22.04
     defaults:
@@ -533,19 +516,6 @@ jobs:
       - name: Download artifacts
         uses: dawidd6/action-download-artifact@v2
 
-      # - name: Create release
-      #   uses: marvinpinto/action-automatic-releases@latest
-      #   with:
-      #     repo_token: ${{ github.token }}
-      #     automatic_release_tag: ${{ env.RELEASE_VERSION }}
-      #     prerelease: false
-      #     title: "MODFLOW ${{ env.RELEASE_VERSION }}"
-      #     files: |
-      #       # double-nested because actions/upload-artifact has no way of
-      #       # disabling compression or detecting files already compressed
-      #       mf*/mf*.zip
-      #       release_notes/release.pdf
-
       - name: Draft release
         working-directory: modflow6
         env:
@@ -554,7 +524,7 @@ jobs:
           # detect release version
           version=$(python distribution/update_version.py --get)
           
-          # create release
+          # create draft release
           title="MODFLOW $version"
           notes='
           This is the approved USGS MODFLOW '$version' release.
@@ -567,6 +537,7 @@ jobs:
 
   reset:
     name: Draft reset PR
+    # runs only after release is published (manually promoted from draft to public)
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-22.04
     defaults:
@@ -604,13 +575,13 @@ jobs:
           git checkout master
           git switch -c $reset_branch
 
-          # increment minor version from latest official release and reset IDEVELOPMODE to 1
+          # increment minor version and reset IDEVELOPMODE to 1
           major_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f1)
           minor_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f2)
           version="$major_version.$((minor_version + 1)).0"
           python distribution/update_version.py -v "$version"
 
-          # commit and push to reset branch
+          # commit and push reset branch
           git config core.sharedRepository true
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -622,6 +593,7 @@ jobs:
           body='
           # Reinitialize for development
 
-          Updates the `develop` branch from `master` following an approved release. Bumps the minor version number and resets `IDEVELOPMODE` back to `1`.
+          Updates the `develop` branch from `master` following a successful release.
+          Increments the minor version number and resets `IDEVELOPMODE` back to `1`.
           '
           gh pr create -B "develop" -H "$reset_branch" --title "Reinitialize develop branch" --draft --body "$body"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
             ostag: linux
           - os: macos-12
             ostag: mac
-          - os: windows-2022
-            ostag: win64
+          # - os: windows-2022
+          #   ostag: win64
     defaults:
       run:
         shell: bash -l {0}
@@ -99,6 +99,56 @@ jobs:
         with:
           name: bin-${{ runner.os }}
           path: modflow6/bin
+
+      - name: Checkout modflow6-testmodels
+        uses: actions/checkout@v3
+        with:
+          repository: MODFLOW-USGS/modflow6-testmodels
+          path: modflow6-testmodels
+
+      - name: Checkout modflow6-examples
+        uses: actions/checkout@v3
+        with:
+          repository: MODFLOW-USGS/modflow6-examples
+          path: modflow6-examples
+
+      - name: Cache modflow6 examples
+        id: cache-examples
+        uses: actions/cache@v3
+        with:
+          path: modflow6-examples/examples
+          key: modflow6-examples-${{ hashFiles('modflow6-examples/scripts/**') }}
+
+      - name: Install extra Python packages
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6-examples/etc
+        run: |
+          pip install -r requirements.pip.txt
+
+      - name: Build example models
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6-examples/etc
+        run: |
+          python ci_build_files.py
+          ls -lh ../examples/
+
+      - name: Update flopy
+        working-directory: modflow6/autotest
+        run: python update_flopy.py
+
+      - name: Get executables
+        working-directory: modflow6/autotest
+        run: pytest -v --durations 0 get_exes.py
+
+      - name: Test programs
+        working-directory: modflow6/autotest
+        run: pytest -v -n auto --durations 0
+
+      - name: Test scripts
+        working-directory: modflow6/distribution
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pytest -v --durations 0
 
   docs:
     name: Build docs
@@ -230,8 +280,8 @@ jobs:
             ostag: linux
           - os: macos-12
             ostag: mac
-          - os: windows-2022
-            ostag: win64
+          # - os: windows-2022
+          #   ostag: win64
     defaults:
       run:
         shell: bash -l {0}
@@ -288,7 +338,13 @@ jobs:
             python update_version.py -v "${ver#"v"}" 
           fi
           
-          echo "DISTNAME=mf${ref#"v"}" >> $GITHUB_ENV
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            dist_name="mf${ref#"v"}"
+          else
+            dist_name="mf${ref#"v"}_${{ matrix.ostag }}"
+          fi
+          
+          echo "DISTNAME=$dist_name" >> $GITHUB_ENV
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -312,19 +368,11 @@ jobs:
           # rename PDF docs
           mv "$DISTNAME/doc/ReleaseNotes.pdf" "$DISTNAME/doc/release.pdf"
           mv "$DISTNAME/doc/converter_mf5to6.pdf" "$DISTNAME/doc/mf5to6.pdf"
-          
-          # set zip name
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            zip_name="${{ env.DISTNAME }}"
-          else
-            zip_name="${{ env.DISTNAME }}_${{ matrix.ostag }}"
-          fi
-          echo "ZIP_NAME=$zip_name" >> $GITHUB_ENV
 
       - name: Zip distribution
         if: runner.os != 'Windows'
         run: |
-          zip -r ${{ env.ZIP_NAME }}.zip \
+          zip -r ${{ env.DISTNAME }}.zip \
             ${{ env.DISTNAME }}/bin \
             ${{ env.DISTNAME }}/src \
             ${{ env.DISTNAME }}/srcbmi \
@@ -345,7 +393,7 @@ jobs:
       - name: Zip distribution (Windows)
         if: runner.os == 'Windows'
         run: |
-          7z a -tzip ${{ env.ZIP_NAME }}.zip \
+          7z a -tzip ${{ env.DISTNAME }}.zip \
             ${{ env.DISTNAME }}/bin \
             ${{ env.DISTNAME }}/src \
             ${{ env.DISTNAME }}/srcbmi \
@@ -369,15 +417,15 @@ jobs:
       - name: Upload distribution
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.ZIP_NAME }}
-          path: ${{ env.ZIP_NAME }}.zip
+          name: ${{ env.DISTNAME }}
+          path: ${{ env.DISTNAME }}.zip
 
       # actions/upload-artifact doesn't preserve execute permissions
       # - name: Upload distribution (Windows)
       #   if: runner.os == 'Windows'
       #   uses: actions/upload-artifact@v3
       #   with:
-      #     name: ${{ env.ZIP_NAME }}
+      #     name: ${{ env.DISTNAME }}
       #     path: |
       #       ${{ env.DISTNAME }}/bin
       #       ${{ env.DISTNAME }}/src

--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    developmode: tests that should only run with IDEVELOPMODE = 1

--- a/autotest/test_gwf_ifmod_buy.py
+++ b/autotest/test_gwf_ifmod_buy.py
@@ -663,6 +663,7 @@ def compare_to_ref(sim):
     "idx, exdir",
     list(enumerate(exdirs)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, exdir):
     # initialize testing framework
     test = testing_framework()

--- a/autotest/test_gwf_ifmod_mult_exg.py
+++ b/autotest/test_gwf_ifmod_mult_exg.py
@@ -352,6 +352,7 @@ def eval_heads(sim):
     "idx, exdir",
     list(enumerate(exdirs)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, exdir):
     # initialize testing framework
     test = testing_framework()

--- a/autotest/test_gwf_ifmod_rewet.py
+++ b/autotest/test_gwf_ifmod_rewet.py
@@ -407,6 +407,7 @@ def compare_to_ref(sim):
     "idx, exdir",
     list(enumerate(exdirs)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, exdir):
     # initialize testing framework
     test = testing_framework()

--- a/autotest/test_gwf_ifmod_vert.py
+++ b/autotest/test_gwf_ifmod_vert.py
@@ -299,6 +299,7 @@ def eval_heads(sim):
     "idx, exdir",
     list(enumerate(exdirs)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, exdir):
     # initialize testing framework
     test = testing_framework()

--- a/autotest/test_gwf_libmf6_ifmod02.py
+++ b/autotest/test_gwf_libmf6_ifmod02.py
@@ -429,6 +429,7 @@ def check_interface_models(mf6):
     "idx, dir",
     list(enumerate(exdirs)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, dir):
     # initialize testing framework
     test = testing_framework()

--- a/autotest/test_gwfgwf_lgr.py
+++ b/autotest/test_gwfgwf_lgr.py
@@ -294,6 +294,7 @@ def eval_heads(sim):
     "idx, exdir",
     list(enumerate(exdirs)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, exdir):
     # initialize testing framework
     test = testing_framework()

--- a/autotest/test_gwt_adv01_gwtgwt.py
+++ b/autotest/test_gwt_adv01_gwtgwt.py
@@ -747,6 +747,7 @@ def eval_transport(sim):
     "idx, dir",
     list(enumerate(exdirs)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, dir):
     # initialize testing framework
     test = testing_framework()

--- a/autotest/test_gwt_dsp01_gwtgwt.py
+++ b/autotest/test_gwt_dsp01_gwtgwt.py
@@ -319,6 +319,7 @@ def eval_transport(sim):
     "idx, dir",
     list(enumerate(exdirs)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, dir):
     # initialize testing framework
     test = testing_framework()

--- a/autotest/test_z01_testmodels_mf6.py
+++ b/autotest/test_z01_testmodels_mf6.py
@@ -105,7 +105,7 @@ def get_mf6_models():
         example_dirs = []
 
     # exclude dev examples on master or release branches
-    if "master" in branch.lower() or "release" in branch.lower():
+    if "master" in branch.lower() or "release" in branch.lower() or branch.lower().startswith("v6"):
         drmv = []
         for d in example_dirs:
             if "_dev" in d.lower():

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -325,11 +325,12 @@ def build_distribution(
         bin_path=output_path / "bin",
         overwrite=overwrite)
 
-    # examples
-    setup_examples(
-        bin_path=output_path / "bin",
-        examples_path=output_path / "examples",
-        overwrite=overwrite)
+    if not development:
+        # examples
+        setup_examples(
+            bin_path=output_path / "bin",
+            examples_path=output_path / "examples",
+            overwrite=overwrite)
 
     # docs
     build_documentation(

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -444,10 +444,10 @@ if __name__ == "__main__":
             current = Version.from_file(project_root_path / "version.txt")
             if args.bump_major:
                 print(f"Incrementing major number")
-                version = Version(current.major + 1, current.minor, current.patch)
+                version = Version(current.major + 1, 0, 0)
             elif args.bump_minor:
                 print(f"Incrementing minor number")
-                version = Version(current.major, current.minor + 1, current.patch)
+                version = Version(current.major, current.minor + 1, 0)
             else:
                 print(f"Incrementing patch number")
                 version = Version(current.major, current.minor, current.patch + 1)


### PR DESCRIPTION
- Only trigger job to open PR reinitializing `develop` after release is published. The automated workflow only creates a draft release &mdash; the release must be published manually after inspection. Previously the reinitialization job was triggered immediately after the release branch was merged to `master`, after this reinit will only happen after the release post is converted from draft to official.

- Update `develop` reinitialization job such that, for minor version releases, minor version number is incremented from just-released version and patch number is reset to 0, while for patch releases, the version on `develop` does not change. This is according to the tentative expectation that minor version releases will branch from `develop`, while patch releases will branch from `master` to exclude broader changesets in progress on `develop`. The forthcoming `6.4.1` release is an exception to the above: `develop` will be bumped to `6.5.0` after `6.4.1` but will then stay there for all subsequent `6.4.X` patches until `6.5.0` is released. 

- Run test suite after building binaries (tests should all pass before a release branch is created, but a final check is probably not a bad idea)

- Fix `test_z01_testmodels_mf6.py` to skip dev testmodels/examples on `v6*` branches, since this is how release branches must be named to trigger the `release.yml` workflow (previously only skipped on branches named `master` and `release`)

- Add `developmode` test marker to skip tests requiring `IDEVELOPMODE = 1` in the release workflow

- Fix `update_version.py` minor/patch version increment flags

- Only build examples in `build_dist.py` for full release