### PR TITLE
fix(distribution): fix branch detection in dist checks

### DIFF
--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -46,9 +46,8 @@ def test_sources(dist_dir_path):
     # make sure IDEVELOPMODE was set correctly
     branch = get_branch()
     idevelopmode = 1 if ("rc" in branch or "candidate" in branch) else 0
-    print(idevelopmode)
-    print(line)
     assert f"IDEVELOPMODE = {idevelopmode}" in line
+
 
 @pytest.mark.skipif(not _fc, reason="needs Fortran compiler")
 def test_makefiles(dist_dir_path):

--- a/distribution/utils.py
+++ b/distribution/utils.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import shutil
 import subprocess
@@ -17,6 +18,7 @@ def get_project_root_path():
 
 
 def get_branch():
+    branch = None
     try:
         # determine current branch
         b = subprocess.Popen(
@@ -29,8 +31,15 @@ def get_branch():
         for line in b.splitlines():
             if "On branch" in line:
                 branch = line.replace("On branch ", "").rstrip()
+        if branch is None:
+            raise
     except:
-        branch = None
+        branch = os.environ.get("GITHUB_REF_NAME", None)
+
+    if branch is None:
+        raise ValueError(f"Couldn't detect branch")
+    else:
+        print(f"Detected branch: {branch}")
 
     return branch
 


### PR DESCRIPTION
Branch detection for distribution checks in `check_dist.py` could fail if invoked from outside the `modflow6` repo directory. PR updates the branch detection function to fall back to checking the [`GITHUB_REF_NAME`](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) environment variable set by default for all GitHub Actions steps if `git` commands fail.