### PR TITLE
fix(sfr): evaporation from sfr reaches should use wetted top width

### DIFF
--- a/autotest/test_gwf_sfr_evap.py
+++ b/autotest/test_gwf_sfr_evap.py
@@ -1,0 +1,483 @@
+# Test evap in SFR reaches (no interaction with gwf)
+
+# Imports
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+from framework import testing_framework
+from simulation import Simulation
+
+ex = ["sfr-evap"]
+exdirs = []
+for s in ex:
+    exdirs.append(os.path.join("temp", s))
+
+
+# Model units
+length_units = "m"
+time_units = "days"
+
+# model domain and grid definition
+Lx = 500.0
+Ly = 300.0
+nrow = 3
+ncol = 5
+nlay = 1
+delr = Lx / ncol
+delc = Ly / nrow
+xmax = ncol * delr
+ymax = nrow * delc
+X, Y = np.meshgrid(
+    np.linspace(delr / 2, xmax - delr / 2, ncol),
+    np.linspace(ymax - delc / 2, 0 + delc / 2, nrow),
+)
+ibound = np.ones((nlay, nrow, ncol))
+# Because eqn uses negative values in the Y direction, need to do a little manipulation
+Y_m = -1 * np.flipud(Y)
+top = np.array(
+    [
+        [101.25, 101.00, 100.75, 100.50, 100.25],
+        [101.00, 100.75, 100.50, 100.25, 100.00],
+        [101.25, 101.00, 100.75, 100.50, 100.25],
+    ]
+)
+
+botm = np.zeros(top.shape)
+strthd = top - 1.0
+
+# NPF parameters
+k11 = 1
+ss = 0.00001
+sy = 0.20
+hani = 1
+laytyp = 1
+
+# Package boundary conditions
+surf_Q_in = 86400  # 1 m^3/s
+sfr_evaprate = 0.1
+streambed_K = 0.0
+
+# time params
+steady = {0: True, 1: False}
+transient = {0: False, 1: True}
+nstp = [1, 1]
+tsmult = [1, 1]
+perlen = [1, 1]
+
+nouter, ninner = 1000, 300
+hclose, rclose, relax = 1e-3, 1e-4, 0.97
+
+#
+# MODFLOW 6 flopy GWF object
+#
+
+
+def build_model(idx, dir):
+    # Base simulation and model name and workspace
+    ws = dir
+    name = ex[idx]
+
+    print("Building model...{}".format(name))
+
+    # generate names for each model
+    gwfname_trapezoidal = "gwf-" + name + "-t"
+    gwfname_rectangular = "gwf-" + name + "-r"
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name=name, sim_ws=ws, exe_name="mf6", version="mf6"
+    )
+
+    # Instantiating time discretization
+    tdis_rc = []
+    for i in range(len(nstp)):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+    flopy.mf6.ModflowTdis(
+        sim, nper=len(nstp), perioddata=tdis_rc, time_units=time_units
+    )
+
+    gwft = flopy.mf6.ModflowGwf(
+        sim,
+        modelname=gwfname_trapezoidal,
+        save_flows=True,
+        newtonoptions="newton",
+    )
+
+    # Instantiating solver
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        print_option="ALL",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="cooley",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename="{}.ims".format(gwfname_trapezoidal),
+    )
+    sim.register_ims_package(ims, [gwfname_trapezoidal])
+
+    # Instantiate discretization package
+    flopy.mf6.ModflowGwfdis(
+        gwft,
+        length_units=length_units,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+
+    # Instantiate node property flow package
+    flopy.mf6.ModflowGwfnpf(
+        gwft,
+        save_specific_discharge=True,
+        icelltype=1,  # >0 means saturated thickness varies with computed head
+        k=k11,
+    )
+
+    # Instantiate storage package
+    flopy.mf6.ModflowGwfsto(
+        gwft,
+        save_flows=False,
+        iconvert=laytyp,
+        ss=ss,
+        sy=sy,
+        steady_state=steady,
+        transient=transient,
+    )
+
+    # Instantiate initial conditions package
+    flopy.mf6.ModflowGwfic(gwft, strt=strthd)
+
+    # Instantiate output control package
+    flopy.mf6.ModflowGwfoc(
+        gwft,
+        budget_filerecord=f"{gwfname_trapezoidal}.cbc",
+        head_filerecord=f"{gwfname_trapezoidal}.hds",
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
+    # Instantiate streamflow routing package
+    # Determine the middle row and store in rMid (account for 0-base)
+    rMid = 1
+    # sfr data
+    nreaches = ncol
+    rlen = delr
+    rwid = 9.0
+    roughness = 0.035
+    rbth = 1.0
+    rhk = streambed_K
+    strm_up = 100
+    strm_dn = 99
+    slope = (strm_up - strm_dn) / ((ncol - 1) * delr)
+    ustrf = 1.0
+    ndv = 0
+    strm_incision = 1.0
+
+    # use trapezoidal cross-section for channel geometry
+    x_coord = [0.0, 2.0, 4.0, 5.0, 7.0, 9.0]
+    x_xsec = [val / rwid for val in x_coord]
+    y_xsec = [0.66666667, 0.33333333, 0.0, 0.0, 0.33333333, 0.66666667]
+    x_sec_tab = [[x, h] for x, h, in zip(x_xsec, y_xsec)]
+
+    sfr_xsec_table_name = "{}.xsec.tab".format(gwfname_trapezoidal)
+    crosssections = []
+    for n in range(nreaches):
+        crosssections.append([n, sfr_xsec_table_name])
+
+    flopy.mf6.ModflowUtlsfrtab(
+        gwft,
+        nrow=len(x_xsec),
+        ncol=2,
+        table=x_sec_tab,
+        filename=sfr_xsec_table_name,
+        pname=f"sfrxsectable",
+    )
+
+    packagedata = []
+    for irch in range(nreaches):
+        nconn = 1
+        if 0 < irch < nreaches - 1:
+            nconn += 1
+        rp = [
+            irch,
+            (0, rMid, irch),
+            rlen,
+            rwid,
+            slope,
+            top[rMid, irch] - strm_incision,
+            rbth,
+            rhk,
+            roughness,
+            nconn,
+            ustrf,
+            ndv,
+        ]
+        packagedata.append(rp)
+
+    connectiondata = []
+    for irch in range(nreaches):
+        rc = [irch]
+        if irch > 0:
+            rc.append(irch - 1)
+        if irch < nreaches - 1:
+            rc.append(-(irch + 1))
+        connectiondata.append(rc)
+
+    sfrbndx = []
+    for i in np.arange(nreaches):
+        if i == 0:
+            sfrbndx.append([i, "INFLOW", surf_Q_in])
+        sfrbndx.append([i, "EVAPORATION", sfr_evaprate])
+
+    sfr_perioddata = {0: sfrbndx}
+
+    # Instantiate SFR observation points
+    sfr_obs = {
+        "{}.sfrobs".format(gwfname_trapezoidal): [
+            ("rch1_in", "ext-inflow", 1),  # For now, these need to be 1-based
+            ("rch1_rain", "rainfall", 1),
+            ("rch1_evap", "evaporation", 1),
+            ("rch1_runoff", "runoff", 1),
+            ("rch1_flow", "sfr", 1),
+            ("rch1_out", "downstream-flow", 1),
+            ("rch1_xsec_area", "wet-area", 1),
+            ("rch1_top_width", "wet-width", 1),
+            ("rch1_depth", "depth", 1),
+            ("rch1_stg", "stage", 1),
+        ],
+        "digits": 8,
+        "print_input": True,
+        "filename": name + ".sfr.obs",
+    }
+
+    budpth = f"{gwfname_trapezoidal}.sfr.cbc"
+    flopy.mf6.ModflowGwfsfr(
+        gwft,
+        save_flows=True,
+        print_stage=True,
+        print_flows=True,
+        print_input=True,
+        unit_conversion=1.0 * 86400,
+        budget_filerecord=budpth,
+        mover=False,
+        nreaches=nreaches,
+        packagedata=packagedata,
+        connectiondata=connectiondata,
+        crosssections=crosssections,
+        perioddata=sfr_perioddata,
+        observations=sfr_obs,
+        pname="SFR-1",
+        filename="{}.sfr".format(gwfname_trapezoidal),
+    )
+
+    # ---------------------------------------------------------------------------
+    # Add a second GWF model that simulates a typical rectangular stream channel
+    # ---------------------------------------------------------------------------
+
+    gwfr = flopy.mf6.ModflowGwf(
+        sim,
+        modelname=gwfname_rectangular,
+        save_flows=True,
+        newtonoptions="newton",
+    )
+
+    # Instantiating solver
+    # (use same settings as above)
+    ims2 = flopy.mf6.ModflowIms(
+        sim,
+        print_option="ALL",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="cooley",
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        rcloserecord=rclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        filename="{}.ims".format(gwfname_trapezoidal),
+    )
+    sim.register_ims_package(ims2, [gwfname_rectangular])
+
+    # Instantiate discretization package
+    flopy.mf6.ModflowGwfdis(
+        gwfr,
+        length_units=length_units,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=delr,
+        delc=delc,
+        top=top,
+        botm=botm,
+    )
+
+    # Instantiate node property flow package
+    flopy.mf6.ModflowGwfnpf(
+        gwfr,
+        save_specific_discharge=True,
+        icelltype=1,  # >0 means saturated thickness varies with computed head
+        k=k11,
+    )
+
+    # Instantiate storage package
+    flopy.mf6.ModflowGwfsto(
+        gwfr,
+        save_flows=False,
+        iconvert=laytyp,
+        ss=ss,
+        sy=sy,
+        steady_state=steady,
+        transient=transient,
+    )
+
+    # Instantiate initial conditions package
+    flopy.mf6.ModflowGwfic(gwfr, strt=strthd)
+
+    # Instantiate output control package
+    flopy.mf6.ModflowGwfoc(
+        gwfr,
+        budget_filerecord=f"{gwfname_rectangular}.cbc",
+        head_filerecord=f"{gwfname_rectangular}.hds",
+        headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
+    # Instantiate streamflow routing package
+    # Uses same datasets established above except does not include x-sections
+    budpth = f"{gwfname_rectangular}.sfr.cbc"
+    flopy.mf6.ModflowGwfsfr(
+        gwfr,
+        save_flows=True,
+        print_stage=True,
+        print_flows=True,
+        print_input=True,
+        unit_conversion=1.0 * 86400,
+        budget_filerecord=budpth,
+        mover=False,
+        nreaches=nreaches,
+        packagedata=packagedata,
+        connectiondata=connectiondata,
+        perioddata=sfr_perioddata,
+        pname="SFR-2",
+        filename="{}.sfr".format(gwfname_rectangular),
+    )
+
+    return sim, None
+
+
+def eval_results(sim):
+    print("evaluating results...")
+
+    # read flow results from model
+    name = ex[sim.idxsim]
+    gwfname_t = "gwf-" + name + "-t"
+    gwfname_r = "gwf-" + name + "-r"
+
+    fname = gwfname_t + ".sfr.cbc"
+    fname = os.path.join(sim.simpath, fname)
+    assert os.path.isfile(fname)
+
+    sfrobj = flopy.utils.binaryfile.CellBudgetFile(fname, precision="double")
+    sfrevap = sfrobj.get_data(text="EVAPORATION")
+
+    # Extract evap
+    sim_evap = []
+    for i in range(ncol):
+        sim_evap.append(sfrevap[-1][i][2])
+
+    sim_evap = np.array(sim_evap)
+
+    # Establish known answer:
+    stored_strm_evap = np.array(
+        [
+            -66.01388942706727,
+            -65.99953139524196,
+            -65.98517173673817,
+            -65.97081044940869,
+            -65.95644753110243,
+        ]
+    )
+
+    msg = "The SFR evaporation test with n-point x-section (trapezoid) is failing."
+    assert np.allclose(stored_strm_evap, sim_evap, atol=1e-4), msg
+
+    # Now check results from standard rectangular x-section setup (not an n-point channel)
+    fname2 = gwfname_r + ".sfr.cbc"
+    fname2 = os.path.join(sim.simpath, fname2)
+    assert os.path.isfile(fname2)
+
+    sfrobj = flopy.utils.binaryfile.CellBudgetFile(fname2, precision="double")
+    sfrevap_r = sfrobj.get_data(text="EVAPORATION")
+
+    # Extract evap
+    sim_evap_r = []
+    for i in range(ncol):
+        sim_evap_r.append(sfrevap_r[-1][i][2])
+
+    sim_evap_r = np.array(sim_evap_r)
+
+    # Establish known answer:
+    stored_strm_evap_r = np.array([-90.0] * 5)
+
+    msg = "The SFR evaporation test with rectangular geometry is failing."
+    assert np.allclose(stored_strm_evap_r, sim_evap_r, atol=1e-4), msg
+
+
+# - No need to change any code below
+@pytest.mark.parametrize(
+    "idx, dir",
+    list(enumerate(exdirs)),
+)
+def test_mf6model(idx, dir):
+    # initialize testing framework
+    test = testing_framework()
+
+    # build the model
+    test.build_mf6_models(build_model, idx, dir)
+
+    # run the test model
+    test.run_mf6(Simulation(dir, exfunc=eval_results, idxsim=idx))
+
+
+def main():
+    # initialize testing framework
+    test = testing_framework()
+
+    # run the test model
+    for idx, dir in enumerate(exdirs):
+        test.build_mf6_models(build_model, idx, dir)
+        sim = Simulation(dir, exfunc=eval_results, idxsim=idx)
+        test.run_mf6(sim)
+
+
+if __name__ == "__main__":
+    # print message
+    print(f"standalone run of {os.path.basename(__file__)}")
+
+    # run main routine
+    main()

--- a/doc/ReleaseNotes/v6.5.0.tex
+++ b/doc/ReleaseNotes/v6.5.0.tex
@@ -20,7 +20,7 @@
 	\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
 	\underline{BASIC FUNCTIONALITY}
 	\begin{itemize}
-		\item xxx
+		\item When n-point cross-sections are active in SFR, the evaporation calculation uses the variable rwid (see MF6io.pdf) to calculate the total amount of evaporation even though the wetted topwidth is less than rwid.  For example, using a trapezoidal cross-section geometry with an rwid of 10, an rlen of 100, and prescribed evaporation rate of 0.1, the calculated evaporative losses would equal 100 even when the wetted top width was only 5.0 units wide.  With this bug fix, the evaporation in this example results in only 50 units of evaporation loss.  A new autotests confirms the evaporation calculation using an n-point cross-section and common rectangular geometries in the same simulation.  It is also worth mentioning that the precipitation calculation currently uses rwid.  Since the precipitation falling outside the margins of the wetted top width but within rwid would likely be accumulated in a channel, it makes sense to leave this calculation as is.
 	%	\item xxx
 	%	\item xxx
 	\end{itemize}

--- a/src/Model/GroundWaterFlow/gwf3sfr8.f90
+++ b/src/Model/GroundWaterFlow/gwf3sfr8.f90
@@ -3272,6 +3272,7 @@ contains
     integer(I4B) :: ibflg
     real(DP) :: hgwf
     real(DP) :: sa
+    real(DP) :: sa_wet
     real(DP) :: qu
     real(DP) :: qi
     real(DP) :: qr
@@ -3355,9 +3356,10 @@ contains
     this%usflow(n) = qu
     ! -- calculate remaining terms
     sa = this%calc_surface_area(n)
+    sa_wet = this%calc_surface_area_wet(n, this%depth(n))
     qi = this%inflow(n)
     qr = this%rain(n) * sa
-    qe = this%evap(n) * sa
+    qe = this%evap(n) * sa_wet
     qro = this%runoff(n)
     !
     ! -- Water mover term; assume that it goes in at the upstream end of the reach
@@ -3831,7 +3833,7 @@ contains
     a = this%calc_surface_area(n)
     ae = this%calc_surface_area_wet(n, depth)
     qr = this%rain(n) * a
-    qe = this%evap(n) * a
+    qe = this%evap(n) * ae
     !
     ! -- calculate mover term
     qfrommvr = DZERO


### PR DESCRIPTION
Currently, evaporation from SFR reaches uses the variable rwid even if the wetted top width in a n-point cross-section is narrower than rwid.

- Includes new autotest (ran black)
- Ran fprettify
- Includes a short description of bug in appropriate release notes .tex file
- Visual inspection of SFR budgets in .lst file looks good
- Rain calculations are currently using the fixed rwid value and not taking into account changing surface area widths associated with an irregular n-point cross-section, but this is probably OK as the rain falling on the dried channel width  falling between `rwid` and the actual wetted top width (< `rwid`) would likely be accumulated in the channel.  
- Also, in `gwf3sfr8.f90` the following code, starting around line 2200, may need updating to account for n-point cross-sections?  In other words, should `this%calc_surface_area(n)` instead be `this%calc_surface_area_wet(n)`?:
```
    !
    ! -- perform package convergence check
    if (icheck /= 0) then
      final_check: do n = 1, this%maxbound
        if (this%iboundpak(n) == 0) cycle
        dh = this%stage0(n) - this%stage(n)
        !
        ! -- evaluate flow difference if the time step is transient
        if (this%gwfiss == 0) then
          r = this%usflow0(n) - this%usflow(n)
          !
          ! -- normalize flow difference and convert to a depth
          r = r * delt / this%calc_surface_area(n)
```
