### PR TITLE
ci: add nightly job to cache intel compilers

### DIFF
--- a/.github/workflows/large.yml
+++ b/.github/workflows/large.yml
@@ -3,6 +3,16 @@ on:
   schedule:
     - cron: '0 6 * * *' # run at 6 AM UTC every day
 jobs:
+  cache_ifort:
+    name: Cache Intel OneAPI compilers
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04, macos-12, windows-2022 ]
+    steps:
+      - name: Setup Intel Fortran
+        uses: modflowpy/install-intelfortran-action@v1
   test:
     name: Test
     runs-on: ubuntu-22.04


### PR DESCRIPTION
According to the [cache docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache) a cache created on the default branch (`develop` in this repo) can be restored by feature branches:

> Workflow runs can restore caches created in either the current branch or the default branch

Testing [on my fork](https://github.com/w-bonelli/modflow6/pull/53) before marking ready. If it works, we can cache oneAPI compilers overnight and restore from `develop` and PR branches all day. Since the key is now invalidated daily, the cache currently starts each day cold until a PR is merged to `develop`.