### PR TITLE
feat(uzf): add qfrommvr convergence check to UZF

### DIFF
--- a/autotest/simulation.py
+++ b/autotest/simulation.py
@@ -771,7 +771,7 @@ class Simulation(object):
                             f"{os.path.basename(fpth0)} - "
                             + f"{key:16s} "
                             + f"difference ({diffmax:10.4g}) "
-                            + f"> {self.pdtol:10.4g} "
+                            + f"> {vmin_tol:10.4g} "
                             + f"at {indices.size} nodes "
                             + f" [first location ({indices[0] + 1})] "
                             + f"at time {t} "

--- a/autotest/test_z01_testmodels_mf6.py
+++ b/autotest/test_z01_testmodels_mf6.py
@@ -189,8 +189,8 @@ def set_make_comparison(test):
         "test051_uzfp3_lakmvr_v2": ("6.2.1",),
         "test051_uzfp3_wellakmvr_v2": ("6.2.1",),
         "test045_lake4ss": ("6.2.2",),
-        "test056_mt3dms_usgs_gwtex_dev": ("6.2.2",),
-        "test056_mt3dms_usgs_gwtex_IR_dev": ("6.2.2",),
+        "test056_mt3dms_usgs_gwtex_dev": ("6.4.1",),
+        "test056_mt3dms_usgs_gwtex_IR_dev": ("6.4.1",),
     }
     make_comparison = True
     if test in compare_tests.keys():
@@ -200,6 +200,7 @@ def set_make_comparison(test):
         print(f"MODFLOW regression version='{version}'")
         if version in compare_tests[test]:
             make_comparison = False
+            print(f"Make comparison has been set to False.")
     return make_comparison
 
 

--- a/doc/ReleaseNotes/v6.5.0.tex
+++ b/doc/ReleaseNotes/v6.5.0.tex
@@ -39,12 +39,12 @@
 	%	\item xxx
 	%\end{itemize}
 
-	%\underline{ADVANCED STRESS PACKAGES}
-	%\begin{itemize}
+	\underline{ADVANCED STRESS PACKAGES}
+	\begin{itemize}
+		\item Added additional convergence check to the Unsaturated Zone Flow (UZF) Package to ensure that flows from the Water Mover (MVR) Package meet solver tolerance.  Mover flows are converted into depths using the time step length and UZF cell area, and the depths are compared to the Iterative Model Solution (IMS) DVCLOSE input parameter.  If a depth is greater than DVCLOSE, then the iteration is marked as not converged.  The maximum depth and UZF cell number is written for each outer iteration to a comma-separated value file, provided the PACKAGE\_CONVERGENCE option is specified for UZF.
 	%	\item xxx
 	%	\item xxx
-	%	\item xxx
-	%\end{itemize}
+	\end{itemize}
 
 	%\underline{SOLUTION}
 	%\begin{itemize}

--- a/doc/ReleaseNotes/v6.5.0.tex
+++ b/doc/ReleaseNotes/v6.5.0.tex
@@ -41,7 +41,7 @@
 
 	\underline{ADVANCED STRESS PACKAGES}
 	\begin{itemize}
-		\item Added additional convergence check to the Unsaturated Zone Flow (UZF) Package to ensure that flows from the Water Mover (MVR) Package meet solver tolerance.  Mover flows are converted into depths using the time step length and UZF cell area, and the depths are compared to the Iterative Model Solution (IMS) DVCLOSE input parameter.  If a depth is greater than DVCLOSE, then the iteration is marked as not converged.  The maximum depth and UZF cell number is written for each outer iteration to a comma-separated value file, provided the PACKAGE\_CONVERGENCE option is specified for UZF.
+		\item Added additional convergence checks to the Streamflow Routing (SFR), Lake (LAK) and Unsaturated Zone Flow (UZF) Packages to ensure that flows from the Water Mover (MVR) Package meet solver tolerance.  Mover flows are converted into depths using the time step length and area, and the depths are compared to the Iterative Model Solution (IMS) DVCLOSE input parameter.  If a depth is greater than DVCLOSE, then the iteration is marked as not converged.  The maximum depth change between iterations and the advanced package feature number is written for each outer iteration to a comma-separated value file, provided the PACKAGE\_CONVERGENCE option is specified in the options block.
 	%	\item xxx
 	%	\item xxx
 	\end{itemize}

--- a/src/Model/GroundWaterFlow/gwf3lak8.f90
+++ b/src/Model/GroundWaterFlow/gwf3lak8.f90
@@ -4163,7 +4163,7 @@ contains
             call this%lak_calculate_outlet_outflow(n, hlak0, inf, qout0)
             call this%lak_calculate_available(n, hlak, inf, ra, ro, qinf, ex)
             call this%lak_calculate_outlet_outflow(n, hlak, inf, qout)
-            dqout = (qout0 - qout) * delt / area
+            dqout = (qout0 - qout) * qtolfact
           end if
         end if
         !

--- a/src/Model/GroundWaterFlow/gwf3sfr8.f90
+++ b/src/Model/GroundWaterFlow/gwf3sfr8.f90
@@ -2136,13 +2136,19 @@ contains
     integer(I4B) :: ipakfail
     integer(I4B) :: locdhmax
     integer(I4B) :: locrmax
+    integer(I4B) :: locdqfrommvrmax
     integer(I4B) :: ntabrows
     integer(I4B) :: ntabcols
     integer(I4B) :: n
+    real(DP) :: q
+    real(DP) :: q0
+    real(DP) :: qtolfact
     real(DP) :: dh
     real(DP) :: r
     real(DP) :: dhmax
     real(DP) :: rmax
+    real(DP) :: dqfrommvr
+    real(DP) :: dqfrommvrmax
     !
     ! -- initialize local variables
     icheck = this%iconvchk
@@ -2152,6 +2158,8 @@ contains
     r = DZERO
     dhmax = DZERO
     rmax = DZERO
+    locdqfrommvrmax = 0
+    dqfrommvrmax = DZERO
     !
     ! -- if not saving package convergence data on check convergence if
     !    the model is considered converged
@@ -2169,6 +2177,9 @@ contains
         ! -- determine the number of columns and rows
         ntabrows = 1
         ntabcols = 9
+        if (this%imover == 1) then
+          ntabcols = ntabcols + 2
+        end if
         !
         ! -- setup table
         call table_cr(this%pakcsvtab, this%packName, '')
@@ -2195,6 +2206,12 @@ contains
         call this%pakcsvtab%initialize_column(tag, 15, alignment=TABLEFT)
         tag = 'dinflowmax_loc'
         call this%pakcsvtab%initialize_column(tag, 15, alignment=TABLEFT)
+        if (this%imover == 1) then
+          tag = 'dqfrommvrmax'
+          call this%pakcsvtab%initialize_column(tag, 15, alignment=TABLEFT)
+          tag = 'dqfrommvrmax_loc'
+          call this%pakcsvtab%initialize_column(tag, 16, alignment=TABLEFT)
+        end if
       end if
     end if
     !
@@ -2202,6 +2219,11 @@ contains
     if (icheck /= 0) then
       final_check: do n = 1, this%maxbound
         if (this%iboundpak(n) == 0) cycle
+        !
+        ! -- set the Q to length factor
+        qtolfact = delt / this%calc_surface_area(n)
+        !
+        ! -- calculate stage change
         dh = this%stage0(n) - this%stage(n)
         !
         ! -- evaluate flow difference if the time step is transient
@@ -2209,7 +2231,15 @@ contains
           r = this%usflow0(n) - this%usflow(n)
           !
           ! -- normalize flow difference and convert to a depth
-          r = r * delt / this%calc_surface_area(n)
+          r = r * qtolfact
+        end if
+        !
+        ! -- q from mvr
+        dqfrommvr = DZERO
+        if (this%imover == 1) then
+          q = this%pakmvrobj%get_qfrommvr(n)
+          q0 = this%pakmvrobj%get_qfrommvr0(n)
+          dqfrommvr = qtolfact * (q0 - q)
         end if
         !
         ! -- evaluate magnitude of differences
@@ -2218,6 +2248,8 @@ contains
           dhmax = dh
           locrmax = n
           rmax = r
+          dqfrommvrmax = dqfrommvr
+          locdqfrommvrmax = n
         else
           if (abs(dh) > abs(dhmax)) then
             locdhmax = n
@@ -2226,6 +2258,10 @@ contains
           if (abs(r) > abs(rmax)) then
             locrmax = n
             rmax = r
+          end if
+          if (ABS(dqfrommvr) > abs(dqfrommvrmax)) then
+            dqfrommvrmax = dqfrommvr
+            locdqfrommvrmax = n
           end if
         end if
       end do final_check
@@ -2243,6 +2279,14 @@ contains
         write (cloc, "(a,'-',a)") trim(this%packName), 'inflow'
         cpak = trim(cloc)
       end if
+      if (this%imover == 1) then
+        if (ABS(dqfrommvrmax) > abs(dpak)) then
+          ipak = locdqfrommvrmax
+          dpak = dqfrommvrmax
+          write (cloc, "(a,'-',a)") trim(this%packName), 'qfrommvr'
+          cpak = trim(cloc)
+        end if
+      end if
       !
       ! -- write convergence data to package csv
       if (this%ipakcsv /= 0) then
@@ -2257,6 +2301,10 @@ contains
         call this%pakcsvtab%add_term(locdhmax)
         call this%pakcsvtab%add_term(rmax)
         call this%pakcsvtab%add_term(locrmax)
+        if (this%imover == 1) then
+          call this%pakcsvtab%add_term(dqfrommvrmax)
+          call this%pakcsvtab%add_term(locdqfrommvrmax)
+        end if
         !
         ! -- finalize the package csv
         if (iend == 1) then

--- a/src/Model/ModelUtilities/PackageMover.f90
+++ b/src/Model/ModelUtilities/PackageMover.f90
@@ -17,10 +17,11 @@ module PackageMoverModule
     integer(I4B), pointer :: nproviders
     integer(I4B), pointer :: nreceivers
     integer(I4B), dimension(:), pointer, contiguous :: iprmap => null() !< map between id1 and feature (needed for lake to map from outlet to lake number)
-    real(DP), dimension(:), pointer, contiguous :: qtformvr => null()
-    real(DP), dimension(:), pointer, contiguous :: qformvr => null()
-    real(DP), dimension(:), pointer, contiguous :: qtomvr => null()
-    real(DP), dimension(:), pointer, contiguous :: qfrommvr => null()
+    real(DP), dimension(:), pointer, contiguous :: qtformvr => null() !< total flow rate available for mover
+    real(DP), dimension(:), pointer, contiguous :: qformvr => null() !< currently available consumed water (changes during fc)
+    real(DP), dimension(:), pointer, contiguous :: qtomvr => null() !< actual amount of water sent to mover
+    real(DP), dimension(:), pointer, contiguous :: qfrommvr => null() !< actual amount of water received from mover
+    real(DP), dimension(:), pointer, contiguous :: qfrommvr0 => null() !< qfrommvr from previous iteration
 
   contains
     procedure :: ar
@@ -31,6 +32,7 @@ module PackageMoverModule
     procedure :: allocate_scalars
     procedure :: allocate_arrays
     procedure :: get_qfrommvr
+    procedure :: get_qfrommvr0
     procedure :: get_qtomvr
     procedure :: accumulate_qformvr
 
@@ -51,6 +53,7 @@ contains
     call mem_setptr(packagemover%qformvr, 'QFORMVR', packagemover%memoryPath)
     call mem_setptr(packagemover%qtomvr, 'QTOMVR', packagemover%memoryPath)
     call mem_setptr(packagemover%qfrommvr, 'QFROMMVR', packagemover%memoryPath)
+    call mem_setptr(packagemover%qfrommvr0, 'QFROMMVR0', packagemover%memoryPath)
   end subroutine set_packagemover_pointer
 
   subroutine nulllify_packagemover_pointer(packagemover)
@@ -63,6 +66,7 @@ contains
     packagemover%qformvr => null()
     packagemover%qtomvr => null()
     packagemover%qfrommvr => null()
+    packagemover%qfrommvr0 => null()
   end subroutine nulllify_packagemover_pointer
 
   subroutine ar(this, nproviders, nreceivers, memoryPath)
@@ -102,6 +106,7 @@ contains
     !
     ! -- set frommvr and qtomvr to zero
     do i = 1, this%nreceivers
+      this%qfrommvr0(i) = this%qfrommvr(i)
       this%qfrommvr(i) = DZERO
     end do
     do i = 1, this%nproviders
@@ -135,6 +140,7 @@ contains
     call mem_deallocate(this%qformvr)
     call mem_deallocate(this%qtomvr)
     call mem_deallocate(this%qfrommvr)
+    call mem_deallocate(this%qfrommvr0)
     !
     ! -- scalars
     call mem_deallocate(this%nproviders)
@@ -169,6 +175,7 @@ contains
     call mem_allocate(this%qformvr, this%nproviders, 'QFORMVR', this%memoryPath)
     call mem_allocate(this%qtomvr, this%nproviders, 'QTOMVR', this%memoryPath)
     call mem_allocate(this%qfrommvr, this%nreceivers, 'QFROMMVR', this%memoryPath)
+    call mem_allocate(this%qfrommvr0, this%nreceivers, 'QFROMMVR0', this%memoryPath)
     !
     ! -- initialize
     do i = 1, this%nproviders
@@ -179,6 +186,7 @@ contains
     end do
     do i = 1, this%nreceivers
       this%qfrommvr(i) = DZERO
+      this%qfrommvr0(i) = DZERO
     end do
     !
     ! -- return
@@ -191,6 +199,13 @@ contains
     integer, intent(in) :: ireceiver
     qfrommvr = this%qfrommvr(ireceiver)
   end function get_qfrommvr
+
+  function get_qfrommvr0(this, ireceiver) result(qfrommvr0)
+    class(PackageMoverType) :: this
+    real(DP) :: qfrommvr0
+    integer, intent(in) :: ireceiver
+    qfrommvr0 = this%qfrommvr0(ireceiver)
+  end function get_qfrommvr0
 
   function get_qtomvr(this, iprovider) result(qtomvr)
     class(PackageMoverType) :: this

--- a/src/Model/ModelUtilities/PackageMover.f90
+++ b/src/Model/ModelUtilities/PackageMover.f90
@@ -175,7 +175,8 @@ contains
     call mem_allocate(this%qformvr, this%nproviders, 'QFORMVR', this%memoryPath)
     call mem_allocate(this%qtomvr, this%nproviders, 'QTOMVR', this%memoryPath)
     call mem_allocate(this%qfrommvr, this%nreceivers, 'QFROMMVR', this%memoryPath)
-    call mem_allocate(this%qfrommvr0, this%nreceivers, 'QFROMMVR0', this%memoryPath)
+    call mem_allocate(this%qfrommvr0, this%nreceivers, 'QFROMMVR0', &
+                      this%memoryPath)
     !
     ! -- initialize
     do i = 1, this%nproviders


### PR DESCRIPTION
* update release notes
* store previous qfrommvr iterate in PackageMover
* add qfrommvr convergence check to UZF, SFR, and LAK.  The qfrommvr rate is converted into a depth (using delt over area), which is used to check against DVCLOSE.  
* Related to #1116