### PR TITLE
ci: add filelock as readthedocs dependency

### DIFF
--- a/.build_rtd_docs/requirements.rtd.txt
+++ b/.build_rtd_docs/requirements.rtd.txt
@@ -9,3 +9,4 @@ rtds_action
 myst_parser
 sphinx_rtd_theme
 pytest
+filelock


### PR DESCRIPTION
Neglected to add `filelock` as another ReadTheDocs dependency in #1132. Like `pytest`, this is used by `update_version.py`, which is run in the automated ReadTheDocs build to update timestamps.