### PR TITLE
ci: fix readthedocs

### DIFF
--- a/.build_rtd_docs/conf.py
+++ b/.build_rtd_docs/conf.py
@@ -17,6 +17,7 @@ import sys
 from subprocess import Popen, PIPE
 
 sys.path.insert(0, os.path.abspath(os.path.join("..", "doc")))
+sys.path.insert(0, os.path.abspath(os.path.join("..", "distribution")))
 
 # -- determine if running on readthedocs ------------------------------------
 on_rtd = os.environ.get("READTHEDOCS") == "True"
@@ -35,18 +36,8 @@ for dox_pth in dox_pths:
 
 # -- Update the modflow 6 version -------------------------------------------
 print("Update the modflow6 version")
-pth = os.path.join("..", "distribution")
-args = (
-    "python",
-    "update_version.py",
-)
-# run the command
-proc = Popen(args, stdout=PIPE, stderr=PIPE, cwd=pth)
-stdout, stderr = proc.communicate()
-if stdout:
-    print(stdout.decode("utf-8"))
-if stderr:
-    print("Errors:\n{}".format(stderr.decode("utf-8")))
+from update_version import update_version
+update_version()
 
 # -- import version from doc/version.py -------------------------------------
 from version import __version__
@@ -92,7 +83,7 @@ with open("Doxyfile", "w") as fp:
 # -- Project information -----------------------------------------------------
 
 project = "MODFLOW 6 Program Documentation"
-copyright = "2020, MODFLOW Development Team"
+copyright = "2023, MODFLOW Development Team"
 author = "MODFLOW Development Team"
 
 # -- Project version ---------------------------------------------------------

--- a/.build_rtd_docs/requirements.rtd.txt
+++ b/.build_rtd_docs/requirements.rtd.txt
@@ -6,7 +6,8 @@ nbsphinx_link
 ipython
 ipykernel
 rtds_action
-myst_parser
+myst-parser
 sphinx_rtd_theme
 pytest
 filelock
+modflow-devtools

--- a/.doc/conf.py
+++ b/.doc/conf.py
@@ -49,7 +49,7 @@ if not on_rtd:
 # -- Project information -----------------------------------------------------
 
 project = "MODFLOW 6 Program Documentation"
-copyright = "2020, MODFLOW Development Team"
+copyright = "2023, MODFLOW Development Team"
 author = "MODFLOW Development Team"
 
 # -- General configuration ---------------------------------------------------
@@ -70,7 +70,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "IPython.sphinxext.ipython_console_highlighting",  # lowercase didn't work
     "sphinx.ext.autosectionlabel",
-    "recommonmark",
+    "myst_parser",
     "sphinx_markdown_tables",
 ]
 

--- a/.doc/requirements.txt
+++ b/.doc/requirements.txt
@@ -3,4 +3,4 @@ ipython
 ipykernel
 rtds_action
 sphinx_rtd_theme
-recommonmark
+myst-parser

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,8 +22,6 @@ jobs:
         shell: bash -l {0}
     env:
       GCC_V: 12
-      working-directory: .build_rtd_docs
-      distribution-directory: distribution
 
     steps:
       - name: Checkout modflow6
@@ -52,12 +50,10 @@ jobs:
 
       - name: Install additional packages for Sphinx using pip
         working-directory: modflow6/.build_rtd_docs
-        run: |
-          pip install -r requirements.rtd.txt
+        run: pip install -r requirements.rtd.txt
 
       - name: Print python package versions
-        run: |
-          pip list
+        run: pip list
 
       - name: Install TeX Live
         run: |
@@ -66,13 +62,11 @@ jobs:
 
       - name: Install USGS LaTeX style files and Univers font
         working-directory: usgslatex/usgsLaTeX
-        run: |
-          sudo ./install.sh --all-users
+        run: sudo ./install.sh --all-users
 
       - name: Test building files from dfn's for LaTeX
         working-directory: modflow6/autotest
-        run: |
-          pytest -v build_mfio_tex.py
+        run: pytest -v build_mfio_tex.py
 
       - name: Setup GNU Fortran ${{ env.GCC_V }}
         uses: awvwgk/setup-fortran@main
@@ -103,21 +97,19 @@ jobs:
 
       - name: Run benchmarks
         working-directory: modflow6/distribution
+        run: python benchmark.py
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: python benchmark.py
 
       - name: Run sphinx
         working-directory: modflow6/.build_rtd_docs
-        run: |
-          make html
+        run: make html
 
-      - name: Show results
+      - name: Show benchmarks
         working-directory: modflow6/distribution
-        run: |
-          cat run-time-comparison.md
+        run: cat run-time-comparison.md
 
-      - name: Upload comparison
+      - name: Upload benchmarks
         uses: actions/upload-artifact@v3
         with:
           name: run-time-comparison
@@ -128,9 +120,9 @@ jobs:
         with:
           name: rtd-files-for-${{ github.sha }}
           path: |
-            modflow6/.build_rtd_docs/
             modflow6/.build_rtd_docs/index.rst
             modflow6/.build_rtd_docs/mf6io.rst
+            # run-time-comparison is moved to _mf6run by conf.py
             modflow6/.build_rtd_docs/_mf6run/
             modflow6/.build_rtd_docs/_mf6io/
             modflow6/.build_rtd_docs/_static/


### PR DESCRIPTION
~~I think this is the last remaining issue breaking the ReadTheDocs build. I tried setting up another RTD project to debug on my fork, but couldn't match this repo's configuration.~~

Fix automated RTD builds where #1132 and #1135 failed to do so. Tested on my fork with a [separate RTD integration](https://modflow6-w-bonelli-test.readthedocs.io/en/latest/index.html). Apologies for all the PRs. Also:

- update copyright year from 2020 to 2023
- use `myst-parser`, drop `recommonmark` [as per recommendation](https://github.com/readthedocs/recommonmark/issues/221)
- use `update_version()` function directly in `conf.py` instead of `Popen`