### PR TITLE
refactor(dist scripts): update modflow-devtools usages

### DIFF
--- a/autotest/get_exes.py
+++ b/autotest/get_exes.py
@@ -41,7 +41,6 @@ def test_rebuild_release(rebuilt_bin_path: Path):
     print(f"Rebuilding and installing last release to: {rebuilt_bin_path}")
     release = get_release(repository)
     assets = release["assets"]
-    ostag = get_ostag()
     asset = next(
         iter([a for a in assets if a["name"] == get_asset_name(a)]), None
     )

--- a/distribution/benchmark.py
+++ b/distribution/benchmark.py
@@ -10,9 +10,9 @@ from pathlib import Path
 from typing import List, Tuple
 
 import flopy
-import pymake
 import pytest
 from modflow_devtools.build import meson_build
+from modflow_devtools.download import download_and_unzip, get_latest_version
 from modflow_devtools.misc import get_model_paths
 
 from utils import get_project_root_path
@@ -31,16 +31,15 @@ _soext = ".dll" if _is_windows else ".so"
 
 def download_previous_version(output_path: PathLike) -> Tuple[str, Path]:
     output_path = Path(output_path).expanduser().absolute()
-    version = pymake.repo_latest_version(github_repo=_github_repo, verify=_verify)
+    version = get_latest_version(_github_repo)
     url = (
         f"https://github.com/{_github_repo}"
         + f"/releases/download/{version}/mf{version}.zip"
     )
-    pymake.download_and_unzip(
+    download_and_unzip(
         url,
-        pth=str(output_path),
+        path=output_path,
         verbose=True,
-        verify=_verify,
     )
 
     return version, output_path / f"mf{version}"

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -3,12 +3,10 @@ import os
 import platform
 import shutil
 import textwrap
-from _warnings import warn
 from datetime import datetime
 from os import PathLike
 from pathlib import Path
 from pprint import pprint
-from shutil import which
 from tempfile import TemporaryDirectory
 from typing import List, Optional
 from urllib.error import HTTPError
@@ -96,17 +94,17 @@ def clean_tex_files():
     assert not os.path.isfile(str(pth) + ".pdf")
 
 
-def download_benchmarks(output_path: PathLike, quiet: bool = True) -> Optional[Path]:
+def download_benchmarks(output_path: PathLike, verbose: bool = False) -> Optional[Path]:
     output_path = Path(output_path).expanduser().absolute()
     name = "run-time-comparison"
     repo = "w-bonelli/modflow6"
-    artifacts = list_artifacts(repo, name=name, quiet=quiet)
+    artifacts = list_artifacts(repo, name=name, verbose=verbose)
     artifacts = sorted(artifacts, key=lambda a: datetime.strptime(a['created_at'], '%Y-%m-%dT%H:%M:%SZ'), reverse=True)
     most_recent = next(iter(artifacts), None)
     print(f"Found most recent benchmarks (artifact {most_recent['id']})")
     if most_recent:
         print(f"Downloading benchmarks (artifact {most_recent['id']})")
-        download_artifact(repo, id=most_recent['id'], path=output_path, quiet=quiet)
+        download_artifact(repo, id=most_recent['id'], path=output_path, verbose=verbose)
         print(f"Downloaded benchmarks to {output_path}")
         path = output_path / f"{name}.md"
         assert path.is_file()
@@ -119,7 +117,7 @@ def download_benchmarks(output_path: PathLike, quiet: bool = True) -> Optional[P
 @flaky
 @requires_github
 def test_download_benchmarks(tmp_path):
-    path = download_benchmarks(tmp_path, quiet=False)
+    path = download_benchmarks(tmp_path, verbose=True)
     if path:
         assert path.name == "run-time-comparison.md"
 


### PR DESCRIPTION
Update `modflow-devtools` usages in distribution scripts. This is to reflect changes introduced in https://github.com/MODFLOW-USGS/modflow-devtools/pull/68. These include improvements to utility functions used for querying/downloading from the GitHub API, including standardized signatures and adding retries. This seemed worthwhile for consistency and resilience to transient network errors, but will try to keep further breaking changes to devtools to an absolute minimum.

To avoid breaking the nightly build, this will need to be merged the same day that a [new version of devtools](https://github.com/MODFLOW-USGS/modflow-devtools/pull/72) is released. CI is expected to fail here in the meantime, pending such.

This PR also replaces a lingering `pymake` usage.