### PR TITLE
ci: fix release branch matching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - v*
+      - v[0-9]+.[0-9]+.[0-9]+*
   release:
     types:
       - published


### PR DESCRIPTION
Match release branches with more selective glob pattern `v[0-9]+.[0-9]+.[0-9]+*`. Previous pattern `v*` matched anything starting with "v". Tested on my fork.