### PR TITLE
fix(dependencies): remove explicit xmipy dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,6 @@ dependencies:
   - pip:
       - git+https://github.com/modflowpy/flopy.git
       - git+https://github.com/modflowpy/pymake.git
-      - git+https://github.com/Deltares/xmipy.git
       - git+https://github.com/MODFLOW-USGS/modflowapi.git
       - modflow-devtools
   - pytest


### PR DESCRIPTION
Today's [update](https://github.com/MODFLOW-USGS/modflowapi/commit/de4452c64d2f0091068af177eae609db7ccce40c#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52R40) to `modflowapi` led to [dependency resolution issues](https://github.com/MODFLOW-USGS/modflow6/actions/runs/4188649571/jobs/7260041004) with the modflow6 Conda environment. Conda does not seem to check pip/GitHub dependencies to determine whether they point to the same branch.

Remove `xmipy` from `environment.yml` since `modflowapi` will install it as its own dependency &mdash; `modflowapi` is used directly in autotests, but `xmipy` is not.