### PR TITLE
fix(Python paths): use absolute paths for scripts and Python executable

### DIFF
--- a/.build_rtd_docs/conf.py
+++ b/.build_rtd_docs/conf.py
@@ -59,7 +59,7 @@ shutil.copy(src, dst)
 # -- build the mf6io markdown files -----------------------------------------
 print("Build the mf6io markdown files")
 pth = os.path.join("..", "doc", "mf6io", "mf6ivar")
-args = ("python", "mf6ivar.py")
+args = (sys.executable, "mf6ivar.py")
 # run the command
 proc = Popen(args, stdout=PIPE, stderr=PIPE, cwd=pth)
 stdout, stderr = proc.communicate()

--- a/autotest/build_exes.py
+++ b/autotest/build_exes.py
@@ -30,4 +30,4 @@ if __name__ == "__main__":
         "-p", "--path", help="path to bin directory", default=top_bin_path
     )
     args = parser.parse_args()
-    test_meson_build(Path(args.path).resolve())
+    test_meson_build(Path(args.path).expanduser().resolve())

--- a/autotest/build_mfio_tex.py
+++ b/autotest/build_mfio_tex.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from contextlib import contextmanager
 
 # base name for mf6io LaTeX document
@@ -60,7 +61,7 @@ def test_rebuild_from_dfn():
             os.remove(fpth)
 
         # run python
-        argv = ["python", "mf6ivar.py"]
+        argv = [sys.executable, "mf6ivar.py"]
         buff, ierr = run_command(argv, pth)
         msg = f"\nERROR {ierr}: could not run {argv[0]} with {argv[1]}"
         assert ierr == 0, buff + msg

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from modflow_devtools.executables import Executables, build_default_exe_dict
 
 pytest_plugins = ["modflow_devtools.fixtures"]
-project_root_path = Path(__file__).parent.parent
+project_root_path = Path(__file__).resolve().parent.parent
 
 
 def should_compare(

--- a/autotest/update_flopy.py
+++ b/autotest/update_flopy.py
@@ -3,6 +3,7 @@ import importlib
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import flopy
@@ -70,7 +71,7 @@ def test_create_packages():
 
     # run createpackages.py script
     print(f"running...{fn}")
-    subprocess.check_output(["python", "createpackages.py"], cwd=pth)
+    subprocess.check_output([sys.executable, "createpackages.py"], cwd=pth)
 
     # reload flopy
     print("reloading flopy")
@@ -124,7 +125,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    path = Path(args.path).resolve()
+    path = Path(args.path).expanduser().resolve()
     print(f"Updating flopy packages from DFN files in: {path}")
 
     test_delete_mf6()

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import platform
 import shutil
+import sys
 import textwrap
 from collections import namedtuple
 from os import PathLike, environ
@@ -162,7 +163,7 @@ def build_examples(examples_repo_path: PathLike, overwrite: bool = False):
         ]
         for script in scripts:
             argv = [
-                "python",
+                sys.executable,
                 script,
                 "--no_run",
                 "--no_plot",

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import platform
 import shutil
+import sys
 import textwrap
 from datetime import datetime
 from os import PathLike
@@ -143,7 +144,7 @@ def build_benchmark_tex(output_path: PathLike, overwrite: bool = False):
     with set_dir(_release_notes_path):
         tex_path = Path("run-time-comparison.tex")
         tex_path.unlink(missing_ok=True)
-        out, err, ret = run_cmd("python", "mk_runtimecomp.py", benchmarks_path, verbose=True)
+        out, err, ret = run_cmd(sys.executable, "mk_runtimecomp.py", benchmarks_path, verbose=True)
         assert not ret, out + err
         assert tex_path.is_file()
 
@@ -202,7 +203,7 @@ def build_mf6io_tex_from_dfn(overwrite: bool = False):
                 f.unlink()
 
             # run python script
-            out, err, ret = run_cmd("python", "mf6ivar.py")
+            out, err, ret = run_cmd(sys.executable, "mf6ivar.py")
             assert not ret, out + err
 
             # check that dfn and tex files match
@@ -246,7 +247,7 @@ def build_tex_folder_structure(overwrite: bool = False):
         return
 
     with set_dir(_release_notes_path):
-        out, err, ret = run_cmd("python", "mk_folder_struct.py", "-dp", _project_root_path)
+        out, err, ret = run_cmd(sys.executable, "mk_folder_struct.py", "-dp", _project_root_path)
         assert not ret, out + err
 
     assert path.is_file(), f"Failed to create {path}"

--- a/distribution/conftest.py
+++ b/distribution/conftest.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 from update_version import Version
 
-_project_root_path = Path(__file__).parent.parent
-_dist_dir_path = Path(__file__).parent.parent.parent / f"mf{str(Version.from_file(_project_root_path / 'version.txt'))}"
+_project_root_path = Path(__file__).resolve().parent.parent
+_dist_dir_path = _project_root_path.parent / f"mf{str(Version.from_file(_project_root_path / 'version.txt'))}"
 
 
 def pytest_addoption(parser):

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -45,7 +45,7 @@ from filelock import FileLock
 from utils import get_modified_time
 
 project_name = "MODFLOW 6"
-project_root_path = Path(__file__).parent.parent
+project_root_path = Path(__file__).resolve().parent.parent
 version_file_path = project_root_path / "version.txt"
 touched_file_paths = [
     version_file_path,

--- a/distribution/utils.py
+++ b/distribution/utils.py
@@ -10,7 +10,7 @@ from warnings import warn
 
 from modflow_devtools.markers import requires_exe
 
-_project_root_path = Path(__file__).parent.parent
+_project_root_path = Path(__file__).resolve().parent.parent
 
 
 def get_project_root_path():
@@ -69,7 +69,7 @@ def get_repo_path() -> Path:
         warn(
             f"REPOS_PATH environment variable missing, defaulting to parent of project root"
         )
-    return Path(repo_path) if repo_path else Path(__file__).parent.parent.parent
+    return Path(repo_path) if repo_path else _project_root_path
 
 
 def copytree(src: PathLike, dst: PathLike, symlinks=False, ignore=None):


### PR DESCRIPTION
The primary fix is with `make_distribution.py`, which would raise non-sense errors like "FileNotFoundError: [Errno 2] No such file or directory: '/path/to/modflow6/distribution/version.txt'" (it is off by one directory) when invoked using a relative path. The issue is that `__file__` when invoked as a script is not always absolute, which is fixed by `Path(__file__).resolve()`. (And there is no need to use `expanduser()` for these instances).

Other changes:

- use the absolute path to the current Python interpreter `sys.executable` instead of `"python"`
- add `expanduser()` in a few places that may need it
- re-use pathlike variables