### PR TITLE
feat(CITATION.cff): add software citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,64 @@
+cff-version: 1.2.0
+message: If you use this software, please cite the software itself.
+type: software
+title: MODFLOW 6 Modular Hydrologic Model
+version: 6.4.1
+date-released: '2022-12-09'
+doi: 10.5066/F76Q1VQV
+abstract: MODFLOW 6 is an object-oriented program and framework developed to provide
+  a platform for supporting multiple models and multiple types of models within the
+  same simulation. Within this framework, a regional-scale groundwater model may be
+  coupled with multiple local-scale groundwater models. Or, a groundwater flow model
+  could be coupled to a groundwater transport model of a single solute species.
+repository-code: https://github.com/MODFLOW-USGS/modflow6
+license: CC0-1.0
+authors:
+- family-names: Langevin
+  given-names: Christian D.
+  alias: langevin-usgs
+  affiliation: U.S. Geological Survey
+  orcid: https://orcid.org/0000-0001-5610-9759
+- family-names: Hughes
+  given-names: Joseph D.
+  alias: jdhughes-usgs
+  affiliation: U.S. Geological Survey
+  orcid: https://orcid.org/0000-0003-1311-2354
+- family-names: Provost
+  given-names: Alden M.
+  alias: aprovost-usgs
+  affiliation: U.S. Geological Survey
+  orcid: https://orcid.org/0000-0002-4443-1107
+- family-names: Russcher
+  given-names: Martijn
+  alias: mjr-deltares
+  affiliation: Deltares
+  orcid: https://orcid.org/0000-0001-8799-6514
+- family-names: Niswonger
+  given-names: Richard G.
+  affiliation: U.S. Geological Survey
+  orcid: https://orcid.org/0000-0001-6397-2403
+- family-names: Panday
+  given-names: Sorab
+  affiliation: GSI Environmental
+- family-names: Merrick
+  given-names: Damian
+  alias: damianmerrick
+  affiliation: HydroAlgorithmics
+- family-names: Morway
+  given-names: Eric D.
+  alias: emorway-usgs
+  affiliation: U.S. Geological Survey
+  orcid: https://orcid.org/0000-0002-8553-6140
+- family-names: Reno
+  given-names: Michael J.
+  affiliation: U.S. Geological Survey
+  alias: mjreno
+- family-names: Bonelli
+  given-names: Wesley P.
+  alias: w-bonelli
+  affiliation: U.S. Geological Survey
+  orcid: https://orcid.org/0000-0002-2665-5078
+- family-names: Banta
+  given-names: Edward R.
+  affiliation: U.S. Geological Survey
+  orcid: https://orcid.org/0000-0001-8132-9315

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -41,6 +41,7 @@ from typing import NamedTuple, Optional
 
 import pytest
 from filelock import FileLock
+import yaml
 
 from utils import get_modified_time
 
@@ -54,6 +55,7 @@ touched_file_paths = [
     project_root_path / "doc" / "version.py",
     project_root_path / "README.md",
     project_root_path / "DISCLAIMER.md",
+    project_root_path / "CITATION.cff",
     project_root_path / "code.json",
     project_root_path / "src" / "Utilities" / "version.f90",
 ]
@@ -291,6 +293,25 @@ def update_readme_and_disclaimer(
     log_update(disclaimer_path, release_type, version)
 
 
+def update_citation_cff(release_type: ReleaseType, timestamp: datetime, version: Version):
+    path = project_root_path / "CITATION.cff"
+    citation = yaml.safe_load(path.read_text())
+
+    # update version and date-released
+    citation["version"] = str(version)
+    citation["date-released"] = timestamp.strftime("%Y-%m-%d")
+
+    with open(path, "w") as f:
+        yaml.safe_dump(
+            citation,
+            f,
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+    log_update(path, release_type, version)
+
+
 def update_codejson(release_type: ReleaseType, timestamp: datetime, version: Version):
     path = project_root_path / "code.json"
     with open(path, "r") as f:
@@ -336,6 +357,7 @@ def update_version(
             update_version_tex(release_type, timestamp, version)
             update_version_f90(release_type, timestamp, version)
             update_readme_and_disclaimer(release_type, timestamp, version)
+            update_citation_cff(release_type, timestamp, version)
             update_codejson(release_type, timestamp, version)
     finally:
         lock_path.unlink(missing_ok=True)


### PR DESCRIPTION
This is similar to https://github.com/modflowpy/flopy/pull/1547. Authors can change for each software release. Not sure if it is useful, but I've added "affiliation" for each author. The list and order in this PR is the same as https://github.com/MODFLOW-USGS/modflow6/releases/tag/6.4.1

A plain-text version of the citation can be show via (first `pip install cffconvert`) `cffconvert -f apalike` or other format. GitHub will show both APA-like and BibTeX versions.

Version number and date is updated via `distribution/update_version.py`

Should https://github.com/dieghernan/cff-validator be added? If so, which workflow?