### PR TITLE
feat(vscode-tasks): add build commands for common tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -223,5 +223,47 @@
                 "clear": true
             }
         },
+        {
+            "label": "Run dfn2f90.py",
+            "type": "shell",
+            "command": "source activate modflow6; pwd; python dfn2f90.py",
+            "options": {"cwd": "${workspaceFolder}/utils/idmloader/scripts"},
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Run update_flopy.py",
+            "type": "shell",
+            "command": "source activate modflow6; pwd; python update_flopy.py",
+            "options": {"cwd": "${workspaceFolder}/autotest"},
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Run mf6ivar.py",
+            "type": "shell",
+            "command": "source activate modflow6; pwd; python mf6ivar.py",
+            "options": {"cwd": "${workspaceFolder}/doc/mf6io/mf6ivar"},
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "clear": true
+            },
+            "problemMatcher": []
+        },
     ]
 }


### PR DESCRIPTION
* run dfn2f90.py -- convert definition files to Fortran 90 input data model equivalents
* run update_flopy.py -- update flopy to support the definition files in the modflow6 repo
* run mf6ivar.py -- rebuild the mf6io latex documents from definition files

With the changes for the input data model and our broader adoption of vscode, this PR adds several vscode build tasks for common operations.