### PR TITLE
refactor(distribution): add release notes to dev dist (nightly build)

### DIFF
--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -44,16 +44,6 @@ _included_dir_paths = [
     "utils",
 ]
 
-# LaTex files included in distribution docs
-_default_tex_paths = [
-    _project_root_path / "doc" / "mf6io" / "mf6io.tex",
-    _project_root_path / "doc" / "ReleaseNotes" / "ReleaseNotes.tex",
-    _project_root_path / "doc" / "zonebudget" / "zonebudget.tex",
-    _project_root_path / "doc" / "ConverterGuide" / "converter_mf5to6.tex",
-    _project_root_path / "doc" / "SuppTechInfo" / "mf6suptechinfo.tex",
-]
-
-
 Makefile = namedtuple('Makefile', ['app', 'src_path', 'out_path'])
 
 

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -31,13 +31,16 @@ _release_notes_path = _project_root_path / "doc" / "ReleaseNotes"
 _distribution_path = _project_root_path / "distribution"
 _benchmarks_path = _project_root_path / "distribution" / ".benchmarks"
 _docs_path = _project_root_path / "doc"
-
-_default_tex_paths = [
-    _project_root_path / "doc" / "mf6io" / "mf6io.tex",
-    _project_root_path / "doc" / "ReleaseNotes" / "ReleaseNotes.tex",
-    _project_root_path / "doc" / "zonebudget" / "zonebudget.tex",
-    _project_root_path / "doc" / "ConverterGuide" / "converter_mf5to6.tex",
-    _project_root_path / "doc" / "SuppTechInfo" / "mf6suptechinfo.tex",
+_dev_dist_tex_paths = [
+    _docs_path / "mf6io" / "mf6io.tex",
+    _docs_path / "ReleaseNotes" / "ReleaseNotes.tex",
+]
+_full_dist_tex_paths = [
+    _docs_path / "mf6io" / "mf6io.tex",
+    _docs_path / "ReleaseNotes" / "ReleaseNotes.tex",
+    _docs_path / "zonebudget" / "zonebudget.tex",
+    _docs_path / "ConverterGuide" / "converter_mf5to6.tex",
+    _docs_path / "SuppTechInfo" / "mf6suptechinfo.tex",
 ]
 _system = platform.system()
 _eext = ".exe" if _system == "Windows" else ""
@@ -402,7 +405,7 @@ def build_documentation(bin_path: PathLike,
                         examples_repo_path: PathLike,
                         development: bool = False,
                         overwrite: bool = False):
-    print(f"Building {'development' if development else 'candidate'} documentation")
+    print(f"Building {'development' if development else 'full'} documentation")
 
     bin_path = Path(bin_path).expanduser().absolute()
     output_path = Path(output_path).expanduser().absolute()
@@ -428,7 +431,7 @@ def build_documentation(bin_path: PathLike,
 
     if development:
         # convert LaTeX to PDF
-        build_pdfs_from_tex(tex_paths=[_docs_path / "mf6io" / "mf6io.tex"], output_path=output_path)
+        build_pdfs_from_tex(tex_paths=_dev_dist_tex_paths, output_path=output_path)
     else:
         # convert benchmarks to LaTex, running them first if necessary
         build_benchmark_tex(output_path=output_path, overwrite=overwrite)
@@ -452,7 +455,7 @@ def build_documentation(bin_path: PathLike,
                     raise
 
         # convert LaTex to PDF
-        build_pdfs_from_tex(tex_paths=_default_tex_paths, output_path=output_path, overwrite=overwrite)
+        build_pdfs_from_tex(tex_paths=_full_dist_tex_paths, output_path=output_path, overwrite=overwrite)
 
     # enforce os line endings on all text files
     windows_line_endings = True
@@ -533,7 +536,7 @@ if __name__ == "__main__":
         help="Whether to recreate and overwrite existing artifacts"
     )
     args = parser.parse_args()
-    tex_paths = _default_tex_paths + ([Path(p) for p in args.tex_path] if args.tex_path else [])
+    tex_paths = _full_dist_tex_paths + ([Path(p) for p in args.tex_path] if args.tex_path else [])
     output_path = Path(args.output_path).expanduser().absolute()
     output_path.mkdir(parents=True, exist_ok=True)
     bin_path = Path(args.bin_path).expanduser().absolute()

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -231,7 +231,6 @@ def update_version_tex(
             + "{Version \\modflowversion---\\modflowdate}"
         )
         f.write(f"{line}\n")
-        f.close()
 
     log_update(path, release_type, version)
 

--- a/doc/ReleaseNotes/v6.5.0.tex
+++ b/doc/ReleaseNotes/v6.5.0.tex
@@ -1,7 +1,7 @@
 % Use this template for starting initializing the release notes
 % after a release has just been made.
 	
-	\item Version mf6.x.x--Month xx, 202x
+	\item \currentmodflowversion
 	
 	\underline{NEW FUNCTIONALITY}
 	\begin{itemize}

--- a/doc/ReleaseNotes/vx.x.x-template.tex
+++ b/doc/ReleaseNotes/vx.x.x-template.tex
@@ -1,7 +1,7 @@
 % Use this template for starting initializing the release notes
 % after a release has just been made.
 	
-	\item Version mf6.x.x--Month xx, 202x
+	\item \currentmodflowversion
 	
 	%\underline{NEW FUNCTIONALITY}
 	%\begin{itemize}


### PR DESCRIPTION
- Include release notes in development mode distributions (e.g. the nightly build)
- Use tex version commands in release notes template
- Miscellaneous cleanup in distribution scripts

https://github.com/MODFLOW-USGS/modflow6-nightly-build/pull/24 updates the nightly build workflow. Here is a [test run](https://github.com/w-bonelli/modflow6-nightly-build/actions/runs/4577430990) on my fork, and the [release created](https://github.com/w-bonelli/modflow6-nightly-build/releases/tag/20230331) by it