### PR TITLE
docs(zbud): mention support for GWT budget files, add test

### DIFF
--- a/doc/zonebudget/zonebudget.tex
+++ b/doc/zonebudget/zonebudget.tex
@@ -155,7 +155,7 @@ where:
 \begin{itemize}
 \item \texttt{BUD <budgetfile>}---is the keyword and name of the MODFLOW 6 budget file.  This file contains double precision numeric values of simulated flow.
 \item \texttt{ZON <zonefile>}---is the keyword and name of the zone input file.
-\item \texttt{GRB <binarygridfile>}---is the keyword and name of the binary grid file created by MODFLOW 6.  Note that if the NOGRB keyword is specified in the OPTIONS block of the Discretization Package input file, then MODFLOW 6 will not create the binary grid file needed to run ZONEBUDGET.  The binary grid file must be provided if the budget file is for a Groundwater Flow (GWF) Model.  The binary grid file is not needed when ZONEBUDGET is used to process the budget file from one of the advanced packages (described later).
+\item \texttt{GRB <binarygridfile>}---is the keyword and name of the binary grid file created by MODFLOW 6.  Note that if the NOGRB keyword is specified in the OPTIONS block of the Discretization Package input file, then MODFLOW 6 will not create the binary grid file needed to run ZONEBUDGET.  The binary grid file must be provided if the budget file is for a Groundwater Flow (GWF) or Groundwater Transport (GWT) Model.  The binary grid file is not needed when ZONEBUDGET is used to process the budget file from one of the advanced packages (described later).
 \end{itemize}
 
 The following is an example of a ZONEBUDGET name file:

--- a/doc/zonebudget/zonebudget.tex
+++ b/doc/zonebudget/zonebudget.tex
@@ -95,7 +95,9 @@ https://www.usgs.gov/mission-areas/water-resources
 
 % -------------------------------------------------
 \section{Abstract}
-The computer program ZONEBUDGET 6, which is written in FORTRAN, calculates subregional water budgets using results from MODFLOW 6. ZONEBUDGET uses cell-by-cell flow data saved by the model in order to calculate the budgets. Subregions of the modeled region are designated by zone numbers. The user assigns a zone number for each cell in the model. 
+The computer program ZONEBUDGET 6, which is written in FORTRAN, calculates subregional water budgets using results from MODFLOW 6. ZONEBUDGET uses cell-by-cell flow data saved by the model in order to calculate the budgets. Subregions of the modeled region are designated by zone numbers. The user assigns a zone number for each cell in the model.
+
+ZONEBUDGET 6 is designed to work with output from the Groundwater Flow (GWF) and Groundwater Transport (GWT) Models, and the advanced packages for those models. Output from new models that may be added to MODFLOW 6 in the future should also work with ZONEBUDGET 6.
 
 % -------------------------------------------------
 \section{Introduction}


### PR DESCRIPTION
- mention support for GWT budget files in zonebudget docs, motivated by https://github.com/MODFLOW-USGS/modflow6/discussions/1181
- add a test case `test_gwt_zb01.py` for zonebudget with GWT budget file
- minor non-functional refactoring to `test_gwf_zb01.py`
  - use `with` context manager for file writing
  - use `pathlib`