### PR TITLE
docs(gwf-sfr.dfn): cross_section keyword is a part of sfrsetting

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
@@ -816,7 +816,7 @@ name cross_sectionrecord
 type record cross_section tab6 filein tab6_filename
 shape
 tagged
-in_record false
+in_record true
 reader urword
 longname
 description


### PR DESCRIPTION
The `false` setting was leading to an oddity in mf6io.pdf

![x-sec](https://user-images.githubusercontent.com/3236576/230671755-1500a0c2-838d-4108-ae97-0f81337dc7f2.png)
