### PR TITLE
docs: fix docstring for BlockParser's DevOpt

### DIFF
--- a/src/Utilities/BlockParser.f90
+++ b/src/Utilities/BlockParser.f90
@@ -565,7 +565,7 @@ contains
   !> @ brief Development option
   !!
   !! Method that will cause the program to terminate with an error if the
-  !! IDEVELOPMODE flag is set to 1.  This is used to allow develop options
+  !! IDEVELOPMODE flag is set to 0. This is used to allow develop options
   !! to be specified for development testing but not for the public release.
   !! For the public release, IDEVELOPMODE is set to zero.
   !!


### PR DESCRIPTION
minor correction to docstring, dev options terminate with error when `IDEVELOPMODE` is 0 (release mode) not 1