### PR TITLE
fix(gwf3drn8): auxddrnname in error msg does not exist

### DIFF
--- a/src/Model/GroundWaterFlow/gwf3drn8.f90
+++ b/src/Model/GroundWaterFlow/gwf3drn8.f90
@@ -204,7 +204,7 @@ contains
       ! -- Error if no aux variable specified
       if (this%naux == 0) then
         write (errmsg, '(a,2(1x,a))') &
-          'AUXDDRNNAME WAS SPECIFIED AS', trim(adjustl(ddrnauxname)), &
+          'AUXDEPTHNAME WAS SPECIFIED AS', trim(adjustl(ddrnauxname)), &
           'BUT NO AUX VARIABLES SPECIFIED.'
         call store_error(errmsg)
       end if
@@ -221,7 +221,7 @@ contains
       ! -- Error if aux variable cannot be found
       if (this%iauxddrncol == 0) then
         write (errmsg, '(a,2(1x,a))') &
-          'AUXDDRNNAME WAS SPECIFIED AS', trim(adjustl(ddrnauxname)), &
+          'AUXDEPTHNAME WAS SPECIFIED AS', trim(adjustl(ddrnauxname)), &
           'BUT NO AUX VARIABLE FOUND WITH THIS NAME.'
         call store_error(errmsg)
       end if


### PR DESCRIPTION
Error msg cites the variable name `AUXDDRNNAME` but the keyword in the OPTIONS block is `AUXDEPTHNAME`.  Suggesting this minor fix for consistency.

Related to #414.