### PR TITLE
Add `get_value_ptr`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - pip:
       - git+https://github.com/modflowpy/flopy.git
       - git+https://github.com/modflowpy/pymake.git
+      - git+https://github.com/Deltares/xmipy.git@get_value_ptr
       - git+https://github.com/MODFLOW-USGS/modflowapi.git
       - modflow-devtools
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - pip:
       - git+https://github.com/modflowpy/flopy.git
       - git+https://github.com/modflowpy/pymake.git
-      - git+https://github.com/Deltares/xmipy.git@get_value_ptr
+      - git+https://github.com/Deltares/xmipy.git
       - git+https://github.com/MODFLOW-USGS/modflowapi.git
       - modflow-devtools
   - pytest

--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -630,7 +630,7 @@ contains
     else if (index(mem_type, "INTEGER") /= 0) then
       bmi_status = get_value_ptr_int(c_var_address, c_arr_ptr)
     else
-      write (bmi_last_error, fmt_unsupported_rank) trim(var_name)
+      write (bmi_last_error, fmt_unsupported_type) trim(var_name)
       call report_bmi_error(bmi_last_error)
       bmi_status = BMI_FAILURE
       return

--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -593,6 +593,54 @@ contains
 
   end function get_value_string
 
+
+  !> @brief Copy the value of a variable into the array
+  !!
+  !! The copied variable is located at @p c_var_address. The caller should
+  !! provide @p c_arr_ptr pointing to an array of the proper shape (the
+  !! BMI function get_var_shape() can be used to create it). Multi-dimensional
+  !! arrays are supported.
+  !<
+  function get_value(c_var_address, c_arr_ptr) result(bmi_status) &
+    bind(C, name="get_value")
+    !DIR$ ATTRIBUTES DLLEXPORT :: get_value
+    ! -- modules
+    use ConstantsModule, only: LENMEMTYPE
+    ! -- dummy variables
+    character(kind=c_char), intent(in) :: c_var_address(*) !< memory address string of the variable
+    type(c_ptr), intent(inout) :: c_arr_ptr !< pointer to the array
+    integer(kind=c_int) :: bmi_status !< BMI status code
+    ! -- local variables
+    character(len=LENMEMPATH) :: mem_path
+    character(len=LENMEMTYPE) :: mem_type
+    character(len=LENVARNAME) :: var_name
+    logical(LGP) :: valid
+
+    bmi_status = BMI_SUCCESS
+
+    call split_address(c_var_address, mem_path, var_name, valid)
+    if (.not. valid) then
+      bmi_status = BMI_FAILURE
+      return
+    end if
+
+    call get_mem_type(var_name, mem_path, mem_type)
+
+    if (index(mem_type, "DOUBLE") /= 0) then
+      bmi_status = get_value_double(c_var_address, c_arr_ptr)
+    else if (index(mem_type, "INTEGER") /= 0) then
+      bmi_status = get_value_int(c_var_address, c_arr_ptr)
+    else if (index(mem_type, "STRING") /= 0) then
+      bmi_status = get_value_string(c_var_address, c_arr_ptr)
+    else
+      write (bmi_last_error, fmt_unsupported_type) trim(var_name)
+      call report_bmi_error(bmi_last_error)
+      bmi_status = BMI_FAILURE
+      return
+    end if
+
+  end function get_value
+
   !> @brief Get a pointer to an array
   !!
   !! The array is located at @p c_var_address. There is no copying of data involved.

--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -593,7 +593,6 @@ contains
 
   end function get_value_string
 
-
   !> @brief Copy the value of a variable into the array
   !!
   !! The copied variable is located at @p c_var_address. The caller should
@@ -796,7 +795,6 @@ contains
 
   end function get_value_ptr_int
 
-  
   !> @brief Set new values for a given variable
   !!
   !! The array pointed to by @p c_arr_ptr can have rank equal to 0, 1, or 2
@@ -840,7 +838,6 @@ contains
     end if
 
   end function set_value
-
 
   !> @brief Set new values for a variable of type double
   !!

--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -796,6 +796,52 @@ contains
 
   end function get_value_ptr_int
 
+  
+  !> @brief Set new values for a given variable
+  !!
+  !! The array pointed to by @p c_arr_ptr can have rank equal to 0, 1, or 2
+  !! and should have a C-style layout, which is particularly important for
+  !! rank > 1.
+  !<
+  function set_value(c_var_address, c_arr_ptr) result(bmi_status) &
+    bind(C, name="set_value")
+    !DIR$ ATTRIBUTES DLLEXPORT :: set_value
+    ! -- modules
+    use ConstantsModule, only: LENMEMTYPE
+    ! -- dummy variables
+    character(kind=c_char), intent(in) :: c_var_address(*) !< memory address string of the variable
+    type(c_ptr), intent(inout) :: c_arr_ptr !< pointer to the array
+    integer(kind=c_int) :: bmi_status !< BMI status code
+    ! -- local variables
+    character(len=LENMEMPATH) :: mem_path
+    character(len=LENMEMTYPE) :: mem_type
+    character(len=LENVARNAME) :: var_name
+    logical(LGP) :: valid
+
+    bmi_status = BMI_SUCCESS
+
+    call split_address(c_var_address, mem_path, var_name, valid)
+    if (.not. valid) then
+      bmi_status = BMI_FAILURE
+      return
+    end if
+
+    call get_mem_type(var_name, mem_path, mem_type)
+
+    if (index(mem_type, "DOUBLE") /= 0) then
+      bmi_status = set_value_double(c_var_address, c_arr_ptr)
+    else if (index(mem_type, "INTEGER") /= 0) then
+      bmi_status = set_value_int(c_var_address, c_arr_ptr)
+    else
+      write (bmi_last_error, fmt_unsupported_type) trim(var_name)
+      call report_bmi_error(bmi_last_error)
+      bmi_status = BMI_FAILURE
+      return
+    end if
+
+  end function set_value
+
+
   !> @brief Set new values for a variable of type double
   !!
   !! The array pointed to by @p c_arr_ptr can have rank equal to 0, 1, or 2

--- a/srcbmi/mf6bmiError.f90
+++ b/srcbmi/mf6bmiError.f90
@@ -28,6 +28,9 @@ module mf6bmiError
   character(len=*), parameter :: fmt_unsupported_rank = & !< Unsupported rank, args: variable name
                                  "('BMI Error, unsupported rank for variable: &
                                  &', a)"
+  character(len=*), parameter :: fmt_unsupported_type = & !< Unsupported type, args: variable name
+                                 "('BMI Error, unsupported type for variable: &
+                                 &', a)"
   character(len=*), parameter :: fmt_invalid_mem_access = & !< Invalid memory access, args: variable name
                                  "('Fatal BMI Error, invalid access of memory &
                                  &for variable: ', a)"


### PR DESCRIPTION
## Summary

By exposing `get_value_ptr_double` and `get_value_ptr_int` we are strictly speaking not BMI conform.
This PR fixes this aspect by adding `get_value_ptr`.
The corresponding PR on the xmipy side can be found here: https://github.com/Deltares/xmipy/pull/98
If merged, we should coordinate the next xmipy and MODFLOW 6 release

## Impact

- New versions of xmipy will not work with older versions of MODFLOW.
- The xmipy API stays the same.

## Alternative Approach
- Remove  `get_value_ptr_double` and `get_value_ptr_int` completely