### PR TITLE
ci: use actions/deploy-pages (allows removing gh-pages branch)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -158,8 +158,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Print branch name
-        run: |
-          echo ${{env.branch-name}}
+        run: echo ${{env.branch-name}}
 
       - name: Install doxygen and graphviz
         run: |
@@ -173,12 +172,10 @@ jobs:
             cache-env: true
 
       - name: Print python package versions
-        run: |
-          pip list
+        run: pip list
 
       - name: update MODFLOW 6 version
-        run: |
-          python update_version.py
+        run: python update_version.py
         working-directory: ${{env.distribution-directory}}
 
       - name: update MODFLOW 6 version in Doxyfile
@@ -201,13 +198,25 @@ jobs:
         working-directory: ${{env.working-directory}}
 
       - name: run doxygen
-        run: |
-          doxygen
+        run: doxygen
         working-directory: ${{env.working-directory}}
-
-      - name: Deploy doxygen html to gh-pages
-        uses: peaceiris/actions-gh-pages@v3.7.3
-        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+      
+      - name: upload pages artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{env.working-directory}}/html
+          path: ${{env.working-directory}}/html
+
+  pages_deploy:
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+    needs: doxygen_build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Switch from `peaceiris/actions-gh-pages` to `actions/deploy-pages` to deploy the Doxygen docs to GitHub Pages. This, in combination with switching the Pages source from branch to actions, allows removing the `gh-pages` branch. This should shrink the `.git` directory and speed up clone/fetch/pull as suggested in #1122

[Tested on my fork](https://github.com/w-bonelli/modflow6/actions/runs/4786691780) with the [deployed site here](https://w-bonelli.github.io/modflow6/)