### PR TITLE
fix(gwtssmspc): another fix for readasarrays with SPC

### DIFF
--- a/src/Model/GroundWaterTransport/gwt1ssm1.f90
+++ b/src/Model/GroundWaterTransport/gwt1ssm1.f90
@@ -283,6 +283,7 @@ contains
     ! -- local
     logical(LGP) :: lauxmixed
     integer(I4B) :: n
+    integer(I4B) :: nbound_flow
     real(DP) :: qbnd
     real(DP) :: ctmp
     real(DP) :: omega
@@ -294,6 +295,7 @@ contains
     rhstmp = DZERO
     ctmp = DZERO
     qbnd = DZERO
+    nbound_flow = this%fmi%gwfpackages(ipackage)%nbound
     n = this%fmi%gwfpackages(ipackage)%nodelist(ientry)
     !
     ! -- If cell is active (ibound > 0) then calculate values
@@ -301,7 +303,7 @@ contains
       !
       ! -- retrieve qbnd and iauxpos
       qbnd = this%fmi%gwfpackages(ipackage)%get_flow(ientry)
-      call this%get_ssm_conc(ipackage, ientry, ctmp, lauxmixed)
+      call this%get_ssm_conc(ipackage, ientry, nbound_flow, ctmp, lauxmixed)
       !
       ! -- assign values for hcoftmp, rhstmp, and ctmp for subsequent assigment
       !    of hcof, rhs, and rate
@@ -368,11 +370,13 @@ contains
   !! The mixed flag indicates whether or not
   !!
   !<
-  subroutine get_ssm_conc(this, ipackage, ientry, conc, lauxmixed)
+  subroutine get_ssm_conc(this, ipackage, ientry, nbound_flow, conc, &
+                          lauxmixed)
     ! -- dummy
     class(GwtSsmType) :: this !< GwtSsmType
     integer(I4B), intent(in) :: ipackage !< package number
     integer(I4B), intent(in) :: ientry !< bound number
+    integer(I4B), intent(in) :: nbound_flow !< size of flow package bound list
     real(DP), intent(out) :: conc !< user-specified concentration for this bound
     logical(LGP), intent(out) :: lauxmixed !< user-specified flag for marking this as a mixed boundary
     ! -- local
@@ -389,7 +393,7 @@ contains
       conc = this%fmi%gwfpackages(ipackage)%auxvar(iauxpos, ientry)
       if (isrctype == 2) lauxmixed = .true.
     case (3, 4)
-      conc = this%ssmivec(ipackage)%get_value(ientry)
+      conc = this%ssmivec(ipackage)%get_value(ientry, nbound_flow)
       if (isrctype == 4) lauxmixed = .true.
     end select
 


### PR DESCRIPTION
The Stress Package Concentration (SPC) input for the GWT SSM package was not working correctly when (1) flow models were run first in a separate simulation before the transport model, (2) the READASARRAYS option was specified, and (3) the model had IDOMAIN active with some cells marked as non-existent.  The problem stems from how lists of boundary conditions that support READASARRAYS (recharge and evapotranspiration) are stored in memory or written to binary budget files.  Lists of recharge entries written to the GWF binary budget file do not include entries for cells that are marked with IDOMAIN < 1.  In most cases, a stress cannot be assigned to a cell marked with IDOMAIN < 1, as mf6 will terminate with an error, but with the READASARRAYS option, stresses can be assigned to non-existent cells, even though they have no effect.

Special handling is required in the SSM Package when it matches up GWF flows to concentrations specified in the SPC input file.  When flow and transport are in the same simulation, the mapping is straightforward for READASARRAYS input, but when flow and transport are in separate simulations, additional mapping is required.  This PR fixes the mapping required to handle this situation.  The PR also improves the existing test for the case where flow and transport are in the same simulation, and adds a new test for the case where flow and transport are in separate simulations. 