### PR TITLE
fix(gwfuzf): fix array assignment to prevent stack overflow

### DIFF
--- a/src/Model/GroundWaterFlow/gwf3uzf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3uzf8.f90
@@ -1764,7 +1764,9 @@ contains
     !
     ! -- Initialize
     ierr = 0
-    this%uzfobj%pet = this%uzfobj%petmax
+    do i = 1, this%nodes
+      this%uzfobj%pet(i) = this%uzfobj%petmax(i)
+    end do
     !
     ! -- Calculate hcof and rhs for each UZF entry
     do i = 1, this%nodes


### PR DESCRIPTION
* implicit array assignment can result in stack overflow for large uzf packages
* change array assignment to explicit loop