### PR TITLE
refactor(tdis): Calculate exact last delt to avoid accumulation errors with totim

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -1,3 +1,4 @@
+import platform
 from pathlib import Path
 
 import pytest
@@ -29,6 +30,17 @@ def should_compare(
 @pytest.fixture(scope="session")
 def bin_path() -> Path:
     return project_root_path / "bin"
+
+
+@pytest.fixture(scope="session")
+def libmf6_path(bin_path) -> Path:
+    ext = {
+        "Darwin": ".dylib",
+        "Linux": ".so",
+        "Windows": ".dll",
+    }[platform.system()]
+    lib_name = bin_path / f"libmf6{ext}"
+    return lib_name
 
 
 @pytest.fixture(scope="session")

--- a/autotest/test_gwf_tdis.py
+++ b/autotest/test_gwf_tdis.py
@@ -1,0 +1,86 @@
+"""Test TDIS package."""
+import flopy
+import numpy as np
+import pytest
+from xmipy import XmiWrapper
+
+
+@pytest.fixture
+def simple_sim(tmp_path):
+    """Create a simple and bogus GWF simulation without TDIS package."""
+    sim = flopy.mf6.MFSimulation(sim_ws=str(tmp_path))
+    _ = flopy.mf6.ModflowTdis(sim)  # placeholder
+    _ = flopy.mf6.ModflowIms(sim)
+    gwf = flopy.mf6.ModflowGwf(sim)
+    _ = flopy.mf6.ModflowGwfdis(gwf)
+    _ = flopy.mf6.ModflowGwfic(gwf)
+    _ = flopy.mf6.ModflowGwfnpf(gwf)
+    sim.write_simulation()
+
+    try:
+        sim.remove_package("TDIS")
+    except AttributeError:
+        pass
+
+    return sim
+
+
+@pytest.mark.parametrize("tsmult", [1.0, 1.2])
+def test_tdis_tsmult(tsmult, libmf6_path, simple_sim):
+    """Check totim values to ensure they avoid accumulation errors."""
+    sim = simple_sim
+
+    # Add TDIS package using time variables
+    nper = 4
+    nstp = 3
+    perlen = 7.0
+    tdis = flopy.mf6.ModflowTdis(
+        sim,
+        time_units="DAYS",
+        nper=nper,
+        perioddata=[(perlen, nstp, tsmult)] * nper,
+    )
+    tdis.write()
+
+    # Run within libmf6
+    mf6 = XmiWrapper(lib_path=libmf6_path, working_directory=sim.sim_path)
+
+    mf6.initialize()
+    dt_list = []
+    totim = mf6.get_current_time()
+    all_times = [totim]
+    sp_times = [totim]
+    for kper in range(nper):
+        for kstep in range(nstp):
+            mf6.update()
+            delt = mf6.get_time_step()
+            totim = mf6.get_current_time()
+            all_times.append(totim)
+            dt_list.append(delt)
+        sp_times.append(totim)
+    mf6.finalize()
+
+    # Stress period times should be exact
+    np.testing.assert_equal(sp_times, np.arange(nper + 1) * perlen)
+
+    if tsmult == 1.0:
+        # Note that delt may not always be exactly unique, but should be close
+        assert max(dt_list) - min(dt_list) < 1e-14
+        assert pytest.approx(dt_list[0]) == perlen / nstp
+
+        # Check all times
+        np.testing.assert_allclose(
+            all_times,
+            np.linspace(0.0, perlen * nper, nper * nstp + 1),
+        )
+    else:
+        # Recreate geometric progression to check delt
+        dt0 = perlen * (1.0 - tsmult) / (1.0 - tsmult**nstp)
+        expected_dt = np.tile(dt0 * tsmult ** np.arange(nstp), nper)
+        np.testing.assert_allclose(dt_list, expected_dt)
+
+        # Check all times
+        np.testing.assert_allclose(
+            all_times,
+            np.cumsum(np.insert(expected_dt, 0, 0.0)),
+        )


### PR DESCRIPTION
This PR ensures that `totim` should more accurately track along `perlen` for the end of each stress period, without introducing floating point errors during geometric progression.

For instance, take a simulation with `nper=4`, `nstp=3`, `perlen=7.0` and `tsmult=1.2`. The total duration is 28.0. Using mf6.4.1 (12/09/2022), here are the `totim` values from the end of each stress period:
```
7.000000000000002
14.000000000000004
21.000000000000004
28.0
```
Using the latest development snapshot:
```
6.999999999999998
13.999999999999996
20.999999999999993
28.0
```
awkward! Only the last `totim` is exact since it is substituted by `totalsimtime`. Older MODFLOW releases have similar accumulation errors. The PR changes the last `totim` values to the expected sequence:
```
7.0
14.0
21.0
28.0
```

This is draft for now for several reasons. I'm not sure if there already was an existing time variable that can be used.  And if not, the name `topertim` is perhaps a placeholder for a better name. Also, there is a similar algorithm in `check_tdis_timing` that may similarly need to be adjusted. Also, tests have not been added yet; suggestions welcome to where they should fit -- any simulation with `tsmul != 1.0`.