### PR TITLE
test(docs): test pdf docs build in linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,13 @@ jobs:
         with:
           repository: MODFLOW-USGS/modflow6-testmodels
           path: modflow6-testmodels
-
+      
+      - name: Checkout modflow6-examples
+        uses: actions/checkout@v3
+        with:
+          repository: MODFLOW-USGS/modflow6-examples
+          path: modflow6-examples
+      
       - name: Setup GNU Fortran ${{ env.GCC_V }}
         uses: awvwgk/setup-fortran@main
         with:
@@ -187,9 +193,10 @@ jobs:
         working-directory: modflow6/autotest
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: pytest -v --durations 0 get_exes.py
+        run: |
+          pytest -v --durations 0 get_exes.py
 
-      - name: Test programs
+      - name: Test modflow6
         working-directory: modflow6/autotest
         env:
           REPOS_PATH: ${{ github.workspace }}
@@ -199,8 +206,48 @@ jobs:
           else
             pytest -v -n auto --durations 0 -m "not large"
           fi
+      
+      # steps below run only on Linux to test distribution procedures, e.g.
+      # compiling binaries, building documentation
+      - name: Checkout usgslatex
+        if: runner.os == 'Linux'
+        uses: actions/checkout@v3
+        with:
+          repository: MODFLOW-USGS/usgslatex
+          path: usgslatex
 
-      - name: Test scripts
+      - name: Install TeX Live
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt install texlive-science \
+            texlive-latex-extra \
+            texlive-font-utils \
+            texlive-fonts-recommended \
+            texlive-fonts-extra
+
+      - name: Install USGS LaTeX style files and Univers font
+        if: runner.os == 'Linux'
+        working-directory: usgslatex/usgsLaTeX
+        run: sudo ./install.sh --all-users
+
+      - name: Install dependencies for ex-gwf-twri example model
+        if: runner.os == 'Linux'
+        working-directory: modflow6-examples/etc
+        run: |
+          # install extra Python packages
+          pip install -r requirements.pip.txt
+
+          # the example model needs executables to be on the path
+          echo "${{ github.workspace }}/modflow6/bin" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/modflow6/bin/downloaded" >> $GITHUB_PATH
+
+      - name: Build ex-gwf-twri example model
+        if: runner.os == 'Linux'
+        working-directory: modflow6-examples/scripts
+        run: python ex-gwf-twri.py
+
+      - name: Test distribution scripts
         working-directory: modflow6/distribution
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
[Un-escaped underscores](https://github.com/MODFLOW-USGS/modflow6/pull/1241) were causing errors when building the documentation PDF. To catch this kind of thing before PRs are merged, install docs dependencies on Linux CI and build the example model used to capture sample mf6 output (`ex-gwf-twri`) so that we test the full docs build. Previously the test for building the PDF was skipped due to missing exes. Also refactor `distribution/build_docs.py` to make the sample example configurable, plus a bit of cleanup