### PR TITLE
ci: refactor/cleanup release workflow, make reusable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,45 @@
 name: MODFLOW 6 release
 on:
-  push:
-    branches:
-      - master
-      - v[0-9]+.[0-9]+.[0-9]+*
-  release:
-    types:
-      - published
+  # workflow_call event lets this workflow be called either
+  # from this repo or the nightly build repo for dev builds
+  workflow_call:
+    inputs:
+      approve:
+        description: 'Whether to approve the release. Default is false for preliminary/provisional releases. Approval is only relevant for full builds: if development is true, approve is not considered.'
+        required: false
+        type: boolean
+        default: false
+      branch:
+        description: 'Branch to use for release. Default is the develop branch.'
+        required: false
+        type: string
+        default: 'develop'
+      development:
+        description: 'Toggle a minimal development build. Default is false, i.e. to perform a full release build. If true, approve is not considered.'
+        required: false
+        type: boolean
+        default: false
+      run_tests:
+        description: 'Whether to run tests after building binaries. Default is true. Can be set to false for rapid testing/debugging, or for a faster nightly/development build.'
+        required: false
+        type: boolean
+        default: true
+      version:
+        description: 'Version number to use for release.'
+        required: true
+        type: string
+    outputs:
+      version:
+        description: 'Version number used for release'
+        value: ${{ jobs.build.outputs.version }}
+      distname:
+        description: 'Distribution name used for release'
+        value: ${{ jobs.build.outputs.distname }}
 env:
   FC: ifort
 jobs:
   build:
     name: Build binaries (${{ matrix.os }})
-    if: ${{ github.event_name == 'push' && github.ref_name != 'master' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -27,57 +54,61 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
+    outputs:
+      version: ${{ steps.set_version.outputs.version }}
+      distname: ${{ steps.set_version.outputs.distname }}
     steps:
       - name: Checkout modflow6
         uses: actions/checkout@v3
         with:
+          repository: ${{ github.repository_owner }}/modflow6
           path: modflow6
-
-      - name: Cache binaries
-        if: ${{ contains(github.ref_name, 'rc') }}
-        id: cache-bin
-        uses: actions/cache@v3
-        with:
-          key: bin-${{ runner.os }}
-          path: modflow6/bin
+          ref: ${{ inputs.branch }}
 
       - name: Setup Micromamba
-        if: ${{ steps.cache-bin.outputs.cache-hit != 'true' }}
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-root-path: ${{ github.workspace }}/micromamba-root
           environment-file: modflow6/environment.yml
           cache-downloads: true
           cache-environment: true
 
       - name: Setup Intel Fortran
-        if: ${{ steps.cache-bin.outputs.cache-hit != 'true' }}
         uses: modflowpy/install-intelfortran-action@v1
 
       - name: Fix Micromamba path (Windows)
-        if: ${{ runner.os == 'Windows' && steps.cache-bin.outputs.cache-hit != 'true' }}
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           # https://github.com/modflowpy/install-intelfortran-action#conda-scripts
-          $mamba_bin = "C:\Users\runneradmin\micromamba-root\envs\modflow6\Scripts"
+          $mamba_bin = "${{ github.workspace }}\micromamba-root\envs\modflow6\Scripts"
           echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Set version number
+        id: set_version
+        run: |
+          # distribution name format is 'mf<major.minor.patch[label]>'
+          distname="mf${{ inputs.version }}"
+
+          # set step outputs and environment variables
+          echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
+          echo "distname=$distname" >> "$GITHUB_OUTPUT"
+          echo "DISTNAME=$distname" >> "$GITHUB_ENV"
+
       - name: Update version
-        if: ${{ steps.cache-bin.outputs.cache-hit != 'true' }}
+        id: update_version
         working-directory: modflow6/distribution
         run: |
-          # extract version from ref name
-          ref="${{ github.ref_name }}"
-          ver="${ref%"rc"}"
-          
-          # update version files
-          if [[ "$ver" == *"rc"* ]]; then
-            python update_version.py -v "${ver#"v"}" 
+          ver="${{ steps.set_version.outputs.version }}"
+          if [[ ("${{ inputs.development }}" == "false") && ("${{ inputs.approve }}" == "true") ]]; then
+            python update_version.py -v "$ver" --approve
           else
-            python update_version.py -v "${ver#"v"}" --approve
+            python update_version.py -v "$ver"
           fi
 
       - name: Build binaries
-        if: ${{ runner.os != 'Windows' && steps.cache-bin.outputs.cache-hit != 'true' }}
+        if: runner.os != 'Windows'
         working-directory: modflow6
         run: |
           meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
@@ -85,7 +116,7 @@ jobs:
           meson test --verbose --no-rebuild -C builddir
 
       - name: Build binaries (Windows)
-        if: ${{ runner.os == 'Windows' && steps.cache-bin.outputs.cache-hit != 'true' }}
+        if: runner.os == 'Windows'
         working-directory: modflow6
         shell: pwsh
         run: |
@@ -99,56 +130,95 @@ jobs:
           name: bin-${{ runner.os }}
           path: modflow6/bin
 
+      # only run steps below if inputs.run_tests is true
       - name: Checkout modflow6-testmodels
+        if: inputs.run_tests == true
         uses: actions/checkout@v3
         with:
           repository: MODFLOW-USGS/modflow6-testmodels
           path: modflow6-testmodels
 
       - name: Checkout modflow6-examples
+        if: inputs.run_tests == true
         uses: actions/checkout@v3
         with:
           repository: MODFLOW-USGS/modflow6-examples
           path: modflow6-examples
 
-      - name: Cache modflow6 examples
-        id: cache-examples
-        uses: actions/cache@v3
-        with:
-          path: modflow6-examples/examples
-          key: modflow6-examples-${{ hashFiles('modflow6-examples/scripts/**') }}
-
-      - name: Install extra Python packages
-        if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6-examples/etc
-        run: pip install -r requirements.pip.txt
-
-      - name: Build example models
-        if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6-examples/etc
-        run: python ci_build_files.py
-
       - name: Update flopy
+        if: inputs.run_tests == true
         working-directory: modflow6/autotest
         run: python update_flopy.py
 
       - name: Get executables
+        if: inputs.run_tests == true
         working-directory: modflow6/autotest
-        run: pytest -v --durations 0 get_exes.py
-
-      - name: Test programs
-        working-directory: modflow6/autotest
-        run: pytest -v -n auto -m "not developmode" --durations 0
-
-      - name: Test scripts
-        working-directory: modflow6/distribution
-        run: pytest -v --durations 0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+        run: pytest -v --durations 0 get_exes.py
+
+      - name: Test modflow6
+        if: inputs.run_tests == true
+        working-directory: modflow6/autotest
+        env:
+          REPOS_PATH: ${{ github.workspace }}
+        run: |
+          marker="not large"
+          if [[ "${{ inputs.development }}" == "false" ]]; then
+            marker="$marker and not developmode"
+          fi
+
+          pytest -v -n auto --durations 0 -m "$marker"
+      
+      # steps below run only on Linux to test distribution procedures, e.g.
+      # compiling binaries, building documentation
+      - name: Checkout usgslatex
+        if: ${{ runner.os == 'Linux' && inputs.run_tests == true }}
+        uses: actions/checkout@v3
+        with:
+          repository: MODFLOW-USGS/usgslatex
+          path: usgslatex
+
+      - name: Install TeX Live
+        if: ${{ runner.os == 'Linux' && inputs.run_tests == true }}
+        run: |
+          sudo apt-get update
+          sudo apt install texlive-science \
+            texlive-latex-extra \
+            texlive-font-utils \
+            texlive-fonts-recommended \
+            texlive-fonts-extra
+
+      - name: Install USGS LaTeX style files and Univers font
+        if: ${{ runner.os == 'Linux' && inputs.run_tests == true }}
+        working-directory: usgslatex/usgsLaTeX
+        run: sudo ./install.sh --all-users
+
+      - name: Install dependencies for ex-gwf-twri example model
+        if: ${{ runner.os == 'Linux' && inputs.run_tests == true }}
+        working-directory: modflow6-examples/etc
+        run: |
+          # install extra Python packages
+          pip install -r requirements.pip.txt
+
+          # the example model needs executables to be on the path
+          echo "${{ github.workspace }}/modflow6/bin" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/modflow6/bin/downloaded" >> $GITHUB_PATH
+
+      - name: Build ex-gwf-twri example model
+        if: ${{ runner.os == 'Linux' && inputs.run_tests == true }}
+        working-directory: modflow6-examples/scripts
+        run: python ex-gwf-twri.py
+
+      - name: Test distribution scripts
+        if: ${{ inputs.run_tests == true }}
+        working-directory: modflow6/distribution
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pytest -v --durations 0
 
   docs:
     name: Build docs
-    if: ${{ github.event_name == 'push' && github.ref_name != 'master' }}
     needs: build
     runs-on: ubuntu-22.04
     defaults:
@@ -159,13 +229,21 @@ jobs:
       - name: Checkout modflow6
         uses: actions/checkout@v3
         with:
+          repository: ${{ github.repository_owner }}/modflow6
           path: modflow6
+          ref: ${{ inputs.branch }}
 
       - name: Checkout modflow6-examples
         uses: actions/checkout@v3
         with:
           repository: MODFLOW-USGS/modflow6-examples
           path: modflow6-examples
+
+      - name: Checkout usgslatex
+        uses: actions/checkout@v3
+        with:
+          repository: MODFLOW-USGS/usgslatex
+          path: usgslatex
 
       - name: Install TeX Live
         run: |
@@ -175,12 +253,6 @@ jobs:
             texlive-font-utils \
             texlive-fonts-recommended \
             texlive-fonts-extra
-
-      - name: Checkout usgslatex
-        uses: actions/checkout@v3
-        with:
-          repository: MODFLOW-USGS/usgslatex
-          path: usgslatex
 
       - name: Install USGS LaTeX style files and Univers font
         working-directory: usgslatex/usgsLaTeX
@@ -196,73 +268,70 @@ jobs:
       - name: Setup Intel Fortran
         uses: modflowpy/install-intelfortran-action@v1
 
-      - name: Fix Micromamba path (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # https://github.com/modflowpy/install-intelfortran-action#conda-scripts
-          $mamba_bin = "C:\Users\runneradmin\micromamba-root\envs\modflow6\Scripts"
-          echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install extra Python packages
-        working-directory: modflow6-examples/etc
-        run: pip install -r requirements.pip.txt
-
-      - name: Build example models
-        working-directory: modflow6-examples/etc
-        run: pytest -v -n auto ci_build_files.py
-
       - name: Update version
+        id: update_version
         working-directory: modflow6/distribution
         run: |
-          # extract version from ref name
-          ref="${{ github.ref_name }}"
-          ver="${ref%"rc"}"
-          
-          # update version files
-          if [[ "$ver" == *"rc"* ]]; then
-            python update_version.py -v "${ver#"v"}" 
+          ver="${{ needs.build.outputs.version }}"
+          if [[ ("${{ inputs.development }}" == "false") && ("${{ inputs.approve }}" == "true") ]]; then
+            python update_version.py -v "$ver" --approve
           else
-            python update_version.py -v "${ver#"v"}" --approve
+            python update_version.py -v "$ver"
           fi
-          
-          # set dist name, format is 'mf<major.minor.patch>' for docs (no os tag)
-          distname="mf${ref#"v"}"
-          echo "DISTNAME=$distname" >> $GITHUB_ENV
 
-      - name: Create directory structure
-        run: |
-          # Create a skeleton of the distribution's folder structure to include in the docs
-          mkdir -p "$DISTNAME/doc"
-          mkdir "$DISTNAME/make"
-          mkdir "$DISTNAME/msvs"
-          mkdir "$DISTNAME/srcbmi"
-          cp modflow6/code.json "$DISTNAME/code.json"
-          cp modflow6/meson.build "$DISTNAME/meson.build"
-          cp -r modflow6-examples/examples "$DISTNAME"
-          cp -r modflow6/src "$DISTNAME"
-          cp -r modflow6/utils "$DISTNAME"
-          
-          # create LaTeX file describing the folder structure
-          cd modflow6/doc/ReleaseNotes
-          python mk_folder_struct.py -dp "${{ github.workspace }}/$DISTNAME"
-
-      - name: Download artifacts
+      - name: Download pre-built binaries
         uses: actions/download-artifact@v3
         with:
           name: bin-${{ runner.os }}
           path: bin
+    
+      - name: Install dependencies for ex-gwf-twri example model
+        working-directory: modflow6-examples/etc
+        run: |
+          # install extra Python packages
+          pip install -r requirements.pip.txt
+  
+          # the example model needs executables to be on the path
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+          # execute permissions may not have survived artifact upload/download
+          chmod +x "${{ github.workspace }}/bin/mf6"
+          chmod +x "${{ github.workspace }}/bin/mf5to6"
+          chmod +x "${{ github.workspace }}/bin/zbud6"
+
+          # the example model also needs mf2005
+          get-modflow "${{ github.workspace }}/bin" --subset mf2005
+  
+      - name: Build ex-gwf-twri example model
+        working-directory: modflow6-examples/scripts
+        run: python ex-gwf-twri.py
+      
+      - name: Create directory structure
+        run: |
+          distname=${{ needs.build.outputs.distname }}
+
+          # Create a skeleton of the distribution's folder structure to include in the docs
+          mkdir -p "$distname/doc"
+          mkdir "$distname/make"
+          mkdir "$distname/msvs"
+          mkdir "$distname/srcbmi"
+          cp modflow6/code.json "$distname/code.json"
+          cp modflow6/meson.build "$distname/meson.build"
+          cp -r modflow6-examples/examples "$distname"
+          cp -r modflow6/src "$distname"
+          cp -r modflow6/utils "$distname"
+          
+          # create LaTeX file describing the folder structure
+          cd modflow6/doc/ReleaseNotes
+          python mk_folder_struct.py -dp "${{ github.workspace }}/$distname"
 
       - name: Build documentation
         env:
+          # need a GITHUB_TOKEN to download example doc PDF asset from modflow6-examples repo
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          chmod +x bin/mf6
-          chmod +x bin/mf5to6
-          chmod +x bin/zbud6
-          python modflow6/distribution/build_docs.py -b bin -o doc
+        run: python modflow6/distribution/build_docs.py -b bin -o doc
 
-      - name: Upload documentation
+      - name: Upload documentation artifact
         uses: actions/upload-artifact@v3
         with:
           name: doc
@@ -270,8 +339,9 @@ jobs:
 
   dist:
     name: Build distribution (${{ matrix.os }})
-    if: ${{ github.event_name == 'push' && github.ref_name != 'master' }}
-    needs: docs
+    needs:
+      - build
+      - docs
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -290,7 +360,9 @@ jobs:
       - name: Checkout modflow6
         uses: actions/checkout@v3
         with:
+          repository: ${{ github.repository_owner }}/modflow6
           path: modflow6
+          ref: ${{ inputs.branch }}
 
       - name: Checkout modflow6-examples
         uses: actions/checkout@v3
@@ -301,6 +373,7 @@ jobs:
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-root-path: ${{ github.workspace }}/micromamba-root
           environment-file: modflow6/environment.yml
           cache-downloads: true
           cache-environment: true
@@ -313,75 +386,65 @@ jobs:
         shell: pwsh
         run: |
           # https://github.com/modflowpy/install-intelfortran-action#conda-scripts
-          $mamba_bin = "C:\Users\runneradmin\micromamba-root\envs\modflow6\Scripts"
+          $mamba_bin = "${{ github.workspace }}\micromamba-root\envs\modflow6\Scripts"
           echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install extra Python packages
-        working-directory: modflow6-examples/etc
-        run: pip install -r requirements.pip.txt
-
-      - name: Build example models
-        working-directory: modflow6-examples/etc
-        run: pytest -v -n auto ci_build_files.py
-
+      
       - name: Update version
+        id: update_version
         working-directory: modflow6/distribution
         run: |
-          # extract version from ref name
-          ref="${{ github.ref_name }}"
-          ver="${ref%"rc"}"
-          
-          # update version files
-          if [[ "$ver" == *"rc"* ]]; then
-            python update_version.py -v "${ver#"v"}" 
+          ver="${{ needs.build.outputs.version }}"
+          if [[ ("${{ inputs.development }}" == "false") && ("${{ inputs.approve }}" == "true") ]]; then
+            python update_version.py -v "$ver" --approve
           else
-            python update_version.py -v "${ver#"v"}" --approve
+            python update_version.py -v "$ver"
           fi
-          
-          # set dist name, format is 'mf<major.minor.patch>_<ostag>'
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            distname="mf${ref#"v"}"
-          else
-            distname="mf${ref#"v"}_${{ matrix.ostag }}"
-          fi
-          echo "DISTNAME=$distname" >> $GITHUB_ENV
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          path: ${{ env.DISTNAME }}
+          # download artifacts to OS-specific directory
+          path: ${{ needs.build.outputs.distname }}_${{ matrix.ostag }}
 
       - name: Select artifacts for OS
         run: |
-          # move binaries for current OS to top level bin dir
-          mv "$DISTNAME/bin-${{ runner.os }}" "$DISTNAME/bin"
-          rm -rf "$DISTNAME/bin-*"
+          # create directory for OS-specific artifacts
+          distname="${{ needs.build.outputs.distname }}"
+          mkdir -p "$distname_${{ matrix.ostag }}/bin"
+
+          # move binaries for current OS to distribution bin dir
+          mv "$distname/bin-${{ runner.os }}" "$distname_${{ matrix.ostag }}/bin"
+
+          # remove binaries for other OSes
+          rm -rf "$distname/bin-*"
 
       - name: Build distribution
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # build dist folder
-          python modflow6/distribution/build_dist.py -o "$DISTNAME" -e modflow6-examples
+          # build distribution
+          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          python modflow6/distribution/build_dist.py -o "$distname" -e modflow6-examples
 
-          # rename PDF docs
-          mv "$DISTNAME/doc/ReleaseNotes.pdf" "$DISTNAME/doc/release.pdf"
-          mv "$DISTNAME/doc/converter_mf5to6.pdf" "$DISTNAME/doc/mf5to6.pdf"
+          # move & rename PDF documents to dist folder
+          mv "$distname/doc/ReleaseNotes.pdf" "$distname/doc/release.pdf"
+          mv "$distname/doc/converter_mf5to6.pdf" "$distname/doc/mf5to6.pdf"
 
       - name: Zip distribution
         if: runner.os != 'Windows'
         run: |
-          zip -r ${{ env.DISTNAME }}.zip \
-            ${{ env.DISTNAME }}/bin \
-            ${{ env.DISTNAME }}/src \
-            ${{ env.DISTNAME }}/srcbmi \
-            ${{ env.DISTNAME }}/doc \
-            ${{ env.DISTNAME }}/examples \
-            ${{ env.DISTNAME }}/make \
-            ${{ env.DISTNAME }}/msvs \
-            ${{ env.DISTNAME }}/utils \
-            ${{ env.DISTNAME }}/code.json \
-            ${{ env.DISTNAME }}/meson.build \
+          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          zip -r $distname.zip \
+            $distname/bin \
+            $distname/src \
+            $distname/srcbmi \
+            $distname/doc \
+            $distname/examples \
+            $distname/make \
+            $distname/msvs \
+            $distname/utils \
+            $distname/code.json \
+            $distname/meson.build \
             -x '*.DS_Store' \
             -x '*libmf6.lib' \
             -x '*idmloader*' \
@@ -392,205 +455,42 @@ jobs:
       - name: Zip distribution (Windows)
         if: runner.os == 'Windows'
         run: |
-          7z a -tzip ${{ env.DISTNAME }}.zip \
-            ${{ env.DISTNAME }}/bin \
-            ${{ env.DISTNAME }}/src \
-            ${{ env.DISTNAME }}/srcbmi \
-            ${{ env.DISTNAME }}/doc \
-            ${{ env.DISTNAME }}/examples \
-            ${{ env.DISTNAME }}/make \
-            ${{ env.DISTNAME }}/msvs \
-            ${{ env.DISTNAME }}/utils \
-            ${{ env.DISTNAME }}/code.json \
-            ${{ env.DISTNAME }}/meson.build \
+          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          7z a -tzip $distname.zip \
+            $distname/bin \
+            $distname/src \
+            $distname/srcbmi \
+            $distname/doc \
+            $distname/examples \
+            $distname/make \
+            $distname/msvs \
+            $distname/utils \
+            $distname/code.json \
+            $distname/meson.build \
             -xr!libmf6.lib \
             -xr!idmloader \
             -xr!pymake \
             -xr!obj_temp \
             -xr!mod_temp
 
-      # validate after zipping to avoid accidentally changing the distribution files
-      - name: Check distribution
-        run: pytest -v -s modflow6/distribution/check_dist.py -P ${{ env.DISTNAME }}
+      # validate only after zipping distribution to avoid accidentally changing any files
+      - name: Validate distribution
+        run: |
+          if [[ "${{ inputs.approve }}" == "true" ]]; then
+            pytest -v -s modflow6/distribution/check_dist.py --path "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}" --approved
+          else
+            pytest -v -s modflow6/distribution/check_dist.py --path "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          fi
 
-      - name: Upload distribution
+      - name: Upload distribution zipfile artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.DISTNAME }}
-          path: ${{ env.DISTNAME }}.zip
+          name: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}.zip"
+          path: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}.zip"
 
-      - name: Upload release notes
+      - name: Upload release notes artifact
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v3
         with:
           name: release_notes
-          path: ${{ env.DISTNAME }}/doc/release.pdf
-
-  pr:
-    name: Draft release PR
-    # only runs if branch name doesn't end with 'rc' (i.e. release is approved)
-    if: ${{ github.event_name == 'push' && github.ref_name != 'master' && !(contains(github.ref_name, 'rc')) }}
-    needs: dist
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      pull-requests: write
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - name: Checkout modflow6
-        uses: actions/checkout@v3
-
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          cache-downloads: true
-          cache-environment: true
-
-      - name: Update version
-        working-directory: distribution
-        run: |
-          # extract version from branch name
-          ref="${{ github.ref_name }}"
-          ver="${ref#"v"}"
-          
-          # update version files
-          if [[ "$ver" == *"rc"* ]]; then
-            python update_version.py -v "$ver" 
-          else
-            python update_version.py -v "$ver" --approve
-          fi
-          
-          # lint version.f90
-          fprettify -c ../.fprettify.yaml ../src/Utilities/version.f90
-          
-          # commit and push
-          git config core.sharedRepository true
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "ci(release): update version to $ver release mode"
-          git push origin "$ref"
-
-      - name: Create pull request
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          ref="${{ github.ref_name }}"
-          ver="${ref#"v"}"
-          body='
-          # MODFLOW '$ver' release
-          
-          The release can be approved by merging this PR into `master`. Merging rather than squashing is necessary to preserve the commit history.
-          
-          When this PR is merged, a final job will be triggered to:
-          1) create and tag a draft GitHub release, then upload assets (OS distributions and release notes)
-          2) open a PR to update `develop` from `master`, resetting version files and setting `IDEVELOPMODE=1`
-          '
-          gh pr create -B "master" -H "$ref" --title "Release $ver" --draft --body "$body"
-
-  release:
-    name: Draft release
-    # runs only after release PR is merged to master
-    if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - name: Checkout modflow6
-        uses: actions/checkout@v3
-        with:
-          path: modflow6
-
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: modflow6/environment.yml
-          cache-downloads: true
-          cache-environment: true
-
-      - name: Download artifacts
-        uses: dawidd6/action-download-artifact@v2
-
-      - name: Draft release
-        working-directory: modflow6
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          # detect release version
-          version=$(python distribution/update_version.py --get)
-          
-          # create draft release
-          title="MODFLOW $version"
-          notes='
-          This is the approved USGS MODFLOW '$version' release.
-      
-          *Insert citation here*
-      
-          Visit the USGS "MODFLOW and Related Programs" site for information on MODFLOW 6 and related software: https://doi.org/10.5066/F76Q1VQV
-          '
-          gh release create "$version" ../mf*/mf*.zip ../release_notes/release.pdf --target master --title "$title" --notes "$notes" --draft --latest
-
-  reset:
-    name: Draft reset PR
-    # runs only after release is published (manually promoted from draft to public)
-    if: ${{ github.event_name == 'release' }}
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-
-      - name: Checkout modflow6
-        uses: actions/checkout@v3
-        with:
-          path: modflow6
-
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: modflow6/environment.yml
-          cache-downloads: true
-          cache-environment: true
-
-      - name: Get release tag
-        uses: oprypin/find-latest-tag@v1
-        id: latest_tag
-        with:
-          repository: ${{ github.repository }}
-          releases-only: true
-
-      - name: Create pull request
-        working-directory: modflow6
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          # create reset branch from master
-          reset_branch="post-release-${{ steps.latest_tag.outputs.tag }}-reset"
-          git fetch origin
-          git checkout master
-          git switch -c $reset_branch
-
-          # increment minor version and reset IDEVELOPMODE to 1
-          major_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f1)
-          minor_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f2)
-          version="$major_version.$((minor_version + 1)).0"
-          python distribution/update_version.py -v "$version"
-
-          # commit and push reset branch
-          git config core.sharedRepository true
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "ci(release): update version to $version development mode"
-          git push -u origin $reset_branch
-
-          # create PR into develop
-          body='
-          # Reinitialize for development
-
-          Updates the `develop` branch from `master` following a successful release. Increments the minor version number and resets `IDEVELOPMODE` back to `1`.
-          '
-          gh pr create -B "develop" -H "$reset_branch" --title "Reinitialize develop branch" --draft --body "$body"
+          path: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}/doc/release.pdf"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,7 +485,7 @@ jobs:
       - name: Upload distribution zipfile artifact
         uses: actions/upload-artifact@v3
         with:
-          name: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}.zip"
+          name: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
           path: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}.zip"
 
       - name: Upload release notes artifact

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -26,17 +26,22 @@ on:
         type: string
         default: ''
       commit_version:
-        description: 'Whether to commit version numbers back to the develop branch on a full release. Default is false. Not considered if approve is false.'
+        description: 'Whether to commit version numbers back to the develop branch. Default is false. Not considered if approve is false.'
+        required: false
+        type: boolean
+        default: false
+      reset:
+        description: 'Whether to reset the develop branch to the state of the master branch. Default is false. Not considered if approve is false.'
         required: false
         type: boolean
         default: false
       run_tests:
-        description: 'Whether to run tests after building binaries. Default is true. Can be set to false for rapid testing/debugging, or for a faster nightly/development build.'
+        description: 'Whether to run tests after building binaries. Default is true.'
         required: true
         type: boolean
         default: true
       version:
-        description: 'Version number to use for release. If a release is triggered by pushing a release branch, the version number is parsed from the branch name.'
+        description: 'Version number to use for release.'
         required: false
         type: string
         default: ''
@@ -57,6 +62,11 @@ jobs:
           # if branch was provided explicitly via workflow_dispatch, use it
           if [[ ("${{ github.event_name }}" == "workflow_dispatch") && (-n "${{ inputs.branch }}") ]]; then
             branch="${{ inputs.branch }}"
+            # prevent releases from develop or master
+            if [[ ("$branch" == "develop") || ("$branch" == "master") ]]; then
+              echo "error: releases may not be triggered from branch $branch"
+              exit 1
+            fi
             echo "using branch $branch from workflow_dispatch"
           elif [[ ("${{ github.event_name }}" == "push") && ("${{ github.ref_name }}" != "master") ]]; then
             # if release was triggered by pushing a release branch, use that branch
@@ -143,7 +153,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "ci(release): update version to $ver"
-          git push origin "$ref"
+          git push origin "${{ github.ref }}"
 
       - name: Create pull request
         env:
@@ -159,7 +169,7 @@ jobs:
           1) create and tag a draft GitHub release, then upload assets (OS distributions and release notes)
           2) open a PR to update `develop` from `master`, resetting version files and setting `IDEVELOPMODE=1`
           '
-          gh pr create -B "master" -H "$ref" --title "Release $ver" --draft --body "$body"
+          gh pr create -B "master" -H "${{ github.ref }}" --title "Release $ver" --draft --body "$body"
 
   release:
     name: Draft release
@@ -206,7 +216,8 @@ jobs:
   reset:
     name: Draft reset PR
     # runs only after GitHub release post is published (manually promoted from draft to public)
-    if: github.event_name == 'release'
+    # to bring the release commits from master back into develop
+    if: github.event_name == 'release' && inputs.reset == 'true'
     runs-on: ubuntu-22.04
     defaults:
       run:

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -1,0 +1,272 @@
+name: MODFLOW 6 release dispatch
+on:
+  push:
+    branches:
+      # initial phase of the release procedure is triggered by pushing a release branch
+      - v[0-9]+.[0-9]+.[0-9]+*
+      # intermediate phase is triggered by merging the release branch to master
+      - master
+  # final phase is triggered by promoting/publishing a GitHub release draft to a full release
+  release:
+    types:
+      - published
+  # workflow_dispatch trigger to start release via GitHub UI or CLI,
+  # as an alternative to triggering when a release branch is pushed.
+  # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+    inputs:
+      approve:
+        description: 'Whether to approve the release. Default is false, i.e. a preliminary/provisional release.'
+        required: false
+        type: boolean
+        default: false
+      branch:
+        description: 'Branch to use for release. Defaults to the current branch (for releases triggered by pushing a release branch).'
+        required: false
+        type: string
+        default: ''
+      commit_version:
+        description: 'Whether to commit version numbers back to the develop branch on a full release. Default is false. Not considered if approve is false.'
+        required: false
+        type: boolean
+        default: false
+      run_tests:
+        description: 'Whether to run tests after building binaries. Default is true. Can be set to false for rapid testing/debugging, or for a faster nightly/development build.'
+        required: true
+        type: boolean
+        default: true
+      version:
+        description: 'Version number to use for release. If a release is triggered by pushing a release branch, the version number is parsed from the branch name.'
+        required: false
+        type: string
+        default: ''
+jobs:
+  set_options:
+    name: Set release options
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
+    outputs:
+      branch: ${{ steps.set_branch.outputs.branch }}
+      version: ${{ steps.set_version.outputs.version }}
+    steps:
+      - name: Set branch
+        id: set_branch
+        run: |
+          # if branch was provided explicitly via workflow_dispatch, use it
+          if [[ ("${{ github.event_name }}" == "workflow_dispatch") && (-n "${{ inputs.branch }}") ]]; then
+            branch="${{ inputs.branch }}"
+            echo "using branch $branch from workflow_dispatch"
+          elif [[ ("${{ github.event_name }}" == "push") && ("${{ github.ref_name }}" != "master") ]]; then
+            # if release was triggered by pushing a release branch, use that branch
+            branch="${{ github.ref_name }}"
+            echo "using branch $branch from ref ${{ github.ref }}"
+          else
+            # otherwise exit with an error
+            echo "error: this workflow should not have triggered for event ${{ github.event_name }} on branch ${{ github.ref_name }}"
+            exit 1
+          fi
+          echo "branch=$branch" >> $GITHUB_OUTPUT
+      - name: Set version
+        id: set_version
+        run: |
+          # if version number was provided explicitly via workflow_dispatch, use it
+          if [[ ("${{ github.event_name }}" == "workflow_dispatch") && (-n "${{ inputs.version }}") ]]; then
+            ver="${{ inputs.version }}"
+            echo "using version number $ver from workflow_dispatch"
+          elif [[ ("${{ github.event_name }}" == "push") && ("${{ github.ref_name }}" != "master") ]]; then
+            # if release was triggered by pushing a release branch, parse version number from branch name (sans leading 'v')
+            ref="${{ github.ref_name }}"
+            ver="${ref#"v"}"
+            echo "parsed version number $ver from branch name $ref"
+          else
+            # otherwise exit with an error
+            echo "error: version number not provided explicitly (via workflow_dispatch input) or implicitly (via branch name)"
+            exit 1
+          fi
+          echo "version=$ver" >> $GITHUB_OUTPUT
+  make_dist:
+    name: Make distribution
+    needs: set_options
+    uses: MODFLOW-USGS/modflow6/.github/workflows/release.yml@develop
+    with:
+      # If the workflow is manually triggered, the maintainer must manually set approve=true to approve a release.
+      # If triggered by pushing a release branch, the release is approved if the branch name doesn't contain "rc".
+      approve: ${{ (github.event_name == 'workflow_dispatch' && inputs.approve == 'true') || (github.event_name != 'workflow_dispatch' && !contains(github.ref_name, 'rc')) }}
+      branch: ${{ needs.set_options.outputs.branch }}
+      development: false
+      run_tests: ${{ inputs.run_tests == '' || inputs.run_tests == 'true' }}
+      version: ${{ needs.set_options.outputs.version }}
+  pr:
+    name: Draft release PR
+    if: ${{ github.event_name == 'push' && github.ref_name != 'master' && (github.event_name == 'workflow_dispatch' && inputs.approve == 'true') || (github.event_name != 'workflow_dispatch' && !contains(github.ref_name, 'rc')) }}
+    needs: make_dist
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Checkout modflow6
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository_owner }}/modflow6
+          ref: ${{ github.ref }}
+
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment.yml
+          cache-downloads: true
+          cache-environment: true
+
+      - name: Update version
+        working-directory: distribution
+        run: |
+          # update version files
+          ver="${{ needs.make_dist.outputs.version }}"
+          if [[ "${{ inputs.approve }}" == "true" ]]; then
+            python update_version.py -v "$ver" --approve
+          else
+            python update_version.py -v "$ver"
+          fi
+          
+          # lint version.f90
+          fprettify -c ../.fprettify.yaml ../src/Utilities/version.f90
+          
+          # commit and push
+          git config core.sharedRepository true
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "ci(release): update version to $ver"
+          git push origin "$ref"
+
+      - name: Create pull request
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          ver="${{ needs.make_dist.outputs.version }}"
+          body='
+          # MODFLOW '$ver' release
+          
+          The release can be approved by merging this PR into `master`. Merging rather than squashing is necessary to preserve the commit history.
+          
+          When this PR is merged, a final job will be triggered to:
+          1) create and tag a draft GitHub release, then upload assets (OS distributions and release notes)
+          2) open a PR to update `develop` from `master`, resetting version files and setting `IDEVELOPMODE=1`
+          '
+          gh pr create -B "master" -H "$ref" --title "Release $ver" --draft --body "$body"
+
+  release:
+    name: Draft release
+    # runs only after release PR is merged to master
+    if: github.event_name == 'push' && github.ref_name == 'master'
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Checkout modflow6
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository_owner }}/modflow6
+          path: modflow6
+
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: modflow6/environment.yml
+          cache-downloads: true
+          cache-environment: true
+
+      - name: Download artifacts
+        uses: dawidd6/action-download-artifact@v2
+
+      - name: Draft release
+        working-directory: modflow6
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # create draft release
+          ver=$(python distribution/update_version.py -g)
+          title="MODFLOW $ver"
+          notes='
+          This is the approved USGS MODFLOW '$ver' release.
+      
+          *Insert citation here*
+      
+          Visit the USGS "MODFLOW and Related Programs" site for information on MODFLOW 6 and related software: https://doi.org/10.5066/F76Q1VQV
+          '
+          gh release create "$ver" ../mf*/mf*.zip ../release_notes/release.pdf --target master --title "$title" --notes "$notes" --draft --latest
+
+  reset:
+    name: Draft reset PR
+    # runs only after GitHub release post is published (manually promoted from draft to public)
+    if: github.event_name == 'release'
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+
+      - name: Checkout modflow6
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository_owner }}/modflow6
+          path: modflow6
+
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: modflow6/environment.yml
+          cache-downloads: true
+          cache-environment: true
+
+      - name: Get release tag
+        uses: oprypin/find-latest-tag@v1
+        id: latest_tag
+        with:
+          repository: ${{ github.repository }}
+          releases-only: true
+
+      - name: Create pull request
+        working-directory: modflow6
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # create reset branch from master
+          reset_branch="post-release-${{ steps.latest_tag.outputs.tag }}-reset"
+          git fetch origin
+          git checkout master
+          git switch -c $reset_branch
+
+          # configure git
+          git config core.sharedRepository true
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # updating version numbers if enabled
+          if [[ "${{ inputs.commit_version }}" == "true" ]]; then
+            ver="${{ steps.latest_tag.outputs.tag }}"
+            python distribution/update_version.py -v "$ver"
+            git add -A
+            git commit -m "ci(release): update version to $ver, reset IDEVELOPMODE to 1"
+          else
+            # in either case we at least need to reset IDEVELOPMODE to 1
+            python distribution/update_version.py
+            git add -A
+            git commit -m "ci(release): reset IDEVELOPMODE to 1"
+          fi
+          
+          # push reset branch
+          git push -u origin $reset_branch
+
+          # create PR into develop
+          body='
+          Reinitialize the `develop` branch following a successful release.
+          '
+          gh pr create -B "develop" -H "$reset_branch" --title "Reinitialize develop branch" --draft --body "$body

--- a/autotest/test_cli.py
+++ b/autotest/test_cli.py
@@ -6,8 +6,7 @@ from conftest import project_root_path
 bin_path = project_root_path / "bin"
 
 
-def split_on_letter(s):
-    # match = re.compile("[^\W\d]").search(s)
+def split_nonnumeric(s):
     match = re.compile("[^0-9]").search(s)
     return [s[:match.start()], s[match.start():]] if match else s
 
@@ -26,5 +25,5 @@ def test_cli_version():
     v_split = version.split(".")
     assert len(v_split) == 3
     assert all(s.isdigit() for s in v_split[:2])
-    sol = split_on_letter(v_split[2])
+    sol = split_nonnumeric(v_split[2])
     assert sol[0].isdigit()

--- a/autotest/test_cli.py
+++ b/autotest/test_cli.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 
 from conftest import project_root_path
@@ -5,19 +6,25 @@ from conftest import project_root_path
 bin_path = project_root_path / "bin"
 
 
+def split_on_letter(s):
+    # match = re.compile("[^\W\d]").search(s)
+    match = re.compile("[^0-9]").search(s)
+    return [s[:match.start()], s[match.start():]] if match else s
+
+
 def test_cli_version():
     output = " ".join(
         subprocess.check_output([str(bin_path / "mf6"), "-v"]).decode().split()
     )
-    assert output.startswith("mf6:")
-    assert output.lower().count("release") == 1
-    # assert output.lower().count("candidate") <= 1
-
     print(output)
+    assert output.startswith("mf6:")
 
     version = (
-        output.lower().rpartition(":")[2].rpartition("release")[0].strip()
+        output.lower().split(' ')[1]
     )
+    print(version)
     v_split = version.split(".")
     assert len(v_split) == 3
-    assert all(s.isdigit() for s in v_split)
+    assert all(s.isdigit() for s in v_split[:2])
+    sol = split_on_letter(v_split[2])
+    assert sol[0].isdigit()

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -128,12 +128,12 @@ If no `--version` is provided, the version is not changed, only the build timest
 An optional label may be appended to the release number, e.g.
 
 ```shell
-python update_version.py -v 6.4.2dev
+python update_version.py -v 6.4.2rc
 ```
 
 The label must start immediately following the patch version number, with no space in between. The label may contain numeric characters or symbols, but *must not* start with a number (otherwise there is no way to distinguish it from the patch version number).
 
-The `--approve` (short `-a`) option can be used to approve an official release. If the `--approve` option is provided, `IDEVELOPMODE` is set to 0. If `--approve` is not provided, `(preliminary)` is substituted into version numbers throughout the repository.
+The `--approve` (short `-a`) option can be used to approve an official release. If the `--approve` option is provided, `IDEVELOPMODE` is set to 0. If `--approve` is not provided, `IDEVELOPMODE = 1` and `(preliminary)` is appended to version numbers.
 
 #### Building makefiles
 

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -86,14 +86,14 @@ Full distributions, on the other hand, contain the items listed above, as well a
   - docs for `mf5to6` and `zbud6`
 
 
-### Preparing a nightly release
+### Preparing a minimal development release
 
 Development releases are built and [posted nightly on the `MODFLOW-USGS/modflow6-nightly-build` repository](https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases). Release assets include:
 
 - platform-specific distributions containing only executables `mf6`, `zbud6`, `mf5to6` and library `libmf6`
 - MODFLOW 6 input/output documentation
 
-The `build_dist.py` script is used to create both development and full distributions. To create a development distribution zipfile in the default location (`<project root>/distribution/`), run the script with the `--development` (short `-d`) flag:
+The `build_dist.py` script can be used to create both development and full distributions. To create a development distribution, run the script with the `--development` (short `-d`) flag:
 
 ```shell
 python build_dist.py -d
@@ -115,7 +115,7 @@ To prepare an official release for distribution, the steps are as follows:
 
 Version information is stored primarily in `version.txt` in the project root, as well as in several other files in the repository.
 
-The `update_version.py` script updates files containing version information. First a file lock is acquired, then `version.txt` is updated, and changes are propagated to other files in the repository, then the lock is released.
+The `update_version.py` script updates files containing version information. First a file lock is acquired, then repository files are updated, then the lock is released.
 
 The version can be specified with the `--version` (short `-v`) option. For instance, to set version to `6.4.1`, run from the `scripts/` folder:
 
@@ -124,6 +124,16 @@ python update_version.py -v 6.4.1
 ```
 
 If no `--version` is provided, the version is not changed, only the build timestamp.
+
+An optional label may be appended to the release number, e.g.
+
+```shell
+python update_version.py -v 6.4.2dev
+```
+
+The label must start immediately following the patch version number, with no space in between. The label may contain numeric characters or symbols, but *must not* start with a number (otherwise there is no way to distinguish it from the patch version number).
+
+The `--approve` (short `-a`) option can be used to approve an official release. If the `--approve` option is provided, `IDEVELOPMODE` is set to 0. If `--approve` is not provided, `(preliminary)` is substituted into version numbers throughout the repository.
 
 #### Building makefiles
 
@@ -160,11 +170,15 @@ The above will write results to a markdown file `.benchmarks/run-time-comparison
 
 Extensive documentation is bundled with official MODFLOW 6 releases. MODFLOW 6 documentation is written in LaTeX. Some LaTeX files (in particular for MODFLOW 6 input/output documentation) is automatically generated from DFN files. The `release.yml` workflow first runs `update_version.py` to update version strings to be substituted into the docs, then runs `build_docs.py` to regenerate LaTeX files where necessary, download benchmark results (and convert the Markdown results file to LaTeX), download publications hosted on the USGS website, and finally convert LaTeX to PDFs.
 
-Manually building MODFLOW 6 documentation requires additional Python dependencies specified in `build_rtd_docs/requirements.rtd.txt`. Styles defined in the [`MODFLOW-USGS/usgslatex`](https://github.com/MODFLOW-USGS/usgslatex) are also required. (See that repository's `README` for installation instructions or this repo's [`../.github/workflows/docs.yml](../.github/workflows/docs.yml) CI workflow for an example.) A Docker image with documentation dependencies pre-installed is also available on Docker Hub: [`wbonelli/usgslatex`](https://hub.docker.com/r/wbonelli/usgslatex). This can be useful for building documentation on a system without a LaTeX installation.
+Manually building MODFLOW 6 documentation requires additional Python dependencies specified in `build_rtd_docs/requirements.rtd.txt`. Styles defined in the [`MODFLOW-USGS/usgslatex`](https://github.com/MODFLOW-USGS/usgslatex) are also required. (See that repository's `README` for installation instructions or this repo's [`../.github/workflows/docs.yml](../.github/workflows/docs.yml) CI workflow for an example.)
 
 #### Building the distribution archive
 
 After each step above is complete, the `build_dist.py` script can be used (without the `--development` flag) to bundle MODFLOW 6 official release artifacts for distribution. See [the `release.yml` workflow](../.github/workflows/release.yml) for a complete example of how to build a distribution archive.
+
+#### Verifying the distribution archive
+
+The `check_dist.py` script can be used to check the release distribution folder. The `--path` argument is the path to the dist folder. The `--approved` flag can be used to signal that the release is approved/official. By default the release is assumed preliminary. The script checks the version string emitted by `mf6 -v` for the presence or absence of "preliminary" depending on this flag.
 
 ## Release automation
 
@@ -176,13 +190,31 @@ As mentioned, development releases are automatically built and posted nightly on
 
 ### Official releases
 
-The procedure above to prepare an official release is reproduced in `.github/workflows/release.yml`. This workflow is configured to run whenever tags are pushed to the `MODFLOW-USGS/modflow6` repository.
+The procedure above to prepare an official release is reproduced in `.github/workflows/release.yml`. This workflow has no triggers of its own, and must be dispatched by `.github/workflows/release_dispatch.yml`. A release can be dispatched in two ways:
+
+- Push a release branch to the `MODFLOW-USGS/modflow6` repository.
+- Manually trigger the workflow via GitHub CLI or web UI.
+
+#### Triggering with a release branch
 
 To release a new version of MODFLOW 6:
 
-1. Create a release candidate branch from the tip of `develop`. The branch's name must begin with `v` followed by the version number, and ending with `rc`. The branch name must must end with `rc` for release candidate branches, e.g. `v6.4.0rc`.
-2. Push the branch to the `MODFLOW-USGS/modflow6` repository. This will trigger a dry run build, in which the distribution archive is constructed with development mode binaries (`IDEVELOPMODE` set to 1) and no release is posted to the repository. Release are cached for easier debugging on dry runs.
-3. If the release candidate build passes inspection, rename the branch (or create another) without the trailing `rc`, and push it. This will trigger another build, in which the distribution archive is constructed with production mode binaries. After binaries and docs are rebuilt, a draft PR will automatically be created on the `MODFLOW-USGS/modflow6` repository's `master` branch. To approve and finalize the release, This PR can be merged into `master`. This will trigger a final CI job to tag the revision to `master`, post a draft release to the `MODFLOW-USGS/modflow6` repository, and create another PR updating the `develop` branch from `master`, resetting version files, and setting `IDEVELOPMODE` back to 1.
+1. Create a release candidate branch from the tip of `develop` or `master`. The branch's name must begin with `v` followed by the version number. For an officially approved release, include *only* the version number. For a preliminary release candidate, append `rc` after the version number, e.g. `v6.4.0rc`. If the branch name does not end in `rc`, the release is assumed to be approved.
+2. Push the branch to the `MODFLOW-USGS/modflow6` repository. This triggers the release workflow. If the release is still an unapproved candidate (i.e. the branch name ends with `rc`) binaries are built with `IDEVELOPMODE` set to 1, and the workflow ends after uploading binaries and documentation artifacts for inspection. If the release is approved/official, the workflow drafts a pull request against the `master` branch.
+3. To continue with the release, merge the PR into `master`. This triggers another job to tag the new tip of `master` with the release number, draft a release post, upload binaries and documentation as release assets, and create another PR updating the `develop` branch from `master`, resetting version files, and setting `IDEVELOPMODE` back to 1.
+4. To finalize the release, publish the release post and merge the PR into `develop`.
+
+#### Triggering a release manually
+
+The `workflow_dispatch` event is GitHub's mechanism for manually triggering workflows. This can be accomplished from the Actions tab in the GitHub UI.
+
+Navigate to the Actions tab of this repository. Select the release dispatch workflow. A `Run workflow` button should be visible in an alert at the top of the list of workflow runs. Click the `Run workflow` button, selecting values for the various inputs:
+
+- `approve`: whether the release is officially approved, or just a release candidate
+- `branch`: the branch to release from
+- `development`: whether to build a minimal development distribution or a full distribution
+- `run_tests`: whether to run autotests after building binaries
+- `version`: the version number of the release
 
 ### Release versioning
 

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -100,8 +100,8 @@ def clean_tex_files():
 
 def download_benchmarks(output_path: PathLike, verbose: bool = False) -> Optional[Path]:
     output_path = Path(output_path).expanduser().absolute()
-    name = "run-time-comparison"
-    repo = "w-bonelli/modflow6"
+    name = "run-time-comparison"  # todo make configurable
+    repo = "MODFLOW-USGS/modflow6"  # todo make configurable, add pytest/cli args
     artifacts = list_artifacts(repo, name=name, verbose=verbose)
     artifacts = sorted(artifacts, key=lambda a: datetime.strptime(a['created_at'], '%Y-%m-%dT%H:%M:%SZ'), reverse=True)
     most_recent = next(iter(artifacts), None)

--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from utils import get_branch
+from utils import get_branch, split_nonnumeric
 
 _system = platform.system()
 _eext = ".exe" if _system == "Windows" else ""
@@ -109,12 +109,6 @@ def test_examples(dist_dir_path):
     print(output)
 
 
-def split_on_letter(s):
-    # match = re.compile("[^\W\d]").search(s)
-    match = re.compile("[^0-9]").search(s)
-    return [s[:match.start()], s[match.start():]] if match else s
-
-
 def test_binaries(dist_dir_path, approved):
     bin_path = dist_dir_path / "bin"
     assert (bin_path / f"mf6{_eext}").is_file()
@@ -139,5 +133,5 @@ def test_binaries(dist_dir_path, approved):
     v_split = version.split(".")
     assert len(v_split) == 3
     assert all(s.isdigit() for s in v_split[:2])
-    sol = split_on_letter(v_split[2])
+    sol = split_nonnumeric(v_split[2])
     assert sol[0].isdigit()

--- a/distribution/conftest.py
+++ b/distribution/conftest.py
@@ -7,4 +7,6 @@ _dist_dir_path = _project_root_path.parent / f"mf{str(Version.from_file(_project
 
 
 def pytest_addoption(parser):
+    # both options below are for check_dist.py
     parser.addoption("-P", "--path", action="store", default=str(_dist_dir_path))
+    parser.addoption("-A", "--approved", action="store_true", default=False)

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -13,28 +13,26 @@ This script is used to update several files in the modflow6 repository, includin
   ../code.json
   ../src/Utilities/version.f90
 
-Information in these files include version number (major.minor.patch), build date, whether or not
-the release is a release candidate or an actual release, whether the source code should be compiled
-in develop mode or in release mode, and the approval status.
+Information in these files include version number major.minor.patch[-label], build timestamp,
+whether or not the release is a prerelease candidate or an official distribution, whether the
+source code should be compiled in develop mode or in release mode, and other version metadata.
 
-The version number is read in from ../../version.txt, which contains major, minor, and patch version
-numbers.  These numbers will be propagated through the source code, latex files, markdown files,
-etc.  The version numbers can be overridden using the command line argument --version major.minor.macro.
+The version number is read from ../version.txt, which contains major, minor, and patch version
+numbers, and an optional label. Version numbers are substituted into source code, latex files,
+markdown files, etc.  The version number can be overridden using argument --version, short -v.
 
-Develop mode is set to 0 if the distribution is approved.
-
-Once this script is run, these updated files will be used in compilation, latex documents, and
-other parts of the repo to mark the overall status.
+Develop mode is set to 0 if the distribution is approved with --approved, short -a, otherwise,
+it is set to 1.
 
 """
 import argparse
 import json
 import os
+import re
 import shutil
 import textwrap
 from collections import OrderedDict
 from datetime import datetime
-from enum import Enum
 from os import PathLike
 from pathlib import Path
 from typing import NamedTuple, Optional
@@ -61,32 +59,43 @@ touched_file_paths = [
 ]
 
 
+def split_on_letter(s):
+    # match = re.compile("[^\W\d]").search(s)
+    match = re.compile("[^0-9]").search(s)
+    return [s[:match.start()], s[match.start():]] if match else s
+
+
 class Version(NamedTuple):
-    """Semantic version number, not including extensions (e.g., 'Release Candidate')"""
+    """Semantic version number, optionally with a short label (e.g, 'rc').
+    The label may contain numbers but must begin with a letter."""
 
     major: int = 0
     minor: int = 0
     patch: int = 0
+    label: Optional[str] = None
 
     def __repr__(self):
-        return f"{self.major}.{self.minor}.{self.patch}"
+        s = f"{self.major}.{self.minor}.{self.patch}"
+        if self.label is not None and self.label != "":
+            s += self.label
+        return s
 
     @classmethod
     def from_string(cls, version: str) -> "Version":
         t = version.split(".")
-
+        assert len(t) > 2
         vmajor = int(t[0])
         vminor = int(t[1])
-        vpatch = int(t[2])
-
-        return cls(major=vmajor, minor=vminor, patch=vpatch)
+        tt = split_on_letter(t[2])
+        vpatch = int(tt[0])
+        vlabel = tt[1] if len(tt) > 1 else None
+        return cls(major=vmajor, minor=vminor, patch=vpatch, label=vlabel)
 
     @classmethod
     def from_file(cls, path: PathLike) -> "Version":
         path = Path(path).expanduser().absolute()
         lines = [line.rstrip("\n") for line in open(Path(path), "r")]
-
-        vmajor = vminor = vpatch = None
+        vmajor = vminor = vpatch = vlabel = None
         for line in lines:
             t = line.split()
             if "major =" in line:
@@ -95,18 +104,15 @@ class Version(NamedTuple):
                 vminor = int(t[2])
             elif "micro =" in line:
                 vpatch = int(t[2])
+            elif "label =" in line:
+                vlabel = t[2].replace("'", "")
 
-        msg = "version string must follow semantic version format: major.minor.patch"
-        assert vmajor is not None, f"Missing major number, {msg}"
-        assert vminor is not None, f"Missing minor number, {msg}"
-        assert vpatch is not None, f"Missing patch number, {msg}"
-
-        return cls(major=vmajor, minor=vminor, patch=vpatch)
-
-
-class ReleaseType(Enum):
-    CANDIDATE = "Release Candidate"
-    APPROVED = "Release"
+        msg = "version string must follow semantic version format, with optional label: major.minor.patch[label]"
+        missing = lambda v: f"Missing {v} number, {msg}"
+        assert vmajor is not None, missing("major")
+        assert vminor is not None, missing("minor")
+        assert vpatch is not None, missing("patch")
+        return cls(major=vmajor, minor=vminor, patch=vpatch, label=vlabel)
 
 
 
@@ -166,18 +172,19 @@ resulting from the authorized or unauthorized use of the software.
 """
 
 
-def get_disclaimer(release_type: ReleaseType, formatted: bool = False) -> str:
-    approved = _approved_fmtdisclaimer if formatted else _approved_disclaimer
-    preliminary = _preliminary_fmtdisclaimer if formatted else _preliminary_disclaimer
-    return approved if release_type == ReleaseType.APPROVED else preliminary
+def get_disclaimer(approved: bool = False, formatted: bool = False) -> str:
+    if approved:
+        return _approved_fmtdisclaimer if formatted else _approved_disclaimer
+    else:
+        return _preliminary_fmtdisclaimer if formatted else _preliminary_disclaimer
 
 
-def log_update(path, release_type: ReleaseType, version: Version):
-    print(f"Updated {path} with version {version}" + (f" {release_type.value}" if release_type != ReleaseType.APPROVED else ""))
+def log_update(path, version: Version):
+    print(f"Updated {path} with version {version}")
 
 
 def update_version_txt_and_py(
-    release_type: ReleaseType, timestamp: datetime, version: Version
+    version: Version, timestamp: datetime
 ):
     with open(version_file_path, "w") as f:
         f.write(
@@ -189,38 +196,34 @@ def update_version_txt_and_py(
         f.write(f"major = {version.major}\n")
         f.write(f"minor = {version.minor}\n")
         f.write(f"micro = {version.patch}\n")
+        f.write("label = " + (("'" + version.label + "'") if version.label else "''") + "\n")
         f.write("__version__ = '{:d}.{:d}.{:d}'.format(major, minor, micro)\n")
+        f.write("if label:\n")
+        f.write("\t__version__ += '{}{}'.format(__version__, label)")
         f.close()
-    log_update(version_file_path, release_type, version)
-
+    log_update(version_file_path, version)
     py_path = project_root_path / "doc" / version_file_path.name.replace(".txt", ".py")
     shutil.copyfile(version_file_path, py_path)
-    log_update(py_path, release_type, version)
+    log_update(py_path, version)
 
 
-def update_meson_build(release_type: ReleaseType, timestamp: datetime, version: Version):
+def update_meson_build(version: Version):
     path = project_root_path / "meson.build"
     lines = open(path, "r").read().splitlines()
     with open(path, "w") as f:
         for line in lines:
             if "version:" in line and "meson_version:" not in line:
-                line = f"  version: '{version.major}.{version.minor}.{version.patch}',"
+                line = f"  version: '{version.major}.{version.minor}.{version.patch}{version.label if version.label else ''}',"
             f.write(f"{line}\n")
-
-    log_update(path, release_type, version)
+    log_update(path, version)
 
 
 def update_version_tex(
-    release_type: ReleaseType, timestamp: datetime, version: Version
+    version: Version, timestamp: datetime
 ):
     path = project_root_path / "doc" / "version.tex"
-
-    version_str = str(version)
-    if release_type != ReleaseType.APPROVED:
-        version_str += "rc"
-
     with open(path, "w") as f:
-        line = "\\newcommand{\\modflowversion}{mf" + f"{version_str}" + "}"
+        line = "\\newcommand{\\modflowversion}{mf" + f"{str(version)}" + "}"
         f.write(f"{line}\n")
         line = (
             "\\newcommand{\\modflowdate}{" + f"{timestamp.strftime('%B %d, %Y')}" + "}"
@@ -231,17 +234,24 @@ def update_version_tex(
             + "{Version \\modflowversion---\\modflowdate}"
         )
         f.write(f"{line}\n")
-
-    log_update(path, release_type, version)
+    log_update(path, version)
 
 
 def update_version_f90(
-    release_type: ReleaseType, timestamp: datetime, version: Optional[Version]
+    version: Optional[Version], timestamp: datetime, approved: bool = False
 ):
     path = project_root_path / "src" / "Utilities" / "version.f90"
     lines = open(path, "r").read().splitlines()
     with open(path, "w") as f:
         skip = False
+        version_spl = str(version).rpartition("-")
+        if version_spl[1]:
+            version_num = version_spl[0]
+            version_label = version_spl[2]
+        else:
+            version_num = str(version_spl[2])
+            version_label = ""
+
         for line in lines:
             # skip all of the disclaimer text
             if skip:
@@ -251,52 +261,51 @@ def update_version_f90(
             elif ":: IDEVELOPMODE =" in line:
                 line = (
                     "  integer(I4B), parameter :: "
-                    + f"IDEVELOPMODE = {1 if release_type == ReleaseType.CANDIDATE else 0}"
+                    + f"IDEVELOPMODE = {0 if approved else 1}"
                 )
             elif ":: VERSIONNUMBER =" in line:
-                line = line.rpartition("::")[0] + f":: VERSIONNUMBER = '{version}'"
+                line = line.rpartition("::")[0] + f":: VERSIONNUMBER = '{version_num}'"
             elif ":: VERSIONTAG =" in line:
                 fmat_tstmp = timestamp.strftime("%m/%d/%Y")
-                line = line.rpartition("::")[0] + f":: VERSIONTAG = ' {release_type.value} {fmat_tstmp}'"
+                label_clause = version_label if version_label else ""
+                label_clause += " (preliminary)" if not approved else ""
+                line = line.rpartition("::")[0] + f":: VERSIONTAG = '{label_clause} {fmat_tstmp}'"
             elif ":: FMTDISCLAIMER =" in line:
-                line = get_disclaimer(release_type, formatted=True)
+                line = get_disclaimer(approved, formatted=True)
                 skip = True
             f.write(f"{line}\n")
-
-    log_update(path, release_type, version)
+    log_update(path, version)
 
 
 def update_readme_and_disclaimer(
-    release_type: ReleaseType, timestamp: datetime, version: Version
+    version: Version, approved: bool = False
 ):
-    disclaimer = get_disclaimer(release_type, formatted=False)
+    disclaimer = get_disclaimer(approved, formatted=False)
     readme_path = str(project_root_path / "README.md")
     readme_lines = open(readme_path, "r").read().splitlines()
     with open(readme_path, "w") as f:
         for line in readme_lines:
             if "## Version " in line:
                 version_line = f"### Version {version}"
-                if release_type != ReleaseType.APPROVED:
-                    version_line += f" {release_type.value}"
+                if not approved:
+                    version_line += " (preliminary)"
                 f.write(f"{version_line}\n")
             elif "Disclaimer" in line:
                 f.write(f"{disclaimer}\n")
                 break
             else:
                 f.write(f"{line}\n")
-    log_update(readme_path, release_type, version)
+    log_update(readme_path, version)
 
     disclaimer_path = project_root_path / "DISCLAIMER.md"
     with open(disclaimer_path, "w") as f:
         f.write(disclaimer)
-    log_update(disclaimer_path, release_type, version)
+    log_update(disclaimer_path, version)
 
 
-def update_citation_cff(release_type: ReleaseType, timestamp: datetime, version: Version):
+def update_citation_cff(version: Version, timestamp: datetime):
     path = project_root_path / "CITATION.cff"
     citation = yaml.safe_load(path.read_text())
-
-    # update version and date-released
     citation["version"] = str(version)
     citation["date-released"] = timestamp.strftime("%Y-%m-%d")
 
@@ -308,28 +317,28 @@ def update_citation_cff(release_type: ReleaseType, timestamp: datetime, version:
             default_flow_style=False,
             sort_keys=False,
         )
-    log_update(path, release_type, version)
+    log_update(path, version)
 
 
-def update_codejson(release_type: ReleaseType, timestamp: datetime, version: Version):
+def update_codejson(version: Version, timestamp: datetime, approved: bool = False):
     path = project_root_path / "code.json"
     with open(path, "r") as f:
         data = json.load(f, object_pairs_hook=OrderedDict)
 
     data[0]["date"]["metadataLastUpdated"] = timestamp.strftime("%Y-%m-%d")
     data[0]["version"] = str(version)
-    data[0]["status"] = release_type.value
+    data[0]["status"] = "Release" if approved else "Preliminary"
     with open(path, "w") as f:
         json.dump(data, f, indent=4)
         f.write("\n")
 
-    log_update(path, release_type, version)
+    log_update(path, version)
 
 
 def update_version(
-    release_type: ReleaseType = ReleaseType.CANDIDATE,
-    timestamp: datetime = datetime.now(),
     version: Version = None,
+    timestamp: datetime = datetime.now(),
+    approved: bool = False
 ):
     """
     Update version information stored in version.txt in the project root,
@@ -351,13 +360,13 @@ def update_version(
         )
 
         with lock:
-            update_version_txt_and_py(release_type, timestamp, version)
-            update_meson_build(release_type, timestamp, version)
-            update_version_tex(release_type, timestamp, version)
-            update_version_f90(release_type, timestamp, version)
-            update_readme_and_disclaimer(release_type, timestamp, version)
-            update_citation_cff(release_type, timestamp, version)
-            update_codejson(release_type, timestamp, version)
+            update_version_txt_and_py(version, timestamp)
+            update_meson_build(version)
+            update_version_tex(version, timestamp)
+            update_version_f90(version, timestamp, approved)
+            update_readme_and_disclaimer(version, approved)
+            update_citation_cff(version, timestamp)
+            update_codejson(version, timestamp, approved)
     finally:
         lock_path.unlink(missing_ok=True)
 
@@ -368,13 +377,12 @@ _current_version = Version.from_file(version_file_path)
 
 @pytest.mark.skip(reason="reverts repo files on cleanup, tread carefully")
 @pytest.mark.parametrize(
-    "release_type", [ReleaseType.CANDIDATE, ReleaseType.APPROVED]
-)
-@pytest.mark.parametrize(
     "version",
-    [None, Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch)],
+    [None,
+     Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch),
+     Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch, label="rc")],
 )
-def test_update_version(tmp_path, release_type, version):
+def test_update_version(release_type, version):
     m_times = [get_modified_time(file) for file in touched_file_paths]
     timestamp = datetime.now()
 
@@ -391,11 +399,18 @@ def test_update_version(tmp_path, release_type, version):
             assert updated.major == _initial_version.major
             assert updated.minor == _initial_version.minor
             assert updated.patch == _initial_version.patch
+            if version.label is not None:
+                assert updated.label == version.label
         else:
             # version should not have changed
             assert updated.major == _current_version.major
             assert updated.minor == _current_version.minor
             assert updated.patch == _current_version.patch
+            if version.label is not None:
+                assert updated.label == version.label
+        
+        if version.label is not None:
+            assert updated.label == _initial_version
     finally:
         for p in touched_file_paths:
             os.system(f"git restore {p}")
@@ -489,7 +504,7 @@ if __name__ == "__main__":
                 version = Version(current.major, current.minor, current.patch + 1)
 
         update_version(
-            release_type=ReleaseType.APPROVED if args.approve else ReleaseType.CANDIDATE,
-            timestamp=datetime.now(),
             version=version,
+            timestamp=datetime.now(),
+            approved=args.approve,
         )

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -41,7 +41,7 @@ import pytest
 from filelock import FileLock
 import yaml
 
-from utils import get_modified_time
+from utils import get_modified_time, split_nonnumeric
 
 project_name = "MODFLOW 6"
 project_root_path = Path(__file__).resolve().parent.parent
@@ -57,12 +57,6 @@ touched_file_paths = [
     project_root_path / "code.json",
     project_root_path / "src" / "Utilities" / "version.f90",
 ]
-
-
-def split_on_letter(s):
-    # match = re.compile("[^\W\d]").search(s)
-    match = re.compile("[^0-9]").search(s)
-    return [s[:match.start()], s[match.start():]] if match else s
 
 
 class Version(NamedTuple):
@@ -86,7 +80,7 @@ class Version(NamedTuple):
         assert len(t) > 2
         vmajor = int(t[0])
         vminor = int(t[1])
-        tt = split_on_letter(t[2])
+        tt = split_nonnumeric(t[2])
         vpatch = int(tt[0])
         vlabel = tt[1] if len(tt) > 1 else None
         return cls(major=vmajor, minor=vminor, patch=vpatch, label=vlabel)

--- a/distribution/utils.py
+++ b/distribution/utils.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -9,6 +10,7 @@ from pathlib import Path
 from warnings import warn
 
 from modflow_devtools.markers import requires_exe
+import pytest
 
 _project_root_path = Path(__file__).resolve().parent.parent
 
@@ -134,5 +136,11 @@ def convert_line_endings(folder, windows=True):
 
 
 @requires_exe("dos2unix", "unix2dos")
+@pytest.mark.skip(reason="todo")
 def test_convert_line_endings():
     pass
+
+
+def split_nonnumeric(s):
+    match = re.compile("[^0-9]").search(s)
+    return [s[:match.start()], s[match.start():]] if match else s


### PR DESCRIPTION
Update release procedures to reduce duplication across repositories and increase configurability. The main changes are:
- make `release.yml` reusable with [`workflow_call` trigger](https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow)
  - allows nightly build repo to test release procedure without duplicating the workflow definition
- add `release_dispatch.yml` workflow
  - preserves previous release trigger mechanism (pushing a release branch named `vx.y.z` etc), preserves mechanism to distinguish preliminary from approved releases (does the branch name end with "rc"?)
  - add support for [manual trigger via UI or CLI](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) with `workflow_dispatch`

### `release.yml`

The `release.yml` workflow is no longer triggered directly, it is called by `release_dispatch.yml`. The previous branch-name trigger has been moved to `release_dispatch.yml`.

The `release.yml` workflow can be configured with inputs:
- `approve`: whether the release is approved/official, defaults false (i.e. provisional/preliminary)
- `branch`: the branch to release from (if release is not triggered by pushing a release branch) &mdash; in combination with `github.repository_owner` instead of hardcoding "MODFLOW-USGS", allows reusing workflow to build feature branches, possibly on a fork
- `development`: toggle a minimal development build, e.g. for use by nightly build repo &mdash; a development build has IDEVELOPMODE = 1 and the only included documentation is mf6io.pdf (defaults false)
- `run_tests`: defaults true, can disable for quicker debugging or for a faster development build
- `version`: the version number of the release, automatically embedded into `version.txt`, `version.f90` and other files

### `release_dispatch.yml`

The `release_dispatch.yml` workflow has the same inputs as above, plus `commit_version` which toggles whether to commit version numbers back to the repo, since this is likely desirable for minor number releases but not patches. The inputs are only relevant for a manually triggered release &mdash; for a release triggered by branch, the defaults are:

- `approve`: false if the branch name ends with "rc", otherwise true
- `branch`: the branch to release from
- `development`: false
- `run_tests`: true
- `version`: parsed from the release branch name

### Miscellaneous

- refactor `distribution/update_version.py` to allow optional version label (e.g. `v6.5.0rc`)
- update `distribution/check_dist.py` and `autotest/test_cli.py` for compatibility with above
- various cleanup