### PR TITLE
refactor(io): remove u8rdcom

### DIFF
--- a/src/Utilities/ArrayReaders.f90
+++ b/src/Utilities/ArrayReaders.f90
@@ -3,7 +3,7 @@ module ArrayReadersModule
   use ConstantsModule, only: DONE, LINELENGTH, LENBIGLINE, LENBOUNDNAME, &
                              NAMEDBOUNDFLAG, LINELENGTH, DZERO, MAXCHARLEN, &
                              DZERO
-  use InputOutputModule, only: openfile, u8rdcom, urword, ucolno, ulaprw, &
+  use InputOutputModule, only: openfile, u9rdcom, urword, ucolno, ulaprw, &
                                BuildFixedFormat, BuildFloatFormat, &
                                BuildIntFormat
   use KindModule, only: DP, I4B
@@ -578,7 +578,8 @@ contains
     ! -- local
     integer(I4B) :: icol, icol1, istart, istop, n
     real(DP) :: r
-    character(len=MAXCHARLEN) :: fname, line
+    character(len=MAXCHARLEN) :: fname
+    character (len=:), allocatable :: line
     !
     ! -- Read CONSTANT, INTERNAL, or OPEN/CLOSE from array control record.
     call read_control_1(iu, iout, aname, locat, iclose, line, icol, fname)
@@ -627,7 +628,8 @@ contains
     ! -- local
     integer(I4B) :: icol, icol1, istart, istop, n
     real(DP) :: r
-    character(len=MAXCHARLEN) :: fname, line
+    character(len=MAXCHARLEN) :: fname
+    character (len=:), allocatable :: line
     !
     ! -- Read CONSTANT, INTERNAL, or OPEN/CLOSE from array control record.
     call read_control_1(iu, iout, aname, locat, iclose, line, icol, fname)
@@ -664,7 +666,7 @@ contains
     character(len=*), intent(in) :: aname
     integer(I4B), intent(out) :: locat
     integer(I4B), intent(out) :: iclose
-    character(len=*), intent(inout) :: line
+    character (len=:), allocatable, intent(inout) :: line
     integer(I4B), intent(inout) :: icol
     character(len=*), intent(inout) :: fname
 
@@ -675,7 +677,7 @@ contains
     character(len=MAXCHARLEN) :: ermsg
     !
     ! -- Read array control record.
-    call u8rdcom(iu, iout, line, ierr)
+    call u9rdcom(iu, iout, line, ierr)
     !
     iclose = 0
     icol = 1

--- a/utils/mf5to6/src/ArrayReadersMF5.f90
+++ b/utils/mf5to6/src/ArrayReadersMF5.f90
@@ -2,7 +2,7 @@ module ArrayReadersMF5Module
   
   use ConstantsModule,   only: LINELENGTH, LENBIGLINE, LENBOUNDNAME, &
                                NAMEDBOUNDFLAG, LINELENGTH, DZERO
-  use InputOutputModule, only: openfile, u8rdcom, urword, ucolno, ulaprw
+  use InputOutputModule, only: openfile, u9rdcom, urword, ucolno, ulaprw
   use KindModule,        only: DP, I4B
   use OpenSpecModule,    only: ACCESS, FORM
   use SimModule,         only: store_error, ustop, store_error_unit
@@ -71,7 +71,7 @@ contains
     integer :: iclose, icol, ierr, ifree, iprn, istart, istop, j, locat, n
     real(DP) :: r, cnstnt
     character(len=20) :: fmtin
-    character(len=200) :: cntrl
+    character (len=:), allocatable :: cntrl
     character(len=200) :: fname
     character(len=linelength) :: ermsg
     integer, parameter :: nunopn=99
@@ -86,7 +86,7 @@ contains
 !   ------------------------------------------------------------------
 !
 !C1------READ ARRAY CONTROL RECORD AS CHARACTER DATA.
-    call u8rdcom(in,iout,cntrl,ierr)
+    call u9rdcom(in,iout,cntrl,ierr)
 !
 !C2------LOOK FOR ALPHABETIC WORD THAT INDICATES THAT THE RECORD IS FREE
 !C2------FORMAT.  SET A FLAG SPECIFYING IF FREE FORMAT OR FIXED FORMAT.
@@ -222,7 +222,7 @@ contains
                locat
     real(DP) :: r
     character(len=20) :: fmtin
-    character(len=200) :: cntrl
+    character (len=:), allocatable :: cntrl
     character(len=200) :: fname
     character(len=linelength) :: ermsg
     integer, parameter :: nunopn=99
@@ -237,7 +237,7 @@ contains
 !   ------------------------------------------------------------------
 !
 !C1------READ ARRAY CONTROL RECORD AS CHARACTER DATA.
-    call u8rdcom(in,iout,cntrl,ierr)
+    call u9rdcom(in,iout,cntrl,ierr)
 !C
 !C2------LOOK FOR ALPHABETIC WORD THAT INDICATES THAT THE RECORD IS FREE
 !C2------FORMAT.  SET A FLAG SPECIFYING IF FREE FORMAT OR FIXED FORMAT.
@@ -373,7 +373,7 @@ contains
                kper, kstp, locat, n, ncol, nrow
     real(DP) :: r, cnstnt, pertim, totim
     character(len=20) :: fmtin
-    character(len=200) :: cntrl
+    character (len=:), allocatable :: cntrl
     character(len=16) :: text
     character(len=200) :: fname
     character(len=20) :: ftype
@@ -400,7 +400,7 @@ contains
 !     ------------------------------------------------------------------
 !
 !C1------READ ARRAY CONTROL RECORD AS CHARACTER DATA.
-    call u8rdcom(in,iout,cntrl,ierr)
+    call u9rdcom(in,iout,cntrl,ierr)
 !
 !C2------LOOK FOR ALPHABETIC WORD THAT INDICATES THAT THE RECORD IS FREE
 !C2------FORMAT.  SET A FLAG SPECIFYING IF FREE FORMAT OR FIXED FORMAT.
@@ -569,7 +569,7 @@ contains
                istop, locat, n
     real(DP) :: r
     character(len=20) :: fmtin
-    character(len=200) :: cntrl
+    character (len=:), allocatable :: cntrl
     character(len=200) :: fname
     character(len=20) :: ftype
     character(len=LINELENGTH) :: ermsg
@@ -605,7 +605,7 @@ contains
 !     ------------------------------------------------------------------
 !
 !C1------READ ARRAY CONTROL RECORD AS CHARACTER DATA.
-    call u8rdcom(in,iout,cntrl,ierr)
+    call u9rdcom(in,iout,cntrl,ierr)
 !
 !C2------LOOK FOR ALPHABETIC WORD THAT INDICATES THAT THE RECORD IS FREE
 !C2------FORMAT.  SET A FLAG SPECIFYING IF FREE FORMAT OR FIXED FORMAT.

--- a/utils/mf5to6/src/Preproc/Utilities.f90
+++ b/utils/mf5to6/src/Preproc/Utilities.f90
@@ -4,7 +4,7 @@ module UtilitiesModule
   use GlobalVariablesModule, only: optfile, PathToPostObsMf, ScriptType, &
                                    verbose, echo
   use InputOutputModule, only: GetUnit, openfile, UPCASE, URWORD, &
-                               uget_block, uterminate_block, u8rdcom
+                               uget_block, uterminate_block, u9rdcom
   use SimModule, onlY: store_error, store_note, store_warning, ustop
 
   private
@@ -895,7 +895,7 @@ contains
       if (found) then
         do
           icol = 1
-          call u8rdcom(iu, 0, line, ierr)
+          call u9rdcom(iu, 0, line, ierr)
           call urword(line, icol, istart, istop, 1, idum, rdum, 0, iu)
           select case (line(istart:istop))
           case ('PATHTOPOSTOBSMF')


### PR DESCRIPTION
The u9rdcom line reader was introduced to replace the u8rdcom line reader, however, u8rdcom was not removed completely.  This PR removes u8rdcom entirely.  This simplification may help with ongoing efforts to remove calls to the Fortran backspace intrinsic so that mf6 will compile with latest versions of ifort.
