### PR TITLE
test: add markers/mechanism to skip developmode tests in release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This repository contains an `./autotest` folder with python scripts for building
 * [MODFLOW-USGS/modflow6-testmodels](https://github.com/MODFLOW-USGS/modflow6-testmodels)
 * [MODFLOW-USGS/modflow6-largetestmodels](https://github.com/MODFLOW-USGS/modflow6-largetestmodels)
 * [MODFLOW-USGS/executables](https://github.com/MODFLOW-USGS/executables)
+* [MODFLOW-USGS/modflow-devtools](https://github.com/MODFLOW-USGS/modflow-devtools)
 * [Deltares/xmipy](https://github.com/Deltares/xmipy)
 
 ## Code Documentation

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -50,8 +50,12 @@ def targets(bin_path) -> Executables:
 
 @pytest.fixture
 def original_regression(request) -> bool:
-    oreg = request.config.getoption("--original-regression")
-    return oreg
+    return request.config.getoption("--original-regression")
+
+
+@pytest.fixture(scope="session")
+def markers(pytestconfig) -> str:
+    return pytestconfig.getoption('-m')
 
 
 def pytest_addoption(parser):

--- a/autotest/test_gwf_ifmod_buy.py
+++ b/autotest/test_gwf_ifmod_buy.py
@@ -649,6 +649,7 @@ def compare_to_ref(sim):
     "idx, name",
     list(enumerate(ex)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework()
     test.build(build_model, idx, str(function_tmpdir))

--- a/autotest/test_gwf_ifmod_idomain.py
+++ b/autotest/test_gwf_ifmod_idomain.py
@@ -379,6 +379,7 @@ def compare_to_ref(sim):
     "idx, name",
     list(enumerate(ex)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework()
     test.build(build_model, idx, str(function_tmpdir))

--- a/autotest/test_gwf_ifmod_mult_exg.py
+++ b/autotest/test_gwf_ifmod_mult_exg.py
@@ -334,6 +334,7 @@ def eval_heads(sim):
     "name",
     ex,
 )
+@pytest.mark.developmode
 def test_mf6model(name, function_tmpdir, targets):
     test = TestFramework()
     test.build(build_model, 0, str(function_tmpdir))

--- a/autotest/test_gwf_ifmod_newton.py
+++ b/autotest/test_gwf_ifmod_newton.py
@@ -384,6 +384,7 @@ def compare_to_ref(sim):
     "idx, name",
     list(enumerate(ex)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework()
     test.build(build_model, idx, str(function_tmpdir))

--- a/autotest/test_gwf_ifmod_rewet.py
+++ b/autotest/test_gwf_ifmod_rewet.py
@@ -404,6 +404,7 @@ def compare_to_ref(sim):
     "idx, name",
     list(enumerate(ex)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework()
     test.build(build_model, idx, str(function_tmpdir))

--- a/autotest/test_gwf_ifmod_vert.py
+++ b/autotest/test_gwf_ifmod_vert.py
@@ -285,6 +285,7 @@ def eval_heads(sim):
     "idx, name",
     list(enumerate(ex)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework()
     test.build(build_model, idx, str(function_tmpdir))

--- a/autotest/test_gwf_libmf6_ifmod02.py
+++ b/autotest/test_gwf_libmf6_ifmod02.py
@@ -407,6 +407,7 @@ def check_interface_models(mf6):
     "idx, name",
     list(enumerate(ex)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework()
     test.build(build_model, idx, str(function_tmpdir))

--- a/autotest/test_gwfgwf_lgr.py
+++ b/autotest/test_gwfgwf_lgr.py
@@ -280,6 +280,7 @@ def eval_heads(sim):
     "idx, name",
     list(enumerate(ex)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     ws = str(function_tmpdir)
     test = TestFramework()

--- a/autotest/test_gwt_adv01_gwtgwt.py
+++ b/autotest/test_gwt_adv01_gwtgwt.py
@@ -730,6 +730,7 @@ def eval_transport(sim):
     "idx, name",
     list(enumerate(ex)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     ws = str(function_tmpdir)
     test = TestFramework()

--- a/autotest/test_gwt_dsp01_gwtgwt.py
+++ b/autotest/test_gwt_dsp01_gwtgwt.py
@@ -302,6 +302,7 @@ def eval_transport(sim):
     "idx, name",
     list(enumerate(ex)),
 )
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     ws = str(function_tmpdir)
     test = TestFramework()

--- a/autotest/test_z01_testmodels_mf6.py
+++ b/autotest/test_z01_testmodels_mf6.py
@@ -37,12 +37,15 @@ excluded_comparisons = {
 
 @pytest.mark.repo
 @pytest.mark.regression
-def test_model(function_tmpdir, test_model_mf6, targets, original_regression):
+def test_model(function_tmpdir, test_model_mf6, targets, original_regression, markers):
     exdir = test_model_mf6.parent
     name = exdir.name
 
     if name in excluded_models:
-        pytest.skip(f"Excluding mf6 model: {name}")
+        pytest.skip(f"Excluding mf6 model '{name}'")
+    
+    if "dev" in name and "not developmode" in markers:
+        pytest.skip(f"Skipping mf6 model '{name}' (develop mode only)")
 
     sim = TestSimulation(
         name=name,

--- a/autotest/test_z03_largetestmodels.py
+++ b/autotest/test_z03_largetestmodels.py
@@ -16,13 +16,16 @@ excluded_comparisons = {
 @pytest.mark.regression
 @pytest.mark.slow
 def test_model(
-    function_tmpdir, large_test_model, targets, original_regression
+    function_tmpdir, large_test_model, targets, original_regression, markers
 ):
     exdir = large_test_model.parent
     name = exdir.name
 
     if name in excluded_models:
-        pytest.skip(f"Excluding large mf6 model: {name}")
+        pytest.skip(f"Excluding large mf6 model '{name}'")
+    
+    if "dev" in name and "not developmode" in markers:
+        pytest.skip(f"Skipping large mf6 model '{name}' (develop mode only)")
 
     sim = TestSimulation(
         name=name,


### PR DESCRIPTION
Some tests were originally marked with `@pytest.mark.developmode` in https://github.com/MODFLOW-USGS/modflow6/commit/8c9388d0f89df97b6b138d7ff981ff48cd799af2, then the marker was mistakenly removed in https://github.com/MODFLOW-USGS/modflow6/commit/e51530cd90d701549a00c216b371fcc6281451da. Also add mechanism to skip tests from modflow6-testmodels repo (in `z0*` scripts) if the name contains "dev".

Tangentially, add a link to modflow-devtools in the CI section of the README since devtools is a testing dependency.