### PR TITLE
ci: fix release refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,9 @@ on:
         type: boolean
         default: false
       branch:
-        description: 'Branch to use for release. Default is the develop branch.'
-        required: false
+        description: 'Branch to use for release.'
+        required: true
         type: string
-        default: 'develop'
       development:
         description: 'Toggle a minimal development build. Default is false, i.e. to perform a full release build. If true, approve is not considered.'
         required: false

--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -36,7 +36,7 @@ def dist_dir_path(request):
     return path
 
 
-def test_sources(dist_dir_path):
+def test_sources(dist_dir_path, approved):
     assert (dist_dir_path / "src").is_dir()
     assert (dist_dir_path / "src" / "mf6.f90").is_file()
 
@@ -51,7 +51,7 @@ def test_sources(dist_dir_path):
 
     # make sure IDEVELOPMODE was set correctly
     branch = get_branch()
-    idevelopmode = 1 if ("rc" in branch or "candidate" in branch) else 0
+    idevelopmode = 0 if approved else 1
     assert f"IDEVELOPMODE = {idevelopmode}" in line
 
 


### PR DESCRIPTION
- Don't default to develop branch in `release.yml` since `release_dispatch.yml` already prevents releasing from develop and master. Releases are expected to come from release branches. Currently the branch must preexist the workflow run, in future we might add a mechanism to automatically create a release branch from develop or master

- Fix tests in `check_dist.py`. Previously the IDEVELOPMODE check was conditioned on the presence of "rc" in the branch name, now there is an explicit pytest arg for it, `--approved`  (short `-A`)