### PR TITLE
rfct(par): change petsc matrix for parallel run with 1 process

### DIFF
--- a/autotest/test_par_gwf03.py
+++ b/autotest/test_par_gwf03.py
@@ -217,21 +217,13 @@ def build_petsc_db(idx, exdir):
     np = ncpus[idx]
     petsc_db_file = os.path.join(exdir, ".petscrc")
     with open(petsc_db_file, 'w') as petsc_file:
-        if np == 1:
-            petsc_file.write("-ksp_type cg\n")
-            petsc_file.write("-pc_type ilu\n")
-            petsc_file.write("-pc_factor_levels 2\n")
-            petsc_file.write(f"-dvclose {Decimal(hclose):.2E}\n")
-            petsc_file.write(f"-nitermax {500}\n")
-            petsc_file.write("-options_left no\n")
-        else:
-            petsc_file.write("-ksp_type cg\n")
-            petsc_file.write("-pc_type bjacobi\n")
-            petsc_file.write("-sub_pc_type ilu\n")
-            petsc_file.write("-sub_pc_factor_levels 2\n")
-            petsc_file.write(f"-dvclose {Decimal(hclose):.2E}\n")
-            petsc_file.write(f"-nitermax {500}\n")
-            petsc_file.write("-options_left no\n")
+        petsc_file.write("-ksp_type cg\n")
+        petsc_file.write("-pc_type bjacobi\n")
+        petsc_file.write("-sub_pc_type ilu\n")
+        petsc_file.write("-sub_pc_factor_levels 2\n")
+        petsc_file.write(f"-dvclose {Decimal(hclose):.2E}\n")
+        petsc_file.write(f"-nitermax {500}\n")
+        petsc_file.write("-options_left no\n")
 
 def build_model(idx, exdir):
     sim = get_simulation(idx, exdir)

--- a/src/Distributed/MpiRunControl.F90
+++ b/src/Distributed/MpiRunControl.F90
@@ -60,7 +60,7 @@ contains
     inquire (file=petsc_db_file, exist=petsc_db_exists)
     if (.not. petsc_db_exists) then
       write (*, *) 'WARNING. PETSc database file not found: '//petsc_db_file
-      call PetscInitialize(ierr)
+      call PetscInitialize(PETSC_NULL_CHARACTER, ierr)
       CHKERRQ(ierr)
     else
       call PetscInitialize(petsc_db_file, ierr)

--- a/src/Utilities/Matrix/PetscMatrix.F90
+++ b/src/Utilities/Matrix/PetscMatrix.F90
@@ -57,7 +57,7 @@ module PetscMatrixModule
 contains
 
   subroutine pm_init(this, sparse, mem_path)
-    use SimVariablesModule, only: simulation_mode, nr_procs
+    use SimVariablesModule, only: simulation_mode
     class(PetscMatrixType) :: this
     type(sparsematrix) :: sparse
     character(len=*) :: mem_path
@@ -89,7 +89,7 @@ contains
     end do
 
     ! create PETSc matrix object
-    if (simulation_mode == 'PARALLEL' .and. nr_procs > 1) then
+    if (simulation_mode == 'PARALLEL') then
       this%is_parallel = .true.
       call MatCreateMPIAIJWithArrays(PETSC_COMM_WORLD, &
                                      sparse%nrow, sparse%nrow, &


### PR DESCRIPTION
- change petsc matrix format for running 1 core
- petsc initialize with backwards compat