### PR TITLE
ci: refine release workflow after feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,14 +364,6 @@ jobs:
       - name: Setup Intel Fortran
         uses: modflowpy/install-intelfortran-action@v1
 
-      - name: Fix Micromamba path (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # https://github.com/modflowpy/install-intelfortran-action#conda-scripts
-          $mamba_bin = "C:\Users\runneradmin\micromamba-root\envs\modflow6\Scripts"
-          echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
       - name: Update version files
         working-directory: modflow6/distribution
         run: python update_version.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,7 +481,7 @@ jobs:
           else
             zip -r $distname.zip \
               $distname/bin/* \
-              $distname/doc/mf6io \
+              $distname/doc/mf6io.pdf \
               $distname/doc/release.pdf \
               $distname/code.json \
               -x '*.DS_Store' \
@@ -516,7 +516,7 @@ jobs:
           else
             7z a -tzip $distname.zip \
               $distname/bin/* \
-              $distname/doc/mf6io \
+              $distname/doc/mf6io.pdf \
               $distname/doc/release.pdf \
               $distname/code.json \
               -xr!libmf6.lib \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,21 +67,15 @@ jobs:
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-root-path: ${{ github.workspace }}/micromamba-root
           environment-file: modflow6/environment.yml
+          init-shell: >-
+            bash
+            powershell
           cache-downloads: true
           cache-environment: true
 
       - name: Setup Intel Fortran
         uses: modflowpy/install-intelfortran-action@v1
-
-      - name: Fix Micromamba path (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # https://github.com/modflowpy/install-intelfortran-action#conda-scripts
-          $mamba_bin = "${{ github.workspace }}\micromamba-root\envs\modflow6\Scripts"
-          echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Set version number
         id: set_version
@@ -157,16 +151,28 @@ jobs:
         run: pytest -v --durations 0 get_exes.py
 
       - name: Test modflow6
-        if: inputs.run_tests == true
+        if: inputs.run_tests == true && runner.os != 'Windows'
         working-directory: modflow6/autotest
         env:
           REPOS_PATH: ${{ github.workspace }}
         run: |
           marker="not large"
-          if [[ "${{ inputs.development }}" == "false" ]]; then
+          if [[ ("${{ inputs.development }}" == "false") && ("${{ inputs.approve }}" == "true") ]]; then
             marker="$marker and not developmode"
           fi
-
+          pytest -v -n auto --durations 0 -m "$marker"
+      
+      - name: Test modflow6 (Windows)
+        if: inputs.run_tests == true && runner.os == 'Windows'
+        working-directory: modflow6/autotest
+        shell: pwsh
+        env:
+          REPOS_PATH: ${{ github.workspace }}
+        run: |
+          $marker="not large"
+          if (("${{ inputs.development }}" -eq "false") -and ("${{ inputs.approve }}" -eq "true")) {
+            $marker="$marker and not developmode"
+          }
           pytest -v -n auto --durations 0 -m "$marker"
       
       # steps below run only on Linux to test distribution procedures, e.g.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,6 +353,7 @@ jobs:
             cmd="$cmd --full"
           fi
           eval "$cmd"
+          mv "doc/ReleaseNotes.pdf" "doc/release.pdf"
 
       - name: Upload documentation artifact
         uses: actions/upload-artifact@v3
@@ -451,7 +452,7 @@ jobs:
           eval "$cmd"
 
           # move & rename PDF documents to dist folder
-          mv "$distname/doc/ReleaseNotes.pdf" "$distname/doc/release.pdf"
+          
           if [[ "${{ inputs.full }}" == "true" ]]; then
             mv "$distname/doc/converter_mf5to6.pdf" "$distname/doc/mf5to6.pdf"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,21 +5,26 @@ on:
   workflow_call:
     inputs:
       approve:
-        description: 'Whether to approve the release. Default is false for preliminary/provisional releases. Approval is only relevant for full builds: if development is true, approve is not considered.'
+        description: 'Approve the release, modifying disclaimer language to indicate the distribution has been reviewed. If false, disclaimers & version strings indicate preliminary/provisional status.'
         required: false
         type: boolean
         default: false
       branch:
-        description: 'Branch to use for release.'
+        description: 'Branch to release from.'
         required: true
         type: string
-      development:
-        description: 'Toggle a minimal development build. Default is false, i.e. to perform a full release build. If true, approve is not considered.'
+      developmode:
+        description: 'Build binaries in develop mode. If false, IDEVELOPMODE is set to 0.'
+        required: false
+        type: boolean
+        default: true
+      full:
+        description: 'Build a full distribution containing sources, examples, and all documentation. If false, the distribution contains only binaries, mf6io, release notes, and code.json.'
         required: false
         type: boolean
         default: false
       run_tests:
-        description: 'Whether to run tests after building binaries. Default is true. Can be set to false for rapid testing/debugging, or for a faster nightly/development build.'
+        description: Run tests after building binaries.'
         required: false
         type: boolean
         default: true
@@ -94,11 +99,14 @@ jobs:
         working-directory: modflow6/distribution
         run: |
           ver="${{ steps.set_version.outputs.version }}"
-          if [[ ("${{ inputs.development }}" == "false") && ("${{ inputs.approve }}" == "true") ]]; then
-            python update_version.py -v "$ver" --approve
-          else
-            python update_version.py -v "$ver"
+          cmd="python update_version.py -v $ver"
+          if [[ "${{ inputs.approve }}" == "true" ]]; then
+            cmd="$cmd --approve"
           fi
+          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+            cmd="$cmd --releasemode"
+          fi
+          eval "$cmd"
 
       - name: Build binaries
         if: runner.os != 'Windows'
@@ -156,11 +164,11 @@ jobs:
         env:
           REPOS_PATH: ${{ github.workspace }}
         run: |
-          marker="not large"
-          if [[ ("${{ inputs.development }}" == "false") && ("${{ inputs.approve }}" == "true") ]]; then
-            marker="$marker and not developmode"
+          markers="not large"
+          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+            markers="$markers and not developmode"
           fi
-          pytest -v -n auto --durations 0 -m "$marker"
+          pytest -v -n auto --durations 0 -m "$markers"
       
       - name: Test modflow6 (Windows)
         if: inputs.run_tests == true && runner.os == 'Windows'
@@ -169,11 +177,11 @@ jobs:
         env:
           REPOS_PATH: ${{ github.workspace }}
         run: |
-          $marker="not large"
-          if (("${{ inputs.development }}" -eq "false") -and ("${{ inputs.approve }}" -eq "true")) {
-            $marker="$marker and not developmode"
+          $markers="not large"
+          if ("${{ inputs.developmode }}" -eq "false") {
+            $markers="$markers and not developmode"
           }
-          pytest -v -n auto --durations 0 -m "$marker"
+          pytest -v -n auto --durations 0 -m "$markers"
       
       # steps below run only on Linux to test distribution procedures, e.g.
       # compiling binaries, building documentation
@@ -278,11 +286,14 @@ jobs:
         working-directory: modflow6/distribution
         run: |
           ver="${{ needs.build.outputs.version }}"
-          if [[ ("${{ inputs.development }}" == "false") && ("${{ inputs.approve }}" == "true") ]]; then
-            python update_version.py -v "$ver" --approve
-          else
-            python update_version.py -v "$ver"
+          cmd="python update_version.py -v $ver"
+          if [[ "${{ inputs.approve }}" == "true" ]]; then
+            cmd="$cmd --approve"
           fi
+          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+            cmd="$cmd --releasemode"
+          fi
+          eval "$cmd"
 
       - name: Download pre-built binaries
         uses: actions/download-artifact@v3
@@ -399,11 +410,14 @@ jobs:
         working-directory: modflow6/distribution
         run: |
           ver="${{ needs.build.outputs.version }}"
-          if [[ ("${{ inputs.development }}" == "false") && ("${{ inputs.approve }}" == "true") ]]; then
-            python update_version.py -v "$ver" --approve
-          else
-            python update_version.py -v "$ver"
+          cmd="python update_version.py -v $ver"
+          if [[ "${{ inputs.approve }}" == "true" ]]; then
+            cmd="$cmd --approve"
           fi
+          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+            cmd="$cmd --releasemode"
+          fi
+          eval "$cmd"
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -429,7 +443,10 @@ jobs:
         run: |
           # build distribution
           distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
-          python modflow6/distribution/build_dist.py -o "$distname" -e modflow6-examples
+          cmd="python modflow6/distribution/build_dist.py -o $distname -e modflow6-examples"
+          if [[ "${{ inputs.full }}" == "false" ]]; then
+            cmd="$cmd --approve"
+          fi
 
           # move & rename PDF documents to dist folder
           mv "$distname/doc/ReleaseNotes.pdf" "$distname/doc/release.pdf"
@@ -481,11 +498,11 @@ jobs:
       # validate only after zipping distribution to avoid accidentally changing any files
       - name: Validate distribution
         run: |
-          if [[ "${{ inputs.approve }}" == "true" ]]; then
-            pytest -v -s modflow6/distribution/check_dist.py --path "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}" --approved
-          else
-            pytest -v -s modflow6/distribution/check_dist.py --path "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          cmd="pytest -v -s modflow6/distribution/check_dist.py --path ${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          if [[ "${{ inputs.developmode }}" == "false" ]]; then
+             cmd="$cmd --releasemode"
           fi
+          eval "$cmd"
 
       - name: Upload distribution zipfile artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,11 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: modflow6/environment.yml
+          cache-downloads: true
+          cache-environment: true
           init-shell: >-
             bash
             powershell
-          cache-downloads: true
-          cache-environment: true
 
       - name: Setup Intel Fortran
         uses: modflowpy/install-intelfortran-action@v1
@@ -322,7 +322,8 @@ jobs:
         working-directory: modflow6-examples/scripts
         run: python ex-gwf-twri.py
       
-      - name: Create directory structure
+      - name: Create full docs folder structure
+        if: inputs.full == true
         run: |
           distname=${{ needs.build.outputs.distname }}
 
@@ -345,7 +346,13 @@ jobs:
         env:
           # need a GITHUB_TOKEN to download example doc PDF asset from modflow6-examples repo
           GITHUB_TOKEN: ${{ github.token }}
-        run: python modflow6/distribution/build_docs.py -b bin -o doc
+        run: |
+          mkdir -p "${{ needs.build.outputs.distname }}/doc"
+          cmd="python modflow6/distribution/build_docs.py -b bin -o doc"
+          if [[ "${{ inputs.full }}" == "true" ]]; then
+            cmd="$cmd --full"
+          fi
+          eval "$cmd"
 
       - name: Upload documentation artifact
         uses: actions/upload-artifact@v3
@@ -389,21 +396,15 @@ jobs:
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-root-path: ${{ github.workspace }}/micromamba-root
           environment-file: modflow6/environment.yml
           cache-downloads: true
           cache-environment: true
+          init-shell: >-
+            bash
+            powershell
 
       - name: Setup Intel Fortran
         uses: modflowpy/install-intelfortran-action@v1
-
-      - name: Fix Micromamba path (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # https://github.com/modflowpy/install-intelfortran-action#conda-scripts
-          $mamba_bin = "${{ github.workspace }}\micromamba-root\envs\modflow6\Scripts"
-          echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       
       - name: Update version
         id: update_version
@@ -444,63 +445,99 @@ jobs:
           # build distribution
           distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
           cmd="python modflow6/distribution/build_dist.py -o $distname -e modflow6-examples"
-          if [[ "${{ inputs.full }}" == "false" ]]; then
-            cmd="$cmd --approve"
+          if [[ "${{ inputs.full }}" == "true" ]]; then
+            cmd="$cmd --full"
           fi
+          eval "$cmd"
 
           # move & rename PDF documents to dist folder
           mv "$distname/doc/ReleaseNotes.pdf" "$distname/doc/release.pdf"
-          mv "$distname/doc/converter_mf5to6.pdf" "$distname/doc/mf5to6.pdf"
+          if [[ "${{ inputs.full }}" == "true" ]]; then
+            mv "$distname/doc/converter_mf5to6.pdf" "$distname/doc/mf5to6.pdf"
+          fi
 
       - name: Zip distribution
         if: runner.os != 'Windows'
         run: |
           distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
-          zip -r $distname.zip \
-            $distname/bin \
-            $distname/src \
-            $distname/srcbmi \
-            $distname/doc \
-            $distname/examples \
-            $distname/make \
-            $distname/msvs \
-            $distname/utils \
-            $distname/code.json \
-            $distname/meson.build \
-            -x '*.DS_Store' \
-            -x '*libmf6.lib' \
-            -x '*idmloader*' \
-            -x '*pymake*' \
-            -x '*obj_temp*' \
-            -x '*mod_temp*'
+          if [[ "${{ inputs.full }}" == "true" ]]; then
+            zip -r $distname.zip \
+              $distname/bin \
+              $distname/src \
+              $distname/srcbmi \
+              $distname/doc \
+              $distname/examples \
+              $distname/make \
+              $distname/msvs \
+              $distname/utils \
+              $distname/code.json \
+              $distname/meson.build \
+              -x '*.DS_Store' \
+              -x '*libmf6.lib' \
+              -x '*idmloader*' \
+              -x '*pymake*' \
+              -x '*obj_temp*' \
+              -x '*mod_temp*'
+          else
+            zip -r $distname.zip \
+              $distname/bin/* \
+              $distname/doc/mf6io \
+              $distname/doc/release.pdf \
+              $distname/code.json \
+              -x '*.DS_Store' \
+              -x '*libmf6.lib' \
+              -x '*idmloader*' \
+              -x '*pymake*' \
+              -x '*obj_temp*' \
+              -x '*mod_temp*'
+          fi
 
       - name: Zip distribution (Windows)
         if: runner.os == 'Windows'
         run: |
           distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
-          7z a -tzip $distname.zip \
-            $distname/bin \
-            $distname/src \
-            $distname/srcbmi \
-            $distname/doc \
-            $distname/examples \
-            $distname/make \
-            $distname/msvs \
-            $distname/utils \
-            $distname/code.json \
-            $distname/meson.build \
-            -xr!libmf6.lib \
-            -xr!idmloader \
-            -xr!pymake \
-            -xr!obj_temp \
-            -xr!mod_temp
+          if [[ "${{ inputs.full }}" == "true" ]]; then
+            7z a -tzip $distname.zip \
+              $distname/bin \
+              $distname/src \
+              $distname/srcbmi \
+              $distname/doc \
+              $distname/examples \
+              $distname/make \
+              $distname/msvs \
+              $distname/utils \
+              $distname/code.json \
+              $distname/meson.build \
+              -xr!libmf6.lib \
+              -xr!idmloader \
+              -xr!pymake \
+              -xr!obj_temp \
+              -xr!mod_temp
+          else
+            7z a -tzip $distname.zip \
+              $distname/bin/* \
+              $distname/doc/mf6io \
+              $distname/doc/release.pdf \
+              $distname/code.json \
+              -xr!libmf6.lib \
+              -xr!idmloader \
+              -xr!pymake \
+              -xr!obj_temp \
+              -xr!mod_temp
+          fi
 
       # validate only after zipping distribution to avoid accidentally changing any files
       - name: Validate distribution
         run: |
           cmd="pytest -v -s modflow6/distribution/check_dist.py --path ${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          if [[ "${{ inputs.approve }}" == "true" ]]; then
+            cmd="$cmd --approved"
+          fi
           if [[ "${{ inputs.developmode }}" == "false" ]]; then
              cmd="$cmd --releasemode"
+          fi
+          if [[ "${{ inputs.full }}" == "true" ]]; then
+            cmd="$cmd --full"
           fi
           eval "$cmd"
 

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -105,7 +105,7 @@ jobs:
       # If triggered by pushing a release branch, the release is approved if the branch name doesn't contain "rc".
       approve: ${{ (github.event_name == 'workflow_dispatch' && inputs.approve == 'true') || (github.event_name != 'workflow_dispatch' && !contains(github.ref_name, 'rc')) }}
       branch: ${{ needs.set_options.outputs.branch }}
-      development: false
+      developmode: false
       run_tests: ${{ inputs.run_tests == '' || inputs.run_tests == 'true' }}
       version: ${{ needs.set_options.outputs.version }}
   pr:

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -111,7 +111,9 @@ jobs:
   pr:
     name: Draft release PR
     if: ${{ github.event_name == 'push' && github.ref_name != 'master' && (github.event_name == 'workflow_dispatch' && inputs.approve == 'true') || (github.event_name != 'workflow_dispatch' && !contains(github.ref_name, 'rc')) }}
-    needs: make_dist
+    needs:
+      - set_options
+      - make_dist
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -137,7 +139,7 @@ jobs:
         working-directory: distribution
         run: |
           # update version files
-          ver="${{ needs.make_dist.outputs.version }}"
+          ver="${{ needs.set_options.outputs.version }}"
           if [[ "${{ inputs.approve }}" == "true" ]]; then
             python update_version.py -v "$ver" --approve
           else
@@ -159,7 +161,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          ver="${{ needs.make_dist.outputs.version }}"
+          ver="${{ needs.set_options.outputs.version }}"
           body='
           # MODFLOW '$ver' release
           

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -106,6 +106,7 @@ jobs:
       approve: ${{ (github.event_name == 'workflow_dispatch' && inputs.approve == 'true') || (github.event_name != 'workflow_dispatch' && !contains(github.ref_name, 'rc')) }}
       branch: ${{ needs.set_options.outputs.branch }}
       developmode: false
+      full: true
       run_tests: ${{ inputs.run_tests == '' || inputs.run_tests == 'true' }}
       version: ${{ needs.set_options.outputs.version }}
   pr:

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -5,11 +5,12 @@ This folder contains scripts to automate MODFLOW 6 distribution tasks.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Overview](#overview)
 - [Requirements](#requirements)
 - [Testing](#testing)
 - [Release procedures](#release-procedures)
-  - [Preparing a nightly release](#preparing-a-nightly-release)
+  - [Preparing a minimal development release](#preparing-a-minimal-development-release)
   - [Preparing an official release](#preparing-an-official-release)
     - [Updating version info](#updating-version-info)
     - [Building makefiles](#building-makefiles)
@@ -17,9 +18,13 @@ This folder contains scripts to automate MODFLOW 6 distribution tasks.
     - [Benchmarking example models](#benchmarking-example-models)
     - [Building documentation](#building-documentation)
     - [Building the distribution archive](#building-the-distribution-archive)
+    - [Verifying the distribution archive](#verifying-the-distribution-archive)
 - [Release automation](#release-automation)
   - [Nightly builds](#nightly-builds)
   - [Official releases](#official-releases)
+    - [Triggering with a release branch](#triggering-with-a-release-branch)
+    - [Triggering a release manually](#triggering-a-release-manually)
+  - [Release versioning](#release-versioning)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -88,22 +88,21 @@ Full distributions, on the other hand, contain the items listed above, as well a
 
 ### Preparing a minimal development release
 
-Development releases are built and [posted nightly on the `MODFLOW-USGS/modflow6-nightly-build` repository](https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases). Release assets include:
+Development releases are built and [posted nightly on the `MODFLOW-USGS/modflow6-nightly-build` repository](https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases). For a minimal release, distribution contents include:
 
 - platform-specific distributions containing only executables `mf6`, `zbud6`, `mf5to6` and library `libmf6`
 - MODFLOW 6 input/output documentation
+- release notes
+- `code.json` metadata
 
-The `build_dist.py` script can be used to create both development and full distributions. To create a development distribution, run the script with the `--development` (short `-d`) flag:
+The `build_dist.py` script can be used to create both minimal and full distributions. By default, a minimal distribution is created. To create a full distribution, run the script with the `--full` flag:
 
-```shell
-python build_dist.py -d
-```
-
-The script has several optional command line arguments:
+The script has several other arguments:
 
 - `--build-path`: path to the build workspace, defaults to `<project root>/builddir`
 - `--output-path (-o)`: path to create a distribution zipfile, defaults to `<project root>/distribution/`
 - `--examples-repo-path (-e)`: path to the [`MODFLOW-USGS/modflow6-examples`](https://github.com/MODFLOW-USGS/modflow6-examples) repository, defaults to `modflow6-examples` side-by-side with project root
+- `--force (-f)`: whether to recreate and overwrite preexisting components of the distribution, if they already exist
 
 Default paths are resolved relative to the script's location on the filesystem, *not* the current working directory, so the script can be run from `distribution/`, from the project root, or from anywhere else. (This is true of all scripts in the `distribution/` directory.)
 
@@ -133,7 +132,9 @@ python update_version.py -v 6.4.2rc
 
 The label must start immediately following the patch version number, with no space in between. The label may contain numeric characters or symbols, but *must not* start with a number (otherwise there is no way to distinguish it from the patch version number).
 
-The `--approve` (short `-a`) option can be used to approve an official release. If the `--approve` option is provided, `IDEVELOPMODE` is set to 0. If `--approve` is not provided, `IDEVELOPMODE = 1` and `(preliminary)` is appended to version numbers.
+The `--approved` (short `-a`) flag can be used to approve an official release. If the `--approved` flag is provided, disclaimer language is altered to reflect approval. If the flag is not provided, the language reflects preliminary/provisional status and `(preliminary)` is appended to version numbers.
+
+The `--releasemode` flag can be used to control whether binaries are built in development or release mode by editing the contents of `src/Utilities/version.f90`. If the `--releasemode` flag is provided, `IDEVELOPMODE` is set to 0. If `--releasemode` is not provided, `IDEVELOPMODE` is set to 1.
 
 #### Building makefiles
 
@@ -174,7 +175,7 @@ Manually building MODFLOW 6 documentation requires additional Python dependencie
 
 #### Building the distribution archive
 
-After each step above is complete, the `build_dist.py` script can be used (without the `--development` flag) to bundle MODFLOW 6 official release artifacts for distribution. See [the `release.yml` workflow](../.github/workflows/release.yml) for a complete example of how to build a distribution archive.
+After each step above is complete, the `build_dist.py` script can be used to construct the MODFLOW 6 distribution. See [the `release.yml` workflow](../.github/workflows/release.yml) for a complete example of how to build a distribution archive.
 
 #### Verifying the distribution archive
 

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -78,9 +78,6 @@ def copy_sources(output_path: PathLike):
     # make sure output directory exists
     output_path.mkdir(exist_ok=True)
 
-    # copy code.json
-    shutil.copy(_project_root_path / "code.json", output_path)
-
     # Copy Visual Studio sln and project files
     print("Copying msvs files to output directory")
     (output_path / "msvs").mkdir(exist_ok=True)
@@ -315,6 +312,9 @@ def build_distribution(
         build_path=build_path,
         bin_path=output_path / "bin",
         overwrite=overwrite)
+    
+    # code.json metadata
+    shutil.copy(_project_root_path / "code.json", output_path)
 
     # full releases include examples, source code, makefiles and docs
     if full:

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -302,9 +302,9 @@ def build_distribution(
         build_path: PathLike,
         output_path: PathLike,
         examples_repo_path: PathLike,
-        development: bool = False,
+        full: bool = False,
         overwrite: bool = False):
-    print(f"Building {'development' if development else 'full'} distribution")
+    print(f"Building {'full' if full else 'minimal'} distribution")
 
     build_path = Path(build_path).expanduser().absolute()
     output_path = Path(output_path).expanduser().absolute()
@@ -317,7 +317,7 @@ def build_distribution(
         overwrite=overwrite)
 
     # full releases include examples, source code, makefiles and docs
-    if not development:
+    if full:
         # examples
         setup_examples(
             bin_path=output_path / "bin",
@@ -336,24 +336,27 @@ def build_distribution(
             output_path=output_path / "doc",
             examples_repo_path=examples_repo_path,
             # benchmarks_path=_benchmarks_path / "run-time-comparison.md",
-            development=development,
+            full=full,
             overwrite=overwrite)
 
 
 @requires_exe("pdflatex")
 @pytest.mark.skip(reason="manual testing")
-@pytest.mark.parametrize("dev", [True, False])
-def test_build_distribution(tmp_path, dev):
+@pytest.mark.parametrize("full", [True, False])
+def test_build_distribution(tmp_path, full):
     output_path = tmp_path / "dist"
     build_distribution(
         build_path=tmp_path / "builddir",
         output_path=output_path,
         examples_repo_path=_examples_repo_path,
-        development=dev,
+        full=full,
         overwrite=True
     )
 
-    if dev:
+    if full:
+        # todo
+        pass
+    else:
         # check binaries and libs
         system = platform.system()
         ext = ".exe" if system == "Windows" else ""
@@ -369,8 +372,6 @@ def test_build_distribution(tmp_path, dev):
 
         # check mf6io docs
         assert (output_path / "mf6io.pdf").is_file()
-    else:
-        pass
 
 
 if __name__ == "__main__":
@@ -381,6 +382,10 @@ if __name__ == "__main__":
             """\
             Create a distribution folder. If no output path is provided
             distribution files are written to the distribution/ folder.
+            By default a minimal distribution containing only binaries,
+            mf6io documentation, release notes and metadata (code.json)
+            is created. To create a full distribution including sources
+            and examples, use the --full flag.
             """
         ),
     )
@@ -412,12 +417,11 @@ if __name__ == "__main__":
     #     help="Path to directory containing benchmark results"
     # )
     parser.add_argument(
-        "-d",
-        "--development",
+        "--full",
         required=False,
         default=False,
         action="store_true",
-        help="Whether to build a development (e.g., nightly) rather than a full distribution"
+        help="Build a full rather than minimal distribution"
     )
     parser.add_argument(
         "-f",
@@ -425,7 +429,7 @@ if __name__ == "__main__":
         required=False,
         default=False,
         action="store_true",
-        help="Whether to recreate and overwrite existing artifacts"
+        help="Recreate and overwrite existing artifacts"
     )
     args = parser.parse_args()
 
@@ -445,6 +449,6 @@ if __name__ == "__main__":
         build_path=build_path,
         output_path=out_path,
         examples_repo_path=examples_repo_path,
-        development=args.development,
+        full=args.full,
         overwrite=args.force,
     )

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -404,9 +404,9 @@ def build_documentation(bin_path: PathLike,
                         # Example to use to render sample mf6 output in the docs.
                         # Must be a valid directory in modflow6-examples/examples
                         example_for_sample: str = "ex-gwf-twri01",
-                        development: bool = False,
+                        full: bool = False,
                         overwrite: bool = False):
-    print(f"Building {'development' if development else 'full'} documentation")
+    print(f"Building {'full' if full else 'full'} documentation")
 
     bin_path = Path(bin_path).expanduser().absolute()
     output_path = Path(output_path).expanduser().absolute()
@@ -430,7 +430,7 @@ def build_documentation(bin_path: PathLike,
     # build LaTeX file describing distribution folder structure
     # build_tex_folder_structure(overwrite=True)
 
-    if development:
+    if not full:
         # convert LaTeX to PDF
         build_pdfs_from_tex(tex_paths=_dev_dist_tex_paths, output_path=output_path)
     else:
@@ -463,9 +463,8 @@ def build_documentation(bin_path: PathLike,
     convert_line_endings(output_path, windows_line_endings)
 
     # make sure we have expected PDFs
-    if development:
-        assert (output_path / "mf6io.pdf").is_file()
-    else:
+    assert (output_path / "mf6io.pdf").is_file()
+    if full:
         assert (output_path / "mf6io.pdf").is_file()
         assert (output_path / "ReleaseNotes.pdf").is_file()
         assert (output_path / "zonebudget.pdf").is_file()
@@ -491,7 +490,8 @@ if __name__ == "__main__":
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent(
             """\
-            Create documentation for a distribution. This includes benchmarks, release notes, the
+            Create documentation for a distribution. By default, this only includes the mf6io PDF
+            document. If the --full flag is provided this includes benchmarks, release notes, the
             MODFLOW 6 input/output specification, example model documentation, supplemental info,
             documentation for the MODFLOW 5 to 6 converter and Zonebudget 6, and several articles
             downloaded from the USGS website. These are all written to a specified --output-path.
@@ -529,12 +529,11 @@ if __name__ == "__main__":
         help="Location to create documentation artifacts",
     )
     parser.add_argument(
-        "-d",
-        "--development",
+        "--full",
         required=False,
         default=False,
         action="store_true",
-        help="Whether to build a development (e.g., nightly) rather than a full distribution"
+        help="Build docs for a full rather than minimal distribution"
     )
     parser.add_argument(
         "-f",
@@ -542,7 +541,7 @@ if __name__ == "__main__":
         required=False,
         default=False,
         action="store_true",
-        help="Whether to recreate and overwrite existing artifacts"
+        help="Recreate and overwrite existing artifacts"
     )
     args = parser.parse_args()
     tex_paths = _full_dist_tex_paths + ([Path(p) for p in args.tex_path] if args.tex_path else [])
@@ -557,5 +556,5 @@ if __name__ == "__main__":
         output_path=output_path,
         examples_repo_path=examples_repo_path,
         example_for_sample=example_for_sample,
-        development=args.development,
+        full=args.full,
         overwrite=args.force)

--- a/distribution/conftest.py
+++ b/distribution/conftest.py
@@ -7,6 +7,8 @@ _dist_dir_path = _project_root_path.parent / f"mf{str(Version.from_file(_project
 
 
 def pytest_addoption(parser):
-    # both options below are for check_dist.py
+    # all options below are for check_dist.py
     parser.addoption("-P", "--path", action="store", default=str(_dist_dir_path))
     parser.addoption("-A", "--approved", action="store_true", default=False)
+    parser.addoption("-R", "--releasemode", action="store_true", default=False)
+    parser.addoption("-F", "--full", action="store_true", default=False)

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -383,7 +383,7 @@ _current_version = Version.from_file(version_file_path)
      Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch),
      Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch, label="rc")],
 )
-@pytest.mark.parametrize("approve", [True, False])
+@pytest.mark.parametrize("approved", [True, False])
 @pytest.mark.parametrize("developmode", [True, False])
 def test_update_version(version, approved, developmode):
     m_times = [get_modified_time(file) for file in touched_file_paths]

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -13,17 +13,20 @@ This script is used to update several files in the modflow6 repository, includin
   ../code.json
   ../src/Utilities/version.f90
 
-Information in these files include version number major.minor.patch[-label], build timestamp,
-whether or not the release is a prerelease candidate or an official distribution, whether the
-source code should be compiled in develop mode or in release mode, and other version metadata.
+Information in these files include version number (major.minor.patch[label]), build timestamp,
+whether or not the release is preliminary/provisional or official/approved, whether the source
+code should be compiled in develop mode (IDEVELOPMODE = 1) or for release, and other metadata.
 
 The version number is read from ../version.txt, which contains major, minor, and patch version
 numbers, and an optional label. Version numbers are substituted into source code, latex files,
-markdown files, etc.  The version number can be overridden using argument --version, short -v.
+markdown files, etc. The version number can be provided explicitly using --version, short -v.
 
-Develop mode is set to 0 if the distribution is approved with --approved, short -a, otherwise,
-it is set to 1.
+If the --releasemode flag is provided, IDEVELOPMODE is set to 0 in src/Utilities/version.f90.
+Otherwise, IDEVELOPMODE is set to 1.
 
+if the --approved flag (short -a) is provided, the disclaimer in src/Utilities/version.f90 and
+the README/DISCLAIMER markdown files is modified to reflect review and approval. Otherwise the
+language reflects preliminary/provisional status, and version strings contain "(preliminary)".
 """
 import argparse
 import json
@@ -232,7 +235,10 @@ def update_version_tex(
 
 
 def update_version_f90(
-    version: Optional[Version], timestamp: datetime, approved: bool = False
+    version: Optional[Version],
+    timestamp: datetime,
+    approved: bool = False,
+    developmode: bool = True
 ):
     path = project_root_path / "src" / "Utilities" / "version.f90"
     lines = open(path, "r").read().splitlines()
@@ -255,7 +261,7 @@ def update_version_f90(
             elif ":: IDEVELOPMODE =" in line:
                 line = (
                     "  integer(I4B), parameter :: "
-                    + f"IDEVELOPMODE = {0 if approved else 1}"
+                    + f"IDEVELOPMODE = {1 if developmode else 0}"
                 )
             elif ":: VERSIONNUMBER =" in line:
                 line = line.rpartition("::")[0] + f":: VERSIONNUMBER = '{version_num}'"
@@ -332,7 +338,8 @@ def update_codejson(version: Version, timestamp: datetime, approved: bool = Fals
 def update_version(
     version: Version = None,
     timestamp: datetime = datetime.now(),
-    approved: bool = False
+    approved: bool = False,
+    developmode: bool = True
 ):
     """
     Update version information stored in version.txt in the project root,
@@ -357,7 +364,7 @@ def update_version(
             update_version_txt_and_py(version, timestamp)
             update_meson_build(version)
             update_version_tex(version, timestamp)
-            update_version_f90(version, timestamp, approved)
+            update_version_f90(version, timestamp, approved, developmode)
             update_readme_and_disclaimer(version, approved)
             update_citation_cff(version, timestamp)
             update_codejson(version, timestamp, approved)
@@ -376,18 +383,26 @@ _current_version = Version.from_file(version_file_path)
      Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch),
      Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch, label="rc")],
 )
-def test_update_version(release_type, version):
+@pytest.mark.parametrize("approve", [True, False])
+@pytest.mark.parametrize("developmode", [True, False])
+def test_update_version(version, approved, developmode):
     m_times = [get_modified_time(file) for file in touched_file_paths]
     timestamp = datetime.now()
 
     try:
-        update_version(release_type=release_type, timestamp=timestamp, version=version)
+        update_version(
+            timestamp=timestamp,
+            version=version,
+            approved=approved,
+            developmode=developmode
+        )
         updated = Version.from_file(version_file_path)
 
         # check files containing version info were modified
         for p, t in zip(touched_file_paths, m_times):
             assert p.stat().st_mtime > t
 
+        # check version number and optional label are correct
         if version:
             # version should be auto-incremented
             assert updated.major == _initial_version.major
@@ -402,9 +417,24 @@ def test_update_version(release_type, version):
             assert updated.patch == _current_version.patch
             if version.label is not None:
                 assert updated.label == version.label
-        
         if version.label is not None:
             assert updated.label == _initial_version
+        
+        # check IDEVELOPMODE was set correctly
+        version_f90_path = project_root_path / "src" / "Utilities" / "version.f90"
+        lines = version_f90_path.read_text().splitlines()
+        assert any(f"IDEVELOPMODE = {1 if developmode else 0}" in line for line in lines)
+
+        # check disclaimer has appropriate language
+        disclaimer_path = project_root_path / "DISCLAIMER.md"
+        disclaimer = disclaimer_path.read_text().splitlines()
+        assert any(("approved for release") in line for line in lines) == approved
+        assert any(("preliminary or provisional") in line for line in lines) != approved
+
+        # check readme has appropriate language
+        readme_path = project_root_path / "README.md"
+        readme = readme_path.read_text().splitlines()
+        assert any(("(preliminary)") in line for line in lines) != approved
     finally:
         for p in touched_file_paths:
             os.system(f"git restore {p}")
@@ -439,10 +469,17 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-a",
-        "--approve",
+        "--approved",
         required=False,
         action="store_true",
-        help="Indicate release is approved (defaults to false for preliminary/development distributions)",
+        help="Approve the release version (defaults to false for preliminary/development distributions)",
+    )
+    parser.add_argument(
+        "-r",
+        "--releasemode",
+        required=False,
+        action="store_true",
+        help="Set IDEVELOPMODE to 0 for release mode (defaults to false for development distributions)",
     )
     parser.add_argument(
         "--bump-major",
@@ -500,5 +537,6 @@ if __name__ == "__main__":
         update_version(
             version=version,
             timestamp=datetime.now(),
-            approved=args.approve,
+            approved=args.approved,
+            developmode=not args.releasemode
         )


### PR DESCRIPTION
Previously there were overlapping concerns between the `development` and `approve` inputs to `release.yml`. This PR

- Introduces `full` to control what is included in the distribution. If false, only binaries, mf6io, release notes, and code.json are included (i.e. a minimal dist). If true, everything (previously listed items plus sources, examples, all docs, etc) is included ((a full distribution).
- Renames `development` to `developmode` which now controls only whether binaries are built in develop or release mode (`IDEVELOPMODE` 1 or 0).
- Modifies the behavior of `approve` to control only whether language is "preliminary/provisional" or "approved for release", etc, in readme and disclaimer, and whether "(preliminary)" is appended to the version string emitted by executables.

This required similar changes to distribution scripts

- `update_version.py`
- `build_dist.py`
- `build_docs.py`
- `check_dist.py`

Corresponding documentation also updated in `distribution/README.md`