### PR TITLE
refactor(print_final_message): flush console buffer output to stdout

### DIFF
--- a/src/Utilities/Sim.f90
+++ b/src/Utilities/Sim.f90
@@ -414,6 +414,9 @@ contains
       end if
     end if
     !
+    ! -- write console buffer output to stdout
+    flush (istdout)
+    !
     ! -- determine if an error condition has occurred
     if (sim_errors%count_message() > 0) then
       ireturnerr = 2


### PR DESCRIPTION
This resolves an issue with mf6 built using GNU Fortran on Linux, which doesn't flush output buffers as frequently as other builds.

Before this PR, running `pytest` with xmipy would delay the output such that it would not be captured by pytest.; see https://github.com/Deltares/xmipy/issues/107