### PR TITLE
ci: fix release scripts and workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -457,16 +457,12 @@ jobs:
       - name: Install extra executables
         uses: modflowpy/install-modflow-action@v1
         with:
-          subset: 'mf2005,triangle,gridgen'
-      
-<<<<<<< HEAD
+          subset: mf2005,triangle,gridgen
+
       - name: Update Flopy
-=======
-      - name: Update flopy
->>>>>>> 9d9bdeee1cbae0e1a44827929e1a92599f58ab78
         working-directory: modflow6/autotest
         run: python update_flopy.py
-      
+  
       - name: Build example models
         working-directory: modflow6-examples/etc
         run: pytest -v -n auto ci_build_files.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,6 +436,30 @@ jobs:
           # remove binaries for other OSes
           rm -rf $distname/bin-*
           ls "$distname"
+      
+      - name: Install dependencies for example models
+        working-directory: modflow6-examples/etc
+        run: |
+          # install extra Python packages
+          pip install -r requirements.pip.txt
+  
+          # the example models need executables to be on the path
+          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          echo "$distname/bin" >> $GITHUB_PATH
+
+          # execute permissions may not have survived artifact upload/download
+          chmod +x "$distname/bin/mf6"
+          chmod +x "$distname/bin/mf5to6"
+          chmod +x "$distname/bin/zbud6"
+
+          # the example models also need mf2005, triangle and gridgen
+          # (install to a temporary bindir since not part of the dist)
+          mkdir -p "${{ runner.temp }}/bin"
+          get-modflow "${{ runner.temp }}/bin" --subset mf2005,triangle,gridgen
+      
+      - name: Build example models
+        working-directory: modflow6-examples/scripts
+        run: pytest -v -n auto ci_build_files.py
 
       - name: Build distribution
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,15 +429,13 @@ jobs:
 
       - name: Select artifacts for OS
         run: |
-          # create directory for OS-specific artifacts
-          distname="${{ needs.build.outputs.distname }}"
-          mkdir -p "$distname_${{ matrix.ostag }}/bin"
-
-          # move binaries for current OS to distribution bin dir
-          mv "$distname/bin-${{ runner.os }}" "$distname_${{ matrix.ostag }}/bin"
+          # rename bin dir for current OS
+          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          mv "$distname/bin-${{ runner.os }}" "$distname/bin"
 
           # remove binaries for other OSes
-          rm -rf "$distname/bin-*"
+          rm -rf $distname/bin-*
+          ls "$distname"
 
       - name: Build distribution
         env:
@@ -451,8 +449,7 @@ jobs:
           fi
           eval "$cmd"
 
-          # move & rename PDF documents to dist folder
-          
+          # rename PDF documents
           if [[ "${{ inputs.full }}" == "true" ]]; then
             mv "$distname/doc/converter_mf5to6.pdf" "$distname/doc/mf5to6.pdf"
           fi
@@ -547,7 +544,6 @@ jobs:
         run: |
           distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
           7z x $distname.zip -o$distname
-          rm -rf "$distname/bin-*"
           rm -rf "$distname/$distname"
 
       - name: Upload distribution zipfile artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -545,12 +545,28 @@ jobs:
             cmd="$cmd --full"
           fi
           eval "$cmd"
+      
+      - name: Unzip (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          7z x $distname.zip -o$distname
+          rm -rf "$distname/bin-*"
+          rm -rf "$distname/$distname"
 
       - name: Upload distribution zipfile artifact
+        if: runner.os != 'Windows'
         uses: actions/upload-artifact@v3
         with:
           name: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
           path: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}.zip"
+
+      - name: Upload distribution zipfile artifact
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v3
+        with:
+          name: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          path: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
 
       - name: Upload release notes artifact
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,10 +453,11 @@ jobs:
           chmod +x "$distname/bin/mf5to6"
           chmod +x "$distname/bin/zbud6"
 
-          # the example models also need mf2005, triangle and gridgen
-          # (install to a temporary bindir since not part of the dist)
-          mkdir -p "${{ runner.temp }}/bin"
-          get-modflow "${{ runner.temp }}/bin" --subset mf2005,triangle,gridgen
+      # the example models also need mf2005, triangle and gridgen
+      - name: Install extra executables
+        uses: modflowpy/install-modflow-action@v1
+        with:
+          subset: 'mf2005,triangle,gridgen'
       
       - name: Build example models
         working-directory: modflow6-examples/etc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -465,7 +465,7 @@ jobs:
   
       - name: Build example models
         working-directory: modflow6-examples/etc
-        run: pytest -v -n auto ci_build_files.py
+        run: python ci_build_files.py
 
       - name: Build distribution
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,12 +438,13 @@ jobs:
           ls "$distname"
       
       - name: Install dependencies for example models
-        working-directory: modflow6-examples/etc
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           # install extra Python packages
-          pip install -r requirements.pip.txt
+          pip install -r modflow6-examples/etc/requirements.pip.txt
   
-          # the example models need executables to be on the path
+          # example models need executables to be on the path
           distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
           echo "$distname/bin" >> $GITHUB_PATH
 
@@ -458,7 +459,7 @@ jobs:
           get-modflow "${{ runner.temp }}/bin" --subset mf2005,triangle,gridgen
       
       - name: Build example models
-        working-directory: modflow6-examples/scripts
+        working-directory: modflow6-examples/etc
         run: pytest -v -n auto ci_build_files.py
 
       - name: Build distribution

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,7 +320,11 @@ jobs:
   
       - name: Build ex-gwf-twri example model
         working-directory: modflow6-examples/scripts
-        run: python ex-gwf-twri.py
+        run: |
+          python ex-gwf-twri.py
+          ls ../examples
+          echo "====================="
+          ls ../examples/ex-gwf-twri01
       
       - name: Create full docs folder structure
         if: inputs.full == true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,11 +320,7 @@ jobs:
   
       - name: Build ex-gwf-twri example model
         working-directory: modflow6-examples/scripts
-        run: |
-          python ex-gwf-twri.py
-          ls ../examples
-          echo "====================="
-          ls ../examples/ex-gwf-twri01
+        run: python ex-gwf-twri.py
       
       - name: Create full docs folder structure
         if: inputs.full == true
@@ -352,7 +348,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "${{ needs.build.outputs.distname }}/doc"
-          cmd="python modflow6/distribution/build_docs.py -b bin -o doc"
+          cmd="python modflow6/distribution/build_docs.py -b bin -o doc -e modflow6-examples"
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,6 +459,14 @@ jobs:
         with:
           subset: 'mf2005,triangle,gridgen'
       
+<<<<<<< HEAD
+      - name: Update Flopy
+=======
+      - name: Update flopy
+>>>>>>> 9d9bdeee1cbae0e1a44827929e1a92599f58ab78
+        working-directory: modflow6/autotest
+        run: python update_flopy.py
+      
       - name: Build example models
         working-directory: modflow6-examples/etc
         run: pytest -v -n auto ci_build_files.py

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -16,35 +16,33 @@ on:
   workflow_dispatch:
     inputs:
       approve:
-        description: 'Whether to approve the release. Default is false, i.e. a preliminary/provisional release.'
+        description: 'Approve the release. Otherwise it is preliminary/provisional.'
         required: false
         type: boolean
         default: false
       branch:
-        description: 'Branch to use for release. Defaults to the current branch (for releases triggered by pushing a release branch).'
-        required: false
+        description: 'Branch to release from.'
+        required: true
         type: string
-        default: ''
       commit_version:
-        description: 'Whether to commit version numbers back to the develop branch. Default is false. Not considered if approve is false.'
+        description: 'Commit version numbers back to the develop branch. Not considered if reset is false.'
         required: false
         type: boolean
         default: false
       reset:
-        description: 'Whether to reset the develop branch to the state of the master branch. Default is false. Not considered if approve is false.'
+        description: 'Reset the develop branch from the master branch. Not considered if approve is false.'
         required: false
         type: boolean
         default: false
       run_tests:
-        description: 'Whether to run tests after building binaries. Default is true.'
+        description: 'Run tests after building binaries.'
         required: true
         type: boolean
         default: true
       version:
         description: 'Version number to use for release.'
-        required: false
+        required: true
         type: string
-        default: ''
 jobs:
   set_options:
     name: Set release options

--- a/distribution/benchmark.py
+++ b/distribution/benchmark.py
@@ -159,12 +159,15 @@ def elapsed_real_to_string(elt):
 
 
 def run_function(id, app, example):
-    return (id, flopy.run_model(
-        app,
-        None,
-        model_ws=example,
-        silent=True,
-        report=True,)
+    return (
+        id,
+        flopy.run_model(
+            app,
+            None,
+            model_ws=example,
+            silent=True,
+            report=True,
+        ),
     )
 
 
@@ -177,7 +180,11 @@ def run_model(current_app: PathLike, previous_app: PathLike, model_path: PathLik
     previous_time = 0.0
 
     generic_names = ["mf6gwf", "mf6gwt"]
-    name = f"{model_path.parent.name}/{model_path.name}" if model_path.name in generic_names else model_path.name
+    name = (
+        f"{model_path.parent.name}/{model_path.name}"
+        if model_path.name in generic_names
+        else model_path.name
+    )
     print(f"Running scenario: {name}")
     line = f"| {name} |"
 
@@ -315,12 +322,13 @@ def write_results(
 
 
 def run_benchmarks(
-        build_path: PathLike,
-        current_bin_path: PathLike,
-        previous_bin_path: PathLike,
-        examples_path: PathLike,
-        output_path: PathLike,
-        excluded: List[str]=[]):
+    build_path: PathLike,
+    current_bin_path: PathLike,
+    previous_bin_path: PathLike,
+    examples_path: PathLike,
+    output_path: PathLike,
+    excluded: List[str] = [],
+):
     """Benchmark current development version against previous release with example models."""
 
     build_path = Path(build_path).expanduser().absolute()
@@ -343,12 +351,20 @@ def run_benchmarks(
 
     if not current_exe.is_file():
         print(f"Building current MODFLOW 6 development version")
-        meson_build(project_path=_project_root_path, build_path=build_path, bin_path=current_bin_path)
+        meson_build(
+            project_path=_project_root_path,
+            build_path=build_path,
+            bin_path=current_bin_path,
+        )
 
     if not previous_exe.is_file():
         version, download_path = download_previous_version(output_path)
         print(f"Rebuilding latest MODFLOW 6 release {version} in development mode")
-        meson_build(project_path=download_path, build_path=build_path, bin_path=previous_bin_path)
+        meson_build(
+            project_path=download_path,
+            build_path=build_path,
+            bin_path=previous_bin_path,
+        )
 
     print(f"Benchmarking MODFLOW 6 versions:")
     print(f"    current: {current_exe}")
@@ -389,7 +405,8 @@ def test_run_benchmarks(tmp_path):
         previous_bin_path=_bin_path / "rebuilt",
         examples_path=_examples_repo_path / "examples",
         output_path=tmp_path,
-        excluded=["previous"])
+        excluded=["previous"],
+    )
     assert (tmp_path / _markdown_file_name).is_file()
 
 
@@ -448,9 +465,7 @@ if __name__ == "__main__":
     )
 
     output_path.mkdir(parents=True, exist_ok=True)
-    assert (
-        examples_repo_path.is_dir()
-    ), f"Examples repo not found: {examples_repo_path}"
+    assert examples_repo_path.is_dir(), f"Examples repo not found: {examples_repo_path}"
 
     run_benchmarks(
         build_path=build_path,
@@ -458,5 +473,5 @@ if __name__ == "__main__":
         previous_bin_path=previous_bin_path,
         examples_path=examples_repo_path / "examples",
         output_path=output_path,
-        excluded=["previous"]
+        excluded=["previous"],
     )

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -17,8 +17,12 @@ from modflow_devtools.markers import requires_exe
 from modflow_devtools.misc import get_model_paths
 
 from build_docs import build_documentation
-from build_makefiles import build_mf6_makefile, build_mf5to6_makefile, build_zbud6_makefile
-from utils import (get_project_root_path, run_command)
+from build_makefiles import (
+    build_mf6_makefile,
+    build_mf5to6_makefile,
+    build_zbud6_makefile,
+)
+from utils import get_project_root_path, run_command
 
 _project_name = "MODFLOW 6"
 
@@ -44,20 +48,22 @@ _included_dir_paths = [
     "utils",
 ]
 
-Makefile = namedtuple('Makefile', ['app', 'src_path', 'out_path'])
+Makefile = namedtuple("Makefile", ["app", "src_path", "out_path"])
 
 
 # makefiles included in distribution
 _makefiles = [
-    Makefile(app="mf6",
-             src_path=_project_root_path / "src",
-             out_path=Path("make")),
-    Makefile(app="zbud6",
-             src_path=_project_root_path / "utils" / "zonebudget" / "src",
-             out_path=Path("utils") / "zonebudget" / "make"),
-    Makefile(app="mf5to6",
-             src_path=_project_root_path / "utils" / "mf5to6" / "src",
-             out_path=Path("utils") / "mf5to6" / "make")
+    Makefile(app="mf6", src_path=_project_root_path / "src", out_path=Path("make")),
+    Makefile(
+        app="zbud6",
+        src_path=_project_root_path / "utils" / "zonebudget" / "src",
+        out_path=Path("utils") / "zonebudget" / "make",
+    ),
+    Makefile(
+        app="mf5to6",
+        src_path=_project_root_path / "utils" / "mf5to6" / "src",
+        out_path=Path("utils") / "mf5to6" / "make",
+    ),
 ]
 
 # system-specific filenames, extensions, etc
@@ -145,8 +151,8 @@ def build_examples(examples_repo_path: PathLike, overwrite: bool = False):
             fname
             for fname in scripts_folder.glob("*")
             if fname.suffix == ".py"
-               and fname.stem.startswith("ex-")
-               and fname.stem not in exclude_list
+            and fname.stem.startswith("ex-")
+            and fname.stem not in exclude_list
         ]
         for script in scripts:
             argv = [
@@ -161,13 +167,17 @@ def build_examples(examples_repo_path: PathLike, overwrite: bool = False):
             run_command(argv, scripts_folder)
 
 
-def setup_examples(bin_path: PathLike, examples_path: PathLike, overwrite: bool = False):
+def setup_examples(
+    bin_path: PathLike, examples_path: PathLike, overwrite: bool = False
+):
     examples_path = Path(examples_path).expanduser().absolute()
 
     # download example models zip asset
     latest = get_release("MODFLOW-USGS/modflow6-examples", "latest")
     assets = latest["assets"]
-    asset = next(iter([a for a in assets if a["name"] == "modflow6-examples.zip"]), None)
+    asset = next(
+        iter([a for a in assets if a["name"] == "modflow6-examples.zip"]), None
+    )
     download_and_unzip(asset["browser_download_url"], examples_path, verbose=True)
 
     # list folders with mfsim.nam (recursively)
@@ -226,27 +236,33 @@ def test_setup_examples():
     pass
 
 
-def build_programs_meson(build_path: PathLike, bin_path: PathLike, overwrite: bool = False):
+def build_programs_meson(
+    build_path: PathLike, bin_path: PathLike, overwrite: bool = False
+):
     build_path = Path(build_path).expanduser().absolute()
     bin_path = Path(bin_path).expanduser().absolute()
 
     exe_paths = [
         bin_path / f"mf6{_eext}",
         bin_path / f"zbud6{_eext}",
-        bin_path / f"mf5to6{_eext}"
+        bin_path / f"mf5to6{_eext}",
     ]
-    lib_paths = [
-        bin_path / f"libmf6{_soext}"
-    ]
+    lib_paths = [bin_path / f"libmf6{_soext}"]
 
-    if not overwrite and all(p.is_file() for p in exe_paths) and all(p.is_file() for p in lib_paths):
+    if (
+        not overwrite
+        and all(p.is_file() for p in exe_paths)
+        and all(p.is_file() for p in lib_paths)
+    ):
         print(f"Binaries already exist:")
         pprint(exe_paths + lib_paths)
     else:
         print(f"Building binaries in {build_path}, installing to {bin_path}")
-        meson_build(project_path=_project_root_path, build_path=build_path, bin_path=bin_path)
+        meson_build(
+            project_path=_project_root_path, build_path=build_path, bin_path=bin_path
+        )
 
-    for target in (exe_paths + lib_paths):
+    for target in exe_paths + lib_paths:
         assert target.is_file(), f"Failed to build {target}"
         target.chmod(target.stat().st_mode | 0o111)
         print(f"Execute permission set for {target}")
@@ -262,22 +278,37 @@ def build_makefiles(output_path: PathLike):
     # create and copy mf6 makefile
     build_mf6_makefile()
     (output_path / "make").mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(_project_root_path / "make" / "makefile", output_path / "make" / "makefile")
-    shutil.copyfile(_project_root_path / "make" / "makedefaults", output_path / "make" / "makedefaults")
+    shutil.copyfile(
+        _project_root_path / "make" / "makefile", output_path / "make" / "makefile"
+    )
+    shutil.copyfile(
+        _project_root_path / "make" / "makedefaults",
+        output_path / "make" / "makedefaults",
+    )
 
     # create and copy zbud6 makefile
     build_zbud6_makefile()
     rel_path = Path("utils") / "zonebudget" / "make"
     (output_path / rel_path).mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(_project_root_path / rel_path / "makefile", output_path / rel_path / "makefile")
-    shutil.copyfile(_project_root_path / rel_path / "makedefaults", output_path / rel_path / "makedefaults")
+    shutil.copyfile(
+        _project_root_path / rel_path / "makefile", output_path / rel_path / "makefile"
+    )
+    shutil.copyfile(
+        _project_root_path / rel_path / "makedefaults",
+        output_path / rel_path / "makedefaults",
+    )
 
     # create and copy mf5to6 makefile
     build_mf5to6_makefile()
     rel_path = Path("utils") / "mf5to6" / "make"
     (output_path / rel_path).mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(_project_root_path / rel_path / "makefile", output_path / rel_path / "makefile")
-    shutil.copyfile(_project_root_path / rel_path / "makedefaults", output_path / rel_path / "makedefaults")
+    shutil.copyfile(
+        _project_root_path / rel_path / "makefile", output_path / rel_path / "makefile"
+    )
+    shutil.copyfile(
+        _project_root_path / rel_path / "makedefaults",
+        output_path / rel_path / "makedefaults",
+    )
 
 
 def test_build_makefiles(tmp_path):
@@ -296,11 +327,12 @@ def test_build_makefiles(tmp_path):
 
 
 def build_distribution(
-        build_path: PathLike,
-        output_path: PathLike,
-        examples_repo_path: PathLike,
-        full: bool = False,
-        overwrite: bool = False):
+    build_path: PathLike,
+    output_path: PathLike,
+    examples_repo_path: PathLike,
+    full: bool = False,
+    overwrite: bool = False,
+):
     print(f"Building {'full' if full else 'minimal'} distribution")
 
     build_path = Path(build_path).expanduser().absolute()
@@ -309,10 +341,9 @@ def build_distribution(
 
     # binaries
     build_programs_meson(
-        build_path=build_path,
-        bin_path=output_path / "bin",
-        overwrite=overwrite)
-    
+        build_path=build_path, bin_path=output_path / "bin", overwrite=overwrite
+    )
+
     # code.json metadata
     shutil.copy(_project_root_path / "code.json", output_path)
 
@@ -322,7 +353,8 @@ def build_distribution(
         setup_examples(
             bin_path=output_path / "bin",
             examples_path=output_path / "examples",
-            overwrite=overwrite)
+            overwrite=overwrite,
+        )
 
         # copy source code files
         copy_sources(output_path=output_path)
@@ -337,7 +369,8 @@ def build_distribution(
             examples_repo_path=examples_repo_path,
             # benchmarks_path=_benchmarks_path / "run-time-comparison.md",
             full=full,
-            overwrite=overwrite)
+            overwrite=overwrite,
+        )
 
 
 @requires_exe("pdflatex")
@@ -350,7 +383,7 @@ def test_build_distribution(tmp_path, full):
         output_path=output_path,
         examples_repo_path=_examples_repo_path,
         full=full,
-        overwrite=True
+        overwrite=True,
     )
 
     if full:
@@ -363,11 +396,15 @@ def test_build_distribution(tmp_path, full):
         for exe in ["mf6", "mf5to6", "zbud6"]:
             assert (output_path / f"{exe}{ext}").is_file()
         assert (
-                output_path
-                / (
-                        "libmf6"
-                        + (".so" if system == "Linux" else (".dylib" if system == "Darwin" else ".dll"))
+            output_path
+            / (
+                "libmf6"
+                + (
+                    ".so"
+                    if system == "Linux"
+                    else (".dylib" if system == "Darwin" else ".dll")
                 )
+            )
         ).is_file()
 
         # check mf6io docs
@@ -407,7 +444,7 @@ if __name__ == "__main__":
         "--examples-repo-path",
         required=False,
         default=str(_examples_repo_path),
-        help="Path to directory containing modflow6 example models"
+        help="Path to directory containing modflow6 example models",
     )
     # parser.add_argument(
     #     "-b",
@@ -421,7 +458,7 @@ if __name__ == "__main__":
         required=False,
         default=False,
         action="store_true",
-        help="Build a full rather than minimal distribution"
+        help="Build a full rather than minimal distribution",
     )
     parser.add_argument(
         "-f",
@@ -429,7 +466,7 @@ if __name__ == "__main__":
         required=False,
         default=False,
         action="store_true",
-        help="Recreate and overwrite existing artifacts"
+        help="Recreate and overwrite existing artifacts",
     )
     args = parser.parse_args()
 

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -284,7 +284,7 @@ def build_mf6io_tex_example(workspace_path: PathLike, bin_path: PathLike, exampl
 
     # run example model
     with set_dir(workspace_path):
-        out, err, ret = run_cmd(cmd)
+        out, err, ret = run_cmd(cmd, verbose=True)
         buff = out + err
         lines = buff.split("\r\n")
         with open(fname1, "w") as f:
@@ -301,7 +301,7 @@ def build_mf6io_tex_example(workspace_path: PathLike, bin_path: PathLike, exampl
 
     # run model without a namefile present
     with set_dir(workspace_path):
-        out, err, ret = run_cmd(cmd)
+        out, err, ret = run_cmd(cmd, verbose=True)
         buff = out + err
         lines = buff.split("\r\n")
         with open(fname2, "w") as f:
@@ -314,7 +314,7 @@ def build_mf6io_tex_example(workspace_path: PathLike, bin_path: PathLike, exampl
 
     with set_dir(workspace_path):
         # run mf6 command with -h to show help
-        out, err, ret = run_cmd(str(mf6_exe_path), "-h")
+        out, err, ret = run_cmd(str(mf6_exe_path), "-h", verbose=True)
         buff = out + err
         lines = buff.split("\r\n")
         with open(fname3, "w") as f:
@@ -518,7 +518,7 @@ if __name__ == "__main__":
         "-s",
         "--example-for-sample",
         required=False,
-        default=str(_examples_repo_path),
+        default="ex-gwf-twri01",
         help="Name of example model to use for sample mf6 output"
     )
     parser.add_argument(

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -16,7 +16,12 @@ from warnings import warn
 import pytest
 from flaky import flaky
 from modflow_devtools.build import meson_build
-from modflow_devtools.download import list_artifacts, download_artifact, get_release, download_and_unzip
+from modflow_devtools.download import (
+    list_artifacts,
+    download_artifact,
+    get_release,
+    download_and_unzip,
+)
 from modflow_devtools.markers import requires_exe, requires_github
 from modflow_devtools.misc import set_dir, run_cmd, is_in_ci
 
@@ -103,12 +108,16 @@ def download_benchmarks(output_path: PathLike, verbose: bool = False) -> Optiona
     name = "run-time-comparison"  # todo make configurable
     repo = "MODFLOW-USGS/modflow6"  # todo make configurable, add pytest/cli args
     artifacts = list_artifacts(repo, name=name, verbose=verbose)
-    artifacts = sorted(artifacts, key=lambda a: datetime.strptime(a['created_at'], '%Y-%m-%dT%H:%M:%SZ'), reverse=True)
+    artifacts = sorted(
+        artifacts,
+        key=lambda a: datetime.strptime(a["created_at"], "%Y-%m-%dT%H:%M:%SZ"),
+        reverse=True,
+    )
     most_recent = next(iter(artifacts), None)
     print(f"Found most recent benchmarks (artifact {most_recent['id']})")
     if most_recent:
         print(f"Downloading benchmarks (artifact {most_recent['id']})")
-        download_artifact(repo, id=most_recent['id'], path=output_path, verbose=verbose)
+        download_artifact(repo, id=most_recent["id"], path=output_path, verbose=verbose)
         print(f"Downloaded benchmarks to {output_path}")
         path = output_path / f"{name}.md"
         assert path.is_file()
@@ -141,13 +150,16 @@ def build_benchmark_tex(output_path: PathLike, overwrite: bool = False):
             current_bin_path=_project_root_path / "bin",
             previous_bin_path=_project_root_path / "bin" / "rebuilt",
             examples_path=_examples_repo_path / "examples",
-            output_path=output_path)
+            output_path=output_path,
+        )
 
     # convert markdown benchmark results to LaTeX
     with set_dir(_release_notes_path):
         tex_path = Path("run-time-comparison.tex")
         tex_path.unlink(missing_ok=True)
-        out, err, ret = run_cmd(sys.executable, "mk_runtimecomp.py", benchmarks_path, verbose=True)
+        out, err, ret = run_cmd(
+            sys.executable, "mk_runtimecomp.py", benchmarks_path, verbose=True
+        )
         assert not ret, out + err
         assert tex_path.is_file()
 
@@ -177,15 +189,15 @@ def build_mf6io_tex_from_dfn(overwrite: bool = False):
             f.stem
             for f in dfn_path.glob("*")
             if f.is_file()
-               and "dfn" in f.suffix
-               and not any(pattern in f.name for pattern in ignored)
+            and "dfn" in f.suffix
+            and not any(pattern in f.name for pattern in ignored)
         ]
         tex_names = [
             f.stem.replace("-desc", "")
             for f in tex_path.glob("*")
             if f.is_file()
-               and "tex" in f.suffix
-               and not any(pattern in f.name for pattern in ignored)
+            and "tex" in f.suffix
+            and not any(pattern in f.name for pattern in ignored)
         ]
 
         return set(tex_names) == set(dfn_names)
@@ -197,7 +209,12 @@ def build_mf6io_tex_from_dfn(overwrite: bool = False):
         tex_files = [f for f in tex_pth.glob("*") if f.is_file()]
         dfn_files = [f for f in dfn_pth.glob("*") if f.is_file()]
 
-        if not overwrite and any(tex_files) and any(dfn_files) and files_match(tex_pth, dfn_pth, ignored):
+        if (
+            not overwrite
+            and any(tex_files)
+            and any(dfn_files)
+            and files_match(tex_pth, dfn_pth, ignored)
+        ):
             print(f"DFN files already exist:")
             pprint(dfn_files)
         else:
@@ -229,13 +246,13 @@ def test_build_mf6io_tex_from_dfn(overwrite):
         for p, t in zip(file_paths, file_mtimes):
             assert overwrite == (p.stat().st_mtime > t)
     finally:
-        for p in (file_paths + [
+        for p in file_paths + [
             # should these be under version control, since they're cleaned in fn above?
             _project_root_path / "doc" / "ConverterGuide" / "converter_mf5to6.bbl",
             _project_root_path / "doc" / "ReleaseNotes" / "ReleaseNotes.bbl",
             _project_root_path / "doc" / "mf6io" / "mf6io.bbl",
-            _project_root_path / "doc" / "zonebudget" / "zonebudget.bbl"
-        ]):
+            _project_root_path / "doc" / "zonebudget" / "zonebudget.bbl",
+        ]:
             os.system(f"git restore {p}")
 
 
@@ -249,7 +266,9 @@ def build_tex_folder_structure(overwrite: bool = False):
         return
 
     with set_dir(_release_notes_path):
-        out, err, ret = run_cmd(sys.executable, "mk_folder_struct.py", "-dp", _project_root_path)
+        out, err, ret = run_cmd(
+            sys.executable, "mk_folder_struct.py", "-dp", _project_root_path
+        )
         assert not ret, out + err
 
     assert path.is_file(), f"Failed to create {path}"
@@ -263,7 +282,9 @@ def test_build_tex_folder_structure():
         os.system(f"git restore {path}")
 
 
-def build_mf6io_tex_example(workspace_path: PathLike, bin_path: PathLike, example_model_path: PathLike):
+def build_mf6io_tex_example(
+    workspace_path: PathLike, bin_path: PathLike, example_model_path: PathLike
+):
     workspace_path = Path(workspace_path) / "workspace"
     bin_path = Path(bin_path).expanduser().absolute()
     mf6_exe_path = bin_path / f"mf6{_eext}"
@@ -331,7 +352,12 @@ def test_build_mf6io_tex_example():
     pass
 
 
-def build_pdfs_from_tex(tex_paths: List[PathLike], output_path: PathLike, passes: int = 3, overwrite: bool = False):
+def build_pdfs_from_tex(
+    tex_paths: List[PathLike],
+    output_path: PathLike,
+    passes: int = 3,
+    overwrite: bool = False,
+):
     print(f"Building PDFs from LaTex:")
     pprint(tex_paths)
 
@@ -394,18 +420,20 @@ def test_build_pdfs_from_tex(tmp_path):
     try:
         build_pdfs_from_tex(tex_paths, tmp_path)
     finally:
-        for p in (tex_paths[:-1] + bbl_paths):
+        for p in tex_paths[:-1] + bbl_paths:
             os.system(f"git restore {p}")
 
 
-def build_documentation(bin_path: PathLike,
-                        output_path: PathLike,
-                        examples_repo_path: PathLike,
-                        # Example to use to render sample mf6 output in the docs.
-                        # Must be a valid directory in modflow6-examples/examples
-                        example_for_sample: str = "ex-gwf-twri01",
-                        full: bool = False,
-                        overwrite: bool = False):
+def build_documentation(
+    bin_path: PathLike,
+    output_path: PathLike,
+    examples_repo_path: PathLike,
+    # Example to use to render sample mf6 output in the docs.
+    # Must be a valid directory in modflow6-examples/examples
+    example_for_sample: str = "ex-gwf-twri01",
+    full: bool = False,
+    overwrite: bool = False,
+):
     print(f"Building {'full' if full else 'full'} documentation")
 
     bin_path = Path(bin_path).expanduser().absolute()
@@ -456,7 +484,9 @@ def build_documentation(bin_path: PathLike,
                     raise
 
         # convert LaTex to PDF
-        build_pdfs_from_tex(tex_paths=_full_dist_tex_paths, output_path=output_path, overwrite=overwrite)
+        build_pdfs_from_tex(
+            tex_paths=_full_dist_tex_paths, output_path=output_path, overwrite=overwrite
+        )
 
     # enforce os line endings on all text files
     windows_line_endings = True
@@ -499,7 +529,13 @@ if __name__ == "__main__":
             """
         ),
     )
-    parser.add_argument("-t", "--tex-path", action="append", required=False, help="Extra LaTeX files to include")
+    parser.add_argument(
+        "-t",
+        "--tex-path",
+        action="append",
+        required=False,
+        help="Extra LaTeX files to include",
+    )
     parser.add_argument(
         "-b",
         "--bin-path",
@@ -512,14 +548,14 @@ if __name__ == "__main__":
         "--examples-repo-path",
         required=False,
         default=str(_examples_repo_path),
-        help="Path to directory containing modflow6 example models"
+        help="Path to directory containing modflow6 example models",
     )
     parser.add_argument(
         "-s",
         "--example-for-sample",
         required=False,
         default="ex-gwf-twri01",
-        help="Name of example model to use for sample mf6 output"
+        help="Name of example model to use for sample mf6 output",
     )
     parser.add_argument(
         "-o",
@@ -533,7 +569,7 @@ if __name__ == "__main__":
         required=False,
         default=False,
         action="store_true",
-        help="Build docs for a full rather than minimal distribution"
+        help="Build docs for a full rather than minimal distribution",
     )
     parser.add_argument(
         "-f",
@@ -541,10 +577,12 @@ if __name__ == "__main__":
         required=False,
         default=False,
         action="store_true",
-        help="Recreate and overwrite existing artifacts"
+        help="Recreate and overwrite existing artifacts",
     )
     args = parser.parse_args()
-    tex_paths = _full_dist_tex_paths + ([Path(p) for p in args.tex_path] if args.tex_path else [])
+    tex_paths = _full_dist_tex_paths + (
+        [Path(p) for p in args.tex_path] if args.tex_path else []
+    )
     output_path = Path(args.output_path).expanduser().absolute()
     output_path.mkdir(parents=True, exist_ok=True)
     bin_path = Path(args.bin_path).expanduser().absolute()
@@ -557,4 +595,5 @@ if __name__ == "__main__":
         examples_repo_path=examples_repo_path,
         example_for_sample=example_for_sample,
         full=args.full,
-        overwrite=args.force)
+        overwrite=args.force,
+    )

--- a/distribution/build_makefiles.py
+++ b/distribution/build_makefiles.py
@@ -108,7 +108,7 @@ def build_mf5to6_makefile():
 def test_build_mf6_makefile():
     makefile_paths = [
         _project_root_path / "make" / "makefile",
-        _project_root_path / "make" / "makedefaults"
+        _project_root_path / "make" / "makedefaults",
     ]
     makefile_mtimes = [p.stat().st_mtime for p in makefile_paths]
 
@@ -150,7 +150,7 @@ def test_build_mf5to6_makefile():
     util_path = _project_root_path / "utils" / "mf5to6"
     makefile_paths = [
         util_path / "make" / "makefile",
-        util_path / "make" / "makedefaults"
+        util_path / "make" / "makedefaults",
     ]
     makefile_mtimes = [p.stat().st_mtime for p in makefile_paths]
 

--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -148,10 +148,14 @@ def test_examples(dist_dir_path, full):
     example_paths = [
         p for p in examples_path.glob("*") if p.is_dir() and p.stem.startswith("ex")
     ]
+    print(f"{len(example_paths)} example models found:")
+    pprint(example_paths)
     for p in example_paths:
         pprint(
             subprocess.check_output([str(p / f"run{_scext}")], cwd=p).decode().split()
         )
+        break
+
 
 
 def test_binaries(dist_dir_path, approved):

--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -3,10 +3,11 @@ import re
 import subprocess
 from os import environ
 from pathlib import Path
+from pprint import pprint
 
 import pytest
 
-from utils import get_branch, split_nonnumeric
+from utils import split_nonnumeric
 
 _system = platform.system()
 _eext = ".exe" if _system == "Windows" else ""
@@ -80,10 +81,18 @@ def test_makefiles(dist_dir_path, full):
     assert (dist_dir_path / "utils" / "mf5to6" / "make" / "makedefaults").is_file()
 
     # makefiles can't be used on Windows with ifort compiler
-    if _system != 'Windows' or _fc != 'ifort':
+    if _system != "Windows" or _fc != "ifort":
         print(subprocess.check_output("make", cwd=dist_dir_path / "make", shell=True))
-        print(subprocess.check_output("make", cwd=dist_dir_path / "utils" / "zonebudget" / "make", shell=True))
-        print(subprocess.check_output("make", cwd=dist_dir_path / "utils" / "mf5to6" / "make", shell=True))
+        print(
+            subprocess.check_output(
+                "make", cwd=dist_dir_path / "utils" / "zonebudget" / "make", shell=True
+            )
+        )
+        print(
+            subprocess.check_output(
+                "make", cwd=dist_dir_path / "utils" / "mf5to6" / "make", shell=True
+            )
+        )
 
 
 def test_msvs(dist_dir_path, full):
@@ -128,11 +137,21 @@ def test_examples(dist_dir_path, full):
     examples_path = dist_dir_path / "examples"
     assert examples_path.is_dir()
 
-    # test run an example model with the provided script
-    example_path = next(examples_path.iterdir(), None)
-    assert example_path
-    output = ' '.join(subprocess.check_output([str(example_path / f"run{_scext}")], cwd=example_path).decode().split())
-    print(output)
+    # test run all example models with provided script
+    pprint(
+        subprocess.check_output(
+            [str(examples_path / f"runall{_scext}")], cwd=examples_path
+        )
+    )
+
+    # test run example models individually with provided scripts
+    example_paths = [
+        p for p in examples_path.glob("*") if p.is_dir() and p.stem.startswith("ex")
+    ]
+    for p in example_paths:
+        pprint(
+            subprocess.check_output([str(p / f"run{_scext}")], cwd=p).decode().split()
+        )
 
 
 def test_binaries(dist_dir_path, approved):
@@ -142,16 +161,16 @@ def test_binaries(dist_dir_path, approved):
     assert (bin_path / f"mf5to6{_eext}").is_file()
     assert (bin_path / f"libmf6{_soext}").is_file()
 
-    output = ' '.join(subprocess.check_output([str(bin_path / f"mf6{_eext}"), "-v"]).decode().split()).lower()
+    output = " ".join(
+        subprocess.check_output([str(bin_path / f"mf6{_eext}"), "-v"]).decode().split()
+    ).lower()
     assert output.startswith("mf6")
 
     # make sure binaries were built in correct mode
     assert ("preliminary" in output) != approved
 
     # check version string
-    version = (
-        output.lower().split(' ')[1]
-    )
+    version = output.lower().split(" ")[1]
     print(version)
     v_split = version.split(".")
     assert len(v_split) == 3

--- a/distribution/conftest.py
+++ b/distribution/conftest.py
@@ -3,7 +3,10 @@ from pathlib import Path
 from update_version import Version
 
 _project_root_path = Path(__file__).resolve().parent.parent
-_dist_dir_path = _project_root_path.parent / f"mf{str(Version.from_file(_project_root_path / 'version.txt'))}"
+_dist_dir_path = (
+    _project_root_path.parent
+    / f"mf{str(Version.from_file(_project_root_path / 'version.txt'))}"
+)
 
 
 def pytest_addoption(parser):

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -112,7 +112,6 @@ class Version(NamedTuple):
         return cls(major=vmajor, minor=vminor, patch=vpatch, label=vlabel)
 
 
-
 _approved_fmtdisclaimer = '''  character(len=*), parameter :: FMTDISCLAIMER = &
     "(/,&
     &'This software has been approved for release by the U.S. Geological ',/,&
@@ -180,9 +179,7 @@ def log_update(path, version: Version):
     print(f"Updated {path} with version {version}")
 
 
-def update_version_txt_and_py(
-    version: Version, timestamp: datetime
-):
+def update_version_txt_and_py(version: Version, timestamp: datetime):
     with open(version_file_path, "w") as f:
         f.write(
             f"# {project_name} version file automatically "
@@ -193,7 +190,9 @@ def update_version_txt_and_py(
         f.write(f"major = {version.major}\n")
         f.write(f"minor = {version.minor}\n")
         f.write(f"micro = {version.patch}\n")
-        f.write("label = " + (("'" + version.label + "'") if version.label else "''") + "\n")
+        f.write(
+            "label = " + (("'" + version.label + "'") if version.label else "''") + "\n"
+        )
         f.write("__version__ = '{:d}.{:d}.{:d}'.format(major, minor, micro)\n")
         f.write("if label:\n")
         f.write("\t__version__ += '{}{}'.format(__version__, label)")
@@ -215,9 +214,7 @@ def update_meson_build(version: Version):
     log_update(path, version)
 
 
-def update_version_tex(
-    version: Version, timestamp: datetime
-):
+def update_version_tex(version: Version, timestamp: datetime):
     path = project_root_path / "doc" / "version.tex"
     with open(path, "w") as f:
         line = "\\newcommand{\\modflowversion}{mf" + f"{str(version)}" + "}"
@@ -238,7 +235,7 @@ def update_version_f90(
     version: Optional[Version],
     timestamp: datetime,
     approved: bool = False,
-    developmode: bool = True
+    developmode: bool = True,
 ):
     path = project_root_path / "src" / "Utilities" / "version.f90"
     lines = open(path, "r").read().splitlines()
@@ -269,7 +266,10 @@ def update_version_f90(
                 fmat_tstmp = timestamp.strftime("%m/%d/%Y")
                 label_clause = version_label if version_label else ""
                 label_clause += " (preliminary)" if not approved else ""
-                line = line.rpartition("::")[0] + f":: VERSIONTAG = '{label_clause} {fmat_tstmp}'"
+                line = (
+                    line.rpartition("::")[0]
+                    + f":: VERSIONTAG = '{label_clause} {fmat_tstmp}'"
+                )
             elif ":: FMTDISCLAIMER =" in line:
                 line = get_disclaimer(approved, formatted=True)
                 skip = True
@@ -277,9 +277,7 @@ def update_version_f90(
     log_update(path, version)
 
 
-def update_readme_and_disclaimer(
-    version: Version, approved: bool = False
-):
+def update_readme_and_disclaimer(version: Version, approved: bool = False):
     disclaimer = get_disclaimer(approved, formatted=False)
     readme_path = str(project_root_path / "README.md")
     readme_lines = open(readme_path, "r").read().splitlines()
@@ -339,7 +337,7 @@ def update_version(
     version: Version = None,
     timestamp: datetime = datetime.now(),
     approved: bool = False,
-    developmode: bool = True
+    developmode: bool = True,
 ):
     """
     Update version information stored in version.txt in the project root,
@@ -379,9 +377,20 @@ _current_version = Version.from_file(version_file_path)
 @pytest.mark.skip(reason="reverts repo files on cleanup, tread carefully")
 @pytest.mark.parametrize(
     "version",
-    [None,
-     Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch),
-     Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch, label="rc")],
+    [
+        None,
+        Version(
+            major=_initial_version.major,
+            minor=_initial_version.minor,
+            patch=_initial_version.patch,
+        ),
+        Version(
+            major=_initial_version.major,
+            minor=_initial_version.minor,
+            patch=_initial_version.patch,
+            label="rc",
+        ),
+    ],
 )
 @pytest.mark.parametrize("approved", [True, False])
 @pytest.mark.parametrize("developmode", [True, False])
@@ -394,7 +403,7 @@ def test_update_version(version, approved, developmode):
             timestamp=timestamp,
             version=version,
             approved=approved,
-            developmode=developmode
+            developmode=developmode,
         )
         updated = Version.from_file(version_file_path)
 
@@ -419,11 +428,13 @@ def test_update_version(version, approved, developmode):
                 assert updated.label == version.label
         if version.label is not None:
             assert updated.label == _initial_version
-        
+
         # check IDEVELOPMODE was set correctly
         version_f90_path = project_root_path / "src" / "Utilities" / "version.f90"
         lines = version_f90_path.read_text().splitlines()
-        assert any(f"IDEVELOPMODE = {1 if developmode else 0}" in line for line in lines)
+        assert any(
+            f"IDEVELOPMODE = {1 if developmode else 0}" in line for line in lines
+        )
 
         # check disclaimer has appropriate language
         disclaimer_path = project_root_path / "DISCLAIMER.md"
@@ -459,7 +470,7 @@ if __name__ == "__main__":
             may not be provided. Likewise, if any of the latter are provided, the
             version number must not be specified.
             """
-        )
+        ),
     )
     parser.add_argument(
         "-v",
@@ -538,5 +549,5 @@ if __name__ == "__main__":
             version=version,
             timestamp=datetime.now(),
             approved=args.approved,
-            developmode=not args.releasemode
+            developmode=not args.releasemode,
         )

--- a/distribution/utils.py
+++ b/distribution/utils.py
@@ -143,4 +143,4 @@ def test_convert_line_endings():
 
 def split_nonnumeric(s):
     match = re.compile("[^0-9]").search(s)
-    return [s[:match.start()], s[match.start():]] if match else s
+    return [s[: match.start()], s[match.start() :]] if match else s


### PR DESCRIPTION
- prevent double-zipping on Windows (workaround [upload/download artifact behavior](https://github.com/actions/upload-artifact/issues/39))
- update `release_dispatch.yml` input descriptions
- fix sample output substituted into mf6io
- fix steps to build examples
- format dist scripts