### PR TITLE
fix(ListReader): fix issue reading binary stress period data with AUX variables

### DIFF
--- a/autotest/test_gwf_chd02.py
+++ b/autotest/test_gwf_chd02.py
@@ -1,0 +1,104 @@
+# test use of binary stress period data with auxilliary data
+import os
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+from simulation import TestSimulation
+
+ex = [
+    "chd02",
+]
+
+
+def build_model(idx, workspace):
+    name = ex[idx]
+    nlay, nrow, ncol = 1, 1, 10
+    sim = flopy.mf6.MFSimulation(sim_ws=workspace, sim_name=name)
+    flopy.mf6.ModflowTdis(sim)
+    flopy.mf6.ModflowIms(sim, complexity="simple")
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, print_input=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=nrow,
+        ncol=ncol,
+        delr=1.0,
+        delc=1.0,
+        top=10.0,
+        botm=0.0,
+    )
+    flopy.mf6.ModflowGwfnpf(
+        gwf,
+        icelltype=1,
+    )
+    flopy.mf6.ModflowGwfic(
+        gwf,
+        strt=10.0,
+    )
+    chd_data = [
+        (0, 0, 0, 10.0, 1.0, 100.),
+        (0, 0, ncol - 1, 5.0, 0.0, 100.),
+    ]
+    chd_data = {
+        0: {
+            "filename": "chd.bin",
+            "binary": True,
+            "data": chd_data,
+        },
+    }
+    flopy.mf6.ModflowGwfchd(
+        gwf,
+        auxiliary=["conc", "something"],
+        stress_period_data=chd_data,
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=f"{name}.hds",
+        saverecord=[("HEAD", "LAST")],
+        printrecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
+    )
+
+    return sim, None
+
+
+def eval_model(sim):
+    print("evaluating model...")
+
+    name = sim.name
+
+    fpth = os.path.join(sim.simpath, f"{name}.hds")
+    hobj = flopy.utils.HeadFile(fpth, precision="double")
+    head = hobj.get_data().flatten()
+
+    # This is the answer to this problem.
+    hres = np.array(
+        [
+            10.00,
+            9.57481441,
+            9.1298034,
+            8.66189866,
+            8.16714512,
+            7.64029169,
+            7.07409994,
+            6.45808724,
+            5.77600498,
+            5.000,
+        ]
+    )
+    assert np.allclose(
+        hres, head
+    ), "simulated head does not match with known solution."
+
+
+@pytest.mark.parametrize("name", ex)
+def test_mf6model(name, function_tmpdir, targets):
+    test = TestFramework()
+    test.build(build_model, 0, str(function_tmpdir))
+    test.run(
+        TestSimulation(
+            name=name, exe_dict=targets, exfunc=eval_model, idxsim=0
+        ),
+        str(function_tmpdir),
+    )

--- a/doc/ReleaseNotes/v6.4.2.tex
+++ b/doc/ReleaseNotes/v6.4.2.tex
@@ -29,6 +29,7 @@
 		\item The SSM Package for the GWT Model did not work properly with Stress Package Concentration (SPC) input with the READARRAY option for transient models.  Under these conditions, the program would prematurely terminate looking for the next BEGIN PERIOD block.  The program was corrected so that SPC input can be read for transient conditions.
 		\item For some Linux systems, observations were not being correctly written to formatted observation output files when the source code was compiled with the Intel IFORT 19.1.0.166 20191121 compiler. This issue has been addressed by adding a flush statement to ObsUtilityModule::write\_unfmtd\_obs after writing each observation for a time step. This change will not affect simulated observations and should not affect simulation run times.
 		\item The wetted area written to the binary LAK package output was modified to be zero when the lake stage is below the bottom of a connected groundwater cell.  The code uses the lak\_calculate\_conn\_warea() function to determine the wetted area, which makes sense for calculating the flow conductance.
+		\item Fix issue with reading boundary package stress period data from binary files when auxiliary data is included.
 	\end{itemize}
 
 	\underline{INTERNAL FLOW PACKAGES}

--- a/src/Utilities/ListReader.f90
+++ b/src/Utilities/ListReader.f90
@@ -344,7 +344,7 @@ contains
 
         ! -- Read remainder of record
         read (this%inlist, iostat=this%ierr) (this%rlist(jj, ii), jj=1, ldim), &
-          (this%auxvar(ii, jj), jj=1, naux)
+          (this%auxvar(jj, ii), jj=1, naux)
         if (this%ierr /= 0) then
           inquire (unit=this%inlist, name=fname)
           write (errmsg, fmtlsterronly) trim(adjustl(fname)), this%inlist


### PR DESCRIPTION
- Added autotest (test_gwf_chd02) to confirm that binary stress period data with auxiliary data can be run.
- Updated the release notes.