### PR TITLE
ci(release): make linux version used for build configurable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: boolean
         default: false
+      linux_version:
+        description: 'Linux runner image to build binaries on.'
+        required: false
+        type: string
+        default: 'ubuntu-20.04'
       run_tests:
         description: Run tests after building binaries.'
         required: false
@@ -49,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ${{ inputs.linux_version }}
             ostag: linux
           - os: macos-12
             ostag: mac


### PR DESCRIPTION
- set default ubuntu used for releases to 20.04

- allows making decisions like https://github.com/MODFLOW-USGS/modflow6/discussions/1163 on a case by case basis. For now the convention has been releases here and executables repo build on 20.04 and nightly build on 22.04. If this is merged, nightly build needs an update to select 22.04 explicitly (if we still want that). Or maybe we could do both 20 and 22 nightly