### PR TITLE
ci: release fixes related to example models

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -88,11 +88,6 @@ jobs:
           pip install -r requirements.pip.txt
           pip install -r requirements.usgs.txt
 
-      - name: Update FloPy
-        if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6/autotest
-        run: python update_flopy.py
-
       - name: Build example models
         if: steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -88,6 +88,11 @@ jobs:
           pip install -r requirements.pip.txt
           pip install -r requirements.usgs.txt
 
+      - name: Update FloPy
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6/autotest
+        run: python update_flopy.py
+
       - name: Build example models
         if: steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
           chmod +x "${{ github.workspace }}/bin/zbud6"
 
           # the example model also needs mf2005
-          get-modflow "${{ github.workspace }}/bin" --subset mf2005
+          get-modflow "${{ github.workspace }}/bin" --subset mf2005,triangle,gridgen
   
       - name: Update FloPy
         working-directory: modflow6/autotest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,8 +365,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "${{ needs.build.outputs.distname }}/doc"
-          # using -f (--force) flag reruns benchmarks instead of using downloaded results
-          cmd="python modflow6/distribution/build_docs.py -b bin -o doc -e modflow6-examples -f"
+          cmd="python modflow6/distribution/build_docs.py -b bin -o doc -e modflow6-examples"
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,7 +306,7 @@ jobs:
           name: bin-${{ runner.os }}
           path: bin
     
-      - name: Install dependencies for ex-gwf-twri example model
+      - name: Install dependencies for building models
         working-directory: modflow6-examples/etc
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -323,11 +323,17 @@ jobs:
           chmod +x "${{ github.workspace }}/bin/zbud6"
 
           # the example model also needs mf2005
-          get-modflow "${{ github.workspace }}/bin" --subset mf2005
+          get-modflow "${{ github.workspace }}/bin" --subset mf2005,triangle,gridgen
   
       - name: Build ex-gwf-twri example model
+        if: inputs.full != true
         working-directory: modflow6-examples/scripts
         run: python ex-gwf-twri.py
+
+      - name: Build example models
+        if: inputs.full == true
+        working-directory: modflow6-examples/etc
+        run: python ci_build_files.py
       
       - name: Create full docs folder structure
         if: inputs.full == true
@@ -355,7 +361,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "${{ needs.build.outputs.distname }}/doc"
-          cmd="python modflow6/distribution/build_docs.py -b bin -o doc -e modflow6-examples"
+          # using -f (--force) flag reruns benchmarks instead of using downloaded results
+          cmd="python modflow6/distribution/build_docs.py -b bin -o doc -e modflow6-examples -f"
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
           chmod +x "${{ github.workspace }}/bin/zbud6"
 
           # the example model also needs mf2005
-          get-modflow "${{ github.workspace }}/bin" --subset mf2005,triangle,gridgen
+          get-modflow "${{ github.workspace }}/bin" --subset mf2005
   
       - name: Update FloPy
         working-directory: modflow6/autotest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,6 +325,10 @@ jobs:
           # the example model also needs mf2005
           get-modflow "${{ github.workspace }}/bin" --subset mf2005,triangle,gridgen
   
+      - name: Update FloPy
+        working-directory: modflow6/autotest
+        run: python update_flopy.py
+
       - name: Build ex-gwf-twri example model
         if: inputs.full != true
         working-directory: modflow6-examples/scripts

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -140,7 +140,9 @@ jobs:
         run: |
           # update version files
           ver="${{ needs.set_options.outputs.version }}"
-          if [[ "${{ inputs.approve }}" == "true" ]]; then
+          # approve will be empty if workflow was triggered by pushing a release branch
+          # todo: pull approve into set_options job/output?
+          if [[ ("${{ inputs.approve }}" == "true") || (${{ inputs.approve }} == "") ]]; then
             python update_version.py -v "$ver" --approve
           else
             python update_version.py -v "$ver"
@@ -217,9 +219,9 @@ jobs:
 
   reset:
     name: Draft reset PR
-    # runs only after GitHub release post is published (manually promoted from draft to public)
-    # to bring the release commits from master back into develop
-    if: github.event_name == 'release' && inputs.reset == 'true'
+    # runs only after GitHub release post is published (promoted from draft to public)
+    # to bring release commits from master back into develop and reset IDEVELOPMODE=1.
+    if: github.event_name == 'release' && (inputs.reset == 'true' || inputs.reset == '')
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -263,7 +265,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # updating version numbers if enabled
-          if [[ "${{ inputs.commit_version }}" == "true" ]]; then
+          if [[ ("${{ inputs.commit_version }}" == "true") || ("${{ inputs.commit_version }}" == "") ]]; then
             ver="${{ steps.latest_tag.outputs.tag }}"
             python distribution/update_version.py -v "$ver"
             git add -A

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -142,7 +142,7 @@ jobs:
           ver="${{ needs.set_options.outputs.version }}"
           # approve will be empty if workflow was triggered by pushing a release branch
           # todo: pull approve into set_options job/output?
-          if [[ ("${{ inputs.approve }}" == "true") || (${{ inputs.approve }} == "") ]]; then
+          if [[ ("${{ inputs.approve }}" == "true") || ("${{ inputs.approve }}" == "") ]]; then
             python update_version.py -v "$ver" --approve
           else
             python update_version.py -v "$ver"


### PR DESCRIPTION
Accommodate empty inputs in `release_dispatch.yml`. Inputs are empty if the workflow is triggered by pushing a release branch. Later on this should be done in a cleaner way, e.g. all inputs should be processed in the `set_options` job, so conditionals later in the workflow can be simplified. Expediting a temporary solution to allow moving forward with the 6.4.2 release.