### PR TITLE
ci: update flopy before benchmarking in docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -88,6 +88,11 @@ jobs:
           pip install -r requirements.pip.txt
           pip install -r requirements.usgs.txt
 
+      - name: Update FloPy
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6/autotest
+        run: python update_flopy.py
+
       - name: Build example models
         if: steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc


### PR DESCRIPTION
MF6 benchmarks run in `docs.yml` and results are uploaded as artifacts, then are downloaded by the release workflow to include in the distribution. However the artifact produced by `docs.yml` has been broken for some time, because FloPy classes were not updated from DFNs before benchmarking. Update flopy before running benchmarks to fix this.