### PR TITLE
docs: add PR template, add compiler version to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**To reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
@@ -23,6 +23,7 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. macOS, Linux, Windows]
- - Version [e.g. 22]
+**Environment**
+ - Operating system (e.g. macOS, Linux, Windows) and version
+ - MODFLOW 6 version (if installed via distribution)
+ - Compiler toolchain/version (if built from source)

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -2,7 +2,7 @@ Feel free to remove check-list items that aren't relevant to your change.
 
 - [ ] Closes #xxxx
 - [ ] Passed autotests
-- [ ] Formatted source files using `fprettify`
-- [ ] Updated makefiles if new source files added
+- [ ] Formatted source files with `fprettify`
 - [ ] Updated definition (*.dfn) files with new or modified options
 - [ ] Described new options, features or behavior changes in release notes
+- [ ] Updated meson files, makefiles, and Visual Studio project files if new source files added

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,7 @@
+Feel free to remove check-list items that aren't relevant to your change.
+
+- [ ] Closes #xxxx
+- [ ] Passed autotests
+- [ ] Formatted source files
+- [ ] Updated makefiles if new source files added
+- [ ] Described new features or behavior changes in release notes

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -2,6 +2,7 @@ Feel free to remove check-list items that aren't relevant to your change.
 
 - [ ] Closes #xxxx
 - [ ] Passed autotests
-- [ ] Formatted source files
+- [ ] Formatted source files using `fprettify`
 - [ ] Updated makefiles if new source files added
-- [ ] Described new features or behavior changes in release notes
+- [ ] Updated definition (*.dfn) files with new or modified options
+- [ ] Described new options, features or behavior changes in release notes


### PR DESCRIPTION
as discussed offline

- add compiler version to suggested info in bug report template (if mf6 built from source)
- introduce [PR template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) with checklist (should there be any more items?)