### PR TITLE
ci(release): make compiler toolchain/version configurable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,15 @@ on:
         required: true
         type: string
       compiler_toolchain:
-        description: 'Compiler toolchain to use. See awvwgk/setup-fortran for supported options.'
-        required: true
+        description: 'Compiler toolchain to use. For supported options see https://github.com/MODFLOW-USGS/modflow6/blob/develop/DEVELOPER.md#compiler-compatibility.'
+        required: false
         type: string
+        default: 'intel-classic'
       compiler_version:
-        description: 'Compiler version to use. See awvwgk/setup-fortran for supported versions of each toolchain.'
-        required: true
+        description: 'Compiler version to use. For supported options see https://github.com/MODFLOW-USGS/modflow6/blob/develop/DEVELOPER.md#compiler-compatibility.'
+        required: false
         type: string
+        default: '2021.7'
       developmode:
         description: 'Build binaries in develop mode. If false, IDEVELOPMODE is set to 0.'
         required: false
@@ -93,7 +95,7 @@ jobs:
             powershell
 
       - name: Setup ${{ inputs.compiler_toolchain }} ${{ inputs.compiler_version }}
-        uses: awvwgk/setup-fortran@main
+        uses: fortran-lang/setup-fortran@v1
         with:
           compiler: ${{ inputs.compiler_toolchain }}
           version: ${{ inputs.compiler_version }}
@@ -290,7 +292,7 @@ jobs:
           cache-environment: true
 
       - name: Setup ${{ inputs.compiler_toolchain }} ${{ inputs.compiler_version }}
-        uses: awvwgk/setup-fortran@main
+        uses: fortran-lang/setup-fortran@v1
         with:
           compiler: ${{ inputs.compiler_toolchain }}
           version: ${{ inputs.compiler_version }}
@@ -444,7 +446,7 @@ jobs:
             powershell
 
       - name: Setup ${{ inputs.compiler_toolchain }} ${{ inputs.compiler_version }}
-        uses: awvwgk/setup-fortran@main
+        uses: fortran-lang/setup-fortran@v1
         with:
           compiler: ${{ inputs.compiler_toolchain }}
           version: ${{ inputs.compiler_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ on:
         description: 'Branch to release from.'
         required: true
         type: string
+      compiler_toolchain:
+        description: 'Compiler toolchain to use. See awvwgk/setup-fortran for supported options.'
+        required: true
+        type: string
+      compiler_version:
+        description: 'Compiler version to use. See awvwgk/setup-fortran for supported versions of each toolchain.'
+        required: true
+        type: string
       developmode:
         description: 'Build binaries in develop mode. If false, IDEVELOPMODE is set to 0.'
         required: false
@@ -84,8 +92,11 @@ jobs:
             bash
             powershell
 
-      - name: Setup Intel Fortran
-        uses: modflowpy/install-intelfortran-action@v1
+      - name: Setup ${{ inputs.compiler_toolchain }} ${{ inputs.compiler_version }}
+        uses: awvwgk/setup-fortran@main
+        with:
+          compiler: ${{ inputs.compiler_toolchain }}
+          version: ${{ inputs.compiler_version }}
 
       - name: Set version number
         id: set_version
@@ -278,8 +289,11 @@ jobs:
           cache-downloads: true
           cache-environment: true
 
-      - name: Setup Intel Fortran
-        uses: modflowpy/install-intelfortran-action@v1
+      - name: Setup ${{ inputs.compiler_toolchain }} ${{ inputs.compiler_version }}
+        uses: awvwgk/setup-fortran@main
+        with:
+          compiler: ${{ inputs.compiler_toolchain }}
+          version: ${{ inputs.compiler_version }}
 
       - name: Update version
         id: update_version
@@ -429,8 +443,11 @@ jobs:
             bash
             powershell
 
-      - name: Setup Intel Fortran
-        uses: modflowpy/install-intelfortran-action@v1
+      - name: Setup ${{ inputs.compiler_toolchain }} ${{ inputs.compiler_version }}
+        uses: awvwgk/setup-fortran@main
+        with:
+          compiler: ${{ inputs.compiler_toolchain }}
+          version: ${{ inputs.compiler_version }}
       
       - name: Update version
         id: update_version

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -25,15 +25,15 @@ on:
         required: true
         type: string
       compiler_toolchain:
-        description: 'Compiler toolchain to use. Options are gcc, intel, or intel-classic, as supported by awvwgk/setup-fortran.'
-        required: true
+        description: 'Compiler toolchain to use. For supported options see https://github.com/MODFLOW-USGS/modflow6/blob/develop/DEVELOPER.md#compiler-compatibility.'
+        required: false
         type: string
-        default: intel-classic
+        default: 'intel-classic'
       compiler_version:
-        description: 'Compiler version to use. See awvwgk/setup-fortran for supported versions of each toolchain.'
-        required: true
+        description: 'Compiler version to use. For supported options see https://github.com/MODFLOW-USGS/modflow6/blob/develop/DEVELOPER.md#compiler-compatibility.'
+        required: false
         type: string
-        default: 2021.7.0
+        default: '2021.7'
       commit_version:
         description: 'Commit version numbers back to the develop branch. Not considered if reset is false.'
         required: false
@@ -46,7 +46,7 @@ on:
         default: false
       run_tests:
         description: 'Run tests after building binaries.'
-        required: true
+        required: false
         type: boolean
         default: true
       version:
@@ -100,7 +100,7 @@ jobs:
           elif [[ ("${{ github.event_name }}" == "push") && ("${{ github.ref_name }}" != "master") ]]; then
             # if release was triggered by pushing a release branch, use the default toolchain and version
             compiler_toolchain="intel-classic"
-            compiler_version="2021.7.0"
+            compiler_version="2021.7"
             echo "using default compiler toolchain $compiler_toolchain version $compiler_version"
           else
             # otherwise exit with an error

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -24,6 +24,16 @@ on:
         description: 'Branch to release from.'
         required: true
         type: string
+      compiler_toolchain:
+        description: 'Compiler toolchain to use. Options are gcc, intel, or intel-classic, as supported by awvwgk/setup-fortran.'
+        required: true
+        type: string
+        default: intel-classic
+      compiler_version:
+        description: 'Compiler version to use. See awvwgk/setup-fortran for supported versions of each toolchain.'
+        required: true
+        type: string
+        default: 2021.7.0
       commit_version:
         description: 'Commit version numbers back to the develop branch. Not considered if reset is false.'
         required: false
@@ -53,6 +63,8 @@ jobs:
         shell: bash -l {0}
     outputs:
       branch: ${{ steps.set_branch.outputs.branch }}
+      compiler_toolchain: ${{ steps.set_compiler.outputs.compiler_toolchain }}
+      compiler_version: ${{ steps.set_compiler.outputs.compiler_version }}
       version: ${{ steps.set_version.outputs.version }}
     steps:
       - name: Set branch
@@ -77,6 +89,26 @@ jobs:
             exit 1
           fi
           echo "branch=$branch" >> $GITHUB_OUTPUT
+      - name: Set compiler
+        id: set_compiler
+        run: |
+          # if compiler toolchain was provided explicitly via workflow_dispatch, use it
+          if [[ ("${{ github.event_name }}" == "workflow_dispatch") && (-n "${{ inputs.compiler_toolchain }}") ]]; then
+            compiler_toolchain="${{ inputs.compiler_toolchain }}"
+            compiler_version="${{ inputs.compiler_version }}"
+            echo "using compiler toolchain $compiler_toolchain version $compiler_version from workflow_dispatch"
+          elif [[ ("${{ github.event_name }}" == "push") && ("${{ github.ref_name }}" != "master") ]]; then
+            # if release was triggered by pushing a release branch, use the default toolchain and version
+            compiler_toolchain="intel-classic"
+            compiler_version="2021.7.0"
+            echo "using default compiler toolchain $compiler_toolchain version $compiler_version"
+          else
+            # otherwise exit with an error
+            echo "error: this workflow should not have triggered for event ${{ github.event_name }} on branch ${{ github.ref_name }}"
+            exit 1
+          fi
+          echo "compiler_toolchain=$compiler_toolchain" >> $GITHUB_OUTPUT
+          echo "compiler_version=$compiler_version" >> $GITHUB_OUTPUT
       - name: Set version
         id: set_version
         run: |
@@ -103,6 +135,8 @@ jobs:
       # If the workflow is manually triggered, the maintainer must manually set approve=true to approve a release.
       # If triggered by pushing a release branch, the release is approved if the branch name doesn't contain "rc".
       approve: ${{ (github.event_name == 'workflow_dispatch' && inputs.approve == 'true') || (github.event_name != 'workflow_dispatch' && !contains(github.ref_name, 'rc')) }}
+      compiler_toolchain: ${{ needs.set_options.outputs.compiler_toolchain }}
+      compiler_version: ${{ needs.set_options.outputs.compiler_version }}
       branch: ${{ needs.set_options.outputs.branch }}
       developmode: false
       full: true


### PR DESCRIPTION
- switch from `modflowpy/install-intelfortran-action` to `fortran-lang/setup-fortran`
- give `release.yml` inputs `compiler_toolchain` and `compiler_version`
  - for supported values see [`fortran-lang/setup-fortran`](https://github.com/fortran-lang/setup-fortran) and [mf6 compatibility matrix](https://github.com/MODFLOW-USGS/modflow6/blob/develop/DEVELOPER.md#compiler-compatibility)
- makes compilers configurable if release is manually triggered or called from another workflow
- if release is triggered with a release branch, default is `intel-classic` (ifort) version `2021.7`

~~**Blocked** until `setup-fortran` action supports intel compilers on ubuntu 20.04~~