### PR TITLE
fix(build_docs.py): filter benchmark artifacts by branch

### DIFF
--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -16,8 +16,12 @@ from warnings import warn
 import pytest
 from flaky import flaky
 from modflow_devtools.build import meson_build
-from modflow_devtools.download import (download_and_unzip, download_artifact,
-                                       get_release, list_artifacts)
+from modflow_devtools.download import (
+    download_and_unzip,
+    download_artifact,
+    get_release,
+    list_artifacts,
+)
 from modflow_devtools.markers import requires_exe, requires_github
 from modflow_devtools.misc import is_in_ci, run_cmd, set_dir
 
@@ -112,6 +116,9 @@ def download_benchmarks(
         key=lambda a: datetime.strptime(a["created_at"], "%Y-%m-%dT%H:%M:%SZ"),
         reverse=True,
     )
+    artifacts = [
+        a for a in artifacts if a["head_branch"] == "develop"  # todo make configurable
+    ]
     most_recent = next(iter(artifacts), None)
     print(f"Found most recent benchmarks (artifact {most_recent['id']})")
     if most_recent:


### PR DESCRIPTION
The GitHub API [list artifacts endpoint](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-artifacts-for-a-repository) does not provide a way to filter by the branch an artifact was produced from, and will return all artifacts for a repo, even those produced by open PR runs. The `distribution/build_docs.py` script previously just took the first artifact named `run-time-comparison` it could find.  This broke the nightly build full distribution tests &mdash; an artifact from #1328 was picked up despite its contents being named differently/incompatibly with the current state of `develop`. Add a filter to make sure the artifact used in `build_docs.py` was produced by a workflow run on `develop` .