### PR TITLE
docs(conf.py): use html_css_files instead of html_context

### DIFF
--- a/.build_rtd_docs/Doxyfile
+++ b/.build_rtd_docs/Doxyfile
@@ -37,7 +37,7 @@ PROJECT_NAME           = "MODFLOW 6"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "version 6.2.2"
+PROJECT_NUMBER         = "version 6.5.0.dev0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/.build_rtd_docs/conf.py
+++ b/.build_rtd_docs/conf.py
@@ -149,11 +149,9 @@ html_theme = "sphinx_rtd_theme"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-html_context = {
-    "css_files": [
-        "_static/theme_overrides.css",  # override wide tables in RTD theme
-    ],
-}
+html_css_files = [
+    "_static/theme_overrides.css",  # override wide tables in RTD theme
+]
 
 # html_theme_options = {
 #     "github_url": "https://github.com/MODFLOW-USGS/modflow6",


### PR DESCRIPTION
- fix broken RTD styling https://stackoverflow.com/questions/73220398/sphinx-rtd-theme-not-formatting-correctly-missing-theme-css
- fix outdated Doxyfile date