### PR TITLE
docs: multiple fixes

### DIFF
--- a/.doc/conf.py
+++ b/.doc/conf.py
@@ -112,14 +112,13 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-
 html_context = {
     "github_repo": "modflow6",
     "doc_path": ".doc",
-    "css_files": [
-        "_static/theme_overrides.css",  # override wide tables in RTD theme
-    ],
 }
+html_css_files = [
+    "_static/theme_overrides.css",  # override wide tables in RTD theme
+]
 
 html_theme_options = {}
 

--- a/.doc/requirements.txt
+++ b/.doc/requirements.txt
@@ -2,5 +2,6 @@ sphinx_markdown_tables
 ipython
 ipykernel
 rtds_action
-sphinx_rtd_theme
+sphinx>=4
+sphinx_rtd_theme>=1
 myst-parser


### PR DESCRIPTION
* use `html_css_files` instead of `html_context` in `.doc/conf.py`
* constrain `sphinx` & `sphinx_rtd_theme` versions in `.doc/requirements.txt`