### PR TITLE
docs: update deprecated config in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: 3.8
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: .doc/conf.py
@@ -18,6 +23,5 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: .build_rtd_docs/requirements.rtd.txt


### PR DESCRIPTION
- use `build.os` as recommended by https://blog.readthedocs.com/use-build-os-config/
- also move python version to `build.tools.python`