### PR TITLE
ci: add gitlab config for automatic denali build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,28 @@
+image: ubuntu:20.04
+before_script:
+  # install ssh agent
+  - 'which ssh-agent || ( apt-get update -y && apt-get install openssh-client git -y )'
+  # configure ssh agent
+  - eval $(ssh-agent -s)
+  # set private key permissions
+  - chmod 400 "$SSH_PRIVATE_KEY"
+  # add key to the agent store
+  - ssh-add "$SSH_PRIVATE_KEY"
+  # configure known hosts
+  - mkdir -p ~/.ssh
+  - cp "$SSH_KNOWN_HOSTS" ~/.ssh/known_hosts
+  - chmod 644 ~/.ssh/known_hosts
+deploy_denali:
+  stage: deploy
+  script: |
+    # fetch and checkout latest
+    ssh -l "$SSH_USERNAME" "$SSH_HOSTNAME" "cd $MF6_PROJ_ROOT && git fetch $GIT_REMOTE && git checkout $GIT_BRANCH && git pull"
+    echo "Updated repository $MF6_PROJ_ROOT"
+    # submit a job to build mf6
+    jobid=$(ssh -l "$SSH_USERNAME" "$SSH_HOSTNAME" "sbatch --account=$SLURM_ACCOUNT --reservation=$SLURM_RESERVATION --parsable -D $MF6_PROJ_ROOT/.hpc $MF6_PROJ_ROOT/$BUILD_SCRIPT" | tail -n 1)
+    echo "Submitted build job $jobid"
+    # submit a job to update the mf6 module
+    jobid=$(ssh -l "$SSH_USERNAME" "$SSH_HOSTNAME" "sbatch --export=ALL,INTEL_VERSION=$INTEL_VERSION,MF6_PROJ_ROOT=$MF6_PROJ_ROOT,MODULES_PATH=$MODULES_PATH --account=$SLURM_ACCOUNT --reservation=$SLURM_RESERVATION --parsable -D $MF6_PROJ_ROOT/.hpc -d afterok:$jobid $MF6_PROJ_ROOT/$MODULE_SCRIPT" | tail -n 1)
+    echo "Submitted module update job $jobid"
+  environment: denali
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,7 @@
 image: ubuntu:20.04
+workflow:
+  rules:
+    - if: $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == 'push'
 before_script:
   # install ssh agent
   - 'which ssh-agent || ( apt-get update -y && apt-get install openssh-client git -y )'

--- a/.hpc/cray-meson-build.slurm.batch
+++ b/.hpc/cray-meson-build.slurm.batch
@@ -3,7 +3,6 @@
 #SBATCH --job-name=meson-MODFLOW-build
 #SBATCH --nodes=1
 #SBATCH --ntasks=2
-#SBATCH --account=impd
 #SBATCH --time=00:10:00
 #SBATCH --output=slurm-%j.out
 

--- a/.hpc/update-module.slurm.batch
+++ b/.hpc/update-module.slurm.batch
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#SBATCH --job-name=update-mf6-module
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --time=00:05:00
+#SBATCH --output=slurm-%j.out
+
+# variables
+MF6_BINDIR="$MF6_PROJ_ROOT/bin"
+MF6_VERSION=$(cat "$MF6_PROJ_ROOT/version.txt")
+MF6_MODULEFILE_PATH="$MODULES_PATH/modulefiles/modflow/$MF6_VERSION"
+MF6_MODULES_PATH="$MODULES_PATH/apps/modflow"
+MF6_MODULE_PATH="$MF6_MODULES_PATH/$MF6_VERSION"
+
+if [ -d "$MF6_MODULE_PATH" ]; then
+  echo "Updating module modflow/$MF6_VERSION"
+else
+  echo "Creating module modflow/$MF6_VERSION"
+
+  mkdir -p "$MF6_MODULE_PATH/$INTEL_VERSION/bin"
+  mkdir -p "$MF6_MODULE_PATH/$INTEL_VERSION/lib"
+  echo "Created bin/lib dirs in $MF6_MODULE_PATH/$INTEL_VERSION/"
+
+  rsync "$MODULES_PATH/modulefiles/modflow/6.4.2" "$MF6_MODULEFILE_PATH"
+  sed -i -e "s/6.4.2/$MF6_VERSION/g" "$MF6_MODULEFILE_PATH"
+  echo "Created module file"
+fi
+
+# copy binaries from build dir
+rsync "$MF6_BINDIR/mf6" "$MF6_MODULE_PATH/$INTEL_VERSION/bin/"
+rsync "$MF6_BINDIR/zbud6" "$MF6_MODULE_PATH/$INTEL_VERSION/bin/"
+rsync "$MF6_BINDIR/libmf6.so" "$MF6_MODULE_PATH/$INTEL_VERSION/lib/"
+echo "Copied binaries to $MF6_MODULE_PATH/$INTEL_VERSION lib/bin dirs"
+


### PR DESCRIPTION
- add `gitlab-ci.yml` with denali deploy job, triggered on push to default branch on internal USGS GitLab mirror
- add `update-module.slurm.batch` job to update denali mf6 module
- move hardcoded info to env vars set via git forge (github or gitlab) variables