### PR TITLE
fix(docs): list-based recharge example has an error

### DIFF
--- a/doc/mf6io/mf6ivar/examples/gwf-rch-example.dat
+++ b/doc/mf6io/mf6ivar/examples/gwf-rch-example.dat
@@ -14,7 +14,6 @@ BEGIN DIMENSIONS
 END DIMENSIONS
 
 BEGIN PERIOD 1
-  RECHARGE
   # Lay  Row  Col  Rate   Var1  Var2   mult  BoundName
      1    1    1   rch_1   1.0   2.0     1.0       Rch-1-1
      1    1    2   rch_1   1.1   2.1     1.0       Rch-1-2


### PR DESCRIPTION
Not sure how this snuck in, but it has been around for some time.  