### PR TITLE
docs(mf6io): fix discrepancy in LAK and MAW descriptions for RATE variable

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwf-lak.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-lak.dfn
@@ -796,7 +796,7 @@ in_record true
 reader urword
 time_series true
 longname extraction rate
-description real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to active (IBOUND $>$ 0) lakes. A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.
+description real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.
 
 block period
 name invert

--- a/doc/mf6io/mf6ivar/dfn/gwf-maw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-maw.dfn
@@ -619,7 +619,7 @@ in_record true
 reader urword
 time_series true
 longname well pumping rate
-description is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (IBOUND $>$ 0) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.
+description is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (STATUS is ACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.
 
 block period
 name well_head


### PR DESCRIPTION
In mf6io.pdf, the descriptions for `RATE` in the LAK and MAW packages allude to an `IBOUND` variable; however, `IBOUND` is not defined anywhere.  Offering a fix for what I think was originally intended. If I'm not understanding what is being described in the documentation, please feel free to close the PR.