### PR TITLE
refactor: use python <= 3.11 for bmipy compatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
   - defaults
 
 dependencies:
+  - python<=3.11
   - appdirs
   - filelock
   - fprettify


### PR DESCRIPTION
* fixes CI failures caused by `setup-micromamba` now using python 3.12 (released 10/2) as default
* see https://github.com/csdms/bmi-python/issues/19#issuecomment-1758408976 for context