### PR TITLE
test(ArrayHandlers): add unit tests via optional framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: modflow6
+      
+      - name: Checkout test-drive
+        uses: actions/checkout@v4
+        with:
+          repository: fortran-lang/test-drive
+          path: test-drive
 
       - name: Setup GNU Fortran ${{ env.GCC_V }}
         uses: awvwgk/setup-fortran@main
@@ -129,6 +135,13 @@ jobs:
           environment-file: modflow6/environment.yml
           cache-environment: true
           cache-downloads: true
+
+      - name: Build test-drive
+        working-directory: test-drive
+        run: |
+          meson setup builddir --prefix=$(pwd) --libdir=lib
+          meson install -C builddir
+          echo "PKG_CONFIG_PATH=$(pwd)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
       - name: Build modflow6
         working-directory: modflow6

--- a/autotest/TestArrayHandlers.f90
+++ b/autotest/TestArrayHandlers.f90
@@ -1,0 +1,69 @@
+module TestArrayHandlers
+  use KindModule, only: I4B, DP
+  use testdrive, only: error_type, unittest_type, new_unittest, check, test_failed
+  use ArrayHandlersModule, only: ExpandArray2D
+  use ConstantsModule, only: LINELENGTH
+  implicit none
+  private
+  public :: collect_arrayhandlers
+
+contains
+
+  subroutine collect_arrayhandlers(testsuite)
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    testsuite = [ &
+                new_unittest("ExpandArray2D_int", test_ExpandArray2D_int), &
+                new_unittest("ExpandArray2D_dbl", test_ExpandArray2D_dbl) &
+                ]
+  end subroutine collect_arrayhandlers
+
+  subroutine test_ExpandArray2D_int(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B), allocatable :: array(:, :)
+
+    ! allocate array
+    allocate (array(2, 2))
+
+    ! check initial array size
+    call check(error, size(array, 1) == 2)
+    call check(error, size(array, 2) == 2)
+    if (allocated(error)) return
+
+    ! resize array
+    call ExpandArray2D(array, 2, 2)
+
+    ! check that arrays have been resized
+    call check(error, size(array, 1) == 4)
+    call check(error, size(array, 2) == 4)
+    if (allocated(error)) then
+      call test_failed(error, "2d int array not resized correctly")
+      return
+    end if
+
+  end subroutine test_ExpandArray2D_int
+
+  subroutine test_ExpandArray2D_dbl(error)
+    type(error_type), allocatable, intent(out) :: error
+    real(DP), allocatable :: array(:, :)
+
+    ! allocate array
+    allocate (array(2, 2))
+
+    ! check initial array size
+    call check(error, size(array, 1) == 2)
+    call check(error, size(array, 2) == 2)
+    if (allocated(error)) return
+
+    ! resize array
+    call ExpandArray2D(array, 2, 2)
+
+    ! check that arrays have been resized
+    call check(error, size(array, 1) == 4)
+    call check(error, size(array, 2) == 4)
+    if (allocated(error)) then
+      call test_failed(error, "2d dbl array not resized correctly")
+      return
+    end if
+
+  end subroutine test_ExpandArray2D_dbl
+end module TestArrayHandlers

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -1,0 +1,26 @@
+test_drive = dependency('test-drive', required : false)
+if test_drive.found()
+  tests = [
+    'ArrayHandlers',
+  ]
+
+  test_srcs = files(
+    'tester.f90',
+  )
+  foreach t : tests
+    test_srcs += files('Test@0@.f90'.format(t.underscorify()))
+  endforeach
+
+  tester = executable(
+    'tester',
+    sources: test_srcs,
+    link_with: mf6core,
+    dependencies: test_drive,
+  )
+
+  test('Test source modules', tester)
+
+  foreach t : tests
+    test(t, tester, args: t)
+  endforeach
+endif

--- a/autotest/tester.f90
+++ b/autotest/tester.f90
@@ -1,0 +1,52 @@
+program tester
+  use, intrinsic :: iso_fortran_env, only: error_unit
+  use testdrive, only: run_testsuite, new_testsuite, testsuite_type, &
+    & select_suite, run_selected, get_argument
+  use TestArrayHandlers, only: collect_arrayhandlers
+  implicit none
+  integer :: stat, is
+  character(len=:), allocatable :: suite_name, test_name
+  type(testsuite_type), allocatable :: testsuites(:)
+  character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+  stat = 0
+  testsuites = [ &
+               new_testsuite("ArrayHandlers", collect_arrayhandlers) &
+               ]
+
+  call get_argument(1, suite_name)
+  call get_argument(2, test_name)
+
+  if (allocated(suite_name)) then
+    is = select_suite(testsuites, suite_name)
+    if (is > 0 .and. is <= size(testsuites)) then
+      if (allocated(test_name)) then
+        write (error_unit, fmt) "Suite:", testsuites(is)%name
+        call run_selected(testsuites(is)%collect, test_name, error_unit, stat)
+        if (stat < 0) then
+          error stop 1
+        end if
+      else
+        write (error_unit, fmt) "Testing:", testsuites(is)%name
+        call run_testsuite(testsuites(is)%collect, error_unit, stat)
+      end if
+    else
+      write (error_unit, fmt) "Available testsuites"
+      do is = 1, size(testsuites)
+        write (error_unit, fmt) "-", testsuites(is)%name
+      end do
+      error stop 1
+    end if
+  else
+    do is = 1, size(testsuites)
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+    end do
+  end if
+
+  if (stat > 0) then
+    write (error_unit, '(i0, 1x, a)') stat, "test(s) failed!"
+    error stop 1
+  end if
+
+end program tester

--- a/meson.build
+++ b/meson.build
@@ -206,8 +206,8 @@ subdir('srcbmi')
 # build zbud6 and mf5to6 utility programs
 subdir('utils')
 
-# add unit test directory
-# subdir('unittests')
+# add autotest directory
+subdir('autotest')
 
 # meson tests to evaluate installation success
 testdir = meson.project_source_root() / '.mf6minsim'


### PR DESCRIPTION
* introduce [test-drive](https://github.com/fortran-lang/test-drive) unit test framework as optional development aid
* tests hook into meson test if test-drive installed, otherwise ignored
* add minimal test cases for ExpandArray2D ArrayHandlers interface
* add unit testing section to developer docs
* include tests in smoke test job in `ci.yml`
* close #1387