### PR TITLE
feat(InputOutput.f90): Introduce padl, a string manipulation function

### DIFF
--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -17,7 +17,7 @@ module InputOutputModule
             UPCASE, URWORD, ULSTLB, UBDSV4,                                    &
             ubdsv06, UBDSVB, UCOLNO, ULAPRW,                                   &
             ULASAV, ubdsv1, ubdsvc, ubdsvd, UWWORD,                            &
-            same_word, get_node, get_ijk, padl, unitinquire,                   &
+            same_word, get_node, get_ijk, str_pad_left, unitinquire,           &
             ParseLine, ulaprufw, openfile,                                     &
             linear_interpolate, lowcase,                                       &
             read_line,                                                         &
@@ -1200,7 +1200,7 @@ END SUBROUTINE URWORD
   
   !> @brief Function for string manipulation
   !<
-  function padl(str, width) result(res)
+  function str_pad_left(str, width) result(res)
     ! -- local
     character(len=*), intent(in) :: str
     integer, intent(in) :: width

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -17,7 +17,7 @@ module InputOutputModule
             UPCASE, URWORD, ULSTLB, UBDSV4,                                    &
             ubdsv06, UBDSVB, UCOLNO, ULAPRW,                                   &
             ULASAV, ubdsv1, ubdsvc, ubdsvd, UWWORD,                            &
-            same_word, get_node, get_ijk, unitinquire,                         &
+            same_word, get_node, get_ijk, padl, unitinquire,                   &
             ParseLine, ulaprufw, openfile,                                     &
             linear_interpolate, lowcase,                                       &
             read_line,                                                         &
@@ -1197,6 +1197,22 @@ END SUBROUTINE URWORD
     !
     return
   end subroutine get_ijk
+  
+  !> @brief Function for string manipulation
+  !<
+  function padl(str, width) result(res)
+    ! -- local
+    character(len=*), intent(in) :: str
+    integer, intent(in) :: width
+    ! -- Return
+    character(len=max(len_trim(str), width)) :: res
+    !
+    res = str
+    res = adjustr(res)
+    !
+    ! -- Return
+    return
+  end function
 
   subroutine get_jk(nodenumber, ncpl, nlay, icpl, ilay)
     ! Calculate icpl, and ilay from the nodenumber and grid


### PR DESCRIPTION
Part of the generalized transport refactoring is that the dependent variable name varies depending on which type of model is implemented (GWT vs GWE).  To accommodate this in the standard output listing file, `padl` assists with writing well-formatted messages.