### PR TITLE
feat(GeomUtil): add geometry module with point_in_polygon utility

### DIFF
--- a/autotest/TestGeomUtil.f90
+++ b/autotest/TestGeomUtil.f90
@@ -1,0 +1,90 @@
+module TestGeomUtil
+  use KindModule, only: I4B, DP
+  use testdrive, only: error_type, unittest_type, new_unittest, check, test_failed
+  use GeomUtilModule, only: point_in_polygon
+  use ConstantsModule, only: LINELENGTH
+  implicit none
+  private
+  public :: collect_geomutil
+
+contains
+
+  subroutine collect_geomutil(testsuite)
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    testsuite = [ &
+                new_unittest("point_in_polygon_rect", &
+                             test_point_in_polygon_rect) &
+                ]
+  end subroutine collect_geomutil
+
+  subroutine test_point_in_polygon_rect(error)
+    type(error_type), allocatable, intent(out) :: error
+    real(DP), allocatable :: poly(:, :)
+
+    ! allocate and define polygon
+    allocate (poly(4, 2))
+    ! vertices in clockwise order
+    poly(1, :) = (/0.0_DP, 0.0_DP/)
+    poly(2, :) = (/0.0_DP, 1.0_DP/)
+    poly(3, :) = (/1.0_DP, 1.0_DP/)
+    poly(4, :) = (/1.0_DP, 0.0_DP/)
+
+    ! points inside polygon
+    call check(error, point_in_polygon(0.99_DP, 0.01_DP, poly))
+    call check(error, point_in_polygon(0.5_DP, 0.5_DP, poly))
+    call check(error, point_in_polygon(0.0001_DP, 0.9999_DP, poly))
+    if (allocated(error)) return
+
+    ! points outside polygon
+    call check(error, (.not. point_in_polygon(0.5_DP, 1.00001_DP, poly)))
+    call check(error, (.not. point_in_polygon(-0.5_DP, 34.0_DP, poly)))
+    if (allocated(error)) return
+
+    ! points on vertices
+    call check(error, point_in_polygon(0.0_DP, 0.0_DP, poly))
+    call check(error, point_in_polygon(1.0_DP, 0.0_DP, poly))
+    call check(error, point_in_polygon(0.0_DP, 1.0_DP, poly))
+    call check(error, point_in_polygon(1.0_DP, 1.0_DP, poly))
+    if (allocated(error)) return
+
+    ! points on faces
+    call check(error, point_in_polygon(0.0_DP, 0.5_DP, poly))
+    call check(error, point_in_polygon(0.5_DP, 0.0_DP, poly))
+    call check(error, point_in_polygon(1.0_DP, 0.5_DP, poly))
+    call check(error, point_in_polygon(0.5_DP, 1.0_DP, poly))
+    if (allocated(error)) return
+
+    ! vertices counter-clockwise
+    poly(1, :) = (/0.0_DP, 0.0_DP/)
+    poly(2, :) = (/1.0_DP, 0.0_DP/)
+    poly(3, :) = (/1.0_DP, 1.0_DP/)
+    poly(4, :) = (/0.0_DP, 1.0_DP/)
+
+    ! points inside polygon
+    call check(error, point_in_polygon(0.99_DP, 0.01_DP, poly))
+    call check(error, point_in_polygon(0.5_DP, 0.5_DP, poly))
+    call check(error, point_in_polygon(0.0001_DP, 0.9999_DP, poly))
+    if (allocated(error)) return
+
+    ! points outside polygon
+    call check(error, (.not. point_in_polygon(0.5_DP, 1.00001_DP, poly)))
+    call check(error, (.not. point_in_polygon(-0.5_DP, 34.0_DP, poly)))
+    if (allocated(error)) return
+
+    ! points on vertices
+    call check(error, point_in_polygon(0.0_DP, 0.0_DP, poly))
+    call check(error, point_in_polygon(1.0_DP, 0.0_DP, poly))
+    call check(error, point_in_polygon(0.0_DP, 1.0_DP, poly))
+    call check(error, point_in_polygon(1.0_DP, 1.0_DP, poly))
+    if (allocated(error)) return
+
+    ! points on faces
+    call check(error, point_in_polygon(0.0_DP, 0.5_DP, poly))
+    call check(error, point_in_polygon(0.5_DP, 0.0_DP, poly))
+    call check(error, point_in_polygon(1.0_DP, 0.5_DP, poly))
+    call check(error, point_in_polygon(0.5_DP, 1.0_DP, poly))
+    if (allocated(error)) return
+
+  end subroutine test_point_in_polygon_rect
+
+end module TestGeomUtil

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -2,6 +2,7 @@ test_drive = dependency('test-drive', required : false)
 if test_drive.found()
   tests = [
     'ArrayHandlers',
+    'GeomUtil'
   ]
 
   test_srcs = files(

--- a/autotest/tester.f90
+++ b/autotest/tester.f90
@@ -3,6 +3,7 @@ program tester
   use testdrive, only: run_testsuite, new_testsuite, testsuite_type, &
     & select_suite, run_selected, get_argument
   use TestArrayHandlers, only: collect_arrayhandlers
+  use TestGeomUtil, only: collect_geomutil
   implicit none
   integer :: stat, is
   character(len=:), allocatable :: suite_name, test_name
@@ -11,7 +12,8 @@ program tester
 
   stat = 0
   testsuites = [ &
-               new_testsuite("ArrayHandlers", collect_arrayhandlers) &
+               new_testsuite("ArrayHandlers", collect_arrayhandlers), &
+               new_testsuite("GeomUtil", collect_geomutil) &
                ]
 
   call get_argument(1, suite_name)

--- a/make/makefile
+++ b/make/makefile
@@ -5,36 +5,37 @@ include ./makedefaults
 
 # Define the source file directories
 SOURCEDIR1=../src
-SOURCEDIR2=../src/Model
-SOURCEDIR3=../src/Model/TransportModel
-SOURCEDIR4=../src/Model/GroundWaterFlow
-SOURCEDIR5=../src/Model/Geometry
-SOURCEDIR6=../src/Model/ModelUtilities
-SOURCEDIR7=../src/Model/GroundWaterTransport
-SOURCEDIR8=../src/Model/Connection
-SOURCEDIR9=../src/Distributed
-SOURCEDIR10=../src/Utilities
-SOURCEDIR11=../src/Utilities/Idm
+SOURCEDIR2=../src/Exchange
+SOURCEDIR3=../src/Distributed
+SOURCEDIR4=../src/Solution
+SOURCEDIR5=../src/Solution/LinearMethods
+SOURCEDIR6=../src/Solution/ParticleTracker
+SOURCEDIR7=../src/Solution/PETSc
+SOURCEDIR8=../src/Timing
+SOURCEDIR9=../src/Utilities
+SOURCEDIR10=../src/Utilities/Idm
+SOURCEDIR11=../src/Utilities/Idm/selector
 SOURCEDIR12=../src/Utilities/Idm/mf6blockfile
-SOURCEDIR13=../src/Utilities/Idm/selector
-SOURCEDIR14=../src/Utilities/Vector
-SOURCEDIR15=../src/Utilities/Matrix
-SOURCEDIR16=../src/Utilities/Observation
-SOURCEDIR17=../src/Utilities/ArrayRead
-SOURCEDIR18=../src/Utilities/OutputControl
-SOURCEDIR19=../src/Utilities/Libraries
-SOURCEDIR20=../src/Utilities/Libraries/blas
-SOURCEDIR21=../src/Utilities/Libraries/rcm
+SOURCEDIR13=../src/Utilities/TimeSeries
+SOURCEDIR14=../src/Utilities/Memory
+SOURCEDIR15=../src/Utilities/OutputControl
+SOURCEDIR16=../src/Utilities/ArrayRead
+SOURCEDIR17=../src/Utilities/Libraries
+SOURCEDIR18=../src/Utilities/Libraries/rcm
+SOURCEDIR19=../src/Utilities/Libraries/blas
+SOURCEDIR20=../src/Utilities/Libraries/sparskit2
+SOURCEDIR21=../src/Utilities/Libraries/daglib
 SOURCEDIR22=../src/Utilities/Libraries/sparsekit
-SOURCEDIR23=../src/Utilities/Libraries/sparskit2
-SOURCEDIR24=../src/Utilities/Libraries/daglib
-SOURCEDIR25=../src/Utilities/Memory
-SOURCEDIR26=../src/Utilities/TimeSeries
-SOURCEDIR27=../src/Timing
-SOURCEDIR28=../src/Solution
-SOURCEDIR29=../src/Solution/PETSc
-SOURCEDIR30=../src/Solution/LinearMethods
-SOURCEDIR31=../src/Exchange
+SOURCEDIR23=../src/Utilities/Vector
+SOURCEDIR24=../src/Utilities/Matrix
+SOURCEDIR25=../src/Utilities/Observation
+SOURCEDIR26=../src/Model
+SOURCEDIR27=../src/Model/Connection
+SOURCEDIR28=../src/Model/GroundWaterTransport
+SOURCEDIR29=../src/Model/ModelUtilities
+SOURCEDIR30=../src/Model/GroundWaterFlow
+SOURCEDIR31=../src/Model/TransportModel
+SOURCEDIR32=../src/Model/Geometry
 
 VPATH = \
 ${SOURCEDIR1} \
@@ -67,7 +68,8 @@ ${SOURCEDIR27} \
 ${SOURCEDIR28} \
 ${SOURCEDIR29} \
 ${SOURCEDIR30} \
-${SOURCEDIR31} 
+${SOURCEDIR31} \
+${SOURCEDIR32} 
 
 .SUFFIXES: .f90 .F90 .o
 
@@ -321,6 +323,7 @@ $(OBJDIR)/sparsekit.o \
 $(OBJDIR)/rcm.o \
 $(OBJDIR)/blas1_d.o \
 $(OBJDIR)/Iunit.o \
+$(OBJDIR)/GeomUtil.o \
 $(OBJDIR)/RectangularGeometry.o \
 $(OBJDIR)/CircularGeometry.o
 

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -381,6 +381,7 @@
 				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
 		<File RelativePath="..\src\Utilities\DevFeature.f90"/>
 		<File RelativePath="..\src\Utilities\genericutils.f90"/>
+		<File RelativePath="..\src\Utilities\GeomUtil.f90"/>
 		<File RelativePath="..\src\Utilities\HashTable.f90"/>
 		<File RelativePath="..\src\Utilities\HeadFileReader.f90"/>
 		<File RelativePath="..\src\Utilities\InputOutput.f90"/>

--- a/msvs/mf6lib.vfproj
+++ b/msvs/mf6lib.vfproj
@@ -144,6 +144,7 @@
 		<File RelativePath="..\src\Utilities\compilerversion.fpp"/>
 		<File RelativePath="..\src\Utilities\Constants.f90"/>
 		<File RelativePath="..\src\Utilities\genericutils.f90"/>
+		<File RelativePath="..\src\Utilities\GeomUtil.f90"/>
 		<File RelativePath="..\src\Utilities\HashTable.f90"/>
 		<File RelativePath="..\src\Utilities\InputOutput.f90"/>
 		<File RelativePath="..\src\Utilities\Iunit.f90"/>

--- a/src/Utilities/GeomUtil.f90
+++ b/src/Utilities/GeomUtil.f90
@@ -1,0 +1,65 @@
+module GeomUtilModule
+  use KindModule, only: I4B, DP
+  implicit none
+  private
+  public :: between, point_in_polygon
+contains
+
+  !> @brief Check if a value is between two other values (inclusive).
+  logical function between(x, a, b)
+    real(DP), intent(in) :: x, a, b
+    between = (x >= a .and. x <= b .or. x <= a .and. x >= b)
+  end function between
+
+  !> @brief Check if a point is within a polygon.
+  !! Vertices and edge points are considered in.
+  !! Reference: https://stackoverflow.com/a/63436180/6514033
+  logical function point_in_polygon(x, y, poly)
+    real(DP), intent(in) :: x
+    real(DP), intent(in) :: y
+    real(DP), allocatable, intent(in) :: poly(:, :)
+    integer(I4B) :: i, ii, num_verts
+    real(DP) :: xa, xb, ya, yb, c = 0.0_DP
+
+    point_in_polygon = .false.
+    num_verts = size(poly, 1)
+    xa = poly(1, 1)
+    ya = poly(1, 2)
+
+    do i = 0, num_verts + 1
+      ii = mod(i, num_verts) + 1
+      xb = poly(ii, 1)
+      yb = poly(ii, 2)
+
+      ! boundary cases
+      if ((x == xa .and. y == ya) .or. (x == xb .and. y == yb)) then
+        ! vertex point
+        point_in_polygon = .true.
+      else if (ya == yb .and. y == ya .and. between(x, xa, xb)) then
+        ! horizontal edge
+        point_in_polygon = .true.
+        ! if within vertical range, cast a ray
+      else if (between(y, ya, yb)) then
+        if (y == ya .and. yb >= ya .or. y == yb .and. ya >= yb) then
+          xa = xb
+          ya = yb
+          cycle
+        end if
+        ! cross product
+        c = (xa - x) * (yb - y) - (xb - x) * (ya - y)
+        ! boundary case
+        if (c == 0) then
+          point_in_polygon = .true.
+          ! standard intersection
+        else if ((ya < yb) .eqv. (c > 0)) then
+          point_in_polygon = .not. point_in_polygon
+        end if
+      end if
+
+      if (point_in_polygon) exit
+      xa = xb
+      ya = yb
+    end do
+  end function point_in_polygon
+
+end module GeomUtilModule

--- a/src/meson.build
+++ b/src/meson.build
@@ -223,6 +223,7 @@ modflow_sources = files(
     'Utilities' / 'defmacro.F90',
     'Utilities' / 'DevFeature.f90',
     'Utilities' / 'genericutils.f90',
+    'Utilities' / 'GeomUtil.f90',
     'Utilities' / 'HashTable.f90',
     'Utilities' / 'HeadFileReader.f90',
     'Utilities' / 'InputOutput.f90',

--- a/utils/mf5to6/make/makefile
+++ b/utils/mf5to6/make/makefile
@@ -5,10 +5,10 @@ include ./makedefaults
 
 # Define the source file directories
 SOURCEDIR1=../src
-SOURCEDIR2=../src/MF2005
-SOURCEDIR3=../src/NWT
-SOURCEDIR4=../src/LGR
-SOURCEDIR5=../src/Preproc
+SOURCEDIR2=../src/NWT
+SOURCEDIR3=../src/LGR
+SOURCEDIR4=../src/Preproc
+SOURCEDIR5=../src/MF2005
 SOURCEDIR6=../../../src/Utilities/Memory
 SOURCEDIR7=../../../src/Utilities/TimeSeries
 SOURCEDIR8=../../../src/Utilities


### PR DESCRIPTION
* add `GeomUtilModule` with `point_in_polygon()` function
* unit test rectangular cell interior/exterior and edge cases (vertices/faces)
* ported from Javascript solution https://stackoverflow.com/a/63436180/6514033
* for use by PRT to check particle release point coordinates with cell IDs &mdash; boundary points are included
* accepts one point, could be reimplemented to support arrays like [flopy](https://github.com/modflowpy/flopy/blob/4ed68a2be1e6b4f607e27c38ce5eab9f66492e3f/flopy/utils/geometry.py#L837) but not yet needed and approach would need modification to include edge cases I think