### PR TITLE
build(meson): add support for NetCDF in meson build system

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - appdirs
   - filelock
   - fprettify
+  - fortran-language-server
   - jupytext
   - matplotlib
   - meson>=1.1.0

--- a/meson.build
+++ b/meson.build
@@ -173,7 +173,7 @@ if is_extended_build
   else
     # For CI testing only; Windows not yet supported
     nc_dir = meson.project_source_root() / '..' / 'ncf' / 'netcdf-fortran-4.6.1' / 'fortran'
-    netcdf = fc.find_library('netcdff', dirs: [ nc_dir ], required : true, static : false)
+    netcdf = fc.find_library('netcdff', dirs: [ nc_dir ], required : false, static : false)
     #nc_incdir = include_directories([ nc_dir ])
   endif
   if netcdf.found()

--- a/meson.build
+++ b/meson.build
@@ -105,14 +105,17 @@ elif fc_id == 'intel-llvm-cl'
 endif
 
 # parallel build options
-is_parallel_build = get_option('parallel')
+is_extended_build = get_option('extended')
 is_cray = get_option('cray')
 is_mpich = get_option('mpich')
 if is_cray and build_machine.system() != 'linux'
   error('cray=true only supported on linux systems')
 endif
-if is_cray and not is_parallel_build
-  is_parallel_build = true
+if not is_extended_build
+ is_extended_build = get_option('parallel')
+endif
+if is_cray and not is_extended_build
+  is_extended_build = true
   is_mpich = true
 endif
 if is_mpich
@@ -122,14 +125,14 @@ if is_mpich
     mpifort_name = 'mpichfort'
   endif
 endif
-message('Parallel build:', is_parallel_build)
+message('Extended build:', is_extended_build)
 
 # windows options for petsc
 petsc_dir = meson.project_source_root() / '..' /'petsc-3.18.5'
 petsc_arch = 'arch-ci-mswin-intel-modflow6'
 
 # on windows only with intel
-if build_machine.system() == 'windows' and is_parallel_build
+if build_machine.system() == 'windows' and is_extended_build
   if fc_id != 'intel-cl'
     error('Parallel build on Windows only with intel compiler. Terminating...')
   endif
@@ -139,8 +142,8 @@ endif
 dependencies = [ ]
 extra_cmp_args = [ ]
 
-# load petsc and mpi dependencies/libraries
-if is_parallel_build
+# load petsc, mpi, and netcdf dependencies/libraries
+if is_extended_build
   # find petsc
   if build_machine.system() != 'windows'
     petsc = dependency('PETSc', required : true)
@@ -163,7 +166,23 @@ if is_parallel_build
   endif
   extra_cmp_args += [ '-D__WITH_MPI__']
   with_mpi = true
+
+  # find netcdf
+  if build_machine.system() != 'windows'
+    netcdf = dependency('netcdf', language : 'fortran', required : false)
+  else
+    # For CI testing only; Windows not yet supported
+    nc_dir = meson.project_source_root() / '..' / 'ncf' / 'netcdf-fortran-4.6.1' / 'fortran'
+    netcdf = fc.find_library('netcdff', dirs: [ nc_dir ], required : true, static : false)
+    #nc_incdir = include_directories([ nc_dir ])
+  endif
+  if netcdf.found()
+    with_netcdf = true
+    extra_cmp_args += [ '-D__WITH_NETCDF__' ]
+    dependencies += [ netcdf ]    
+  endif
 else
+  with_netcdf = false
   with_petsc = false
   with_mpi = false
 endif
@@ -173,7 +192,7 @@ compile_args += extra_cmp_args
 add_project_arguments(fc.get_supported_arguments(compile_args), language: 'fortran')
 add_project_link_arguments(fc.get_supported_arguments(link_args), language: 'fortran')
 
-if is_parallel_build and build_machine.system() == 'windows'
+if is_extended_build and build_machine.system() == 'windows'
   message('Compiling PETSc Fortran modules')
   petsc_incdir = include_directories([petsc_dir / 'include', petsc_compiled / 'include'])
   petsc_src = petsc_dir / 'src'

--- a/meson.options
+++ b/meson.options
@@ -1,4 +1,5 @@
-option('parallel', type : 'boolean', value : false, description : 'Parallel build')
+option('extended', type : 'boolean', value : false, description : 'Extended build with external libraries')
+option('parallel', type : 'boolean', value : false, description : 'Extended parallel build')
 option('mpich', type : 'boolean', value : false, description : 'Use MPICH version of MPI')
-option('cray', type : 'boolean', value : false, description : 'Parallel build on CRAY with MPICH')
+option('cray', type : 'boolean', value : false, description : 'Extended build on CRAY with MPICH')
 option('buildname', type : 'string', value : 'mf6', description : 'Optional build name')

--- a/src/Utilities/defmacro.F90
+++ b/src/Utilities/defmacro.F90
@@ -4,7 +4,7 @@ module DefinedMacros
   use ConstantsModule, only: OSUNDEF, OSLINUX, OSMAC, OSWIN
   implicit none
   private
-  public :: get_os, is_pro, using_petsc
+  public :: get_os, is_extended, using_petsc, using_netcdf
 contains
 
   !> @brief Get operating system
@@ -48,33 +48,47 @@ contains
     return
   end function get_os
 
-  !> @brief Determine if this is the professional version
+  !> @brief Determine if this is the extended version
   !!
   !! Function to get a logical indicating if this is the
-  !! professional version of MODFLOW.
+  !! extended version of MODFLOW.
   !!
-  !! @return      ispro                pro version logical
+  !! @return      isextended           extended version logical
   !<
-  function is_pro() result(ispro)
+  function is_extended() result(isextended)
+    ! -- return variables
+    logical(LGP) :: isextended !< extended version logical
     ! -- local variables
-    logical(LGP) :: ispro !< pro version logical
+    logical(LGP) :: ispetsc
+    logical(LGP) :: isnetcdf
+    !
+    ! -- initialize isextended
+    isextended = .FALSE.
     !
     ! -- check if using petsc
-    ispro = using_petsc()
+    ispetsc = using_petsc()
+    !
+    ! -- check if using netcf
+    isnetcdf = using_netcdf()
+    !
+    !
+    if (ispetsc .EQV. .TRUE. .OR. isnetcdf .EQV. .TRUE.) then
+      isextended = .TRUE.
+    end if
     !
     ! return
     return
-  end function is_pro
+  end function is_extended
 
   !> @brief Determine if using petsc
   !!
   !! Function to get a logical indicating if petsc is
   !! being used.
   !!
-  !! @return      petscavail                petsc used logical
+  !! @return      petscused                petsc used logical
   !<
   function using_petsc() result(petscused)
-    ! -- local variables
+    ! -- return variable
     logical(LGP) :: petscused !< petsc used logical
     !
     ! -- initialize petscavail
@@ -88,5 +102,28 @@ contains
     ! return
     return
   end function using_petsc
+
+  !> @brief Determine if using netcdf
+  !!
+  !! Function to get a logical indicating if netcdf is
+  !! being used.
+  !!
+  !! @return      netcdfused                netcdf used logical
+  !<
+  function using_netcdf() result(netcdfused)
+    ! -- return variable
+    logical(LGP) :: netcdfused !< netcdf used logical
+    !
+    ! -- initialize petscavail
+    netcdfused = .FALSE.
+    !
+    ! -- set operating system variables
+#ifdef __WITH_NETCDF__
+    netcdfused = .TRUE.
+#endif
+    !
+    ! return
+    return
+  end function using_netcdf
 
 end module DefinedMacros

--- a/src/Utilities/version.f90
+++ b/src/Utilities/version.f90
@@ -7,7 +7,7 @@
 module VersionModule
   ! -- module imports
   use KindModule
-  use DefinedMacros, only: is_pro, using_petsc
+  use DefinedMacros, only: is_extended, using_petsc, using_netcdf
   use ConstantsModule, only: LENBIGLINE, LENHUGELINE, DZERO
   use SimVariablesModule, only: istdout
   use GenericUtilitiesModule, only: write_centered, write_message, sim_message
@@ -61,6 +61,16 @@ module VersionModule
   &'      and the PETSc Development Team All rights reserved.',/,&
   &'      (https://petsc.org/release/)',/&
   &)"
+  character(len=*), parameter :: NETCDFLICENSE = &
+  "(&
+  &'The following library is used in this USGS product:',//,&
+  &'    NetCDF, network Common Data Form software library',/,&
+  &'      Copyright (c) 1993-2014 University Corporation for Atmospheric',/,&
+  &'      Research/Unidata. Redistribution and use in source and binary',/,&
+  &'      forms, with or without modification, are permitted provided that',/,&
+  &'      the conditions in the NetCDF copyright are met',/,&
+  &'        (https://www.unidata.ucar.edu/software/netcdf/copyright.html)',/&
+  &)"
   ! -- disclaimer must be appropriate for version (release or release candidate)
   character(len=*), parameter :: FMTDISCLAIMER = &
     "(/,&
@@ -99,8 +109,8 @@ contains
     logical(LGP) :: wsc
     !
     ! -- set pro string
-    if (is_pro()) then
-      write (cheader, '(3a)') 'MODFLOW', MFVNAM, ' PROFESSIONAL'
+    if (is_extended()) then
+      write (cheader, '(3a)') 'MODFLOW', MFVNAM, ' EXTENDED'
     else
       write (cheader, '(2a)') 'MODFLOW', MFVNAM
     end if
@@ -177,6 +187,15 @@ contains
       write (iout, FMTLICENSE)
     else
       call sim_message('', fmt=FMTLICENSE)
+    end if
+    !
+    ! -- write NetCDF license
+    if (using_netcdf()) then
+      if (present(iout)) then
+        write (iout, NETCDFLICENSE)
+      else
+        call sim_message('', fmt=NETCDFLICENSE)
+      end if
     end if
     !
     ! -- write PETSc license


### PR DESCRIPTION
* rename PROFESSIONAL to EXTENDED version
* add function to test if __WITH_NETCDF__ define
* refactor is_pro to is_extended function that evaluates if either WITH_PETSC or WITH_NETCDF are defined
* add -Dextended=true meson option that will eventually replace -Dparallel=true