### PR TITLE
chore: unpin python<=3.11, mention Xcode 15 workaround in dev docs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -97,8 +97,16 @@ GNU Fortran can be installed on all three major platforms.
 
 ##### macOS
 
-- [Homebrew](https://brew.sh/): `brew install gcc`
-- [MacPorts](https://www.macports.org/): `sudo port install gcc10`
+- [Homebrew](https://brew.sh/): `brew install gcc@13`
+- [MacPorts](https://www.macports.org/): `sudo port install gcc13`
+
+**Note:** Xcode 15 includes a new linker implementation which breaks GNU Fortran compatibility. A workaround is to set `LDFLAGS` to use the classic linker, for instance:
+
+```shell
+export LDFLAGS="$LDFLAGS -Wl,-ld_classic"
+```
+
+See [this ticket](https://github.com/mesonbuild/meson/issues/12282) on the Meson repository for more information.
 
 ##### Windows
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 
 dependencies:
-  - python<=3.11
+  - python
   - appdirs
   - filelock
   - fprettify


### PR DESCRIPTION
* new bmipy release is out, compatible with python3.12: https://github.com/csdms/bmi-python/issues/19#event-10771075714
* mention macOS classic linker workaround for Xcode 15 in `DEVELOPER.md`, [more info](https://github.com/mesonbuild/meson/issues/12282)
* update macOS gcc install examples to use latest (13)