### PR TITLE
refactor: disable test-drive dependency with intel compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ unittests/
 
 # compiler compatibility markdown tables
 .github/compat/*.md
+
+**.DS_Store

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -1,5 +1,5 @@
 test_drive = dependency('test-drive', required : false)
-if test_drive.found()
+if test_drive.found() and not fc_id.contains('intel')
   tests = [
     'ArrayHandlers',
     'DevFeature',


### PR DESCRIPTION
* test-drive has limited intel compatibility, limit it to gnu builds for now
  * needs ifort <= 2021.6 on linux and mac
  * link errors on windows (all versions AFAICT)
* add `.DS_Store` to `.gitignore`