### PR TITLE
ci(netcdf): add netcdf-fortran dependency to extended (parallel) test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,11 +505,7 @@ jobs:
       - name: Update PKG_CONFIG_PATH
         working-directory: modflow6
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            echo "PKG_CONFIG_PATH=/home/runner/micromamba/envs/modflow6/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            echo "PKG_CONFIG_PATH=/Users/runner/micromamba/envs/modflow6/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-          fi
+          echo "PKG_CONFIG_PATH=$CONDA_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
       - name: Build modflow6
         working-directory: modflow6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,16 +494,29 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: modflow6/environment.yml
+          create-args: >-
+            netcdf-fortran
           init-shell: >-
             bash
             powershell
           cache-environment: true
           cache-downloads: true
 
+      - name: Fix pc file and set PKG_CONFIG_PATH
+        working-directory: modflow6
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sed -i "s|libdir=/home/runner/micromamba/envs/modflow6//home/runner/micromamba/envs/modflow6/lib|libdir=/home/runner/micromamba/envs/modflow6/lib|g" /home/runner/micromamba/envs/modflow6/lib/pkgconfig/netcdf-fortran.pc
+            echo "PKG_CONFIG_PATH=/home/runner/micromamba/envs/modflow6/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            sed -i '' -e "s|libdir=/Users/runner/micromamba/envs/modflow6//Users/runner/micromamba/envs/modflow6/lib|libdir=/Users/runner/micromamba/envs/modflow6/lib|g" /Users/runner/micromamba/envs/modflow6/lib/pkgconfig/netcdf-fortran.pc
+            echo "PKG_CONFIG_PATH=/Users/runner/micromamba/envs/modflow6/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+          fi
+
       - name: Build modflow6
         working-directory: modflow6
         run: |
-          meson setup builddir -Ddebug=false -Dparallel=true --prefix=$(pwd) --libdir=bin
+          meson setup builddir -Ddebug=false -Dextended=true --prefix=$(pwd) --libdir=bin
           meson install -C builddir
           meson test --verbose --no-rebuild -C builddir
 
@@ -521,6 +534,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: pytest -v --durations 0 get_exes.py
+
+      - name: Confirm netcdf build
+        working-directory: modflow6/autotest
+        env:
+          REPOS_PATH: ${{ github.workspace }}
+        run: |
+          pytest test_gwf_chd01.py --keep temp
+          if grep -Fx "    NetCDF, network Common Data Form software library" temp/test_mf6model[chd01]0/mfsim.lst
+          then
+            echo "NetCDF dependency confirmed."
+          else
+            echo "NetCDF dependency not found."
+            exit 1
+          fi
 
       - name: Test programs (parallel)
         working-directory: modflow6/autotest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,14 +502,12 @@ jobs:
           cache-environment: true
           cache-downloads: true
 
-      - name: Fix pc file and set PKG_CONFIG_PATH
+      - name: Update PKG_CONFIG_PATH
         working-directory: modflow6
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            sed -i "s|libdir=/home/runner/micromamba/envs/modflow6//home/runner/micromamba/envs/modflow6/lib|libdir=/home/runner/micromamba/envs/modflow6/lib|g" /home/runner/micromamba/envs/modflow6/lib/pkgconfig/netcdf-fortran.pc
             echo "PKG_CONFIG_PATH=/home/runner/micromamba/envs/modflow6/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            sed -i '' -e "s|libdir=/Users/runner/micromamba/envs/modflow6//Users/runner/micromamba/envs/modflow6/lib|libdir=/Users/runner/micromamba/envs/modflow6/lib|g" /Users/runner/micromamba/envs/modflow6/lib/pkgconfig/netcdf-fortran.pc
             echo "PKG_CONFIG_PATH=/Users/runner/micromamba/envs/modflow6/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
           fi
 
@@ -535,7 +533,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pytest -v --durations 0 get_exes.py
 
-      - name: Confirm netcdf build
+      - name: Confirm netcdf license logged
         working-directory: modflow6/autotest
         env:
           REPOS_PATH: ${{ github.workspace }}
@@ -543,9 +541,9 @@ jobs:
           pytest test_gwf_chd01.py --keep temp
           if grep -Fx "    NetCDF, network Common Data Form software library" temp/test_mf6model[chd01]0/mfsim.lst
           then
-            echo "NetCDF dependency confirmed."
+            echo "NetCDF license logging confirmed."
           else
-            echo "NetCDF dependency not found."
+            echo "NetCDF license logging not found."
             exit 1
           fi
 

--- a/meson.build
+++ b/meson.build
@@ -169,18 +169,16 @@ if is_extended_build
 
   # find netcdf
   if build_machine.system() != 'windows'
-    netcdf = dependency('netcdf', language : 'fortran', required : false)
+    netcdf = dependency('netcdf', language : 'fortran', required : true)
   else
     # For CI testing only; Windows not yet supported
     nc_dir = meson.project_source_root() / '..' / 'ncf' / 'netcdf-fortran-4.6.1' / 'fortran'
-    netcdf = fc.find_library('netcdff', dirs: [ nc_dir ], required : false, static : false)
+    netcdf = fc.find_library('netcdff', dirs: [ nc_dir ], required : true, static : false)
     #nc_incdir = include_directories([ nc_dir ])
   endif
-  if netcdf.found()
-    with_netcdf = true
-    extra_cmp_args += [ '-D__WITH_NETCDF__' ]
-    dependencies += [ netcdf ]    
-  endif
+  extra_cmp_args += [ '-D__WITH_NETCDF__' ]
+  dependencies += [ netcdf ]
+  with_netcdf = true
 else
   with_netcdf = false
   with_petsc = false


### PR DESCRIPTION
Adds simple check to confirm NetCDF license information is logged to mfsim.lst by extended executable.  This check is temporary and will be replaced with netcdf integrated autotests in time.

**NOTE**
Micromamba based installation of netcdf-fortran yields a pkg-config file (netcdf-fortran.pc) with an erroneous libdir path that leads to link failures.  A workaround in this PR has been added to fix the file.  Investigation is ongoing.  

UPDATE netcdf-fortran-feedstock updated to fix pkg-config libdir path.