### PR TITLE
test: require dev exes, warn/skip if download/rebuilt not found

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -1,8 +1,9 @@
 import platform
 import sys
-from pathlib import Path
 from os import PathLike
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Optional
+from warnings import warn
 
 import pytest
 from modflow_devtools.executables import Executables, get_suffixes
@@ -59,39 +60,57 @@ def targets(bin_path) -> Executables:
     exe_ext, lib_ext = get_suffixes(sys.platform)
     dl_bin = bin_path / "downloaded"
     rb_bin = bin_path / "rebuilt"
-    tgts = dict()
-
-    # downloaded executables
-    tgts["mf2000"] = dl_bin / f"mf2000{exe_ext}"
-    tgts["mf2005"] = dl_bin / f"mf2005dbl{exe_ext}"
-    tgts["mfnwt"] = dl_bin / f"mfnwtdbl{exe_ext}"
-    tgts["mfusg"] = dl_bin / f"mfusgdbl{exe_ext}"
-    tgts["mflgr"] = dl_bin / f"mflgrdbl{exe_ext}"
-    tgts["mf2005s"] = dl_bin / f"mf2005{exe_ext}"
-    tgts["mt3dms"] = dl_bin / f"mt3dms{exe_ext}"
-    tgts["crt"] = dl_bin / f"crt{exe_ext}"
-    tgts["gridgen"] = dl_bin / f"gridgen{exe_ext}"
-    tgts["mp6"] = dl_bin / f"mp6{exe_ext}"
-    tgts["mp7"] = dl_bin / f"mp7{exe_ext}"
-    tgts["swtv4"] = dl_bin / f"swtv4{exe_ext}"
-    tgts["sutra"] = dl_bin / f"sutra{exe_ext}"
-    tgts["triangle"] = dl_bin / f"triangle{exe_ext}"
-    tgts["vs2dt"] = dl_bin / f"vs2dt{exe_ext}"
-    tgts["zonbudusg"] = dl_bin / f"zonbudusg{exe_ext}"
-
-    # binaries rebuilt from last release
-    tgts["mf6_regression"] = rb_bin / f"mf6{exe_ext}"
-    tgts["libmf6_regression"] = rb_bin / f"libmf6{lib_ext}"
-    tgts["mf5to6_regression"] = rb_bin / f"mf5to6{exe_ext}"
-    tgts["zbud6_regression"] = rb_bin / f"zbud6{exe_ext}"
+    targets = dict()
 
     # local development binaries
-    tgts["mf6"] = bin_path / f"mf6{exe_ext}"
-    tgts["libmf6"] = bin_path / f"libmf6{lib_ext}"
-    tgts["mf5to6"] = bin_path / f"mf5to6{exe_ext}"
-    tgts["zbud6"] = bin_path / f"zbud6{exe_ext}"
+    development = [
+        ("mf6", bin_path / f"mf6{exe_ext}"),
+        ("libmf6", bin_path / f"libmf6{lib_ext}"),
+        ("mf5to6", bin_path / f"mf5to6{exe_ext}"),
+        ("zbud6", bin_path / f"zbud6{exe_ext}"),
+    ]
 
-    return Executables(**tgts)
+    # downloaded executables
+    downloaded = [
+        ("mf2000", dl_bin / f"mf2000{exe_ext}"),
+        ("mf2005", dl_bin / f"mf2005dbl{exe_ext}"),
+        ("mfnwt", dl_bin / f"mfnwtdbl{exe_ext}"),
+        ("mfusg", dl_bin / f"mfusgdbl{exe_ext}"),
+        ("mflgr", dl_bin / f"mflgrdbl{exe_ext}"),
+        ("mf2005s", dl_bin / f"mf2005{exe_ext}"),
+        ("mt3dms", dl_bin / f"mt3dms{exe_ext}"),
+        ("crt", dl_bin / f"crt{exe_ext}"),
+        ("gridgen", dl_bin / f"gridgen{exe_ext}"),
+        ("mp6", dl_bin / f"mp6{exe_ext}"),
+        ("mp7", dl_bin / f"mp7{exe_ext}"),
+        ("swtv4", dl_bin / f"swtv4{exe_ext}"),
+        ("sutra", dl_bin / f"sutra{exe_ext}"),
+        ("triangle", dl_bin / f"triangle{exe_ext}"),
+        ("vs2dt", dl_bin / f"vs2dt{exe_ext}"),
+        ("zonbudusg", dl_bin / f"zonbudusg{exe_ext}"),
+    ]
+
+    # binaries rebuilt from last release
+    rebuilt = [
+        ("mf6_regression", rb_bin / f"mf6{exe_ext}"),
+        ("libmf6_regression", rb_bin / f"libmf6{lib_ext}"),
+        ("mf5to6_regression", rb_bin / f"mf5to6{exe_ext}"),
+        ("zbud6_regression", rb_bin / f"zbud6{exe_ext}"),
+    ]
+
+    # require development binaries
+    for k, v in development:
+        assert v.is_file(), f"Couldn't find binary '{k}' expected at: {v}"
+        targets[k] = v
+
+    # downloaded/rebuilt binaries are optional
+    for k, v in downloaded + rebuilt:
+        if v.is_file():
+            targets[k] = v
+        else:
+            warn(f"Couldn't find binary '{k}' expected at: {v}")
+
+    return Executables(**targets)
 
 
 @pytest.fixture

--- a/autotest/test_gwf_csub_distypes.py
+++ b/autotest/test_gwf_csub_distypes.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from flopy.utils.gridgen import Gridgen
 
+from conftest import try_get_target
 from framework import TestFramework
 from simulation import TestSimulation
 
@@ -425,17 +426,16 @@ def eval_zdis(sim):
             + f"z-displacement at time {totim}"
         )
 
-    return
-
 
 @pytest.mark.parametrize(
     "idx, name",
     list(enumerate(ex)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
+    gridgen = try_get_target(targets, "gridgen")
     ws = function_tmpdir
     test = TestFramework()
-    test.build(lambda i, w: build_model(i, w, targets.gridgen), idx, ws)
+    test.build(lambda i, w: build_model(i, w, gridgen), idx, ws)
     test.run(
         TestSimulation(
             name=name,

--- a/autotest/test_gwf_returncodes.py
+++ b/autotest/test_gwf_returncodes.py
@@ -271,5 +271,5 @@ def compiler_argv(dir, exe):
     ),
 )
 def test_main(fn, function_tmpdir, targets):
-    mf6 = targets.as_dict()["mf6"]
+    mf6 = targets.mf6
     eval(fn)(function_tmpdir, mf6)

--- a/autotest/test_gwt_mt3dms_p01.py
+++ b/autotest/test_gwt_mt3dms_p01.py
@@ -20,9 +20,12 @@ dispersion, and reaction (sorption and decay):
 """
 
 import os
+from pathlib import Path
+from typing import Tuple
 
 import flopy
 import numpy as np
+import pytest
 
 testgroup = "mt3dms_p01"
 
@@ -383,7 +386,6 @@ def p01mf6(
         theta_immobile = prsity2
         porosity_immobile = theta_immobile / volfrac_immobile
         porosity_mobile = prsity / volfrac_mobile
-        
 
     first_order_decay = True
     if zero_order_decay:
@@ -470,6 +472,20 @@ def p01mf6(
     return sim, conc
 
 
+def get_binaries(targets) -> Tuple[Path, Path]:
+    mf6 = targets["mf6"]
+    mf2005 = targets.get("mf2005s")
+    mt3dms = targets.get("mt3dms")
+
+    assert mf6, f"Couldn't find binary 'mf6'"
+    if not mf2005:
+        pytest.skip(f"Couldn't find binary 'mf2005s'")
+    if not mt3dms:
+        pytest.skip(f"Couldn't find binary 'mt3dms'")
+
+    return mf6, mf2005, mt3dms
+
+
 def test_mt3dmsp01a(function_tmpdir, targets):
     longitudinal_dispersivity = 0.0
     retardation = 1.0
@@ -478,8 +494,10 @@ def test_mt3dmsp01a(function_tmpdir, targets):
     zeta = None
     prsity2 = None
 
-    mf6 = targets["mf6"]
-    mf6_ws = str(function_tmpdir / (testgroup + "a"))
+    mf6, mf2005, mt3dms = get_binaries(targets)
+    mf6_ws = function_tmpdir / f"{testgroup}a"
+    mt3d_ws = mf6_ws / "mt3d"
+
     sim, conc_mf6 = p01mf6(
         mf6_ws,
         longitudinal_dispersivity,
@@ -491,9 +509,6 @@ def test_mt3dmsp01a(function_tmpdir, targets):
         exe=mf6,
     )
 
-    mf2005 = targets["mf2005s"]
-    mt3dms = targets["mt3dms"]
-    mt3d_ws = os.path.join(mf6_ws, "mt3d")
     mf, mt, conc_mt3d, cvt, mvt = p01mt3d(
         mt3d_ws,
         longitudinal_dispersivity,
@@ -506,8 +521,9 @@ def test_mt3dmsp01a(function_tmpdir, targets):
         mt3dms=mt3dms,
     )
 
-    msg = f"concentrations not equal {conc_mt3d} {conc_mf6}"
-    assert np.allclose(conc_mt3d, conc_mf6, atol=1e-4), msg
+    assert np.allclose(
+        conc_mt3d, conc_mf6, atol=1e-4
+    ), f"concentrations not equal {conc_mt3d} {conc_mf6}"
 
     # load transport budget
     # budget text:
@@ -543,8 +559,10 @@ def test_mt3dmsp01b(function_tmpdir, targets):
     zeta = None
     prsity2 = None
 
-    mf6 = targets["mf6"]
-    mf6_ws = str(function_tmpdir / (testgroup + "b"))
+    mf6, mf2005, mt3dms = get_binaries(targets)
+    mf6_ws = function_tmpdir / f"{testgroup}b"
+    mt3d_ws = mf6_ws / "mt3d"
+
     sim, conc_mf6 = p01mf6(
         mf6_ws,
         longitudinal_dispersivity,
@@ -556,9 +574,6 @@ def test_mt3dmsp01b(function_tmpdir, targets):
         exe=mf6,
     )
 
-    mf2005 = targets["mf2005s"]
-    mt3dms = targets["mt3dms"]
-    mt3d_ws = os.path.join(mf6_ws, "mt3d")
     mf, mt, conc_mt3d, cvt, mvt = p01mt3d(
         mt3d_ws,
         longitudinal_dispersivity,
@@ -571,8 +586,9 @@ def test_mt3dmsp01b(function_tmpdir, targets):
         mt3dms=mt3dms,
     )
 
-    msg = f"concentrations not equal {conc_mt3d} {conc_mf6}"
-    assert np.allclose(conc_mt3d, conc_mf6, atol=1e-4), msg
+    assert np.allclose(
+        conc_mt3d, conc_mf6, atol=1e-4
+    ), f"concentrations not equal {conc_mt3d} {conc_mf6}"
 
 
 def test_mt3dmsp01c(function_tmpdir, targets):
@@ -583,8 +599,10 @@ def test_mt3dmsp01c(function_tmpdir, targets):
     zeta = None
     prsity2 = None
 
-    mf6 = targets["mf6"]
-    mf6_ws = str(function_tmpdir / (testgroup + "c"))
+    mf6, mf2005, mt3dms = get_binaries(targets)
+    mf6_ws = function_tmpdir / f"{testgroup}c"
+    mt3d_ws = mf6_ws / "mt3d"
+
     sim, conc_mf6 = p01mf6(
         mf6_ws,
         longitudinal_dispersivity,
@@ -596,9 +614,6 @@ def test_mt3dmsp01c(function_tmpdir, targets):
         exe=mf6,
     )
 
-    mf2005 = targets["mf2005s"]
-    mt3dms = targets["mt3dms"]
-    mt3d_ws = os.path.join(mf6_ws, "mt3d")
     mf, mt, conc_mt3d, cvt, mvt = p01mt3d(
         mt3d_ws,
         longitudinal_dispersivity,
@@ -611,8 +626,9 @@ def test_mt3dmsp01c(function_tmpdir, targets):
         mt3dms=mt3dms,
     )
 
-    msg = f"concentrations not equal {conc_mt3d} {conc_mf6}"
-    assert np.allclose(conc_mt3d, conc_mf6, atol=1e-4), msg
+    assert np.allclose(
+        conc_mt3d, conc_mf6, atol=1e-4
+    ), f"concentrations not equal {conc_mt3d} {conc_mf6}"
 
 
 def test_mt3dmsp01d(function_tmpdir, targets):
@@ -623,8 +639,10 @@ def test_mt3dmsp01d(function_tmpdir, targets):
     zeta = None
     prsity2 = None
 
-    mf6 = targets["mf6"]
-    mf6_ws = str(function_tmpdir / (testgroup + "d"))
+    mf6, mf2005, mt3dms = get_binaries(targets)
+    mf6_ws = function_tmpdir / f"{testgroup}d"
+    mt3d_ws = mf6_ws / "mt3d"
+
     sim, conc_mf6 = p01mf6(
         mf6_ws,
         longitudinal_dispersivity,
@@ -636,9 +654,6 @@ def test_mt3dmsp01d(function_tmpdir, targets):
         exe=mf6,
     )
 
-    mf2005 = targets["mf2005s"]
-    mt3dms = targets["mt3dms"]
-    mt3d_ws = os.path.join(mf6_ws, "mt3d")
     mf, mt, conc_mt3d, cvt, mvt = p01mt3d(
         mt3d_ws,
         longitudinal_dispersivity,
@@ -651,8 +666,9 @@ def test_mt3dmsp01d(function_tmpdir, targets):
         mt3dms=mt3dms,
     )
 
-    msg = f"concentrations not equal {conc_mt3d} {conc_mf6}"
-    assert np.allclose(conc_mt3d, conc_mf6, atol=1e-4), msg
+    assert np.allclose(
+        conc_mt3d, conc_mf6, atol=1e-4
+    ), f"concentrations not equal {conc_mt3d} {conc_mf6}"
 
 
 def test_mt3dmsp01e(function_tmpdir, targets):
@@ -663,8 +679,10 @@ def test_mt3dmsp01e(function_tmpdir, targets):
     zeta = 0.1
     prsity2 = 0.05
 
-    mf6 = targets["mf6"]
-    mf6_ws = str(function_tmpdir / (testgroup + "e"))
+    mf6, mf2005, mt3dms = get_binaries(targets)
+    mf6_ws = function_tmpdir / f"{testgroup}e"
+    mt3d_ws = mf6_ws / "mt3d"
+
     sim, conc_mf6 = p01mf6(
         mf6_ws,
         longitudinal_dispersivity,
@@ -676,9 +694,6 @@ def test_mt3dmsp01e(function_tmpdir, targets):
         exe=mf6,
     )
 
-    mf2005 = targets["mf2005s"]
-    mt3dms = targets["mt3dms"]
-    mt3d_ws = os.path.join(mf6_ws, "mt3d")
     mf, mt, conc_mt3d, cvt, mvt = p01mt3d(
         mt3d_ws,
         longitudinal_dispersivity,
@@ -691,8 +706,9 @@ def test_mt3dmsp01e(function_tmpdir, targets):
         mt3dms=mt3dms,
     )
 
-    msg = f"concentrations not equal {conc_mt3d} {conc_mf6}"
-    assert np.allclose(conc_mt3d, conc_mf6, atol=1e-1), msg
+    assert np.allclose(
+        conc_mt3d, conc_mf6, atol=1e-1
+    ), f"concentrations not equal {conc_mt3d} {conc_mf6}"
 
 
 def test_mt3dmsp01f(function_tmpdir, targets):
@@ -703,8 +719,10 @@ def test_mt3dmsp01f(function_tmpdir, targets):
     zeta = 0.1
     prsity2 = 0.05
 
-    mf6 = targets["mf6"]
-    mf6_ws = str(function_tmpdir / (testgroup + "f"))
+    mf6, mf2005, mt3dms = get_binaries(targets)
+    mf6_ws = function_tmpdir / f"{testgroup}f"
+    mt3d_ws = mf6_ws / "mt3d"
+
     sim, conc_mf6 = p01mf6(
         mf6_ws,
         longitudinal_dispersivity,
@@ -717,9 +735,6 @@ def test_mt3dmsp01f(function_tmpdir, targets):
         exe=mf6,
     )
 
-    mf2005 = targets["mf2005s"]
-    mt3dms = targets["mt3dms"]
-    mt3d_ws = os.path.join(mf6_ws, "mt3d")
     mf, mt, conc_mt3d, cvt, mvt = p01mt3d(
         mt3d_ws,
         longitudinal_dispersivity,
@@ -732,8 +747,9 @@ def test_mt3dmsp01f(function_tmpdir, targets):
         mt3dms=mt3dms,
     )
 
-    msg = f"concentrations not equal {conc_mt3d} {conc_mf6}"
-    assert np.allclose(conc_mt3d, conc_mf6, atol=1e-1), msg
+    assert np.allclose(
+        conc_mt3d, conc_mf6, atol=1e-1
+    ), f"concentrations not equal {conc_mt3d} {conc_mf6}"
 
 
 def test_mt3dmsp01g(function_tmpdir, targets):
@@ -744,8 +760,10 @@ def test_mt3dmsp01g(function_tmpdir, targets):
     zeta = None
     prsity2 = None
 
-    mf6 = targets["mf6"]
-    mf6_ws = str(function_tmpdir / (testgroup + "g"))
+    mf6, mf2005, mt3dms = get_binaries(targets)
+    mf6_ws = function_tmpdir / f"{testgroup}g"
+    mt3d_ws = mf6_ws / "mt3d"
+
     sim, conc_mf6 = p01mf6(
         mf6_ws,
         longitudinal_dispersivity,
@@ -758,9 +776,6 @@ def test_mt3dmsp01g(function_tmpdir, targets):
         exe=mf6,
     )
 
-    mf2005 = targets["mf2005s"]
-    mt3dms = targets["mt3dms"]
-    mt3d_ws = os.path.join(mf6_ws, "mt3d")
     mf, mt, conc_mt3d, cvt, mvt = p01mt3d(
         mt3d_ws,
         longitudinal_dispersivity,
@@ -775,5 +790,6 @@ def test_mt3dmsp01g(function_tmpdir, targets):
         mt3dms=mt3dms,
     )
 
-    msg = f"concentrations not equal {conc_mt3d} {conc_mf6}"
-    assert np.allclose(conc_mt3d, conc_mf6, atol=1.0e-4), msg
+    assert np.allclose(
+        conc_mt3d, conc_mf6, atol=1.0e-4
+    ), f"concentrations not equal {conc_mt3d} {conc_mf6}"

--- a/autotest/test_gwt_mt3dms_p01.py
+++ b/autotest/test_gwt_mt3dms_p01.py
@@ -27,6 +27,8 @@ import flopy
 import numpy as np
 import pytest
 
+from conftest import try_get_target
+
 testgroup = "mt3dms_p01"
 
 
@@ -472,18 +474,12 @@ def p01mf6(
     return sim, conc
 
 
-def get_binaries(targets) -> Tuple[Path, Path]:
-    mf6 = targets["mf6"]
-    mf2005 = targets.get("mf2005s")
-    mt3dms = targets.get("mt3dms")
-
-    assert mf6, f"Couldn't find binary 'mf6'"
-    if not mf2005:
-        pytest.skip(f"Couldn't find binary 'mf2005s'")
-    if not mt3dms:
-        pytest.skip(f"Couldn't find binary 'mt3dms'")
-
-    return mf6, mf2005, mt3dms
+def get_binaries(targets) -> Tuple[Path, Path, Path]:
+    return (
+        targets.mf6,
+        try_get_target(targets, "mf2005s"),
+        try_get_target(targets, "mt3dms"),
+    )
 
 
 def test_mt3dmsp01a(function_tmpdir, targets):

--- a/autotest/test_z03_examples.py
+++ b/autotest/test_z03_examples.py
@@ -1,4 +1,5 @@
 import pytest
+
 from conftest import should_compare
 from simulation import TestSimulation
 
@@ -62,7 +63,7 @@ def test_scenario(function_tmpdir, example_scenario, targets):
         workspace = function_tmpdir / model_name
         sim = TestSimulation(
             name=model_name,
-            exe_dict=targets.as_dict(),
+            exe_dict=targets,
             mf6_regression=True,
             cmp_verbose=False,
             make_comparison=should_compare(

--- a/autotest/test_z03_largetestmodels.py
+++ b/autotest/test_z03_largetestmodels.py
@@ -1,13 +1,22 @@
 import pytest
+
 from conftest import should_compare
 from simulation import TestSimulation
 
 excluded_models = []
 excluded_comparisons = {
-    "test1004_mvlake_laksfr_tr": ["6.4.1",],
-    "test1004_mvlake_lak_tr": ["6.4.1",],
-    "test1003_MNW2_Fig28": ["6.2.1",],
-    "test1001_Peterson": ["6.2.1",],
+    "test1004_mvlake_laksfr_tr": [
+        "6.4.1",
+    ],
+    "test1004_mvlake_lak_tr": [
+        "6.4.1",
+    ],
+    "test1003_MNW2_Fig28": [
+        "6.2.1",
+    ],
+    "test1001_Peterson": [
+        "6.2.1",
+    ],
 }
 
 
@@ -23,13 +32,13 @@ def test_model(
 
     if name in excluded_models:
         pytest.skip(f"Excluding large mf6 model '{name}'")
-    
+
     if "dev" in name and "not developmode" in markers:
         pytest.skip(f"Skipping large mf6 model '{name}' (develop mode only)")
 
     sim = TestSimulation(
         name=name,
-        exe_dict=targets.as_dict(),
+        exe_dict=targets,
         mf6_regression=not original_regression,
         cmp_verbose=False,
         make_comparison=should_compare(name, excluded_comparisons, targets),


### PR DESCRIPTION
* update `autotest/conftest.py` and test scripts to
  * fail tests if development binaries not found
  * warn if downloaded or rebuilt binaries not found
* allow testing to proceed even without all downloaded/rebuilt binaries
* motivated by test failures in https://github.com/MODFLOW-USGS/executables/pull/22