### PR TITLE
refactor(.gitattributes): Configure github-linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,8 @@
 *.png binary
 *.jpg binary
 *.pdf binary
+
+# Configure github-linguist
+*.inc linguist-language=Fortran
+.build_rtd_docs/** linguist-documentation
+.doc/** linguist-documentation


### PR DESCRIPTION
This applies a few [overrides](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md) to configure github-linguist, marking (and excluding) documentation and re-classifying `*.inc` as Fortran files (not C++). Autotests are kept (as I guess is expected?). The new breakdown is:
```bash
$ github-linguist
76.57%  8244554    Fortran
22.90%  2465281    Python
0.27%   29321      Meson
0.22%   23329      Makefile
0.04%   4375       Shell
```