### PR TITLE
refactor(ListModule): trim dependencies, add defaults, improve docstrings

### DIFF
--- a/make/makefile
+++ b/make/makefile
@@ -6,35 +6,35 @@ include ./makedefaults
 # Define the source file directories
 SOURCEDIR1=../src
 SOURCEDIR2=../src/Exchange
-SOURCEDIR3=../src/Model
-SOURCEDIR4=../src/Model/Geometry
-SOURCEDIR5=../src/Model/TransportModel
-SOURCEDIR6=../src/Model/ModelUtilities
-SOURCEDIR7=../src/Model/Connection
-SOURCEDIR8=../src/Model/GroundWaterTransport
-SOURCEDIR9=../src/Model/GroundWaterFlow
-SOURCEDIR10=../src/Distributed
-SOURCEDIR11=../src/Solution
-SOURCEDIR12=../src/Solution/PETSc
-SOURCEDIR13=../src/Solution/LinearMethods
-SOURCEDIR14=../src/Timing
-SOURCEDIR15=../src/Utilities
-SOURCEDIR16=../src/Utilities/TimeSeries
-SOURCEDIR17=../src/Utilities/Libraries
-SOURCEDIR18=../src/Utilities/Libraries/rcm
-SOURCEDIR19=../src/Utilities/Libraries/sparsekit
-SOURCEDIR20=../src/Utilities/Libraries/sparskit2
-SOURCEDIR21=../src/Utilities/Libraries/blas
-SOURCEDIR22=../src/Utilities/Libraries/daglib
-SOURCEDIR23=../src/Utilities/Idm
-SOURCEDIR24=../src/Utilities/Idm/selector
-SOURCEDIR25=../src/Utilities/Idm/mf6blockfile
-SOURCEDIR26=../src/Utilities/Matrix
-SOURCEDIR27=../src/Utilities/Vector
-SOURCEDIR28=../src/Utilities/Observation
-SOURCEDIR29=../src/Utilities/OutputControl
-SOURCEDIR30=../src/Utilities/Memory
-SOURCEDIR31=../src/Utilities/ArrayRead
+SOURCEDIR3=../src/Distributed
+SOURCEDIR4=../src/Solution
+SOURCEDIR5=../src/Solution/LinearMethods
+SOURCEDIR6=../src/Solution/PETSc
+SOURCEDIR7=../src/Timing
+SOURCEDIR8=../src/Utilities
+SOURCEDIR9=../src/Utilities/Idm
+SOURCEDIR10=../src/Utilities/Idm/selector
+SOURCEDIR11=../src/Utilities/Idm/mf6blockfile
+SOURCEDIR12=../src/Utilities/TimeSeries
+SOURCEDIR13=../src/Utilities/Memory
+SOURCEDIR14=../src/Utilities/OutputControl
+SOURCEDIR15=../src/Utilities/ArrayRead
+SOURCEDIR16=../src/Utilities/Libraries
+SOURCEDIR17=../src/Utilities/Libraries/rcm
+SOURCEDIR18=../src/Utilities/Libraries/blas
+SOURCEDIR19=../src/Utilities/Libraries/sparskit2
+SOURCEDIR20=../src/Utilities/Libraries/daglib
+SOURCEDIR21=../src/Utilities/Libraries/sparsekit
+SOURCEDIR22=../src/Utilities/Vector
+SOURCEDIR23=../src/Utilities/Matrix
+SOURCEDIR24=../src/Utilities/Observation
+SOURCEDIR25=../src/Model
+SOURCEDIR26=../src/Model/Connection
+SOURCEDIR27=../src/Model/GroundWaterTransport
+SOURCEDIR28=../src/Model/ModelUtilities
+SOURCEDIR29=../src/Model/GroundWaterFlow
+SOURCEDIR30=../src/Model/TransportModel
+SOURCEDIR31=../src/Model/Geometry
 
 VPATH = \
 ${SOURCEDIR1} \
@@ -81,6 +81,7 @@ $(OBJDIR)/compilerversion.o \
 $(OBJDIR)/ArrayHandlers.o \
 $(OBJDIR)/version.o \
 $(OBJDIR)/Message.o \
+$(OBJDIR)/ErrorUtil.o \
 $(OBJDIR)/Sim.o \
 $(OBJDIR)/OpenSpec.o \
 $(OBJDIR)/InputOutput.o \

--- a/make/makefile
+++ b/make/makefile
@@ -75,13 +75,13 @@ OBJECTS = \
 $(OBJDIR)/kind.o \
 $(OBJDIR)/Constants.o \
 $(OBJDIR)/SimVariables.o \
+$(OBJDIR)/ErrorUtil.o \
 $(OBJDIR)/genericutils.o \
 $(OBJDIR)/defmacro.o \
 $(OBJDIR)/compilerversion.o \
 $(OBJDIR)/ArrayHandlers.o \
 $(OBJDIR)/version.o \
 $(OBJDIR)/Message.o \
-$(OBJDIR)/ErrorUtil.o \
 $(OBJDIR)/Sim.o \
 $(OBJDIR)/OpenSpec.o \
 $(OBJDIR)/InputOutput.o \

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -385,6 +385,7 @@
 				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
 		<File RelativePath="..\src\Utilities\DevFeature.f90"/>
 		<File RelativePath="..\src\Utilities\genericutils.f90"/>
+		<File RelativePath="..\src\Utilities\ErrorUtil.f90"/>
 		<File RelativePath="..\src\Utilities\GeomUtil.f90"/>
 		<File RelativePath="..\src\Utilities\HashTable.f90"/>
 		<File RelativePath="..\src\Utilities\HeadFileReader.f90"/>

--- a/msvs/mf6lib.vfproj
+++ b/msvs/mf6lib.vfproj
@@ -144,6 +144,7 @@
 		<File RelativePath="..\src\Utilities\compilerversion.fpp"/>
 		<File RelativePath="..\src\Utilities\Constants.f90"/>
 		<File RelativePath="..\src\Utilities\genericutils.f90"/>
+		<File RelativePath="..\src\Utilities\ErrorUtil.f90"/>
 		<File RelativePath="..\src\Utilities\GeomUtil.f90"/>
 		<File RelativePath="..\src\Utilities\HashTable.f90"/>
 		<File RelativePath="..\src\Utilities\InputOutput.f90"/>

--- a/src/Model/Connection/ConnectionBuilder.f90
+++ b/src/Model/Connection/ConnectionBuilder.f90
@@ -2,7 +2,7 @@ module ConnectionBuilderModule
   use KindModule, only: I4B, LGP
   use SimModule, only: store_error, count_errors, ustop
   use SimVariablesModule, only: iout
-  use ListModule, only: ListType, arePointersEqual, isEqualIface, ListNodeType
+  use ListModule, only: ListType, isEqualIface, ListNodeType
   use BaseSolutionModule, only: BaseSolutionType
   use NumericalSolutionModule, only: NumericalSolutionType
   use BaseExchangeModule, only: BaseExchangeType, GetBaseExchangeFromList

--- a/src/Model/Connection/GridConnection.f90
+++ b/src/Model/Connection/GridConnection.f90
@@ -9,7 +9,7 @@ module GridConnectionModule
   use CharacterStringModule
   use MemoryManagerModule, only: mem_allocate, mem_deallocate
   use MemoryHelperModule, only: create_mem_path
-  use ListModule, only: ListType, isEqualIface, arePointersEqual
+  use ListModule, only: ListType, isEqualIface
   use NumericalModelModule
   use GwfDisuModule
   use DisConnExchangeModule
@@ -218,11 +218,9 @@ contains
     class(VirtualModelType), pointer :: v_model !< the model to add to the region
     ! local
     class(*), pointer :: vm_obj
-    procedure(isEqualIface), pointer :: areEqualMethod
 
     vm_obj => v_model
-    areEqualMethod => arePointersEqual
-    if (.not. this%regionalModels%ContainsObject(vm_obj, areEqualMethod)) then
+    if (.not. this%regionalModels%ContainsObject(vm_obj)) then
       call this%regionalModels%Add(vm_obj)
     end if
 

--- a/src/Solution/NumericalSolution.f90
+++ b/src/Solution/NumericalSolution.f90
@@ -12,7 +12,7 @@ module NumericalSolutionModule
                              LENMEMPATH
   use MemoryHelperModule, only: create_mem_path
   use TableModule, only: TableType, table_cr
-  use GenericUtilitiesModule, only: is_same, sim_message, stop_with_error
+  use GenericUtilitiesModule, only: is_same, sim_message
   use VersionModule, only: IDEVELOPMODE
   use BaseModelModule, only: BaseModelType
   use BaseExchangeModule, only: BaseExchangeType
@@ -1610,7 +1610,7 @@ contains
       WRITE (99, *) 'MATRIX SOLUTION FOLLOWS'
       WRITE (99, '(10(I8,G15.4))') (n, this%x(N), N=1, this%NEQ)
       close (99)
-      call stop_with_error()
+      call exit(0)
     end if
     !-------------------------------------------------------
     !

--- a/src/Solution/NumericalSolution.f90
+++ b/src/Solution/NumericalSolution.f90
@@ -2,6 +2,7 @@
 
 module NumericalSolutionModule
   use KindModule, only: DP, I4B, LGP
+  use ErrorUtilModule, only: pstop
   use TimerModule, only: code_timer
   use ConstantsModule, only: LINELENGTH, LENSOLUTIONNAME, LENPAKLOC, &
                              DPREC, DZERO, DEM20, DEM15, DEM6, &
@@ -1610,7 +1611,7 @@ contains
       WRITE (99, *) 'MATRIX SOLUTION FOLLOWS'
       WRITE (99, '(10(I8,G15.4))') (n, this%x(N), N=1, this%NEQ)
       close (99)
-      call exit(0)
+      call pstop()
     end if
     !-------------------------------------------------------
     !

--- a/src/Utilities/ArrayHandlers.f90
+++ b/src/Utilities/ArrayHandlers.f90
@@ -198,7 +198,6 @@ contains
     character(len=*), allocatable, intent(inout) :: array(:)
     integer(I4B), optional, intent(in) :: increment
     ! -- local
-    character(len=LINELENGTH) :: line
     character(len=MAXCHARLEN), allocatable, dimension(:) :: array_temp
     integer(I4B) :: i, inclocal, isize, lenc, newsize
     ! -- format
@@ -330,7 +329,6 @@ contains
     real(DP), dimension(:), pointer, contiguous, intent(inout) :: array
     integer(I4B), optional, intent(in) :: increment
     ! -- local
-    character(len=LINELENGTH) :: line
     character(len=100) :: ermsg
     integer(I4B) :: i, inclocal, isize, istat, newsize
     real(DP), dimension(:), pointer, contiguous :: array_temp => null()
@@ -377,7 +375,6 @@ contains
     integer(I4B), dimension(:), pointer, contiguous, intent(inout) :: array
     integer(I4B), optional, intent(in) :: increment
     ! -- local
-    character(len=LINELENGTH) :: line
     character(len=100) :: ermsg
     integer(I4B) :: i, inclocal, isize, istat, newsize
     integer(I4B), dimension(:), pointer, contiguous :: array_temp => null()
@@ -505,7 +502,6 @@ contains
     character(len=*), allocatable, intent(inout) :: array(:)
     integer(I4B), intent(in) :: ipos
     ! -- local
-    character(len=LINELENGTH) :: line
     character(len=MAXCHARLEN), allocatable, dimension(:) :: array_temp
     integer(I4B) :: i, isize, lenc, newsize, inew
     ! -- format

--- a/src/Utilities/ArrayHandlers.f90
+++ b/src/Utilities/ArrayHandlers.f90
@@ -1,6 +1,7 @@
 module ArrayHandlersModule
 
   use KindModule, only: DP, I4B, LGP
+  use ErrorUtilModule, only: pstop
   use ConstantsModule, only: LINELENGTH, MAXCHARLEN, DZERO, DTEN
   implicit none
   private
@@ -206,9 +207,8 @@ contains
     ! -- check character length
     lenc = len(array)
     if (lenc > MAXCHARLEN) then
-      print *, 'Error in ArrayHandlersModule: '// &
-        'Need to increase MAXCHARLEN. Stopping...'
-      call exit(138)
+      call pstop(138, 'Error in ArrayHandlersModule: '// &
+                 'Need to increase MAXCHARLEN. Stopping...')
     end if
     !
     ! -- initialize
@@ -364,9 +364,8 @@ contains
     ! -- Error reporting
 99  continue
 
-    print *, 'Error in ArrayHandlersModule: '// &
-      'Could not increase array size. Stopping...'
-    call exit(138)
+    call pstop(138, 'Error in ArrayHandlersModule: '// &
+               'Could not increase array size. Stopping...')
 
   end subroutine extend_double
 
@@ -410,9 +409,8 @@ contains
     ! -- Error reporting
 99  continue
 
-    print *, 'Error in ArrayHandlersModule: '// &
-      'Could not increase array size. Stopping ...'
-    call exit(138)
+    call pstop(138, 'Error in ArrayHandlersModule: '// &
+               'Could not increase array size. Stopping ...')
 
   end subroutine extend_integer
 
@@ -511,9 +509,8 @@ contains
     lenc = len(array)
     if (lenc > MAXCHARLEN) then
 
-      print *, 'Error in ArrayHandlersModule: '// &
-        'Need to increase MAXCHARLEN. Stopping...'
-      call exit(138)
+      call pstop(138, 'Error in ArrayHandlersModule: '// &
+                 'Need to increase MAXCHARLEN. Stopping...')
     end if
     !
     ! -- calculate sizes

--- a/src/Utilities/ArrayHandlers.f90
+++ b/src/Utilities/ArrayHandlers.f90
@@ -2,8 +2,6 @@ module ArrayHandlersModule
 
   use KindModule, only: DP, I4B, LGP
   use ConstantsModule, only: LINELENGTH, MAXCHARLEN, DZERO, DTEN
-  use SimVariablesModule, only: iout
-  use GenericUtilitiesModule, only: sim_message, stop_with_error
   implicit none
   private
   public :: ExpandArray, ExpandArray2D, ExpandArrayWrapper, ExtendPtrArray
@@ -209,16 +207,9 @@ contains
     ! -- check character length
     lenc = len(array)
     if (lenc > MAXCHARLEN) then
-      write (line, '(a)') 'Error in ArrayHandlersModule: '// &
-        'Need to increase MAXCHARLEN'
-      call sim_message(line, iunit=iout, fmt=stdfmt)
-      call sim_message(line, fmt=stdfmt)
-      !
-      ! -- stop message
-      write (line, '(a)') 'Stopping...'
-      call sim_message(line, iunit=iout)
-      call sim_message(line)
-      call stop_with_error(138)
+      print *, 'Error in ArrayHandlersModule: '// &
+        'Need to increase MAXCHARLEN. Stopping...'
+      call exit(138)
     end if
     !
     ! -- initialize
@@ -375,20 +366,9 @@ contains
     ! -- Error reporting
 99  continue
 
-    write (line, '(a)') 'Error in ArrayHandlersModule: '// &
-      'Could not increase array size'
-    call sim_message(line, iunit=iout, fmt=stdfmt)
-    call sim_message(line, fmt=stdfmt)
-    !
-    ! -- error message
-    call sim_message(ermsg, iunit=iout)
-    call sim_message(ermsg)
-    !
-    ! -- stop message
-    write (line, '(a)') 'Stopping...'
-    call sim_message(line, iunit=iout)
-    call sim_message(line)
-    call stop_with_error(138)
+    print *, 'Error in ArrayHandlersModule: '// &
+      'Could not increase array size. Stopping...'
+    call exit(138)
 
   end subroutine extend_double
 
@@ -433,20 +413,9 @@ contains
     ! -- Error reporting
 99  continue
 
-    write (line, '(a)') 'Error in ArrayHandlersModule: '// &
-      'Could not increase array size'
-    call sim_message(line, iunit=iout, fmt=stdfmt)
-    call sim_message(line, fmt=stdfmt)
-    !
-    ! -- error message
-    call sim_message(ermsg, iunit=iout)
-    call sim_message(ermsg)
-    !
-    ! -- stop message
-    write (line, '(a)') 'Stopping...'
-    call sim_message(line, iunit=iout)
-    call sim_message(line)
-    call stop_with_error(138)
+    print *, 'Error in ArrayHandlersModule: '// &
+      'Could not increase array size. Stopping ...'
+    call exit(138)
 
   end subroutine extend_integer
 
@@ -546,16 +515,9 @@ contains
     lenc = len(array)
     if (lenc > MAXCHARLEN) then
 
-      write (line, '(a)') 'Error in ArrayHandlersModule: '// &
-        'Need to increase MAXCHARLEN'
-      call sim_message(line, iunit=iout, fmt=stdfmt)
-      call sim_message(line, fmt=stdfmt)
-      !
-      ! -- stop message
-      write (line, '(a)') 'Stopping...'
-      call sim_message(line, iunit=iout)
-      call sim_message(line)
-      call stop_with_error(138)
+      print *, 'Error in ArrayHandlersModule: '// &
+        'Need to increase MAXCHARLEN. Stopping...'
+      call exit(138)
     end if
     !
     ! -- calculate sizes

--- a/src/Utilities/DevFeature.f90
+++ b/src/Utilities/DevFeature.f90
@@ -9,7 +9,7 @@ module DevFeatureModule
 
 contains
 
-  !> @ brief Development feature, terminate if in release mode
+  !> @brief Terminate if in release mode (guard development features)
   !!
   !! Terminate the program with an error if the IDEVELOPMODE flag
   !! is set to 0. This allows developing features on the mainline
@@ -21,7 +21,7 @@ contains
     ! -- dummy
     character(len=*), intent(in) :: errmsg
     integer(I4B), intent(in), optional :: iunit
-    !
+    
     ! -- store error and terminate if in release mode
     if (IDEVELOPMODE == 0) then
       if (present(iunit)) then
@@ -31,9 +31,7 @@ contains
         call store_error(errmsg, terminate=.true.)
       end if
     end if
-    !
-    ! -- return
-    return
+
   end subroutine dev_feature
 
 end module DevFeatureModule

--- a/src/Utilities/DevFeature.f90
+++ b/src/Utilities/DevFeature.f90
@@ -21,7 +21,7 @@ contains
     ! -- dummy
     character(len=*), intent(in) :: errmsg
     integer(I4B), intent(in), optional :: iunit
-    
+
     ! -- store error and terminate if in release mode
     if (IDEVELOPMODE == 0) then
       if (present(iunit)) then

--- a/src/Utilities/ErrorUtil.f90
+++ b/src/Utilities/ErrorUtil.f90
@@ -1,7 +1,7 @@
 module ErrorUtilModule
   use KindModule, only: I4B
   implicit none
-  contains
+contains
 
   !> @brief Stop the program with an optional status code.
   !!
@@ -13,7 +13,7 @@ module ErrorUtilModule
   subroutine pstop(status, message)
     integer(I4B), intent(in), optional :: status !< optional error code to return (default=0)
     character(len=*), intent(in), optional :: message !< optional message to print before stopping
-    
+
     if (present(message)) print *, message
     if (present(status)) then
       if (status == 0) stop

--- a/src/Utilities/ErrorUtil.f90
+++ b/src/Utilities/ErrorUtil.f90
@@ -1,0 +1,30 @@
+module ErrorUtilModule
+  use KindModule, only: I4B
+  implicit none
+  private
+  public :: stop_with_error
+
+  !> @brief Exit the program, optionally specifying status code and error message.
+  subroutine stop_with_error(status, message)
+    ! -- dummy variables
+    integer(I4B), intent(in), optional :: status !< optional error code to return (default=0)
+    character(len=*), intent(in), optional :: message !< optional message to print before stopping
+    ! -- local variables
+    integer(I4B) :: istatus
+    
+    ! -- process optional dummy variables
+    if (present(status)) then
+      istatus = status
+    else
+      istatus = 0
+    end if
+
+    ! -- print message, if there is one
+    if (present(message)) print *, message
+
+    ! -- exit with the given status code
+    call exit(istatus)
+
+  end subroutine stop_with_error
+
+end module ErrorUtilModule

--- a/src/Utilities/ErrorUtil.f90
+++ b/src/Utilities/ErrorUtil.f90
@@ -3,10 +3,10 @@ module ErrorUtilModule
   implicit none
 contains
 
-  !> @brief Stop the program with an optional status code.
+  !> @brief Stop the program, optionally specifying an error status code.
   !!
   !! If a non-zero status is specified, the program is terminated with the
-  !! given status code. If no status is specified or status=0, the program
+  !! error status code. If no status is specified or status=0, the program
   !! stops with code 0. A message may be provided to print before exiting,
   !! useful e.g. for "contact developer" messages upon programming errors.
   !<

--- a/src/Utilities/ErrorUtil.f90
+++ b/src/Utilities/ErrorUtil.f90
@@ -1,30 +1,26 @@
 module ErrorUtilModule
   use KindModule, only: I4B
   implicit none
-  private
-  public :: stop_with_error
+  contains
 
-  !> @brief Exit the program, optionally specifying status code and error message.
-  subroutine stop_with_error(status, message)
-    ! -- dummy variables
+  !> @brief Stop the program with an optional status code.
+  !!
+  !! If a non-zero status is specified, the program is terminated with the
+  !! given status code. If no status is specified or status=0, the program
+  !! stops with code 0. A message may be provided to print before exiting,
+  !! useful e.g. for "contact developer" messages upon programming errors.
+  !<
+  subroutine pstop(status, message)
     integer(I4B), intent(in), optional :: status !< optional error code to return (default=0)
     character(len=*), intent(in), optional :: message !< optional message to print before stopping
-    ! -- local variables
-    integer(I4B) :: istatus
     
-    ! -- process optional dummy variables
-    if (present(status)) then
-      istatus = status
-    else
-      istatus = 0
-    end if
-
-    ! -- print message, if there is one
     if (present(message)) print *, message
-
-    ! -- exit with the given status code
-    call exit(istatus)
-
-  end subroutine stop_with_error
+    if (present(status)) then
+      if (status == 0) stop
+      call exit(status)
+    else
+      stop
+    end if
+  end subroutine pstop
 
 end module ErrorUtilModule

--- a/src/Utilities/List.f90
+++ b/src/Utilities/List.f90
@@ -1,5 +1,6 @@
 module ListModule
   use KindModule, only: DP, I4B
+  use ErrorUtilModule, only: pstop
   use ConstantsModule, only: LINELENGTH
   implicit none
   private
@@ -254,8 +255,7 @@ contains
         followingNode%prevNode => newNode
         this%nodeCount = this%nodeCount + 1
       else
-        print *, 'Programming error in ListType%insert_after'
-        error stop 1
+        call pstop(1, 'Programming error in ListType%insert_after')
       end if
     end if
 
@@ -270,10 +270,8 @@ contains
     ! -- local
     type(ListNodeType), pointer :: newNode => null()
     !
-    if (.not. associated(targetNode)) then
-      print *, "Programming error in ListType%InsertBefore"
-      error stop 1
-    end if
+    if (.not. associated(targetNode)) &
+      call pstop(1, 'Programming error in ListType%InsertBefore')
     !
     ! Allocate a new list node and point its Value member to the object
     allocate (newNode)

--- a/src/Utilities/Sim.f90
+++ b/src/Utilities/Sim.f90
@@ -10,6 +10,7 @@
 module SimModule
 
   use KindModule, only: DP, I4B
+  use ErrorUtilModule, only: pstop
   use DefinedMacros, only: get_os
   use ConstantsModule, only: MAXCHARLEN, LINELENGTH, &
                              DONE, &
@@ -370,8 +371,8 @@ contains
     ! -- print the final message
     call print_final_message(stopmess, ioutlocal)
     !
-    ! -- return appropriate error codes when terminating the program
-    error stop ireturnerr
+    ! -- terminate with the appropriate error code
+    call pstop(ireturnerr)
 
   end subroutine ustop
 
@@ -569,7 +570,7 @@ contains
     !
     ! -- return or halt
     if (iforcestop == 1) then
-      call error stop ireturnerr
+      call pstop(ireturnerr)
     end if
 
   end subroutine final_message

--- a/src/Utilities/Sim.f90
+++ b/src/Utilities/Sim.f90
@@ -19,7 +19,7 @@ module SimModule
   use SimVariablesModule, only: istdout, iout, isim_level, ireturnerr, &
                                 iforcestop, iunext, &
                                 warnmsg
-  use GenericUtilitiesModule, only: sim_message, stop_with_error
+  use GenericUtilitiesModule, only: sim_message
   use MessageModule, only: MessageType
 
   implicit none
@@ -371,7 +371,7 @@ contains
     call print_final_message(stopmess, ioutlocal)
     !
     ! -- return appropriate error codes when terminating the program
-    call stop_with_error(ireturnerr)
+    error stop ireturnerr
 
   end subroutine ustop
 
@@ -569,7 +569,7 @@ contains
     !
     ! -- return or halt
     if (iforcestop == 1) then
-      call stop_with_error(ireturnerr)
+      call error stop ireturnerr
     end if
 
   end subroutine final_message

--- a/src/Utilities/genericutils.f90
+++ b/src/Utilities/genericutils.f90
@@ -19,7 +19,6 @@ module GenericUtilitiesModule
   public :: write_message
   public :: write_centered
   public :: is_same
-  public :: stop_with_error
 
 contains
 
@@ -386,28 +385,5 @@ contains
     ! -- return
     return
   end function is_same
-
-  !> @brief Subroutine to stop the program
-  !!
-  !! Subroutine to stop the program and issue the correct return code.
-  !!
-  !<
-  subroutine stop_with_error(ierr)
-    ! -- dummy variables
-    integer(I4B), intent(in), optional :: ierr !< optional error code to return (default=0)
-    ! -- local variables
-    integer(I4B) :: ireturn_err
-    !
-    ! -- process optional dummy variables
-    if (present(ierr)) then
-      ireturn_err = ierr
-    else
-      ireturn_err = 0
-    end if
-
-    ! -- return the correct return code
-    call exit(ireturn_err)
-
-  end subroutine stop_with_error
 
 end module GenericUtilitiesModule

--- a/src/meson.build
+++ b/src/meson.build
@@ -226,6 +226,7 @@ modflow_sources = files(
     'Utilities' / 'Constants.f90',
     'Utilities' / 'defmacro.F90',
     'Utilities' / 'DevFeature.f90',
+    'Utilities' / 'ErrorUtil.f90',
     'Utilities' / 'genericutils.f90',
     'Utilities' / 'GeomUtil.f90',
     'Utilities' / 'HashTable.f90',

--- a/utils/mf5to6/make/makefile
+++ b/utils/mf5to6/make/makefile
@@ -5,10 +5,10 @@ include ./makedefaults
 
 # Define the source file directories
 SOURCEDIR1=../src
-SOURCEDIR2=../src/LGR
-SOURCEDIR3=../src/Preproc
-SOURCEDIR4=../src/MF2005
-SOURCEDIR5=../src/NWT
+SOURCEDIR2=../src/NWT
+SOURCEDIR3=../src/LGR
+SOURCEDIR4=../src/Preproc
+SOURCEDIR5=../src/MF2005
 SOURCEDIR6=../../../src/Utilities/Memory
 SOURCEDIR7=../../../src/Utilities/TimeSeries
 SOURCEDIR8=../../../src/Utilities
@@ -43,6 +43,7 @@ $(OBJDIR)/TableTerm.o \
 $(OBJDIR)/Table.o \
 $(OBJDIR)/MemoryHelper.o \
 $(OBJDIR)/CharString.o \
+$(OBJDIR)/ErrorUtil.o \
 $(OBJDIR)/Memory.o \
 $(OBJDIR)/List.o \
 $(OBJDIR)/MemoryList.o \

--- a/utils/mf5to6/msvs/mf5to6.vfproj
+++ b/utils/mf5to6/msvs/mf5to6.vfproj
@@ -104,6 +104,7 @@
 			<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
 		<File RelativePath="..\..\..\src\Utilities\DevFeature.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\genericutils.f90"/>
+		<File RelativePath="..\..\..\src\Utilities\ErrorUtil.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\InputOutput.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\kind.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\List.f90"/>

--- a/utils/mf5to6/pymake/extrafiles.txt
+++ b/utils/mf5to6/pymake/extrafiles.txt
@@ -10,6 +10,7 @@
 ../../../src/Utilities/SimVariables.f90
 ../../../src/Utilities/compilerversion.F90
 ../../../src/Utilities/genericutils.f90
+../../../src/Utilities/ErrorUtil.f90
 ../../../src/Utilities/InputOutput.f90
 ../../../src/Utilities/kind.f90
 ../../../src/Utilities/List.f90

--- a/utils/zonebudget/make/makefile
+++ b/utils/zonebudget/make/makefile
@@ -23,6 +23,7 @@ $(OBJDIR)/compilerversion.o \
 $(OBJDIR)/ArrayHandlers.o \
 $(OBJDIR)/version.o \
 $(OBJDIR)/Message.o \
+$(OBJDIR)/ErrorUtil.o \
 $(OBJDIR)/Sim.o \
 $(OBJDIR)/OpenSpec.o \
 $(OBJDIR)/InputOutput.o \

--- a/utils/zonebudget/make/makefile
+++ b/utils/zonebudget/make/makefile
@@ -17,13 +17,13 @@ OBJECTS = \
 $(OBJDIR)/kind.o \
 $(OBJDIR)/Constants.o \
 $(OBJDIR)/SimVariables.o \
+$(OBJDIR)/ErrorUtil.o \
 $(OBJDIR)/genericutils.o \
 $(OBJDIR)/defmacro.o \
 $(OBJDIR)/compilerversion.o \
 $(OBJDIR)/ArrayHandlers.o \
 $(OBJDIR)/version.o \
 $(OBJDIR)/Message.o \
-$(OBJDIR)/ErrorUtil.o \
 $(OBJDIR)/Sim.o \
 $(OBJDIR)/OpenSpec.o \
 $(OBJDIR)/InputOutput.o \

--- a/utils/zonebudget/msvs/zonebudget.vfproj
+++ b/utils/zonebudget/msvs/zonebudget.vfproj
@@ -45,6 +45,7 @@
 			<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
 		<File RelativePath="..\..\..\src\Utilities\DevFeature.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\genericutils.f90"/>
+		<File RelativePath="..\..\..\src\Utilities\ErrorUtil.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\InputOutput.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\kind.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\LongLineReader.f90"/>

--- a/utils/zonebudget/pymake/extrafiles.txt
+++ b/utils/zonebudget/pymake/extrafiles.txt
@@ -5,6 +5,7 @@
 ../../../src/Utilities/Constants.f90
 ../../../src/Utilities/compilerversion.F90
 ../../../src/Utilities/genericutils.f90
+../../../src/Utilities/ErrorUtil.f90
 ../../../src/Utilities/InputOutput.f90
 ../../../src/Utilities/kind.f90
 ../../../src/Utilities/LongLineReader.f90


### PR DESCRIPTION
* remove `SimModule` dependency and `sim_message()`/`stop_with_error()` usages
  * minimize dependencies of generic utilities on simulation modules so latter can use former without circularity
  * on programmer error, just print error message and `error stop 1`
* use `associated(x, y)` as default `isEqual` procedure for `ContainsObject`
* more descriptive docstrings, use compact format