### PR TITLE
test: remove return statement causing checks to be skipped

### DIFF
--- a/autotest/common_regression.py
+++ b/autotest/common_regression.py
@@ -423,7 +423,7 @@ def setup_mf6_comparison(
                     break
 
 
-def get_mf6_files(namefile):
+def get_mf6_files(namefile, verbose=False):
     """Get all MODFLOW 6 input and output files in this simulation.
 
     Parameters
@@ -499,6 +499,14 @@ def get_mf6_files(namefile):
         # if len(flist) < 1 and len(olist) < 1:
         if len(flist) < 1:
             break
+
+    if verbose:
+        from pprint import pprint
+
+        print(f"Found input files for {namefile}:")
+        pprint(pkg_files)
+        print(f"Expecting output files for {namefile}:")
+        pprint(out_files)
 
     return pkg_files, out_files
 

--- a/autotest/test_gwf_ats01.py
+++ b/autotest/test_gwf_ats01.py
@@ -7,9 +7,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_ats01a"]
+cases = ["gwf_ats01a"]
 nlay, nrow, ncol = 1, 1, 2
 
 # set dt0, dtmin, dtmax, dtadj, dtfailadj
@@ -39,7 +40,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -173,9 +174,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating flow...")
-
+def check_output(idx, test):
     # This will fail if budget numbers cannot be read
     fpth = os.path.join(test.workspace, f"{test.name}.lst")
     mflist = flopy.utils.Mf6ListBudget(fpth)
@@ -205,14 +204,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_ats02.py
+++ b/autotest/test_gwf_ats02.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_ats02a"]
+cases = ["gwf_ats02a"]
 nlay, nrow, ncol = 5, 1, 1
 botm = [80.0, 60.0, 40.0, 20.0, 0.0]
 
@@ -40,7 +41,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -204,9 +205,7 @@ def make_plot(test):
     plt.show()
 
 
-def check_output(test):
-    print("evaluating flow...")
-
+def check_output(idx, test):
     # This will fail if budget numbers cannot be read
     fpth = os.path.join(test.workspace, f"{test.name}.lst")
     mflist = flopy.utils.Mf6ListBudget(fpth)
@@ -231,14 +230,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_ats03.py
+++ b/autotest/test_gwf_ats03.py
@@ -14,9 +14,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_ats03a"]
+cases = ["gwf_ats03a"]
 nlay, nrow, ncol = 1, 1, 10
 
 
@@ -39,7 +40,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -189,9 +190,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating flow...")
-
+def check_output(idx, test):
     # ensure obs2 (a constant head time series) drops linearly from 100 to 50
     fpth = os.path.join(test.workspace, test.name + ".obs.csv")
     try:
@@ -207,14 +206,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_ats_lak01.py
+++ b/autotest/test_gwf_ats_lak01.py
@@ -9,9 +9,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_ats_lak_01a"]
+cases = ["gwf_ats_lak_01a"]
 gwf = None
 
 
@@ -49,7 +50,7 @@ def build_models(idx, test):
     nouter, ninner = 250, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -289,9 +290,7 @@ def get_kij_from_node(node, nrow, ncol):
     return k, i, j
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # calculate volume of water and make sure it is conserved
     fname = test.name + ".lak.bin"
     fname = os.path.join(test.workspace, fname)
@@ -412,14 +411,14 @@ def check_output(test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_auxvars.py
+++ b/autotest/test_gwf_auxvars.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import DNODATA, TestFramework
 
-ex = ["aux01"]
+cases = ["aux01"]
 auxvar1 = 101.0
 auxvar2 = 102.0
 
@@ -28,7 +29,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -242,9 +243,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     # maw budget aux variables
     fpth = os.path.join(test.workspace, "aux01.maw.bud")
     bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
@@ -300,14 +299,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_auxvars02.py
+++ b/autotest/test_gwf_auxvars02.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["aux02"]
+cases = ["aux02"]
 
 
 def build_models(idx, test):
@@ -26,7 +27,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -105,9 +106,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     # maw budget aux variables
     fpth = os.path.join(test.workspace, "aux02.bud")
     bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
@@ -120,14 +119,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_buy_lak01.py
+++ b/autotest/test_gwf_buy_lak01.py
@@ -1,22 +1,25 @@
-# Test the buoyancy package and the variable density flows between the lake
-# and the gwf model.  This model has 4 layers and a lake incised within it.
-# The model is transient and has heads in the aquifer higher than the initial
-# stage in the lake.  As the model runs, the lake and aquifer equalize and
-# should end up at the same level.  The test ensures that the initial and
-# final water volumes in the entire system are the same.  There are three
-# different cases:
-#  1.  No buoyancy package
-#  2.  Buoyancy package with lake and aquifer density = 1000.
-#  3.  Buoyancy package with lake and aquifer density = 1024.5
+"""
+Test the buoyancy package and the variable density flows between the lake
+and the gwf model.  This model has 4 layers and a lake incised within it.
+The model is transient and has heads in the aquifer higher than the initial
+stage in the lake.  As the model runs, the lake and aquifer equalize and
+should end up at the same level.  The test ensures that the initial and
+final water volumes in the entire system are the same.  There are three
+different cases:
+ 1.  No buoyancy package
+ 2.  Buoyancy package with lake and aquifer density = 1000.
+ 3.  Buoyancy package with lake and aquifer density = 1024.5
+"""
 
 import os
 
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["buy_lak_01a"]  # , 'buy_lak_01b', 'buy_lak_01c']
+cases = ["buy_lak_01a"]  # , 'buy_lak_01b', 'buy_lak_01c']
 buy_on_list = [False]  # , True, True]
 concbuylist = [0.0]  # , 0., 35.]
 
@@ -48,7 +51,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -207,9 +210,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # calculate volume of water and make sure it is conserved
     gwfname = "gwf_" + test.name
     fname = gwfname + ".lak.bin"
@@ -253,14 +254,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_buy_lak02.py
+++ b/autotest/test_gwf_buy_lak02.py
@@ -22,7 +22,7 @@ import pytest
 from framework import TestFramework
 
 simname = "gwfbuylak02"
-ex = [
+cases = [
     f"{simname}a",
     f"{simname}b",
     f"{simname}c",
@@ -33,7 +33,7 @@ lak_conc = [0, 35, 0, 35]
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
 
     lx = 7.0
     lz = 4.0
@@ -369,8 +369,6 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # calculate volume of water and make sure it is conserved
     gwfname = "gwf_" + test.name
     gwtname = "gwt_" + test.name
@@ -448,7 +446,7 @@ def check_output(idx, test):
     # todo: add a better check of the lake concentrations
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, targets, function_tmpdir):
     framework = TestFramework(
         name=name,

--- a/autotest/test_gwf_buy_maw01.py
+++ b/autotest/test_gwf_buy_maw01.py
@@ -16,9 +16,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["buy_maw_01a"]  # , 'buy_maw_01b', 'buy_maw_01c']
+cases = ["buy_maw_01a"]  # , 'buy_maw_01b', 'buy_maw_01c']
 buy_on_list = [False]  # , True, True]
 concbuylist = [0.0]  # , 0., 35.]
 
@@ -50,7 +51,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 10
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -185,9 +186,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # calculate volume of water and make sure it is conserved
     gwfname = "gwf_" + test.name
     fname = gwfname + ".maw.bin"
@@ -252,14 +251,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_buy_sfr01.py
+++ b/autotest/test_gwf_buy_sfr01.py
@@ -1,14 +1,17 @@
-# Simple one-layer model with sfr on top.  Purpose is to test buy package in a
-# one-d sfr network.
+"""
+Simple one-layer model with sfr on top.  Purpose is to test buy package in a
+one-d sfr network.
+"""
 
 import os
 
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["buy_sfr_01"]
+cases = ["buy_sfr_01"]
 
 
 def build_models(idx, test):
@@ -42,7 +45,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -370,9 +373,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # assign names
     gwtname = "gwt_" + test.name
     gwfname = "gwf_" + test.name
@@ -455,13 +456,13 @@ def check_output(test):
         ), f"reach {n} flow {qcalc} not equal {qsim}"
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_chd01.py
+++ b/autotest/test_gwf_chd01.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "chd01",
 ]
 
@@ -33,7 +34,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -117,9 +118,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     gwfname = "gwf_" + test.name
 
     fpth = os.path.join(test.workspace, f"{gwfname}.hds")
@@ -133,13 +132,13 @@ def check_output(test):
     ), "simulated head do not match with known solution."
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_chd02.py
+++ b/autotest/test_gwf_chd02.py
@@ -4,15 +4,16 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "chd02",
 ]
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
     nlay, nrow, ncol = 1, 1, 10
     sim = flopy.mf6.MFSimulation(sim_ws=test.workspace, sim_name=name)
     flopy.mf6.ModflowTdis(sim)
@@ -62,9 +63,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     name = test.name
 
     fpth = os.path.join(test.workspace, f"{name}.hds")
@@ -91,13 +90,13 @@ def check_output(test):
     ), "simulated head does not match with known solution."
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_csub_db01_nr.py
+++ b/autotest/test_gwf_csub_db01_nr.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = (
+cases = (
     "csub_db01a",
     "csub_db01b",
     "csub_db01c",
@@ -58,10 +59,10 @@ bud_lst = (
 nlay, nrow, ncol = 2, 1, 2
 nper = 3
 tsp0 = 1.0
-perlen = [tsp0] + [365.2500000 for i in range(nper - 1)]
-nstp = [1] + [200 for i in range(nper - 1)]
-tsmult = [1.0] + [1.0 for i in range(nper - 1)]
-steady = [True] + [False for i in range(nper - 1)]
+perlen = [tsp0] + [365.2500000 for _ in range(nper - 1)]
+nstp = [1] + [200 for _ in range(nper - 1)]
+tsmult = [1.0] + [1.0 for _ in range(nper - 1)]
+steady = [True] + [False for _ in range(nper - 1)]
 delr, delc = 1000.0, 1000.0
 top = 0.0
 botm = [-10.0, -20.0]
@@ -80,8 +81,8 @@ nouter, ninner = 50, 300
 hclose, rclose, relax = 1e-9, 1e-3, 1.0
 
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # all cells are active
 ib = 1
@@ -106,7 +107,7 @@ H0 = 0.0
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
     newton = newtons[idx]
 
     # build MODFLOW 6 files
@@ -322,9 +323,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating compaction...")
-
+def check_output(idx, test):
     # MODFLOW 6 total compaction results
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -349,7 +348,7 @@ def check_output(test):
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -362,13 +361,13 @@ def check_output(test):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
     for idx, key in enumerate(bud_lst):
@@ -380,22 +379,21 @@ def check_output(test):
     fpth = os.path.join(
         test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     if diffmax > budtol:
         test.success = False
@@ -408,14 +406,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
         htol=htol,
     )

--- a/autotest/test_gwf_csub_distypes.py
+++ b/autotest/test_gwf_csub_distypes.py
@@ -3,12 +3,13 @@ import pathlib as pl
 import flopy
 import numpy as np
 import pytest
-from conftest import try_get_target
 from flopy.utils.gridgen import Gridgen
+
+from conftest import try_get_target
 from framework import TestFramework
 
-ex = ["csub_dis", "csub_disv", "csub_disu", "csub_disu01", "csub_disu02"]
-ex_dict = {name: None for name in ex}
+cases = ["csub_dis", "csub_disv", "csub_disu", "csub_disu01", "csub_disu02"]
+ex_dict = {name: None for name in cases}
 ex_dict["csub_disu01"] = 0
 ex_dict["csub_disu02"] = 2
 paktest = "csub"
@@ -19,8 +20,8 @@ perlen = [1.0, 100.0]
 nstp = [1, 10]
 tsmult = [1.0] * nper
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # base spatial discretization
 nlay, nrow, ncol = 3, 9, 9
@@ -223,7 +224,7 @@ def build_models(idx, test, gridgen):
 
 # build MODFLOW 6 files
 def build_mf6(idx, ws, gridgen):
-    name = ex[idx]
+    name = cases[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         version="mf6",
@@ -342,9 +343,7 @@ def build_mf6(idx, ws, gridgen):
 
 
 def check_output(idx, test):
-    print("evaluating z-displacement...")
-
-    name = ex[idx]
+    name = cases[idx]
     ws = pl.Path(test.workspace)
     test = flopy.mf6.MFSimulation.load(sim_name=name, sim_ws=ws)
     gwf = test.get_model()
@@ -402,7 +401,7 @@ def check_output(idx, test):
                 if k == layer_refinement:
                     comp_temp = np.zeros(shape2d_refined, dtype=float)
                     zdis_temp = np.zeros(shape2d_refined, dtype=float)
-                    for key, value in map_dict.items():
+                    for value in map_dict.values():
                         comp_temp[value["cellid"]] = comp1d[value["node"]]
                         zdis_temp[value["cellid"]] = zdis1d[value["node"]]
                     comp[k] = comp_temp.reshape(
@@ -425,7 +424,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     gridgen = try_get_target(targets, "gridgen")

--- a/autotest/test_gwf_csub_ndb01_nr.py
+++ b/autotest/test_gwf_csub_ndb01_nr.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = (
+cases = (
     "csub_ndb01a",
     "csub_ndb01b",
     "csub_ndb01c",
@@ -58,10 +59,10 @@ bud_lst = (
 nlay, nrow, ncol = 2, 1, 2
 nper = 3
 tsp0 = 1.0
-perlen = [tsp0] + [365.2500000 for i in range(nper - 1)]
-nstp = [1] + [200 for i in range(nper - 1)]
-tsmult = [1.0] + [1.0 for i in range(nper - 1)]
-steady = [True] + [False for i in range(nper - 1)]
+perlen = [tsp0] + [365.2500000 for _ in range(nper - 1)]
+nstp = [1] + [200 for _ in range(nper - 1)]
+tsmult = [1.0] + [1.0 for _ in range(nper - 1)]
+steady = [True] + [False for _ in range(nper - 1)]
 delr, delc = 1000.0, 1000.0
 top = 0.0
 botm = [-10.0, -20.0]
@@ -80,8 +81,8 @@ nouter, ninner = 50, 300
 hclose, rclose, relax = 1e-9, 1e-3, 1.0
 
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # all cells are active
 ib = 1
@@ -106,7 +107,7 @@ H0 = 0.0
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
     newton = newtons[idx]
 
     # build MODFLOW 6 files
@@ -294,9 +295,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating compaction...")
-
+def check_output(idx, test):
     # MODFLOW 6 total compaction results
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -321,7 +320,7 @@ def check_output(test):
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -334,17 +333,17 @@ def check_output(test):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
@@ -352,22 +351,21 @@ def check_output(test):
     fpth = os.path.join(
         test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     if diffmax > budtol:
         test.success = False
@@ -380,14 +378,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
         htol=htol,
     )

--- a/autotest/test_gwf_csub_sk04_nr.py
+++ b/autotest/test_gwf_csub_sk04_nr.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = (
+cases = (
     "csub_sk04a",
     "csub_sk04b",
     "csub_sk04c",
@@ -32,10 +33,10 @@ bud_lst = (
 nlay, nrow, ncol = 2, 1, 2
 nper = 3
 tsp0 = 1.0
-perlen = [tsp0] + [365.2500000 for i in range(nper - 1)]
-nstp = [1] + [200 for i in range(nper - 1)]
-tsmult = [1.0] + [1.0 for i in range(nper - 1)]
-steady = [True] + [False for i in range(nper - 1)]
+perlen = [tsp0] + [365.2500000 for _ in range(nper - 1)]
+nstp = [1] + [200 for _ in range(nper - 1)]
+tsmult = [1.0] + [1.0 for _ in range(nper - 1)]
+steady = [True] + [False for _ in range(nper - 1)]
 delr, delc = 1000.0, 1000.0
 top = 0.0
 botm = [-10.0, -20.0]
@@ -54,8 +55,8 @@ nouter, ninner = 50, 300
 hclose, rclose, relax = 1e-9, 1e-3, 1.0
 
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # all cells are active
 ib = 1
@@ -77,7 +78,7 @@ crnd0[:, 0, 0] = 0.0
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
     newton = newtons[idx]
 
     # build MODFLOW 6 files
@@ -243,9 +244,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating compaction...")
-
+def check_output(idx, test):
     # MODFLOW 6 total compaction results
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -270,7 +269,7 @@ def check_output(test):
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -283,17 +282,17 @@ def check_output(test):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
@@ -301,22 +300,21 @@ def check_output(test):
     fpth = os.path.join(
         test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     if diffmax > budtol:
         test.success = False
@@ -329,7 +327,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -337,7 +335,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         htol=htol,
     )
     test.run()

--- a/autotest/test_gwf_csub_sub01_adjmat.py
+++ b/autotest/test_gwf_csub_sub01_adjmat.py
@@ -3,15 +3,15 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
+cases = ["csub_sub01_adj"]
 paktest = "csub"
 budtol = 1e-2
-
 compdir = "mf6"
-ex = ["csub_sub01_adj"]
 compression_indices = [None]
-ndcell = [19] * len(ex)
+ndcell = [19] * len(cases)
 
 # static model data
 # spatial discretization
@@ -24,10 +24,10 @@ botm = [-100.0]
 
 # temporal discretization
 nper = 1
-perlen = [1000.0 for i in range(nper)]
-nstp = [100 for i in range(nper)]
-tsmult = [1.05 for i in range(nper)]
-steady = [False for i in range(nper)]
+perlen = [1000.0 for _ in range(nper)]
+nstp = [100 for _ in range(nper)]
+tsmult = [1.05 for _ in range(nper)]
+steady = [False for _ in range(nper)]
 
 strt = 0.0
 strt6 = 1.0
@@ -42,8 +42,8 @@ nouter, ninner = 1000, 500
 hclose, rclose, relax = 1e-12, 1e-6, 0.97
 
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 ib = 1
 
@@ -95,7 +95,7 @@ def build_models(idx, test):
 
 
 def get_model(idx, dir, adjustmat=False):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = dir
@@ -220,9 +220,7 @@ def calc_theta_thick(comp, thickini=1.0):
     return poro, b
 
 
-def check_output(test):
-    print("evaluating subsidence...")
-
+def check_output(idx, test):
     # MODFLOW 6 compaction results
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -247,19 +245,18 @@ def check_output(test):
     fpth = os.path.join(
         test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
     )
-    f = open(fpth, "w")
-    line = f"{'TOTIM':>15s}"
-    line += f" {'CSUB':>15s}"
-    line += f" {'MF':>15s}"
-    line += f" {'DIFF':>15s}"
-    f.write(line + "\n")
-    for i in range(diff.shape[0]):
-        line = f"{tc['time'][i]:15g}"
-        line += f" {tc['TCOMP'][i]:15g}"
-        line += f" {tcb['TCOMP'][i]:15g}"
-        line += f" {diff[i]:15g}"
+    with open(fpth, "w") as f:
+        line = f"{'TOTIM':>15s}"
+        line += f" {'CSUB':>15s}"
+        line += f" {'MF':>15s}"
+        line += f" {'DIFF':>15s}"
         f.write(line + "\n")
-    f.close()
+        for i in range(diff.shape[0]):
+            line = f"{tc['time'][i]:15g}"
+            line += f" {tc['TCOMP'][i]:15g}"
+            line += f" {tcb['TCOMP'][i]:15g}"
+            line += f" {diff[i]:15g}"
+            f.write(line + "\n")
 
     if diffmax > dtol:
         test.success = False
@@ -348,9 +345,9 @@ def check_output(test):
 
 
 # compare cbc and lst budgets
-def cbc_compare(sim):
+def cbc_compare(test):
     # open cbc file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.cbc")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.cbc")
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
 
     # build list of cbc data to retrieve
@@ -367,7 +364,7 @@ def cbc_compare(sim):
             bud_lst.append(f"{t}_OUT")
 
     # get results from listing file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.lst")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.lst")
     budl = flopy.utils.Mf6ListBudget(fpth)
     names = list(bud_lst)
     d0 = budl.get_budget(names=names)[0]
@@ -380,7 +377,7 @@ def cbc_compare(sim):
     # get data from cbc dile
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -398,59 +395,58 @@ def cbc_compare(sim):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
     fpth = os.path.join(
-        sim.workspace, f"{os.path.basename(sim.name)}.bud.cmp.out"
+        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     dtol = 1e-6
 
     if diffmax > budtol:
-        sim.success = False
+        test.success = False
         msg += f"exceeds {dtol}"
         assert diffmax < dtol, msg
     else:
-        sim.success = True
+        test.success = True
         print("    " + msg)
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_csub_sub01_elastic.py
+++ b/autotest/test_gwf_csub_sub01_elastic.py
@@ -3,13 +3,14 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
+cases = ["csub_sub01_elasa"]
 cmppth = "mf6"
 paktest = "csub"
 dtol = 1e-3
 budtol = 1e-2
-ex = ["csub_sub01_elasa"]
 ndcell = [19]
 
 # static model data
@@ -23,13 +24,13 @@ botm = [-100.0]
 
 # temporal discretization
 nper = 1
-perlen = [1000.0 for i in range(nper)]
-nstp = [100 for i in range(nper)]
-tsmult = [1.05 for i in range(nper)]
-steady = [False for i in range(nper)]
+perlen = [1000.0 for _ in range(nper)]
+nstp = [100 for _ in range(nper)]
+tsmult = [1.05 for _ in range(nper)]
+steady = [False for _ in range(nper)]
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 strt = 0.0
 strt6 = 1.0
@@ -89,7 +90,7 @@ sub6 = [
 
 
 def build_mf6(idx, ws, newton=None):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     sim = flopy.mf6.MFSimulation(
@@ -182,9 +183,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def check_output(test):
-    print("evaluating subsidence...")
-
+def check_output(idx, test):
     # MODFLOW 6 total compaction results
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -214,21 +213,20 @@ def check_output(test):
     fpth = os.path.join(
         test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
     )
-    f = open(fpth, "w")
-    line = f"{'TOTIM':>15s}"
-    for tag in tc.dtype.names[1:]:
-        line += f" {f'{tag}_SK':>15s}"
-        line += f" {f'{tag}_SKIB':>15s}"
-        line += f" {f'{tag}_DIFF':>15s}"
-    f.write(line + "\n")
-    for i in range(diff.shape[0]):
-        line = f"{tc['time'][i]:15g}"
+    with open(fpth, "w") as f:
+        line = f"{'TOTIM':>15s}"
         for tag in tc.dtype.names[1:]:
-            line += f" {tc[tag][i]:15g}"
-            line += f" {tci[tag][i]:15g}"
-            line += f" {tc[tag][i] - tci[tag][i]:15g}"
+            line += f" {f'{tag}_SK':>15s}"
+            line += f" {f'{tag}_SKIB':>15s}"
+            line += f" {f'{tag}_DIFF':>15s}"
         f.write(line + "\n")
-    f.close()
+        for i in range(diff.shape[0]):
+            line = f"{tc['time'][i]:15g}"
+            for tag in tc.dtype.names[1:]:
+                line += f" {tc[tag][i]:15g}"
+                line += f" {tci[tag][i]:15g}"
+                line += f" {tc[tag][i] - tci[tag][i]:15g}"
+            f.write(line + "\n")
 
     if diffmax > dtol:
         test.success = False
@@ -241,13 +239,11 @@ def check_output(test):
     # compare budgets
     cbc_compare(test)
 
-    return
-
 
 # compare cbc and lst budgets
-def cbc_compare(sim):
+def cbc_compare(test):
     # open cbc file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.cbc")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.cbc")
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
 
     # build list of cbc data to retrieve
@@ -264,7 +260,7 @@ def cbc_compare(sim):
             bud_lst.append(f"{t}_OUT")
 
     # get results from listing file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.lst")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.lst")
     budl = flopy.utils.Mf6ListBudget(fpth)
     names = list(bud_lst)
     d0 = budl.get_budget(names=names)[0]
@@ -277,7 +273,7 @@ def cbc_compare(sim):
     # get data from cbc dile
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -295,60 +291,59 @@ def cbc_compare(sim):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
     fpth = os.path.join(
-        sim.workspace, f"{os.path.basename(sim.name)}.bud.cmp.out"
+        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     if diffmax > budtol:
-        sim.success = False
+        test.success = False
         msg += f"exceeds {dtol}"
         assert diffmax < dtol, msg
     else:
-        sim.success = True
+        test.success = True
         print("    " + msg)
 
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_csub_sub01_pch.py
+++ b/autotest/test_gwf_csub_sub01_pch.py
@@ -3,13 +3,14 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
+cases = ["csub_sub01_pch"]
 paktest = "csub"
 budtol = 1e-2
 compdir = "mf6"
-ex = ["csub_sub01_pch"]
-ndcell = [19] * len(ex)
+ndcell = [19] * len(cases)
 
 # static model data
 # spatial discretization
@@ -22,10 +23,10 @@ botm = [-100.0]
 
 # temporal discretization
 nper = 1
-perlen = [1000.0 for i in range(nper)]
-nstp = [100 for i in range(nper)]
-tsmult = [1.05 for i in range(nper)]
-steady = [False for i in range(nper)]
+perlen = [1000.0 for _ in range(nper)]
+nstp = [100 for _ in range(nper)]
+tsmult = [1.05 for _ in range(nper)]
+steady = [False for _ in range(nper)]
 
 strt = 0.0
 strt6 = 1.0
@@ -40,8 +41,8 @@ nouter, ninner = 1000, 500
 hclose, rclose, relax = 1e-12, 1e-6, 0.97
 
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 ib = 1
 
@@ -79,7 +80,7 @@ def build_models(idx, test):
 
 
 def get_model(idx, dir, pch=None):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = dir
@@ -220,9 +221,7 @@ def get_model(idx, dir, pch=None):
     return sim
 
 
-def check_output(test):
-    print("evaluating subsidence...")
-
+def check_output(idx, test):
     # MODFLOW 6 compaction results
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -247,19 +246,18 @@ def check_output(test):
     fpth = os.path.join(
         test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
     )
-    f = open(fpth, "w")
-    line = f"{'TOTIM':>15s}"
-    line += f" {'CSUB':>15s}"
-    line += f" {'MF':>15s}"
-    line += f" {'DIFF':>15s}"
-    f.write(line + "\n")
-    for i in range(diff.shape[0]):
-        line = f"{tc['time'][i]:15g}"
-        line += f" {tc['TCOMP'][i]:15g}"
-        line += f" {tcb['TCOMP'][i]:15g}"
-        line += f" {diff[i]:15g}"
+    with open(fpth, "w") as f:
+        line = f"{'TOTIM':>15s}"
+        line += f" {'CSUB':>15s}"
+        line += f" {'MF':>15s}"
+        line += f" {'DIFF':>15s}"
         f.write(line + "\n")
-    f.close()
+        for i in range(diff.shape[0]):
+            line = f"{tc['time'][i]:15g}"
+            line += f" {tc['TCOMP'][i]:15g}"
+            line += f" {tcb['TCOMP'][i]:15g}"
+            line += f" {diff[i]:15g}"
+            f.write(line + "\n")
 
     if diffmax > dtol:
         test.success = False
@@ -274,9 +272,9 @@ def check_output(test):
 
 
 # compare cbc and lst budgets
-def cbc_compare(sim):
+def cbc_compare(test):
     # open cbc file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.cbc")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.cbc")
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
 
     # build list of cbc data to retrieve
@@ -293,7 +291,7 @@ def cbc_compare(sim):
             bud_lst.append(f"{t}_OUT")
 
     # get results from listing file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.lst")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.lst")
     budl = flopy.utils.Mf6ListBudget(fpth)
     names = list(bud_lst)
     d0 = budl.get_budget(names=names)[0]
@@ -306,7 +304,7 @@ def cbc_compare(sim):
     # get data from cbc dile
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -324,62 +322,61 @@ def cbc_compare(sim):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
     fpth = os.path.join(
-        sim.workspace, f"{os.path.basename(sim.name)}.bud.cmp.out"
+        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     dtol = 1e-6
 
     if diffmax > budtol:
-        sim.success = False
+        test.success = False
         msg += f"exceeds {dtol}"
         assert diffmax < dtol, msg
     else:
-        sim.success = True
+        test.success = True
         print("    " + msg)
 
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_csub_sub02.py
+++ b/autotest/test_gwf_csub_sub02.py
@@ -2,9 +2,10 @@ import os
 
 import flopy
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "csub_sub02a",
     "csub_sub02b",
     "csub_sub02c",
@@ -22,10 +23,10 @@ ndelaycells = [None, 19, None, 19, 19]
 # static model data
 nlay, nrow, ncol = 1, 1, 1
 nper = 10
-perlen = [182.625 for i in range(nper)]
-nstp = [10 for i in range(nper)]
-tsmult = [1.05 for i in range(nper)]
-steady = [False for i in range(nper)]
+perlen = [182.625 for _ in range(nper)]
+nstp = [10 for _ in range(nper)]
+tsmult = [1.05 for _ in range(nper)]
+steady = [False for _ in range(nper)]
 delr, delc = 1000.0, 1000.0
 top = -100.0
 botm = [-600.0]
@@ -40,8 +41,8 @@ nouter, ninner = 1000, 300
 hclose, rclose, relax = 1e-6, 1e-6, 0.97
 
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 ib = 1
 
@@ -75,7 +76,7 @@ dp = [[kv, cr, cc]]
 
 
 def get_model(idx, ws):
-    name = ex[idx]
+    name = cases[idx]
     ss = 1.14e-3
     sc6 = True
     if not storagecoeff[idx]:
@@ -208,7 +209,7 @@ def build_models(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_csub_sub03.py
+++ b/autotest/test_gwf_csub_sub03.py
@@ -3,10 +3,11 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from conftest import project_root_path
 from framework import TestFramework
 
-ex = ["csub_sub03a", "csub_sub03b"]
+cases = ["csub_sub03a", "csub_sub03b"]
 cmppth = "mf6_regression"
 cvopt = [None, None, None]
 constantcv = [True, True]
@@ -24,10 +25,10 @@ bud_lst = [
 # static model data
 nlay, nrow, ncol = 3, 10, 10
 nper = 31
-perlen = [1.0] + [365.2500000 for i in range(nper - 1)]
-nstp = [1] + [6 for i in range(nper - 1)]
-tsmult = [1.0] + [1.3 for i in range(nper - 1)]
-steady = [True] + [False for i in range(nper - 1)]
+perlen = [1.0] + [365.2500000 for _ in range(nper - 1)]
+nstp = [1] + [6 for _ in range(nper - 1)]
+tsmult = [1.0] + [1.3 for _ in range(nper - 1)]
+steady = [True] + [False for _ in range(nper - 1)]
 delr, delc = 1000.0, 2000.0
 top = 0.0
 botm = [-100, -150.0, -350.0]
@@ -58,8 +59,8 @@ nouter, ninner = 500, 300
 hclose, rclose, relax = 1e-9, 1e-6, 1.0
 
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # all cells are active
 ib = 1
@@ -139,7 +140,7 @@ for k in ldnd:
 
 # SUB package problem 3
 def get_model(idx, ws):
-    name = ex[idx]
+    name = cases[idx]
     # ibc packagedata container counter
     sub6 = []
     ibcno = 0
@@ -352,9 +353,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def check_output(test):
-    print("evaluating compaction...")
-
+def check_output(idx, test):
     # MODFLOW 6 total compaction results
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -399,7 +398,7 @@ def check_output(test):
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -409,17 +408,17 @@ def check_output(test):
                     qout -= vv
                 else:
                     qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
@@ -435,14 +434,14 @@ def check_output(test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
         htol=htol[idx],
         compare="mf6_regression",

--- a/autotest/test_gwf_csub_subwt01.py
+++ b/autotest/test_gwf_csub_subwt01.py
@@ -3,11 +3,12 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["csub_subwt01a", "csub_subwt01b", "csub_subwt01c", "csub_subwt01d"]
+cases = ["csub_subwt01a", "csub_subwt01b", "csub_subwt01c", "csub_subwt01d"]
 cmppth = "mf6_regression"
-htol = [None for n in ex]
+htol = [None for _ in cases]
 dtol = 1e-3
 budtol = 1e-2
 paktest = "csub"
@@ -61,8 +62,8 @@ hclose, rclose, relax = 1e-6, 0.01, 0.97
 fluxtol = rclose
 
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # this used to work
 # ib = np.zeros((nlay, nrow, ncol), dtype=int)
@@ -118,7 +119,7 @@ for k in range(len(thick)):
 
 
 def get_model(idx, ws):
-    name = ex[idx]
+    name = cases[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         memory_print_option="all",
@@ -248,8 +249,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def check_output(test):
-    print("evaluating compaction...")
+def check_output(idx, test):
     # MODFLOW 6 total compaction results
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -275,19 +275,18 @@ def check_output(test):
     fpth = os.path.join(
         test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
     )
-    f = open(fpth, "w")
-    line = f"{'TOTIM':>15s}"
-    line += f" {'CSUB':>15s}"
-    line += f" {'MF':>15s}"
-    line += f" {'DIFF':>15s}"
-    f.write(line + "\n")
-    for i in range(diff.shape[0]):
-        line = f"{tc0['time'][i]:15g}"
-        line += f" {tc[loctag][i]:15g}"
-        line += f" {tc0[loctag][i]:15g}"
-        line += f" {diff[i]:15g}"
+    with open(fpth, "w") as f:
+        line = f"{'TOTIM':>15s}"
+        line += f" {'CSUB':>15s}"
+        line += f" {'MF':>15s}"
+        line += f" {'DIFF':>15s}"
         f.write(line + "\n")
-    f.close()
+        for i in range(diff.shape[0]):
+            line = f"{tc0['time'][i]:15g}"
+            line += f" {tc[loctag][i]:15g}"
+            line += f" {tc0[loctag][i]:15g}"
+            line += f" {diff[i]:15g}"
+            f.write(line + "\n")
 
     if diffmax > dtol:
         test.success = False
@@ -300,14 +299,11 @@ def check_output(test):
     # compare budgets
     cbc_compare(test)
 
-    return
-
 
 # compare cbc and lst budgets
-def cbc_compare(sim):
-    print("evaluating cbc and budget...")
+def cbc_compare(test):
     # open cbc file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.cbc")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.cbc")
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
 
     # build list of cbc data to retrieve
@@ -324,7 +320,7 @@ def cbc_compare(sim):
             bud_lst.append(f"{t}_OUT")
 
     # get results from listing file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.lst")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.lst")
     budl = flopy.utils.Mf6ListBudget(fpth)
     names = list(bud_lst)
     d0 = budl.get_budget(names=names)[0]
@@ -337,7 +333,7 @@ def cbc_compare(sim):
     # get data from cbc dile
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -355,61 +351,60 @@ def cbc_compare(sim):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
     fpth = os.path.join(
-        sim.workspace, f"{os.path.basename(sim.name)}.bud.cmp.out"
+        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     if diffmax > budtol:
-        sim.success = False
+        test.success = False
         msg += f"exceeds {dtol}"
         assert diffmax < dtol, msg
     else:
-        sim.success = True
+        test.success = True
         print("    " + msg)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
         htol=htol[idx],
         compare="mf6_regression",

--- a/autotest/test_gwf_csub_subwt02.py
+++ b/autotest/test_gwf_csub_subwt02.py
@@ -3,10 +3,11 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from conftest import project_root_path
 from framework import TestFramework
 
-ex = ["csub_subwt02a", "csub_subwt02b", "csub_subwt02c", "csub_subwt02d"]
+cases = ["csub_subwt02a", "csub_subwt02b", "csub_subwt02c", "csub_subwt02d"]
 timeseries = [True, False, True, False]
 cmppth = "mf6_regression"
 htol = [None, None, None, None]
@@ -182,7 +183,7 @@ beta = 0.0
 # beta = 4.65120000e-10
 gammaw = 9806.65000000
 sw = beta * gammaw * theta
-ss = [sw for k in range(nlay)]
+ss = [sw for _ in range(nlay)]
 
 swt6 = []
 ibcno = 0
@@ -215,7 +216,7 @@ for k in range(nlay):
 
 
 def get_model(idx, ws):
-    name = ex[idx]
+    name = cases[idx]
 
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
@@ -418,8 +419,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def check_output(test):
-    print("evaluating compaction...")
+def check_output(idx, test):
     # MODFLOW 6 total compaction results
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -474,10 +474,9 @@ def check_output(test):
 
 
 # compare cbc and lst budgets
-def cbc_compare(sim):
-    print("evaluating cbc and budget...")
+def cbc_compare(test):
     # open cbc file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.cbc")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.cbc")
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
 
     # build list of cbc data to retrieve
@@ -494,7 +493,7 @@ def cbc_compare(sim):
             bud_lst.append(f"{t}_OUT")
 
     # get results from listing file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.lst")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.lst")
     budl = flopy.utils.Mf6ListBudget(fpth)
     names = list(bud_lst)
     d0 = budl.get_budget(names=names)[0]
@@ -507,7 +506,7 @@ def cbc_compare(sim):
     # get data from cbc dile
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -525,61 +524,60 @@ def cbc_compare(sim):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
     fpth = os.path.join(
-        sim.workspace, f"{os.path.basename(sim.name)}.bud.cmp.out"
+        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     if diffmax > budtol:
-        sim.success = False
+        test.success = False
         msg += f"exceeds {dtol}"
         assert diffmax < dtol, msg
     else:
-        sim.success = True
+        test.success = True
         print("    " + msg)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
         htol=htol[idx],
         compare="mf6_regression",

--- a/autotest/test_gwf_csub_subwt03.py
+++ b/autotest/test_gwf_csub_subwt03.py
@@ -3,11 +3,12 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from conftest import project_root_path
 from framework import TestFramework
 
-ex = ["csub_subwt03a", "csub_subwt03b", "csub_subwt03c", "csub_subwt03d"]
-nex = len(ex)
+cases = ["csub_subwt03a", "csub_subwt03b", "csub_subwt03c", "csub_subwt03d"]
+nex = len(cases)
 cmppth = "mf6"
 htol = None  # 0.1
 dtol = 1e-3
@@ -28,8 +29,8 @@ nstp = [1, 60, 60]
 tsmult = [1.0, 1.0, 1.0]
 steady = [True, False, False]
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # spatial discretization
 nlay, nrow, ncol = 4, ib0.shape[0], ib0.shape[1]
@@ -56,18 +57,18 @@ sy = [0.3, 0.0, 0.0, 0.0]
 wnlays = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3]
 wnrows = [0, 1, 1, 1, 2, 3, 4, 4, 5, 6, 13, 13, 15, 15, 16, 17, 17, 18, 8, 11]
 wncols = [7, 4, 7, 11, 3, 11, 2, 12, 13, 1, 1, 13, 2, 12, 12, 3, 11, 6, 9, 6]
-wrates0 = [2.2e3 for n in range(18)] + [0.0, 0.0]
-wrates1 = [2.2e3 for n in range(18)] + [-7.2e04, -7.2e04]
+wrates0 = [2.2e3 for _ in range(18)] + [0.0, 0.0]
+wrates1 = [2.2e3 for _ in range(18)] + [-7.2e04, -7.2e04]
 
 w0 = []
 w1 = []
 ws0 = []
 ws1 = []
-for idx, (k, i, j) in enumerate(zip(wnlays, wnrows, wncols)):
-    w0.append((k, i, j, wrates0[idx]))
-    w1.append((k, i, j, wrates1[idx]))
-    ws0.append(((k, i, j), wrates0[idx]))
-    ws1.append(((k, i, j), wrates1[idx]))
+for i, (k, i, j) in enumerate(zip(wnlays, wnrows, wncols)):
+    w0.append((k, i, j, wrates0[i]))
+    w1.append((k, i, j, wrates1[i]))
+    ws0.append(((k, i, j), wrates0[i]))
+    ws1.append(((k, i, j), wrates1[i]))
 wd = {0: w0, 1: w1, 2: w0}
 wd6 = {0: ws0, 1: ws1, 2: ws0}
 
@@ -213,7 +214,7 @@ def build_models(idx, test):
 
 # build MODFLOW 6 files
 def build_mf6(idx, ws, interbed=False):
-    name = ex[idx]
+    name = cases[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
@@ -351,9 +352,7 @@ def build_mf6(idx, ws, interbed=False):
     return sim
 
 
-def check_output(test):
-    print("evaluating compaction...")
-
+def check_output(idx, test):
     # MODFLOW 6 without interbeds
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -383,21 +382,20 @@ def check_output(test):
     fpth = os.path.join(
         test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
     )
-    f = open(fpth, "w")
-    line = f"{'TOTIM':>15s}"
-    for tag in tc.dtype.names[1:]:
-        line += f" {f'{tag}_SK':>15s}"
-        line += f" {f'{tag}_SKIB':>15s}"
-        line += f" {f'{tag}_DIFF':>15s}"
-    f.write(line + "\n")
-    for i in range(diff.shape[0]):
-        line = f"{tc['time'][i]:15g}"
+    with open(fpth, "w") as f:
+        line = f"{'TOTIM':>15s}"
         for tag in tc.dtype.names[1:]:
-            line += f" {tc[tag][i]:15g}"
-            line += f" {tci[tag][i]:15g}"
-            line += f" {tc[tag][i] - tci[tag][i]:15g}"
+            line += f" {f'{tag}_SK':>15s}"
+            line += f" {f'{tag}_SKIB':>15s}"
+            line += f" {f'{tag}_DIFF':>15s}"
         f.write(line + "\n")
-    f.close()
+        for i in range(diff.shape[0]):
+            line = f"{tc['time'][i]:15g}"
+            for tag in tc.dtype.names[1:]:
+                line += f" {tc[tag][i]:15g}"
+                line += f" {tci[tag][i]:15g}"
+                line += f" {tc[tag][i] - tci[tag][i]:15g}"
+            f.write(line + "\n")
 
     if diffmax > dtol:
         test.success = False
@@ -412,10 +410,9 @@ def check_output(test):
 
 
 # compare cbc and lst budgets
-def cbc_compare(sim):
-    print("evaluating cbc and budget...")
+def cbc_compare(test):
     # open cbc file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.cbc")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.cbc")
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
 
     # build list of cbc data to retrieve
@@ -432,7 +429,7 @@ def cbc_compare(sim):
             bud_lst.append(f"{t}_OUT")
 
     # get results from listing file
-    fpth = os.path.join(sim.workspace, f"{os.path.basename(sim.name)}.lst")
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.lst")
     budl = flopy.utils.Mf6ListBudget(fpth)
     names = list(bud_lst)
     d0 = budl.get_budget(names=names)[0]
@@ -445,7 +442,7 @@ def cbc_compare(sim):
     # get data from cbc dile
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -463,54 +460,53 @@ def cbc_compare(sim):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
     fpth = os.path.join(
-        sim.workspace, f"{os.path.basename(sim.name)}.bud.cmp.out"
+        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     if diffmax > budtol:
-        sim.success = False
+        test.success = False
         msg += f"exceeds {dtol}"
         assert diffmax < dtol, msg
     else:
-        sim.success = True
+        test.success = True
         print("    " + msg)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -518,7 +514,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         htol=htol,
     )
     test.run()

--- a/autotest/test_gwf_csub_wtgeo.py
+++ b/autotest/test_gwf_csub_wtgeo.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "csub_wtgeoa",
     "csub_wtgeob",
     "csub_wtgeoc",
@@ -14,19 +15,19 @@ ex = [
     "csub_wtgeof",
     "csub_wtgeog",
 ]
-constantcv = [True for _ in range(len(ex))]
+constantcv = [True for _ in range(len(cases))]
 cmppth = "mf6_regression"
-compare = [True for _ in range(len(ex))]
+compare = [True for _ in range(len(cases))]
 tops = [0.0, 0.0, 150.0, 0.0, 0.0, 150.0, 150.0]
 ump = [None, None, True, None, True, None, True]
 iump = [0, 0, 1, 0, 1, 0, 1]
-eslag = [True for _ in range(len(ex) - 2)] + 2 * [False]
+eslag = [True for _ in range(len(cases) - 2)] + 2 * [False]
 # eslag = [True, True, True, False, True, False, False]
 headformulation = [True, False, False, True, True, False, False]
 ndc = [None, None, None, 19, 19, 19, 19]
 delay = [False, False, False, True, True, True, True]
 # newton = ["", "", "", "", "", None, ""]
-newton = ["NEWTON" for _ in range(len(ex))]
+newton = ["NEWTON" for _ in range(len(cases))]
 
 htol = [None, None, None, 0.2, None, None, None]
 dtol = 1e-3
@@ -36,13 +37,13 @@ paktest = "csub"
 # static model data
 # temporal discretization
 nper = 31
-perlen = [1.0] + [365.2500000 for i in range(nper - 1)]
+perlen = [1.0] + [365.2500000 for _ in range(nper - 1)]
 nstp = [1] + [6 for _ in range(nper - 1)]
 tsmult = [1.0] + [1.3 for _ in range(nper - 1)]
 steady = [True] + [False for _ in range(nper - 1)]
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # spatial discretization data
 nlay, nrow, ncol = 3, 10, 10
@@ -160,7 +161,7 @@ def calc_stress(sgm0, sgs0, h, bt):
 
 
 def get_model(idx, ws):
-    name = ex[idx]
+    name = cases[idx]
 
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
@@ -481,7 +482,6 @@ def build_models(idx, test):
 
 def check_output(idx, test):
     if compare[idx]:
-        print("evaluating compaction...")
         # MODFLOW 6 total compaction results
         fpth = os.path.join(test.workspace, "csub_obs.csv")
         try:
@@ -505,19 +505,18 @@ def check_output(idx, test):
         fpth = os.path.join(
             test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
         )
-        f = open(fpth, "w")
-        line = f"{'TOTIM':>15s}"
-        line += f" {'CSUB':>15s}"
-        line += f" {'MF':>15s}"
-        line += f" {'DIFF':>15s}"
-        f.write(line + "\n")
-        for i in range(diff.shape[0]):
-            line = f"{tc0['time'][i]:15g}"
-            line += f" {tc['TCOMP3'][i]:15g}"
-            line += f" {tc0['TCOMP3'][i]:15g}"
-            line += f" {diff[i]:15g}"
+        with open(fpth, "w") as f:
+            line = f"{'TOTIM':>15s}"
+            line += f" {'CSUB':>15s}"
+            line += f" {'MF':>15s}"
+            line += f" {'DIFF':>15s}"
             f.write(line + "\n")
-        f.close()
+            for i in range(diff.shape[0]):
+                line = f"{tc0['time'][i]:15g}"
+                line += f" {tc['TCOMP3'][i]:15g}"
+                line += f" {tc0['TCOMP3'][i]:15g}"
+                line += f" {diff[i]:15g}"
+                f.write(line + "\n")
 
         if diffmax > dtol:
             test.success = False
@@ -532,7 +531,6 @@ def check_output(idx, test):
 
 
 def cbc_compare(test):
-    print("evaluating cbc and budget...")
     # open cbc file
     fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.cbc")
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")
@@ -564,7 +562,7 @@ def cbc_compare(test):
     # get data from cbc dile
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -582,17 +580,17 @@ def cbc_compare(test):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
@@ -600,22 +598,21 @@ def cbc_compare(test):
     fpth = os.path.join(
         test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     if diffmax > budtol:
         test.success = False
@@ -627,7 +624,7 @@ def cbc_compare(test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_zdisp01.py
+++ b/autotest/test_gwf_csub_zdisp01.py
@@ -4,11 +4,12 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.compare import compare_heads
+
 from framework import TestFramework
 
-ex = ["csub_zdisp01"]
+cases = ["csub_zdisp01"]
 cmppth = "mfnwt"
-htol = [None for _ in range(len(ex))]
+htol = [None for _ in range(len(cases))]
 dtol = 1e-3
 budtol = 1e-2
 bud_lst = [
@@ -29,14 +30,14 @@ bud_lst = [
 # static model data
 # temporal discretization
 nper = 31
-perlen = [1.0] + [365.2500000 for i in range(nper - 1)]
-nstp = [1] + [6 for i in range(nper - 1)]
-tsmult = [1.0] + [1.3 for i in range(nper - 1)]
-# tsmult = [1.0] + [1.0 for i in range(nper - 1)]
-steady = [True] + [False for i in range(nper - 1)]
+perlen = [1.0] + [365.2500000 for _ in range(nper - 1)]
+nstp = [1] + [6 for _ in range(nper - 1)]
+tsmult = [1.0] + [1.3 for _ in range(nper - 1)]
+# tsmult = [1.0] + [1.0 for _ in range(nper - 1)]
+steady = [True] + [False for _ in range(nper - 1)]
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # spatial discretization data
 nlay, nrow, ncol = 3, 20, 20
@@ -192,7 +193,7 @@ ds16 = [0, nper - 1, 0, nstp[-1] - 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1]
 
 # variant SUB package problem 3
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -395,9 +396,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def check_output(test):
-    print("evaluating z-displacement...")
-
+def check_output(idx, test):
     # MODFLOW 6 total compaction results
     fpth = os.path.join(test.workspace, "csub_obs.csv")
     try:
@@ -453,7 +452,7 @@ def check_output(test):
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double", verbose=False)
     kk = cobj.get_kstpkper()
     times = cobj.get_times()
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             qin = 0.0
             qout = 0.0
@@ -471,17 +470,17 @@ def check_output(test):
                             qout -= vv
                         else:
                             qin += vv
-            d["totim"][idx] = t
-            d["time_step"][idx] = k[0]
+            d["totim"][i] = t
+            d["time_step"][i] = k[0]
             d["stress_period"] = k[1]
             key = f"{text}_IN"
-            d[key][idx] = qin
+            d[key][i] = qin
             key = f"{text}_OUT"
-            d[key][idx] = qout
+            d[key][i] = qout
 
     diff = np.zeros((nbud, len(bud_lst)), dtype=float)
-    for idx, key in enumerate(bud_lst):
-        diff[:, idx] = d0[key] - d[key]
+    for i, key in enumerate(bud_lst):
+        diff[:, i] = d0[key] - d[key]
     diffmax = np.abs(diff).max()
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
@@ -489,22 +488,21 @@ def check_output(test):
     fpth = os.path.join(
         test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
     )
-    f = open(fpth, "w")
-    for i in range(diff.shape[0]):
-        if i == 0:
-            line = f"{'TIME':>10s}"
-            for idx, key in enumerate(bud_lst):
-                line += f"{key + '_LST':>25s}"
-                line += f"{key + '_CBC':>25s}"
-                line += f"{key + '_DIF':>25s}"
+    with open(fpth, "w") as f:
+        for i in range(diff.shape[0]):
+            if i == 0:
+                line = f"{'TIME':>10s}"
+                for key in bud_lst:
+                    line += f"{key + '_LST':>25s}"
+                    line += f"{key + '_CBC':>25s}"
+                    line += f"{key + '_DIF':>25s}"
+                f.write(line + "\n")
+            line = f"{d['totim'][i]:10g}"
+            for ii, key in enumerate(bud_lst):
+                line += f"{d0[key][i]:25g}"
+                line += f"{d[key][i]:25g}"
+                line += f"{diff[i, ii]:25g}"
             f.write(line + "\n")
-        line = f"{d['totim'][i]:10g}"
-        for idx, key in enumerate(bud_lst):
-            line += f"{d0[key][i]:25g}"
-            line += f"{d[key][i]:25g}"
-            line += f"{diff[i, idx]:25g}"
-        f.write(line + "\n")
-    f.close()
 
     if diffmax > budtol:
         test.success = False
@@ -550,7 +548,7 @@ def check_output(test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -558,7 +556,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         htol=htol[idx],
         verbose=False,
     )

--- a/autotest/test_gwf_disu.py
+++ b/autotest/test_gwf_disu.py
@@ -12,13 +12,14 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.gridutil import get_disu_kwargs
+
 from framework import TestFramework
 
-ex = ["disu01a", "disu01b"]
+cases = ["disu01a", "disu01b"]
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
     ws = test.workspace
     nlay = 3
     nrow = 3
@@ -60,8 +61,6 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     name = test.name
 
     fname = os.path.join(test.workspace, name + ".disu.grb")
@@ -78,7 +77,7 @@ def check_output(idx, test):
         assert ja.shape[0] == 126, "ja should have size of 126"
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_disv.py
+++ b/autotest/test_gwf_disv.py
@@ -13,13 +13,14 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.gridutil import get_disv_kwargs
+
 from framework import TestFramework
 
-ex = ["disv01a", "disv01b"]
+cases = ["disv01a", "disv01b"]
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
     ws = test.workspace
     nlay = 3
     nrow = 3
@@ -65,8 +66,6 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     name = test.name
 
     fname = os.path.join(test.workspace, name + ".disv.grb")
@@ -84,7 +83,7 @@ def check_output(idx, test):
         assert ja.shape[0] == 126, "ja should have size of 126"
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_evt01.py
+++ b/autotest/test_gwf_evt01.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["evt01"]
+cases = ["evt01"]
 
 
 def build_models(idx, test):
@@ -26,7 +27,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -151,9 +152,7 @@ def etfunc(h, qmax, surf, exdp, petm, pxdp, petm0=1.0):
     return q, hcof, rhs
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     fpth = os.path.join(test.workspace, "evt01.cbc")
     bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
     records = bobj.get_data(text="evt")
@@ -177,7 +176,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -185,6 +184,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_evt02.py
+++ b/autotest/test_gwf_evt02.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["evt02"]
+cases = ["evt02"]
 
 
 def build_models(idx, test):
@@ -26,7 +27,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -149,9 +150,7 @@ def etfunc(h, qmax, surf, exdp, petm, pxdp, petm0=1.0):
     return q, hcof, rhs
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     # The nature of the bug is that the model crashes with nseg=1
     fpth = os.path.join(test.workspace, "evt02.cbc")
     assert os.path.isfile(fpth), "model did not run with nseg=1 in EVT input"
@@ -159,7 +158,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -167,6 +166,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_henry_nr.py
+++ b/autotest/test_gwf_henry_nr.py
@@ -10,10 +10,11 @@ the effects of tides on the aquifer.
 import flopy
 import numpy as np
 import pytest
+
 from conftest import should_compare
 from framework import TestFramework
 
-ex = ["gwf_henrynr01"]
+cases = ["gwf_henrynr01"]
 
 # global model variables
 nlay = 20
@@ -68,7 +69,7 @@ def sinfunc(a, b, c, d, x):
 
 def build_models(idx, test):
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     nrow = 1
     delr = lx / ncol
@@ -235,7 +236,7 @@ def build_models(idx, test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     name = "gwf-henry-nr"
@@ -245,7 +246,9 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        compare="mf6_regression" if should_compare(name, comparisons, targets) else "auto",
+        compare="mf6_regression"
+        if should_compare(name, comparisons, targets)
+        else "auto",
         verbose=False,
     )
     test.run()

--- a/autotest/test_gwf_ifmod_buy.py
+++ b/autotest/test_gwf_ifmod_buy.py
@@ -1,33 +1,36 @@
+"""
+General test for the interface model approach.
+It compares the result of a single reference model
+to the equivalent case where the domain is decomposed
+and joined by a GWF-GWF exchange.
+
+       'refmodel'              'leftmodel'     'rightmodel'
+
+   1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
+   1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
+   1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
+   1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
+   1 1 1 1 1 1 1 1 1 1    VS    1 1 1 1 1   +   1 1 1 1 1
+   1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
+   1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
+   1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
+   1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
+   1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
+
+We assert equality on the head values and the (components of)
+specific discharges. All models are part of the same solution
+for convenience. Finally, the budget error is checked.
+"""
+
 import os
 
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-# General test for the interface model approach.
-# It compares the result of a single reference model
-# to the equivalent case where the domain is decomposed
-# and joined by a GWF-GWF exchange.
-#
-#        'refmodel'              'leftmodel'     'rightmodel'
-#
-#    1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
-#    1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
-#    1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
-#    1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
-#    1 1 1 1 1 1 1 1 1 1    VS    1 1 1 1 1   +   1 1 1 1 1
-#    1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
-#    1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
-#    1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
-#    1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
-#    1 1 1 1 1 1 1 1 1 1          1 1 1 1 1       1 1 1 1 1
-#
-# We assert equality on the head values and the (components of)
-# specific discharges. All models are part of the same solution
-# for convenience. Finally, the budget error is checked.
-
-ex = ["ifmod_buy01"]
+cases = ["ifmod_buy01"]
 
 # some global convenience...:
 # model names
@@ -83,7 +86,7 @@ porosity = 0.30
 
 
 def get_model(idx, dir):
-    name = ex[idx]
+    name = cases[idx]
 
     # parameters and spd
     # tdis
@@ -534,7 +537,7 @@ def qxqyqz(fname, nlay, nrow, ncol):
     return qx, qy, qz
 
 
-def check_output(test):
+def check_output(idx, test):
     print("comparing heads and spec. discharge to single model reference...")
 
     fpth = os.path.join(test.workspace, f"{mname_ref}.hds")
@@ -638,7 +641,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
@@ -647,6 +650,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_ifmod_idomain.py
+++ b/autotest/test_gwf_ifmod_idomain.py
@@ -1,10 +1,3 @@
-import os
-
-import flopy
-import numpy as np
-import pytest
-from framework import TestFramework
-
 """
 General test for the interface model approach.
 It compares the result of a single reference model
@@ -23,7 +16,15 @@ We assert equality on the head values. All models are part of a single
 solution for convenience. Finally, the budget error is checked.
 """
 
-ex = ["ifmod_ibound"]
+import os
+
+import flopy
+import numpy as np
+import pytest
+
+from framework import TestFramework
+
+cases = ["ifmod_ibound"]
 
 # some global convenience...:
 # model names
@@ -104,7 +105,7 @@ chd_spd_right = {0: rchd_right}
 
 
 def get_model(idx, dir):
-    name = ex[idx]
+    name = cases[idx]
 
     # parameters and spd
     # tdis
@@ -329,7 +330,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
+def check_output(idx, test):
     print("comparing heads to single model reference...")
 
     fpth = os.path.join(test.workspace, f"{mname_ref}.hds")
@@ -374,7 +375,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
@@ -382,7 +383,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_ifmod_mult_exg.py
+++ b/autotest/test_gwf_ifmod_mult_exg.py
@@ -26,9 +26,10 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.lgrutil import Lgr
+
 from framework import TestFramework
 
-ex = ["ifmod_mult_exg"]
+cases = ["ifmod_mult_exg"]
 name_parent = "parent"
 name_child = "child"
 g_delr = 10.0
@@ -39,7 +40,7 @@ g_hclose = 10e-12
 
 
 def get_model(idx, dir):
-    name = ex[idx]
+    name = cases[idx]
 
     # parameters and spd
     # tdis
@@ -259,7 +260,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
+def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{name_parent}.hds")
     hds = flopy.utils.HeadFile(fpth)
     heads = hds.get_data()
@@ -330,7 +331,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
@@ -339,6 +340,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_ifmod_newton.py
+++ b/autotest/test_gwf_ifmod_newton.py
@@ -27,9 +27,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["ifmod_newton01"]
+cases = ["ifmod_newton01"]
 
 # some global convenience...:
 # model names
@@ -111,7 +112,7 @@ chd_spd_right[1] = rchd_right
 
 
 def get_model(idx, ws):
-    name = ex[idx]
+    name = cases[idx]
 
     # parameters and spd
     # tdis
@@ -345,7 +346,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
+def check_output(idx, test):
     print("comparing heads to single model reference...")
 
     fpth = os.path.join(test.workspace, f"{mname_ref}.hds")
@@ -386,7 +387,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
@@ -395,6 +396,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_ifmod_rewet.py
+++ b/autotest/test_gwf_ifmod_rewet.py
@@ -29,9 +29,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["ifmod_rewet01"]
+cases = ["ifmod_rewet01"]
 
 # some global convenience...:
 # model names
@@ -117,7 +118,7 @@ wetdry = -0.001
 
 
 def get_model(idx, dir):
-    name = ex[idx]
+    name = cases[idx]
 
     # parameters and spd
     # tdis
@@ -354,7 +355,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
+def check_output(idx, test):
     print("comparing heads to single model reference...")
 
     fpth = os.path.join(test.workspace, f"{mname_ref}.hds")
@@ -407,7 +408,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
@@ -415,7 +416,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_ifmod_vert.py
+++ b/autotest/test_gwf_ifmod_vert.py
@@ -36,9 +36,10 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.lgrutil import Lgr
+
 from framework import TestFramework
 
-ex = ["ifmod_vert"]
+cases = ["ifmod_vert"]
 
 parent_name = "parent"
 child_name = "child"
@@ -54,7 +55,7 @@ def get_model(idx, dir):
     global child_domain
     global hclose
 
-    name = ex[idx]
+    name = cases[idx]
 
     # tdis period data
     nper = 1
@@ -238,7 +239,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
+def check_output(idx, test):
     print("comparing heads  for child model to analytical result...")
 
     fpth = os.path.join(test.workspace, f"{child_name}.hds")
@@ -282,7 +283,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
@@ -291,6 +292,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_ifmod_xt3d01.py
+++ b/autotest/test_gwf_ifmod_xt3d01.py
@@ -30,9 +30,10 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.lgrutil import Lgr
+
 from framework import TestFramework
 
-ex = ["ifmod_xt3d01"]
+cases = ["ifmod_xt3d01"]
 
 # globally for convenience...
 useXT3D = True
@@ -52,7 +53,7 @@ def get_model(idx, dir):
     global child_domain
     global hclose
 
-    name = ex[idx]
+    name = cases[idx]
 
     # tdis period data
     nper = 1
@@ -300,7 +301,7 @@ def qxqyqz(fname, nlay, nrow, ncol):
     return qx, qy, qz
 
 
-def check_output(test):
+def check_output(idx, test):
     print("comparing heads and spec. discharges to analytical result...")
 
     fpth = os.path.join(test.workspace, f"{parent_name}.hds")
@@ -477,7 +478,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -485,6 +486,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_ifmod_xt3d02.py
+++ b/autotest/test_gwf_ifmod_xt3d02.py
@@ -30,20 +30,20 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["ifmod_xt3d02"]
+cases = ["ifmod_xt3d02"]
 mname_ref = "refmodel"
 mname_left = "leftmodel"
 mname_right = "rightmodel"
 hclose_check = 1e-9
 max_inner_it = 300
-
 useXT3D = True
 
 
 def get_model(idx, dir):
-    name = ex[idx]
+    name = cases[idx]
 
     # parameters and spd
     # tdis
@@ -309,7 +309,7 @@ def qxqyqz(fname, nlay, nrow, ncol):
     return qx, qy, qz
 
 
-def check_output(test):
+def check_output(idx, test):
     print("comparing heads and spec. discharge to single model reference...")
 
     fpth = os.path.join(test.workspace, f"{mname_ref}.hds")
@@ -413,7 +413,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -421,6 +421,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_ims_rcm_reorder.py
+++ b/autotest/test_gwf_ims_rcm_reorder.py
@@ -3,10 +3,11 @@ import os
 import flopy
 import pytest
 from flopy.utils.compare import eval_bud_diff
+
 from framework import TestFramework
 
 paktest = "ims"
-ex = ["ims_rcm"]
+cases = ["ims_rcm"]
 cmp_prefix = "mf6"
 
 # spatial discretization data
@@ -26,7 +27,7 @@ def build_model(idx, ws):
     tdis_rc = [(1.0, 1, 1.0)]
 
     # build MODFLOW 6 files
-    name = ex[idx]
+    name = cases[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         version="mf6",
@@ -117,10 +118,8 @@ def build_models(idx, test):
     )
 
 
-def check_output(test):
+def check_output(idx, test):
     name = test.name
-    print("evaluating flow results..." f"({name})")
-
     fpth = os.path.join(test.workspace, f"{name}.dis.grb")
     ia = flopy.mf6.utils.MfGrdFile(fpth).ia
 
@@ -140,7 +139,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -148,6 +147,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_lak_bedleak.py
+++ b/autotest/test_gwf_lak_bedleak.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import DNODATA, TestFramework
 
-ex = ["bedleak", "bedleak_fail", "bedleak_none"]
+cases = ["bedleak", "bedleak_fail", "bedleak_none"]
 
 
 def build_models(idx, test):
@@ -32,7 +33,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -152,9 +153,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating model...")
-
-    name = ex[idx]
+    name = cases[idx]
 
     # lak budget
     if "fail" not in name:
@@ -169,7 +168,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_lak_wetlakbedarea01.py
+++ b/autotest/test_gwf_lak_wetlakbedarea01.py
@@ -12,9 +12,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["lak-1cellkbd"]
+cases = ["lak-1cellkbd"]
 
 # Model units
 length_units = "feet"
@@ -153,7 +154,7 @@ def calc_qSat(top, bot, thk):
 def build_models(idx, test):
     # Base simulation and model name and workspace
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     print("Building model...{}".format(name))
 
@@ -349,10 +350,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # read flow results from model
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf-" + name
 
     # read flow results from model
@@ -368,8 +367,8 @@ def check_output(idx, test):
     lkstg_val = lkstg["STAGE"].tolist()
 
     # Store only the values at the end of the time step
-    idx = [i for i, val in enumerate(lkstg_time) if not val.is_integer()]
-    for i in idx[::-1]:
+    indices = [i for i, val in enumerate(lkstg_time) if not val.is_integer()]
+    for i in indices[::-1]:
         lkstg_time.pop(i)
         lkstg_val.pop(i)
 
@@ -444,7 +443,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_lak_wetlakbedarea02.py
+++ b/autotest/test_gwf_lak_wetlakbedarea02.py
@@ -1,16 +1,19 @@
-# An adaptation of the LAK package problem 1 supplemented with an additional
-# layer that has variable thinkness to help test that the shared wetted area
-# between a lakebed and groundwater cells in contact with the lake are written
-# to the LAK cbc output file correctly.
+"""
+An adaptation of the LAK package problem 1 supplemented with an additional
+layer that has variable thinkness to help test that the shared wetted area
+between a lakebed and groundwater cells in contact with the lake are written
+to the LAK cbc output file correctly.
+"""
 
 import os
 
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["lak-wetlkbd"]
+cases = ["lak-wetlkbd"]
 
 # Model units
 length_units = "feet"
@@ -203,7 +206,7 @@ def calc_qSat(top, bot, thk):
 def build_models(idx, test):
     # Base simulation and model name and workspace
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     print("Building model...{}".format(name))
 
@@ -330,10 +333,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # read flow results from model
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf-" + name
 
     # read flow results from model
@@ -374,7 +375,7 @@ def check_output(idx, test):
         "The wetted interfacial areas saved in the binary output file "
         "(.cbc) do not match the values calculated in the autotest script"
     )
-    for idx, itm in enumerate(lak_con):
+    for ii, itm in enumerate(lak_con):
         k, i, j = itm[2]
         ctype = itm[3]
         if ctype[0] == "h":
@@ -394,12 +395,12 @@ def check_output(idx, test):
             width = delc[i]
             warea = length * width
 
-        assert np.isclose(warea, checks_out[idx], atol=1e-5), msg
+        assert np.isclose(warea, checks_out[ii], atol=1e-5), msg
 
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_laket.py
+++ b/autotest/test_gwf_laket.py
@@ -2,15 +2,14 @@
 
 
 import os
-import shutil
-import sys
 
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "gwf_laket01",
     "gwf_laket02",
     "gwf_laket03",
@@ -22,7 +21,7 @@ lakestage = [6.0, 5.0, 6.0]
 
 
 def get_model(idx, ws):
-    name = ex[idx]
+    name = cases[idx]
     nlay = 1
     nrow = 1
     ncol = 1
@@ -181,8 +180,6 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    msg = "Evaluating Lake ET. "
-
     fpth = os.path.join(test.workspace, f"{test.name}.lak.obs.csv")
     try:
         tc = np.genfromtxt(fpth, names=True, delimiter=",")
@@ -297,7 +294,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_lakobs01.py
+++ b/autotest/test_gwf_lakobs01.py
@@ -13,7 +13,7 @@ import flopy
 import numpy as np
 import pytest
 
-ex = "gwf_lakobs_01a"
+cases = "gwf_lakobs_01a"
 gwf = None
 
 
@@ -52,7 +52,7 @@ def build_model(dir, exe):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex
+    name = cases
 
     # build MODFLOW 6 files
     sim = flopy.mf6.MFSimulation(
@@ -228,8 +228,8 @@ def test_mf6model(function_tmpdir, targets):
     )
 
     # fix the error and attempt to rerun model
-    orig_fl = str(function_tmpdir / (ex + ".lak.obs"))
-    new_fl = str(function_tmpdir / (ex + ".lak.obs.new"))
+    orig_fl = str(function_tmpdir / (cases + ".lak.obs"))
+    new_fl = str(function_tmpdir / (cases + ".lak.obs.new"))
     sr = open(orig_fl, "r")
     sw = open(new_fl, "w")
 

--- a/autotest/test_gwf_libmf6_evt01.py
+++ b/autotest/test_gwf_libmf6_evt01.py
@@ -8,10 +8,11 @@ import os
 import flopy
 import numpy as np
 import pytest
-from framework import TestFramework
 from modflowapi import ModflowApi
 
-ex = ["libgwf_evt01"]
+from framework import TestFramework
+
+cases = ["libgwf_evt01"]
 
 # et variables
 et_max = 0.1
@@ -128,7 +129,7 @@ def get_model(ws, name, bmi=False):
 def build_models(idx, test):
     # build MODFLOW 6 files
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
     sim = get_model(ws, name)
 
     # build comparison model
@@ -150,7 +151,7 @@ def head2et_wellrate(h):
 
 
 def api_func(exe, idx, model_ws=None):
-    name = ex[idx].upper()
+    name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."
     output_file_path = os.path.join(model_ws, "mfsim.stdout")
@@ -251,7 +252,7 @@ def api_func(exe, idx, model_ws=None):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_ghb01.py
+++ b/autotest/test_gwf_libmf6_ghb01.py
@@ -9,10 +9,11 @@ import os
 import flopy
 import numpy as np
 import pytest
-from framework import TestFramework
 from modflowapi import ModflowApi
 
-ex = ["libgwf_ghb01"]
+from framework import TestFramework
+
+cases = ["libgwf_ghb01"]
 
 # temporal discretization
 nper = 10
@@ -162,7 +163,7 @@ def get_model(ws, name, api=False):
 def build_models(idx, test):
     # build MODFLOW 6 files
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
     sim = get_model(ws, name)
 
     # build comparison model with zeroed values
@@ -179,7 +180,7 @@ def api_ghb_pak(hcof, rhs):
 
 
 def api_func(exe, idx, model_ws=None):
-    name = ex[idx].upper()
+    name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."
     output_file_path = os.path.join(model_ws, "mfsim.stdout")
@@ -274,7 +275,7 @@ def api_func(exe, idx, model_ws=None):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_ifmod01.py
+++ b/autotest/test_gwf_libmf6_ifmod01.py
@@ -15,12 +15,11 @@ import os
 
 import flopy
 import pytest
-from framework import TestFramework
 from modflowapi import ModflowApi
 
-ex = ["libgwf_ifmod01"]
+from framework import TestFramework
 
-# global convenience...
+cases = ["libgwf_ifmod01"]
 name_left = "leftmodel"
 name_right = "rightmodel"
 
@@ -197,7 +196,7 @@ def get_model(dir, name):
 def build_models(idx, test):
     # build MODFLOW 6 files
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
     sim = get_model(ws, name)
 
     # build comparison model
@@ -306,7 +305,7 @@ def check_interface_models(mf6):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_ifmod02.py
+++ b/autotest/test_gwf_libmf6_ifmod02.py
@@ -40,10 +40,11 @@ import os
 import flopy
 import numpy as np
 import pytest
-from framework import TestFramework
 from modflowapi import ModflowApi
 
-ex = ["libgwf_ifmod02"]
+from framework import TestFramework
+
+cases = ["libgwf_ifmod02"]
 
 # global convenience...
 name_tl = "topleft"
@@ -291,7 +292,7 @@ def get_model(dir, name):
 def build_models(idx, test):
     # build MODFLOW 6 files
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
     sim = get_model(ws, name)
 
     # build comparison model
@@ -402,7 +403,7 @@ def check_interface_models(mf6):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):

--- a/autotest/test_gwf_libmf6_ifmod03.py
+++ b/autotest/test_gwf_libmf6_ifmod03.py
@@ -30,10 +30,11 @@ import os
 import flopy
 import numpy as np
 import pytest
-from framework import TestFramework
 from modflowapi import ModflowApi
 
-ex = ["libgwf_ifmod03"]
+from framework import TestFramework
+
+cases = ["libgwf_ifmod03"]
 
 # global convenience...
 name_left = "left"
@@ -46,7 +47,7 @@ def get_model(dir, name):
     # tdis
     nper = 1
     tdis_rc = []
-    for i in range(nper):
+    for _ in range(nper):
         tdis_rc.append((1.0, 1, 1))
 
     # solver data
@@ -208,7 +209,7 @@ def get_model(dir, name):
 def build_models(idx, test):
     # build MODFLOW 6 files
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
     sim = get_model(ws, name)
 
     # build comparison model
@@ -288,7 +289,7 @@ def check_interface_models(mf6):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_rch01.py
+++ b/autotest/test_gwf_libmf6_rch01.py
@@ -12,10 +12,11 @@ import os
 import flopy
 import numpy as np
 import pytest
-from framework import TestFramework
 from modflowapi import ModflowApi
 
-ex = ["libgwf_rch01"]
+from framework import TestFramework
+
+cases = ["libgwf_rch01"]
 
 # recharge package name
 rch_pname = "RCH-1"
@@ -136,7 +137,7 @@ def get_model(ws, name, rech):
 def build_models(idx, test):
     # build MODFLOW 6 files
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
     sim = get_model(ws, name, rech=rch_spd)
 
     # build comparison model
@@ -147,7 +148,7 @@ def build_models(idx, test):
 
 
 def api_func(exe, idx, model_ws=None):
-    name = ex[idx].upper()
+    name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."
 
@@ -231,7 +232,7 @@ def api_func(exe, idx, model_ws=None):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_rch02.py
+++ b/autotest/test_gwf_libmf6_rch02.py
@@ -9,10 +9,11 @@ import os
 import flopy
 import numpy as np
 import pytest
-from framework import TestFramework
 from modflowapi import ModflowApi
 
-ex = ["libgwf_rch02"]
+from framework import TestFramework
+
+cases = ["libgwf_rch02"]
 
 # recharge package name
 rch_pname = "RCH-1"
@@ -154,7 +155,7 @@ def get_model(ws, name, exe, rech=rch_spd):
 def build_models(idx, test):
     # build MODFLOW 6 files
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
     sim = get_model(ws, name, "mf6")
 
     # build comparison model
@@ -182,7 +183,7 @@ def run_perturbation(mf6, max_iter, recharge, tag, rch):
 def api_func(exe, idx, model_ws=None):
     print("\nBMI implementation test:")
 
-    name = ex[idx].upper()
+    name = cases[idx].upper()
     init_wd = os.path.abspath(os.getcwd())
     if model_ws is not None:
         os.chdir(model_ws)
@@ -190,7 +191,7 @@ def api_func(exe, idx, model_ws=None):
     output_file_path = os.path.join(model_ws, "mfsim.stdout")
 
     # get the observations from the standard run
-    fpth = os.path.join("..", f"{ex[idx]}.head.obs.csv")
+    fpth = os.path.join("..", f"{cases[idx]}.head.obs.csv")
     hobs = np.genfromtxt(fpth, delimiter=",", names=True)["H1_6_6"]
 
     try:
@@ -306,7 +307,7 @@ def api_func(exe, idx, model_ws=None):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_riv01.py
+++ b/autotest/test_gwf_libmf6_riv01.py
@@ -7,10 +7,11 @@ import os
 import flopy
 import numpy as np
 import pytest
-from framework import TestFramework
 from modflowapi import ModflowApi
 
-ex = ["libgwf_riv01"]
+from framework import TestFramework
+
+cases = ["libgwf_riv01"]
 
 # temporal discretization
 nper = 10
@@ -130,7 +131,7 @@ def get_model(ws, name, riv_spd):
 def build_models(idx, test):
     # build MODFLOW 6 files
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     # create river data
     rd = [
@@ -152,7 +153,7 @@ def build_models(idx, test):
 
 
 def api_func(exe, idx, model_ws=None):
-    name = ex[idx].upper()
+    name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."
 
@@ -247,7 +248,7 @@ def api_func(exe, idx, model_ws=None):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_riv02.py
+++ b/autotest/test_gwf_libmf6_riv02.py
@@ -7,10 +7,11 @@ import os
 import flopy
 import numpy as np
 import pytest
-from framework import TestFramework
 from modflowapi import ModflowApi
 
-ex = ["libgwf_riv02"]
+from framework import TestFramework
+
+cases = ["libgwf_riv02"]
 
 # temporal discretization
 nper = 10
@@ -133,7 +134,7 @@ def get_model(ws, name, riv_spd, api=False):
 def build_models(idx, test):
     # build MODFLOW 6 files
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     # create river data
     rd = [
@@ -166,7 +167,7 @@ def api_riv_pak(stage, h, hcof, rhs):
 
 
 def api_func(exe, idx, model_ws=None):
-    name = ex[idx].upper()
+    name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."
 
@@ -272,7 +273,7 @@ def api_func(exe, idx, model_ws=None):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_sto01.py
+++ b/autotest/test_gwf_libmf6_sto01.py
@@ -9,10 +9,11 @@ import os
 import flopy
 import numpy as np
 import pytest
-from framework import TestFramework
 from modflowapi import ModflowApi
 
-ex = ["libgwf_sto01"]
+from framework import TestFramework
+
+cases = ["libgwf_sto01"]
 
 # average recharge rate
 avg_rch = 0.001
@@ -139,7 +140,7 @@ def get_model(ws, name, sy):
 def build_models(idx, test):
     # build MODFLOW 6 files
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
     sim = get_model(ws, name, sy=sy_val)
 
     # build comparison model
@@ -150,7 +151,7 @@ def build_models(idx, test):
 
 
 def api_func(exe, idx, model_ws=None):
-    name = ex[idx].upper()
+    name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."
 
@@ -208,7 +209,7 @@ def api_func(exe, idx, model_ws=None):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_maw02.py
+++ b/autotest/test_gwf_maw02.py
@@ -1,14 +1,24 @@
 import os
-from types import SimpleNamespace as Case
+from types import SimpleNamespace
 
 import flopy
 import numpy as np
 import pytest
 
+cases = ["maw02"]
 budtol = 1e-2
 bud_lst = ["GWF_IN", "GWF_OUT", "RATE_IN", "RATE_OUT"]
-
-well2 = Case(
+krylov = "CG"
+nlay = 1
+nrow = 1
+ncol = 3
+nper = 5
+delr = 300
+delc = 300
+perlen = 5 * [1]
+nstp = 5 * [1]
+tsmult = 5 * [1]
+well = SimpleNamespace(
     observations={"maw_obs.csv": [("mh1", "head", 1)]},
     packagedata=[
         [0, 0.1, 0.0, 100.0, "THIEM", 1],
@@ -37,19 +47,6 @@ well2 = Case(
         4: [[0, "status", "active"]],
     },
 )
-
-ex = ["maw02"]
-krylov = "CG"
-nlay = 1
-nrow = 1
-ncol = 3
-nper = 5
-delr = 300
-delc = 300
-perlen = 5 * [1]
-nstp = 5 * [1]
-tsmult = 5 * [1]
-well = well2
 strt = 100
 hk = 1
 nouter = 100
@@ -61,7 +58,7 @@ compare = False
 
 
 def build_model(idx, ws, mf6):
-    name = ex[idx]
+    name = cases[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name=mf6, sim_ws=ws
     )
@@ -182,8 +179,6 @@ def build_model(idx, ws, mf6):
 
 
 def eval_results(name, workspace):
-    print("evaluating MAW budgets...")
-
     shape3d = (nlay, nrow, ncol)
     size3d = nlay * nrow * ncol
 
@@ -285,7 +280,7 @@ def eval_results(name, workspace):
     assert diffv < budtol, msg + f"diffv {diffv} exceeds tolerance {budtol}"
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, function_tmpdir, targets):
     ws = str(function_tmpdir)
     sim, _ = build_model(idx, ws, targets.mf6)

--- a/autotest/test_gwf_maw04.py
+++ b/autotest/test_gwf_maw04.py
@@ -1,5 +1,5 @@
 import os
-from types import SimpleNamespace as Case
+from types import SimpleNamespace
 
 import flopy
 import numpy as np
@@ -91,7 +91,7 @@ def well4(label):
         [0, 1, (1, nhalf, nhalf), botm[0], botm[1], hks, sradius[label]],
     ]
     perioddata = {1: [[0, "RATE", wellq]]}
-    return Case(
+    return SimpleNamespace(
         print_input=True,
         no_well_storage=True,
         packagedata=packagedata,

--- a/autotest/test_gwf_maw05.py
+++ b/autotest/test_gwf_maw05.py
@@ -10,9 +10,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["maw_05a", "maw_05b", "maw_05c"]
+cases = ["maw_05a", "maw_05b", "maw_05c"]
 mawstrt = [4.0, 3.5, 2.5]  # add 3.0
 
 
@@ -43,7 +44,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 10
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -179,10 +180,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # calculate volume of water and make sure it is conserved
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf_" + name
     fname = gwfname + ".maw.bin"
     fname = os.path.join(test.workspace, fname)
@@ -243,7 +242,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_maw06.py
+++ b/autotest/test_gwf_maw06.py
@@ -9,9 +9,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["maw_06a", "maw_06b"]
+cases = ["maw_06a", "maw_06b"]
 
 nlay = 2
 nrow = 1
@@ -61,7 +62,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 200
     hclose, rclose, relax = 1e-9, 1e-9, 1.0
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -199,10 +200,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # calculate volume of water and make sure it is conserved
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf_" + name
     fname = gwfname + ".maw.bin"
     fname = os.path.join(test.workspace, fname)
@@ -282,7 +281,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_maw07.py
+++ b/autotest/test_gwf_maw07.py
@@ -9,9 +9,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["maw_07a", "maw_07b"]
+cases = ["maw_07a", "maw_07b"]
 
 nlay = 2
 nrow = 1
@@ -61,7 +62,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 200
     hclose, rclose, relax = 1e-9, 1e-9, 1.0
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -201,10 +202,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # calculate volume of water and make sure it is conserved
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf_" + name
     fname = gwfname + ".maw.bin"
     fname = os.path.join(test.workspace, fname)
@@ -288,7 +287,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_maw08.py
+++ b/autotest/test_gwf_maw08.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ("maw_08a", "maw_08b")
+cases = ("maw_08a", "maw_08b")
 dis_option = ("dis", "disv")
 
 nlay = 3
@@ -46,7 +47,7 @@ radius = 0.05
 def build_models(idx, test):
     dvclose, rclose, relax = 1e-9, 1e-9, 1.0
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -196,10 +197,8 @@ def build_models(idx, test):
 
 
 def eval_results(idx, test):
-    print("evaluating results...")
-
     # calculate volume of water and make sure it is conserved
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf_" + name
     fname = gwfname + ".maw.bin"
     fname = os.path.join(test.workspace, fname)
@@ -243,7 +242,7 @@ def eval_results(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_maw09.py
+++ b/autotest/test_gwf_maw09.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ("maw_09a", "maw_09b", "maw_09c", "maw_09d")
+cases = ("maw_09a", "maw_09b", "maw_09c", "maw_09d")
 dis_option = ("dis", "dis", "disv", "disv")
 flow_correction = (None, True, None, True)
 
@@ -48,7 +49,7 @@ radius = np.sqrt(1.0 / np.pi)
 def build_models(idx, test):
     dvclose, rclose, relax = 1e-9, 1e-9, 1.0
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -222,9 +223,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf_" + name
 
     # get well observations
@@ -243,10 +242,10 @@ def check_output(idx, test):
     # volume comparisons can be made based on saturated thickness because
     # the cell area and well area are both equal to 1
     v0 = (maw_strt - 10.0) + (strt - 0.0)
-    for idx, w in enumerate(wobs):
+    for i, w in enumerate(wobs):
         vg = 0.0
         for jdx, tag in enumerate(("C1", "C2", "C3")):
-            g = gobs[tag][idx]
+            g = gobs[tag][i]
             ctop = zelevs[jdx]
             cbot = zelevs[jdx + 1]
             if g > ctop:
@@ -260,7 +259,7 @@ def check_output(idx, test):
         vt = vw + vg
 
         # write a message
-        msg = f"{idx}\n  well volume: {vw} "
+        msg = f"{i}\n  well volume: {vw} "
         msg += f"\n  groundwater volume: {vg}"
         msg += f"\n  total volume: {vt}"
         print(msg)
@@ -308,7 +307,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_maw10.py
+++ b/autotest/test_gwf_maw10.py
@@ -11,9 +11,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["maw10a", "maw10b", "maw10c", "maw10d"]
+cases = ["maw10a", "maw10b", "maw10c", "maw10d"]
 mawsetting_a = {
     0: [
         [0, "rate", -2000.0],
@@ -78,7 +79,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -209,11 +210,9 @@ def build_models(idx, test):
 # 1. within the .maw-reduction.csv file, do values of actual + reduction = requested?
 # 2. do the values in .maw-reduction.csv file match with the .maw.obs.csv file at each time
 #  (and all are reduction times present in the obs file)?
-def eval_results(idx, test):
-    print("evaluating MAW flow reduction outputs...")
-
+def check_output(idx, test):
     # MODFLOW 6 maw results
-    name = ex[idx]
+    name = cases[idx]
     fpthobs = os.path.join(test.workspace, f"{name}.maw.obs.csv")
     fpthmfr = os.path.join(test.workspace, f"{name}.maw-reduction.csv")
     try:
@@ -264,14 +263,14 @@ def eval_results(idx, test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=lambda t: eval_results(idx, t),
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_maw_obs.py
+++ b/autotest/test_gwf_maw_obs.py
@@ -11,7 +11,7 @@ import os
 import flopy
 
 newtonoptions = [None, "NEWTON", "NEWTON UNDER_RELAXATION"]
-ex = "maw_obs"
+cases = "maw_obs"
 
 
 def build_model(dir, exe):
@@ -35,7 +35,7 @@ def build_model(dir, exe):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex
+    name = cases
 
     # build MODFLOW 6 files
     ws = dir
@@ -188,8 +188,8 @@ def test_mf6model(function_tmpdir, targets):
     )
 
     # fix the error and attempt to rerun model
-    orig_fl = str(function_tmpdir / (ex + ".maw.obs"))
-    new_fl = str(function_tmpdir / (ex + ".maw.obs.new"))
+    orig_fl = str(function_tmpdir / (cases + ".maw.obs"))
+    new_fl = str(function_tmpdir / (cases + ".maw.obs.new"))
     sr = open(orig_fl, "r")
     sw = open(new_fl, "w")
 

--- a/autotest/test_gwf_multimvr.py
+++ b/autotest/test_gwf_multimvr.py
@@ -5,9 +5,10 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.lgrutil import Lgr
+
 from framework import TestFramework
 
-mvr_scens = ["mltmvr", "mltmvr5050", "mltmvr7525"]
+cases = ["mltmvr", "mltmvr5050", "mltmvr7525"]
 sim_workspaces = []
 gwf_names = []
 
@@ -973,7 +974,7 @@ def add_sim_mvr(sim, gwfname, gwfnamec, remaining_frac=None):
 
 def build_models(idx, test):
     scen_nm, conns, frac = (
-        mvr_scens[idx],
+        cases[idx],
         scen_conns[idx],
         parent_mvr_frac[idx],
     )
@@ -1005,7 +1006,7 @@ def check_output(idx, test):
 
     # cur_ws, gwfparent = ex[idx], gwf_names[idx]
     cur_ws = test.workspace
-    gwfparent = "gwf_" + mvr_scens[idx] + "_p"
+    gwfparent = "gwf_" + cases[idx] + "_p"
     with open(os.path.join(cur_ws, gwfparent + ".lst"), "r") as gwf_lst, open(
         os.path.join(cur_ws, "mfsim.lst"), "r"
     ) as sim_lst:
@@ -1072,7 +1073,7 @@ def check_output(idx, test):
         rel_tol=0.1,
     ), (
         "Flow in the last reach of scenario "
-        + mvr_scens[idx]
+        + cases[idx]
         + " = "
         + str(parent_sfr_last_reach_flow)
         + ", whereas the target flow "
@@ -1118,7 +1119,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(mvr_scens)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_mvr01.py
+++ b/autotest/test_gwf_mvr01.py
@@ -3,10 +3,11 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
 name = "gwf_mvr01"
-ex = [name]
+cases = [name]
 
 
 def build_models(idx, test):
@@ -14,7 +15,7 @@ def build_models(idx, test):
     # temporal discretization
     nper = 1
     tdis_rc = []
-    for idx in range(nper):
+    for _ in range(nper):
         tdis_rc.append((1.0, 1, 1.0))
 
     # spatial discretization data
@@ -371,9 +372,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     # mvr budget terms
     fpth = os.path.join(test.workspace, "gwf_mvr01.mvr.bud")
     bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
@@ -447,7 +446,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -455,6 +454,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_newton01.py
+++ b/autotest/test_gwf_newton01.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["newton01"]
+cases = ["newton01"]
 nlay = 2
 nrow, ncol = 3, 3
 top = 20
@@ -30,7 +31,7 @@ def build_models(idx, test):
     nper = 1
     tdis_rc = [(1.0, 1, 1.0)]
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     sim = flopy.mf6.MFSimulation(
@@ -96,8 +97,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def eval_head(test):
-    print("evaluating heads...")
+def check_output(idx, test):
     fpth = os.path.join(test.workspace, oname)
     v = np.genfromtxt(fpth, delimiter=",", names=True)
 
@@ -110,7 +110,7 @@ def eval_head(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -118,6 +118,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=eval_head,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_newton_under_relaxation.py
+++ b/autotest/test_gwf_newton_under_relaxation.py
@@ -1,14 +1,13 @@
-import os
 import pathlib as pl
 
 import flopy
 import numpy as np
 import pytest
+
 from conftest import project_root_path
 from framework import TestFramework
 
-ex = ["nr_ur01", "nr_ur02"]
-
+cases = ["nr_ur01", "nr_ur02"]
 data_path = project_root_path / "autotest/data/ex-gwf-bump/"
 nper = 1
 nlay = 1
@@ -37,7 +36,7 @@ base_heads = flopy.utils.HeadFile(data_path / "results.hds.cmp").get_data()
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
     if idx == 1:
         sim_ws = pl.Path(f"{test.workspace}/working")
     else:
@@ -105,7 +104,6 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print(f"evaluating heads...{idx}")
     mf6sim = flopy.mf6.MFSimulation.load(sim_ws=test.workspace)
     if idx == 1:
         mfsplit = flopy.mf6.utils.Mf6Splitter(mf6sim)
@@ -127,7 +125,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_noptc01.py
+++ b/autotest/test_gwf_noptc01.py
@@ -2,11 +2,12 @@ import os
 
 import flopy
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_noptc01", "gwf_noptc02", "gwf_noptc03"]
+cases = ["gwf_noptc01", "gwf_noptc02", "gwf_noptc03"]
 no_ptcrecords = ["FIRST", "ALL", None]
-htol = [None for _ in range(len(ex))]
+htol = [None for _ in range(len(cases))]
 
 # static model data
 # temporal discretization
@@ -48,7 +49,7 @@ rech = {0: 0.001}
 
 
 def get_model(idx, dir, no_ptcrecord):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = dir
@@ -134,7 +135,7 @@ def build_models(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_npf01_75x75.py
+++ b/autotest/test_gwf_npf01_75x75.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["npf01a_75x75", "npf01b_75x75"]
+cases = ["npf01a_75x75", "npf01b_75x75"]
 top = [100.0, 0.0]
 laytyp = [1, 0]
 ss = [0.0, 1.0e-4]
@@ -53,7 +54,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -191,7 +192,7 @@ def build_models(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_npf02_rewet.py
+++ b/autotest/test_gwf_npf02_rewet.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["npf02_hreweta", "npf02_hrewetb", "npf02_hrewetc", "npf02_hrewetd"]
+cases = ["npf02_hreweta", "npf02_hrewetb", "npf02_hrewetc", "npf02_hrewetd"]
 ncols = [[15], [10, 5], [15], [10, 5]]
 nlays = [1, 1, 3, 3]
 
@@ -50,7 +51,7 @@ def get_local_data(idx):
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
     nlay = nlays[idx]
 
     if nlay == 1:
@@ -207,8 +208,6 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating rewet heads...")
-
     hdata01lay = [
         [
             1.000000000000000000e02,
@@ -337,7 +336,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_npf03_sfr.py
+++ b/autotest/test_gwf_npf03_sfr.py
@@ -3,10 +3,11 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from conftest import project_root_path
 from framework import TestFramework
 
-ex = ["npf03_sfra", "npf03_sfrb"]
+cases = ["npf03_sfra", "npf03_sfrb"]
 fpth = str(project_root_path / "autotest" / "data" / "npf03_hk.ref")
 shape = (50, 108)
 hk = flopy.utils.Util2d.load_txt(shape, fpth, dtype=float, fmtin="(FREE)")
@@ -55,7 +56,7 @@ def get_local_data(idx):
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
 
     # set local data for this model
     ncolst, nmodels, mnames = get_local_data(idx)
@@ -336,8 +337,6 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating mover test heads...")
-
     hdata = np.array(
         [
             1.200000000000000000e01,
@@ -5779,7 +5778,7 @@ def check_output(idx, test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_npf04_spdis.py
+++ b/autotest/test_gwf_npf04_spdis.py
@@ -1,11 +1,9 @@
 """
-MODFLOW 6 Autotest
 Test the specific discharge calculation for an LGR-like simulation that has
 a parent model and a child model.  The child model is inset into the parent
 model, but they both have the same resolution, so it is essentially a simple
 3D grid.  The child qx velocity should be the same as the qx velocity in
 the parent grid.  The heads are also compared.
-
 """
 
 import os
@@ -14,9 +12,10 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.lgrutil import Lgr
+
 from framework import TestFramework
 
-ex = ["npf04"]
+cases = ["npf04"]
 namea = "a"
 nameb = "b"
 
@@ -44,7 +43,7 @@ def build_models(idx, test):
     ncppl = [1, 1, 1]
     lgr = Lgr(nlay, nrow, ncol, delr, delc, top, botm, idomain, ncpp, ncppl)
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     # create simulation
@@ -173,9 +172,7 @@ def qxqyqz(fname, nlay, nrow, ncol):
     return qx, qy, qz
 
 
-def check_output(test):
-    print("evaluating head and qx in parent and child models...")
-
+def check_output(idx, test):
     # make sure parent head is same as child head in same column
     fname = os.path.join(test.workspace, f"{namea}.hds")
     hdobj = flopy.utils.HeadFile(fname)
@@ -212,7 +209,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -220,6 +217,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_npf05_anisotropy.py
+++ b/autotest/test_gwf_npf05_anisotropy.py
@@ -1,5 +1,4 @@
 """
-MODFLOW 6 Autotest
 Test to make sure that NPF anisotropy ratio options are read and processed
 correctly.
 """
@@ -9,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["npf05a"]
+cases = ["npf05a"]
 
 
 def build_models(idx, test):
@@ -123,8 +123,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
+def check_output(idx, test):
     fpth = os.path.join(test.workspace, "npf.hds")
     hobj = flopy.utils.HeadFile(fpth, precision="double")
     heads = hobj.get_alldata()
@@ -147,7 +146,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -155,6 +154,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_npf_thickstrt.py
+++ b/autotest/test_gwf_npf_thickstrt.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "gwf_npf_thickstrt01",  # case 01 -- icelltype=0
     "gwf_npf_thickstrt02",  # case 02 -- icelltype=0, using thickstrt, but it has no effect
     "gwf_npf_thickstrt03",  # case 03 -- icelltype=-1, using thickstrt and strt = 5.
@@ -136,8 +137,6 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating model...")
-
     name = "flow"
 
     fpth = os.path.join(test.workspace, f"{name}.hds")
@@ -212,7 +211,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_npf_tvk01.py
+++ b/autotest/test_gwf_npf_tvk01.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["tvk01"]
+cases = ["tvk01"]
 time_varying_k = [1.0, 10.0]
 
 
@@ -30,7 +31,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -137,9 +138,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     gwfname = "gwf_" + test.name
 
     # head
@@ -171,16 +170,14 @@ def check_output(test):
         print(f"Calculated q is {flow_rate_calc}")
         for node, node2, q in bud:
             print(node, node2, q, flow_rate_calc)
-            errmsg = f"Expected flow rate {flow_rate_calc} but found {q}"
-            assert np.isclose(flow_rate_calc, abs(q))
-
-    # comment when done testing
-    # assert False
+            assert np.isclose(
+                flow_rate_calc, abs(q)
+            ), f"Expected flow rate {flow_rate_calc} but found {q}"
 
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -188,6 +185,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_npf_tvk03.py
+++ b/autotest/test_gwf_npf_tvk03.py
@@ -3,12 +3,13 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["tvk03"]
+cases = ["tvk03"]
 
 
-def build_model(idx, test):
+def build_models(idx, test):
     nlay, nrow, ncol = 3, 1, 1
     perlen = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
     nper = len(perlen)
@@ -31,7 +32,7 @@ def build_model(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -157,9 +158,7 @@ def build_model(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     gwfname = "gwf_" + test.name
 
     # head
@@ -192,28 +191,22 @@ def check_output(test):
 
     for kper, expected_result in enumerate(expected_results):
         h = head[kper, ex_lay - 1, ex_row - 1, ex_col - 1]
-
         print(kper, h, expected_result)
-
-        errmsg = (
-            f"Expected head {expected_result} in period {kper} but found {h}"
-        )
-        assert np.isclose(h, expected_result)
-
-    # comment when done testing
-    # assert False
+        assert np.isclose(
+            h, expected_result
+        ), f"Expected head {expected_result} in period {kper} but found {h}"
 
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_model(idx, t),
-        check=check_output,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_npf_tvk04.py
+++ b/autotest/test_gwf_npf_tvk04.py
@@ -3,13 +3,14 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["tvk05"]
+cases = ["tvk05"]
 time_varying_k = [1.0, 10.0]
 
 
-def build_model(idx, test):
+def build_models(idx, test):
     nlay, nrow, ncol = 3, 3, 3
     perlen = [100.0, 100.0]
     nper = len(perlen)
@@ -31,7 +32,7 @@ def build_model(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -154,9 +155,7 @@ def build_model(idx, test):
     return sim, None
 
 
-def eval_model(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     # budget
     try:
         fname = f"gwf_{test.name}.lst"
@@ -185,14 +184,14 @@ def eval_model(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_model(idx, t),
-        check=eval_model,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_npf_tvk05.py
+++ b/autotest/test_gwf_npf_tvk05.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["tvk05"]
+cases = ["tvk05"]
 time_varying_k = [1.0, 10.0]
 
 
@@ -31,7 +32,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -155,9 +156,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def eval_model(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     # budget
     try:
         fname = f"gwf_{test.name}.lst"
@@ -186,7 +185,7 @@ def eval_model(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -194,6 +193,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=eval_model,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_obs02.py
+++ b/autotest/test_gwf_obs02.py
@@ -7,10 +7,11 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
 cell_dimensions = (300,)
-ex = ["gwf_obs02"]
+cases = ["gwf_obs02"]
 h0, h1 = 1.0, 0.0
 nlay, nrow, ncol = 1, 10, 10
 
@@ -34,7 +35,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -123,8 +124,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model observations...")
+def check_output(idx, test):
     headcsv = np.empty((nlay, nrow, ncol), dtype=float)
     for i in range(nrow):
         fname = f"{test.name}.{i}.obs.csv"
@@ -152,14 +152,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_pertim.py
+++ b/autotest/test_gwf_pertim.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "gwf_pertim",
 ]
 
@@ -16,8 +17,8 @@ perlen = [0.0]
 nstp = [1]
 tsmult = [1.0]
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # spatial discretization data
 nlay, nrow, ncol = 3, 21, 20
@@ -38,7 +39,7 @@ river_spd = [(0, i, ncol - 1, 320.0, "river") for i in range(nrow)]
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -113,9 +114,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{test.name}.lst")
     mflist = flopy.utils.Mf6ListBudget(fpth)
     inc = mflist.get_incremental()
@@ -133,14 +132,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_ptc01.py
+++ b/autotest/test_gwf_ptc01.py
@@ -9,9 +9,10 @@ import os
 
 import flopy
 import pytest
+
 from framework import TestFramework
 
-ex = ["ptc01"]
+cases = ["ptc01"]
 # static model data
 # temporal discretization
 nper = 1
@@ -54,7 +55,7 @@ rech = {0: 0.001}
 
 
 def build_mf6(idx, ws, storage=True):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     sim = flopy.mf6.MFSimulation(
@@ -139,7 +140,7 @@ def build_models(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_rch01.py
+++ b/autotest/test_gwf_rch01.py
@@ -1,5 +1,4 @@
 """
-MODFLOW 6 Autotest
 Test to make sure that recharge is passed to the highest active layer and
 verify that recharge is in the highest active layer by looking at the
 individual budget terms.  For this test, there are two layers and five
@@ -13,9 +12,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["rch01a", "rch01b", "rch01c"]
+cases = ["rch01a", "rch01b", "rch01c"]
 irch = [None, 0, [1, 1, 0, 1, 1]]
 
 
@@ -119,9 +119,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     fpth = os.path.join(test.workspace, "rch.cbc")
     bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
     records = bobj.get_data(text="rch")[0]
@@ -141,14 +139,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_rch02.py
+++ b/autotest/test_gwf_rch02.py
@@ -1,5 +1,4 @@
 """
-MODFLOW 6 Autotest
 Test to make sure that array based recharge is applied correctly when idomain
 is used to remove part of the grid.
 """
@@ -9,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["rch02"]
+cases = ["rch02"]
 
 
 def build_models(idx, test):
@@ -108,9 +108,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     fpth = os.path.join(test.workspace, "rch.cbc")
     bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
     records = bobj.get_data(text="rch")[0]
@@ -133,14 +131,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_rch03.py
+++ b/autotest/test_gwf_rch03.py
@@ -1,5 +1,4 @@
 """
-MODFLOW 6 Autotest
 Test to make sure that array based recharge is applied correctly when idomain
 is used with -1, 0, and 1 for top layer.
 """
@@ -9,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["rch03"]
+cases = ["rch03"]
 
 
 def build_models(idx, test):
@@ -130,9 +130,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating model...")
-
+def check_output(idx, test):
     fpth = os.path.join(test.workspace, "rch.cbc")
     bobj = flopy.utils.CellBudgetFile(fpth, precision="double")
     records = bobj.get_data(text="rch")[0]
@@ -159,14 +157,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_sfr01gwfgwf.py
+++ b/autotest/test_gwf_sfr01gwfgwf.py
@@ -1,23 +1,26 @@
-# Based on sft01 gwf model, but split into two gwf models test gwf-gwf and
-# mvr. The single base model is split using the model splitter into two models.
-# The single model is run as the regression model
+"""
+Based on sft01 gwf model, but split into two gwf models test gwf-gwf and
+mvr. The single base model is split using the model splitter into two models.
+The single model is run as the regression model
 
-# The final split model look like:
-#
-#       flow1                        flow2
-#  sfr  1 2 3 4 5 6 7  gwfgwf-mvr => 1 2 3 4 5 6 7
-#       -------------                -------------
-#  gwf  1 2 3 4 5 6 7  gwfgwf     => 1 2 3 4 5 6 7
+The final split model look like:
+
+      flow1                        flow2
+ sfr  1 2 3 4 5 6 7  gwfgwf-mvr => 1 2 3 4 5 6 7
+      -------------                -------------
+ gwf  1 2 3 4 5 6 7  gwfgwf     => 1 2 3 4 5 6 7
+"""
 
 
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
 # from flopy.mf6.utils import Mf6Splitter
 
-ex = ["sfr01gwfgwf"]
+cases = ["sfr01gwfgwf"]
 
 # properties for single model combination
 lx = 14.0
@@ -36,7 +39,7 @@ Kv = 20.0
 
 
 def build_simulation(idx, sim_ws, sim_type="single"):
-    name = ex[idx]
+    name = cases[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         sim_ws=sim_ws,
@@ -273,11 +276,9 @@ def build_models(idx, test):
     return sim, sim_base
 
 
-def check_output(sim):
-    print("evaluating sfr stage results...")
-
+def check_output(idx, test):
     # base simulations stage
-    ws = sim.workspace
+    ws = test.workspace
     fpth = ws / "mf6/single.sfr.stg"
     single_stage_obj = flopy.utils.HeadFile(fpth, text="STAGE")
     single_stage = single_stage_obj.get_data().squeeze()
@@ -300,7 +301,7 @@ def check_output(sim):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -308,7 +309,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         compare="run_only",
     )
     test.run()

--- a/autotest/test_gwf_sfr_diversion.py
+++ b/autotest/test_gwf_sfr_diversion.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["sfr_div"]
+cases = ["sfr_div"]
 inflows = np.array([10, 0, 10, 0, 10])
 diversion = np.array([0.5, 0.5, 0.5, 0.5, 0.0])
 
@@ -26,7 +27,7 @@ def build_models(idx, test):
     strt = 0.0
 
     # build MODFLOW 6 files
-    name = ex[idx]
+    name = cases[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         version="mf6",
@@ -139,9 +140,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # check flow for indivdual reach
     fname = os.path.join(test.workspace, f"{test.name}.sfr.cbb")
     with flopy.utils.CellBudgetFile(fname) as cbb:
@@ -168,13 +167,13 @@ def check_output(test):
     ), "Large mass balance error in SFR"
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_sfr_evap.py
+++ b/autotest/test_gwf_sfr_evap.py
@@ -1,13 +1,16 @@
-# Test evap in SFR reaches (no interaction with gwf)
+"""
+Test evap in SFR reaches (no interaction with gwf)
+"""
 
 import os
 
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["sfr-evap"]
+cases = ["sfr-evap"]
 
 
 # Model units
@@ -68,7 +71,7 @@ hclose, rclose, relax = 1e-3, 1e-4, 0.97
 def build_models(idx, test):
     # Base simulation and model name and workspace
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     print("Building model...{}".format(name))
 
@@ -374,10 +377,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # read flow results from model
-    name = ex[idx]
+    name = cases[idx]
     gwfname_t = "gwf-" + name + "-t"
     gwfname_r = "gwf-" + name + "-r"
 
@@ -433,7 +434,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_sfr_gwf_conn.py
+++ b/autotest/test_gwf_sfr_gwf_conn.py
@@ -3,10 +3,11 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
 paktest = "sfr"
-ex = [
+cases = [
     "sfr_dis",
     "sfr_dis_fail",
     "sfr_dis_none",
@@ -61,7 +62,7 @@ def build_model(idx, ws):
     ts_flows = np.array([1000.0] + [float(q) for q in range(1000, -100, -100)])
 
     # build MODFLOW 6 files
-    name = ex[idx]
+    name = cases[idx]
     dis_type = dis_types[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
@@ -269,7 +270,7 @@ def build_models(idx, test):
     return sim, None
 
 
-@pytest.mark.parametrize("idx, name", enumerate(ex))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sfr_npoint01.py
+++ b/autotest/test_gwf_sfr_npoint01.py
@@ -3,11 +3,12 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from cross_section_functions import get_depths
 from framework import TestFramework
 
 paktest = "sfr"
-ex = [
+cases = [
     "sfr_npt01a",
     "sfr_npt01b",
     "sfr_npt01c",
@@ -127,7 +128,7 @@ def build_models(idx, test):
     ts_flows = np.array([1000.0] + [float(q) for q in range(1000, -100, -100)])
 
     # build MODFLOW 6 files
-    name = ex[idx]
+    name = cases[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         version="mf6",
@@ -297,8 +298,6 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating n-point cross-section results..." f"({test.name})")
-
     obs_pth = os.path.join(test.workspace, f"{test.name}.sfr.obs.csv")
     obs = flopy.utils.Mf6Obs(obs_pth).get_data()
 
@@ -326,7 +325,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_sfr_npoint02.py
+++ b/autotest/test_gwf_sfr_npoint02.py
@@ -3,12 +3,13 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from cross_section_functions import get_depths
 from framework import TestFramework
 
 paktest = "sfr"
 
-ex = [
+cases = [
     "sfr_npt02a",
 ]
 
@@ -54,7 +55,7 @@ def flow_to_depth_wide(rwid, q):
 
 def build_models(idx, test):
     # build MODFLOW 6 files
-    name = ex[idx]
+    name = cases[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         version="mf6",
@@ -207,11 +208,9 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(sim):
-    name = sim.name
-    print("evaluating n-point cross-section results..." f"({name})")
-
-    obs_pth = os.path.join(sim.workspace, f"{name}.sfr.obs.csv")
+def check_output(idx, test):
+    name = test.name
+    obs_pth = os.path.join(test.workspace, f"{name}.sfr.obs.csv")
     obs = flopy.utils.Mf6Obs(obs_pth).get_data()
 
     assert np.allclose(
@@ -242,7 +241,7 @@ def check_output(sim):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -250,6 +249,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_sfr_npoint03.py
+++ b/autotest/test_gwf_sfr_npoint03.py
@@ -3,11 +3,12 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from cross_section_functions import calculate_rectchan_mannings_discharge
 from framework import TestFramework
 
 paktest = "sfr"
-ex = [
+cases = [
     "sfr_npt03a",
     "sfr_npt03b",
     "sfr_npt03c",
@@ -74,7 +75,7 @@ def build_model(idx, ws, base=False):
         ws = os.path.join(ws, "mf6")
 
     # build MODFLOW 6 files
-    name = ex[idx]
+    name = cases[idx]
     sim = flopy.mf6.MFSimulation(
         sim_name=name,
         version="mf6",
@@ -274,9 +275,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def check_output(test):
-    print("evaluating n-point cross-section results..." f"({test.name})")
-
+def check_output(idx, test):
     obs_pth0 = os.path.join(test.workspace, f"{test.name}.sfr.obs.csv")
     obs0 = np.genfromtxt(obs_pth0, names=True, delimiter=",")
 
@@ -298,7 +297,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -306,6 +305,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_sfr_wetstrmbedarea.py
+++ b/autotest/test_gwf_sfr_wetstrmbedarea.py
@@ -6,9 +6,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["sfr-wetperim"]
+cases = ["sfr-wetperim"]
 
 
 def get_x_frac(x_coord1, rwid):
@@ -122,7 +123,7 @@ hclose, rclose, relax = 1e-3, 1e-4, 0.97
 def build_models(idx, test):
     # Base simulation and model name and workspace
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     print("Building model...{}".format(name))
 
@@ -329,10 +330,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # read flow results from model
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf-" + name
 
     fname = gwfname + ".sfr.cbc"
@@ -378,7 +377,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_sto02.py
+++ b/autotest/test_gwf_sto02.py
@@ -1,6 +1,5 @@
 """
 Test adaptive time step module
-
 """
 
 import os
@@ -8,9 +7,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_sto02a", "gwf_sto02b"]
+cases = ["gwf_sto02a", "gwf_sto02b"]
 ncols = [1, 2]
 (
     nlay,
@@ -21,7 +21,7 @@ ncols = [1, 2]
 )
 
 
-def build_model(idx, test):
+def build_models(idx, test):
     perlen = [10]
     nper = len(perlen)
     nstp = [1]
@@ -40,7 +40,7 @@ def build_model(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
     ncol = ncols[idx]
 
     # build MODFLOW 6 files
@@ -141,10 +141,8 @@ def build_model(idx, test):
     return sim, None
 
 
-def eval_flow(idx, test):
-    print("evaluating flow...")
-
-    name = ex[idx]
+def check_output(idx, test):
+    name = cases[idx]
     gwfname = "gwf_" + name
 
     # This will fail if budget numbers cannot be read
@@ -159,14 +157,14 @@ def eval_flow(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_model(idx, t),
-        check=lambda t: eval_flow(idx, t),
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_sto03.py
+++ b/autotest/test_gwf_sto03.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "gwf_sto03a",
     "gwf_sto03b",
 ]
@@ -14,7 +15,7 @@ newton = (
     True,
 )
 cmppth = "mf6"
-htol = [None for idx in range(len(ex))]
+htol = [None for _ in range(len(cases))]
 dtol = 1e-3
 budtol = 1e-2
 
@@ -30,8 +31,8 @@ perlen = [1.0 for i in range(nper)]
 nstp = [50 for i in range(nper)]
 tsmult = [1.1 for i in range(nper)]
 tdis_rc = []
-for idx in range(nper):
-    tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+for i in range(nper):
+    tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
 # spatial discretization data
 nlay, nrow, ncol = 1, 1, 1
@@ -61,12 +62,12 @@ hclose, rclose, relax, ur_gamma = 1e-9, 1e-6, 1.0, 0.95
 # pumping well data
 absrate = 1.1 * ss * (zelev[-2] - zelev[-1]) * 90.0
 well_spd = {}
-for idx in range(nper):
-    if idx % 2 == 0:
+for i in range(nper):
+    if i % 2 == 0:
         mult = 1.0
     else:
         mult = -1.0
-    well_spd[idx] = [[0, 0, 0, mult * absrate]]
+    well_spd[i] = [[0, 0, 0, mult * absrate]]
 
 
 def get_model(name, ws, newton_bool, offset=0.0):
@@ -171,8 +172,8 @@ def get_model(name, ws, newton_bool, offset=0.0):
 
 
 # variant SUB package problem 3
-def build_model(idx, test):
-    name = ex[idx]
+def build_models(idx, test):
+    name = cases[idx]
     # model with no offset
     sim = get_model(name, test.workspace, newton_bool=newton[idx])
     # model with offset
@@ -192,8 +193,8 @@ def eval_hmax(fpth):
     bv = np.zeros(ctimes.shape, dtype=float)
     bv[:] = b.get_data(totim=1.0)[obsname]
     sv = np.zeros(ctimes.shape, dtype=float)
-    for idx, t in enumerate(ctimes):
-        sv[idx] = b.get_data(totim=t)[obsname]
+    for i, t in enumerate(ctimes):
+        sv[i] = b.get_data(totim=t)[obsname]
 
     msg = (
         "maximum heads in {} exceed tolerance ".format(fpth)
@@ -202,8 +203,7 @@ def eval_hmax(fpth):
     assert np.allclose(bv, sv), msg
 
 
-def eval_sto(idx, test):
-    print("evaluating head differences...")
+def check_output(idx, test):
     fpth = os.path.join(test.workspace, "head.obs.csv")
     base_obs = flopy.utils.Mf6Obs(fpth).get_data()[obsname]
 
@@ -217,7 +217,6 @@ def eval_sto(idx, test):
     )
     assert np.allclose(base_obs, offset_obs, atol=1e-6), msg
 
-    print("evaluating maximum heads...")
     fpth = os.path.join(test.workspace, "head.obs.csv")
     eval_hmax(fpth)
     fpth = os.path.join(test.workspace, cmppth, "head.obs.csv")
@@ -238,8 +237,7 @@ def eval_sto(idx, test):
     )
     assert np.allclose(base_cmp, offset_cmp), msg
 
-    print("evaluating storage...")
-    name = ex[idx]
+    name = cases[idx]
     fpth = os.path.join(test.workspace, f"{name}.cbc")
     base_cbc = flopy.utils.CellBudgetFile(fpth, precision="double")
     fpth = os.path.join(test.workspace, cmppth, f"{name}.cbc")
@@ -250,27 +248,27 @@ def eval_sto(idx, test):
     kk = base_cbc.get_kstpkper()
     times = base_cbc.get_times()
     max_diff = np.zeros(len(times), dtype=float)
-    for idx, (k, t) in enumerate(zip(kk, times)):
+    for i, (k, t) in enumerate(zip(kk, times)):
         for text in cbc_bud:
             base_v = base_cbc.get_data(totim=t, text=text)[0]
             offset_v = offset_cbc.get_data(totim=t, text=text)[0]
             if not np.allclose(base_v, offset_v):
-                max_diff[idx] = np.abs(base_v - offset_v).max()
+                max_diff[i] = np.abs(base_v - offset_v).max()
 
     assert max_diff.sum() == 0.0, "simulated storage is not the same"
 
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_model(idx, t),
-        check=lambda t: eval_sto(idx, t),
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
         htol=htol[idx],
     )
     test.run()

--- a/autotest/test_gwf_sto_tvs01.py
+++ b/autotest/test_gwf_sto_tvs01.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["tvs01"]
+cases = ["tvs01"]
 
 
 def build_models(idx, test):
@@ -36,7 +37,7 @@ def build_models(idx, test):
     for i in range(nper):
         transient[i] = True
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -161,13 +162,11 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(sim):
-    print("evaluating model...")
-
-    gwfname = "gwf_" + sim.name
+def check_output(idx, test):
+    gwfname = "gwf_" + test.name
 
     # head
-    fpth = os.path.join(sim.workspace, f"{gwfname}.hds")
+    fpth = os.path.join(test.workspace, f"{gwfname}.hds")
     try:
         hobj = flopy.utils.HeadFile(fpth, precision="double")
         head = hobj.get_alldata()
@@ -192,21 +191,15 @@ def check_output(sim):
 
     for kper, expected_result in enumerate(expected_results):
         h = head[kper, ex_lay - 1, ex_row - 1, ex_col - 1]
-
         print(kper, h, expected_result)
-
-        errmsg = (
-            f"Expected head {expected_result} in period {kper} but found {h}"
-        )
-        assert np.isclose(h, expected_result)
-
-    # comment when done testing
-    # assert False
+        assert np.isclose(
+            h, expected_result
+        ), f"Expected head {expected_result} in period {kper} but found {h}"
 
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -214,6 +207,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_ts_lak01.py
+++ b/autotest/test_gwf_ts_lak01.py
@@ -4,11 +4,12 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.compare import eval_bud_diff
+
 from framework import TestFramework
 
 paktest = "lak"
 budtol = 1e-2
-ex = ["ts_lak01"]
+cases = ["ts_lak01"]
 
 # static model data
 # spatial discretization
@@ -313,7 +314,7 @@ def get_model(ws, name, timeseries=False):
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -326,8 +327,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def check_output(test):
-    print("evaluating budgets...")
+def check_output(idx, test):
 
     # get ia/ja from binary grid file
     fname = f"{os.path.basename(test.name)}.dis.grb"
@@ -354,14 +354,14 @@ def check_output(test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_ts_maw01.py
+++ b/autotest/test_gwf_ts_maw01.py
@@ -4,10 +4,11 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.compare import eval_bud_diff
+
 from framework import TestFramework
 
 paktest = "maw"
-ex = [f"ts_{paktest}01"]
+cases = [f"ts_{paktest}01"]
 
 
 def get_model(ws, name, timeseries=False):
@@ -15,7 +16,7 @@ def get_model(ws, name, timeseries=False):
     # temporal discretization
     nper = 1
     tdis_rc = []
-    for idx in range(nper):
+    for _ in range(nper):
         tdis_rc.append((1.0, 1, 1.0))
     ts_times = np.arange(0.0, 2.0, 1.0, dtype=float)
 
@@ -399,7 +400,7 @@ def get_model(ws, name, timeseries=False):
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -412,8 +413,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def check_output(test):
-    print("evaluating model budgets...")
+def check_output(idx, test):
     # get ia/ja from binary grid file
     fname = f"{os.path.basename(test.name)}.dis.grb"
     fpth = os.path.join(test.workspace, fname)
@@ -453,14 +453,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_ts_sfr02.py
+++ b/autotest/test_gwf_ts_sfr02.py
@@ -4,10 +4,11 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.compare import eval_bud_diff
+
 from framework import TestFramework
 
 paktest = "sfr"
-ex = ["ts_sfr02"]
+cases = ["ts_sfr02"]
 
 
 def get_model(ws, name, timeseries=False):
@@ -15,7 +16,7 @@ def get_model(ws, name, timeseries=False):
     # temporal discretization
     nper = 1
     tdis_rc = []
-    for idx in range(nper):
+    for _ in range(nper):
         tdis_rc.append((1.0, 1, 1.0))
     ts_times = np.arange(0.0, 2.0, 1.0, dtype=float)
 
@@ -505,7 +506,7 @@ def get_model(ws, name, timeseries=False):
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -518,9 +519,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def check_output(test):
-    print("evaluating model budgets...")
-
+def check_output(idx, test):
     # get ia/ja from binary grid file
     fname = f"{os.path.basename(test.name)}.dis.grb"
     fpth = os.path.join(test.workspace, fname)
@@ -562,9 +561,9 @@ def check_output(test):
     # FLOW-JA-FACE
     v0 = cobj0.get_data(totim=1.0, text="FLOW-JA-FACE")[0]
     q = []
-    for idx, node in enumerate(v0["node"]):
+    for i, node in enumerate(v0["node"]):
         if node in nodes:
-            q.append(v0["q"][idx])
+            q.append(v0["q"][i])
     v0 = np.array(q)
     check = np.ones(v0.shape, dtype=float) * 5e-2
     check[1] = 0.76743
@@ -573,27 +572,27 @@ def check_output(test):
 
     v0 = cobj0.get_data(totim=1.0, text="EXT-OUTFLOW")[0]
     q = []
-    for idx, node in enumerate(v0["node"]):
+    for i, node in enumerate(v0["node"]):
         if node in nodes:
-            q.append(v0["q"][idx])
+            q.append(v0["q"][i])
     v0 = np.array(q)
     check = np.array([-2.5e-2, -0.80871, -5e-2, -5e-2, -2.0e-2, -5e-2])
     assert np.allclose(v0, check), "EXT-OUTFLOW failed"
 
     v0 = cobj0.get_data(totim=1.0, text="FROM-MVR")[0]
     q = []
-    for idx, node in enumerate(v0["node"]):
+    for i, node in enumerate(v0["node"]):
         if node in nodes:
-            q.append(v0["q"][idx])
+            q.append(v0["q"][i])
     v0 = np.array(q)
     check = np.array([0.0, 4.5e-2, 0.0, 0.0, 0.0, 0.0])
     assert np.allclose(v0, check), "FROM-MVR failed"
 
     v0 = cobj0.get_data(totim=1.0, text="TO-MVR")[0]
     q = []
-    for idx, node in enumerate(v0["node"]):
+    for i, node in enumerate(v0["node"]):
         if node in nodes:
-            q.append(v0["q"][idx])
+            q.append(v0["q"][i])
     v0 = np.array(q)
     check = np.array([-2.5e-2, 0.0, 0.0, 0.0, -2.0e-2, 0.0])
     assert np.allclose(v0, check), "TO-MVR failed"
@@ -601,14 +600,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_ts_uzf01.py
+++ b/autotest/test_gwf_ts_uzf01.py
@@ -4,10 +4,11 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.compare import eval_bud_diff
+
 from framework import TestFramework
 
 paktest = "uzf"
-ex = ["ts_uzf01"]
+cases = ["ts_uzf01"]
 
 
 def get_model(ws, name, timeseries=False):
@@ -15,7 +16,7 @@ def get_model(ws, name, timeseries=False):
     # temporal discretization
     nper = 1
     tdis_rc = []
-    for idx in range(nper):
+    for _ in range(nper):
         tdis_rc.append((1.0, 1, 1.0))
     ts_times = np.arange(0.0, 2.0, 1.0, dtype=float)
 
@@ -637,7 +638,7 @@ def get_model(ws, name, timeseries=False):
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -650,9 +651,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def check_output(test):
-    print("evaluating model budgets...")
-
+def check_output(idx, test):
     # get ia/ja from binary grid file
     fname = f"{os.path.basename(test.name)}.dis.grb"
     fpth = os.path.join(test.workspace, fname)
@@ -692,14 +691,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_utl01_binaryinput.py
+++ b/autotest/test_gwf_utl01_binaryinput.py
@@ -1,5 +1,5 @@
 """
-test reading of binary initial heads (float) and also binary icelltype (int).
+Test reading of binary initial heads (float) and also binary icelltype (int).
 1. Have binary data in a separate record for each layer
 2. Have binary data in a single record for all layers
 """
@@ -9,9 +9,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["binary01", "binary02"]
+cases = ["binary01", "binary02"]
 
 
 def build_models(idx, test):
@@ -32,10 +33,10 @@ def build_models(idx, test):
     hclose, rclose, relax = 1e-6, 1e-3, 1.0
 
     tdis_rc = []
-    for i in range(nper):
+    for _ in range(nper):
         tdis_rc.append((perlen, nstp, tsmult))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -429,7 +430,7 @@ def build_models(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_utl02_timeseries.py
+++ b/autotest/test_gwf_utl02_timeseries.py
@@ -1,8 +1,9 @@
 import flopy
 import pytest
+
 from framework import TestFramework
 
-ex = ["ts01"]
+cases = ["ts01"]
 
 
 def build_models(idx, test):
@@ -24,7 +25,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp, tsmult))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -148,7 +149,7 @@ def build_models(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_utl04_auxmult.py
+++ b/autotest/test_gwf_utl04_auxmult.py
@@ -7,9 +7,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["auxmult01"]
+cases = ["auxmult01"]
 
 
 def build_models(idx, test):
@@ -30,7 +31,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -156,10 +157,8 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(sim):
-    print("evaluating model...")
-
-    fpth = os.path.join(sim.workspace, "auxmult01.bud")
+def check_output(idx, test):
+    fpth = os.path.join(test.workspace, "auxmult01.bud")
     bobj = flopy.utils.CellBudgetFile(fpth, precision="double", verbose=False)
     records = bobj.get_data(text="wel")
 
@@ -173,19 +172,17 @@ def check_output(sim):
     msg = f"err {qlist} /= {answer}"
     assert np.allclose(qlist, answer), msg
 
-    # assert False
-
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_utl05_budparse.py
+++ b/autotest/test_gwf_utl05_budparse.py
@@ -7,9 +7,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_utl05"]
+cases = ["gwf_utl05"]
 laytyp = [1]
 ss = [1.0e-10]
 sy = [0.1]
@@ -32,10 +33,10 @@ def build_models(idx, test):
     hclose, rclose, relax = 1e-6, 1e-6, 0.97
 
     tdis_rc = []
-    for id in range(nper):
-        tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -138,9 +139,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def eval_flow(test):
-    print("evaluating flow...")
-
+def check_output(idx, test):
     gwfname = "gwf_" + test.name
 
     # This will fail if budget numbers cannot be read
@@ -158,14 +157,14 @@ def eval_flow(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=eval_flow,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_utl06_tas.py
+++ b/autotest/test_gwf_utl06_tas.py
@@ -7,9 +7,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "utl06_tas_a",
     "utl06_tas_b",
     "utl06_tas_c",
@@ -188,8 +189,6 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
     gwfname = "gwf"
 
     # load concentration file
@@ -363,7 +362,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_uzf01.py
+++ b/autotest/test_gwf_uzf01.py
@@ -8,14 +8,15 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_uzf01a"]
+cases = ["gwf_uzf01a"]
 nlay, nrow, ncol = 100, 1, 1
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
 
     perlen = [500.0]
     nper = len(perlen)
@@ -33,8 +34,8 @@ def build_models(idx, test):
     sy = 0.1
 
     tdis_rc = []
-    for idx in range(nper):
-        tdis_rc.append((perlen[idx], nstp[idx], tsmult[idx]))
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -210,9 +211,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating flow...")
-
+def check_output(idx, test):
     name = test.name
     ws = test.workspace
 
@@ -252,8 +251,8 @@ def check_output(test):
         names[-1]: obs_obj.get_data(obsname=names[-1]),
     }
     cbc = uobj.get_ts(idx=[[0, 0, 1], [0, 0, 49]], text="GWF")
-    for idx, key in enumerate(obs.keys()):
-        assert np.allclose(obs[key][key], -cbc[:, idx + 1]), (
+    for i, key in enumerate(obs.keys()):
+        assert np.allclose(obs[key][key], -cbc[:, i + 1]), (
             f"observation data for {key} is not the same as "
             "data in the cell-by-cell file."
         )
@@ -261,14 +260,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_uzf02.py
+++ b/autotest/test_gwf_uzf02.py
@@ -1,6 +1,5 @@
 """
-# Test uzf for the vs2d comparison problem in the uzf documentation
-
+Test uzf for the vs2d comparison problem in the uzf documentation
 """
 
 import os
@@ -8,9 +7,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_uzf02a"]
+cases = ["gwf_uzf02a"]
 nlay, nrow, ncol = 1, 1, 1
 
 
@@ -44,7 +44,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -228,10 +228,10 @@ def make_plot(sim, obsvals):
 
     # shows curves for times 2.5, 7.5, 12.6, 17.7
     # which are indices 24, 74, 125, and -1
-    idx = [24, 74, 125, -1]
+    indices = [24, 74, 125, -1]
 
     obsvals = [list(row) for row in obsvals]
-    obsvals = [obsvals[i] for i in idx]
+    obsvals = [obsvals[i] for i in indices]
     obsvals = np.array(obsvals)
 
     import matplotlib.pyplot as plt
@@ -255,11 +255,9 @@ def make_plot(sim, obsvals):
     plt.savefig(fname, bbox_inches="tight")
 
 
-def check_output(sim):
-    print("evaluating flow...")
-
-    name = sim.name
-    ws = sim.workspace
+def check_output(idx, test):
+    name = test.name
+    ws = test.workspace
 
     # check binary grid file
     fname = os.path.join(ws, name + ".dis.grb")
@@ -296,7 +294,7 @@ def check_output(sim):
         assert np.allclose(uz["q"], uz_answer), "unsat ET is not correct"
 
     # Make plot of obs
-    fpth = os.path.join(sim.workspace, name + ".uzf.obs.csv")
+    fpth = os.path.join(test.workspace, name + ".uzf.obs.csv")
     try:
         obsvals = np.genfromtxt(fpth, names=True, delimiter=",")
     except:
@@ -306,14 +304,14 @@ def check_output(sim):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_uzf03.py
+++ b/autotest/test_gwf_uzf03.py
@@ -1,7 +1,6 @@
 """
-# Test uzf for the vs2d comparison problem in the uzf documentation except in
-# this case there are 15 gwf and uzf cells, rather than just one cell.
-
+Test uzf for the vs2d comparison problem in the uzf documentation except in
+this case there are 15 gwf and uzf cells, rather than just one cell.
 """
 
 import os
@@ -9,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_uzf03a"]
+cases = ["gwf_uzf03a"]
 nlay, nrow, ncol = 15, 1, 1
 
 
@@ -45,7 +45,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -230,10 +230,10 @@ def make_plot(sim, obsvals):
 
     # shows curves for times 2.5, 7.5, 12.6, 17.7
     # which are indices 24, 74, 125, and -1
-    idx = [24, 74, 125, -1]
+    indices = [24, 74, 125, -1]
 
     obsvals = [list(row) for row in obsvals]
-    obsvals = [obsvals[i] for i in idx]
+    obsvals = [obsvals[i] for i in indices]
     obsvals = np.array(obsvals)
 
     import matplotlib.pyplot as plt
@@ -256,9 +256,7 @@ def make_plot(sim, obsvals):
     plt.savefig(fname, bbox_inches="tight")
 
 
-def check_output(test):
-    print("evaluating flow...")
-
+def check_output(idx, test):
     name = test.name
     ws = test.workspace
 
@@ -307,14 +305,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_uzf04.py
+++ b/autotest/test_gwf_uzf04.py
@@ -13,9 +13,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_uzf04a"]
+cases = ["gwf_uzf04a"]
 nlay, nrow, ncol = 1, 1, 1
 thts = 0.30  # saturated water content
 thtr = 0.05  # residual water content
@@ -48,7 +49,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -212,9 +213,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating flow...")
-
+def check_output(idx, test):
     name = test.name
     ws = test.workspace
 
@@ -256,14 +255,14 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_uzf05.py
+++ b/autotest/test_gwf_uzf05.py
@@ -2,7 +2,6 @@
 Test uzf for case where uzf is only in top cell.  There was a
 bug with this in the past in which case UZF would not send
 water to water table unless there was a uzf in each cell.
-
 """
 
 import os
@@ -10,9 +9,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwf_uzf05a"]
+cases = ["gwf_uzf05a"]
 nlay, nrow, ncol = 3, 1, 1
 
 thts = 0.30  # saturated water content
@@ -46,7 +46,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -212,11 +212,9 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(sim):
-    print("evaluating flow...")
-
-    name = sim.name
-    ws = sim.workspace
+def check_output(idx, test):
+    name = test.name
+    ws = test.workspace
 
     fname = os.path.join(ws, f"{name}.uzf.bin")
     wobj = flopy.utils.HeadFile(fname, text="WATER-CONTENT")
@@ -239,14 +237,14 @@ def check_output(sim):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_uzf_wc_output.py
+++ b/autotest/test_gwf_uzf_wc_output.py
@@ -4,11 +4,12 @@ import flopy
 import flopy.utils.binaryfile as bf
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
 include_NWT = False
 
-ex = ["uzf_3lay_wc_chk"]
+cases = ["uzf_3lay_wc_chk"]
 
 iuz_cell_dict = {}
 cell_iuz_dict = {}
@@ -226,7 +227,7 @@ def build_mf6_model(idx, ws):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     sim = flopy.mf6.MFSimulation(
@@ -341,7 +342,7 @@ def build_mf6_model(idx, ws):
 
 
 def build_mfnwt_model(idx, ws):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW-NWT files
     ws = os.path.join(ws, "mfnwt")
@@ -446,10 +447,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-def eval_model(test):
-    print("evaluating model...")
-
-    name = test.name
+def check_output(idx, test):
     ws = test.workspace
 
     # Get the MF6 heads
@@ -458,7 +456,7 @@ def eval_model(test):
     hds = hobj.get_alldata()
 
     # Get the MF6 water contents
-    wcpth = os.path.join(ws, ex[0] + ".uzfwc.bin")
+    wcpth = os.path.join(ws, cases[0] + ".uzfwc.bin")
     mf6_wc_obj = bf.HeadFile(wcpth, text="   water-content")
 
     ckstpkper_wc = mf6_wc_obj.get_kstpkper()
@@ -540,14 +538,14 @@ def eval_model(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
-        check=eval_model,
+        check=lambda t: check_output(idx, t),
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwf_vsc01.py
+++ b/autotest/test_gwf_vsc01.py
@@ -1,6 +1,4 @@
 """
-Test problem for VSC
-
 Uses constant head and general-head boundaries on the left and right
 sides of the model domain, respectively, to drive flow from left to
 right.  Tests that head-dependent boundary conditions are properly
@@ -15,10 +13,11 @@ import sys
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
+cases = ["no-vsc01-bnd", "vsc01-bnd", "no-vsc01-k"]
 hyd_cond = [1205.49396942506, 864.0]  # Hydraulic conductivity (m/d)
-ex = ["no-vsc01-bnd", "vsc01-bnd", "no-vsc01-k"]
 viscosity_on = [False, True, False]
 hydraulic_conductivity = [hyd_cond[0], hyd_cond[1], hyd_cond[1]]
 
@@ -61,7 +60,7 @@ hclose, rclose, relax = 1e-10, 1e-6, 0.97
 def build_models(idx, test):
     # Base simulation and model name and workspace
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     print("Building model...{}".format(name))
 
@@ -250,10 +249,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # read flow results from model
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf-" + name
 
     fname = gwfname + ".bud"
@@ -272,7 +269,7 @@ def check_output(idx, test):
         # Ensure latest simulated value hasn't changed from stored answer
         assert np.allclose(
             sim_val_1, stored_ans, atol=1e-4
-        ), "Flow in the " + ex[
+        ), "Flow in the " + cases[
             0
         ] + " test problem (doesn't simulate " "viscosity) has changed,\n should be " + str(
             stored_ans
@@ -287,7 +284,7 @@ def check_output(idx, test):
         # Ensure latest simulated value hasn't changed from stored answer
         assert np.allclose(
             sim_val_2, stored_ans, atol=1e-4
-        ), "Flow in the " + ex[
+        ), "Flow in the " + cases[
             1
         ] + " test problem (simulates " "viscosity) has changed,\n should be " + str(
             stored_ans
@@ -302,9 +299,9 @@ def check_output(idx, test):
         # Ensure the flow leaving model 3 is less than what leaves model 2
         assert abs(stored_ans) > abs(sim_val_3), (
             "Exit flow from model "
-            + ex[1]
+            + cases[1]
             + " should be greater than flow exiting "
-            + ex[2]
+            + cases[2]
             + ", but it is not."
         )
 
@@ -325,7 +322,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_vsc02.py
+++ b/autotest/test_gwf_vsc02.py
@@ -1,6 +1,4 @@
-"""Test problem for VSC
-
-Uses general-head and drain boundaries on the left and right
+"""Uses general-head and drain boundaries on the left and right
 sides of the model domain, respectively, to drive flow from left to
 right.  Tests that head-dependent boundary conditions are properly
 accounting for viscosity when VSC is active.  Similar to gwf-vsc01-bnd
@@ -16,11 +14,12 @@ import sys
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
 # Setup scenario input
+cases = ["no-vsc02-bnd", "vsc02-bnd", "no-vsc02-k"]
 hyd_cond = [1205.49396942506, 864.0]  # Hydraulic conductivity (m/d)
-ex = ["no-vsc02-bnd", "vsc02-bnd", "no-vsc02-k"]
 viscosity_on = [False, True, False]
 hydraulic_conductivity = [hyd_cond[0], hyd_cond[1], hyd_cond[1]]
 
@@ -63,7 +62,7 @@ hclose, rclose, relax = 1e-10, 1e-6, 0.97
 def build_models(idx, test):
     # Base simulation and model name and workspace
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     print("Building model...{}".format(name))
 
@@ -253,10 +252,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # read flow results from model
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf-" + name
 
     fname = gwfname + ".bud"
@@ -275,7 +272,7 @@ def check_output(idx, test):
         # Ensure latest simulated value hasn't changed from stored answer
         assert np.allclose(
             sim_val_1, stored_ans, atol=1e-4
-        ), "Flow in the " + ex[
+        ), "Flow in the " + cases[
             0
         ] + " test problem (doesn't simulate " "viscosity) has changed,\n should be " + str(
             stored_ans
@@ -290,7 +287,7 @@ def check_output(idx, test):
         # Ensure latest simulated value hasn't changed from stored answer
         assert np.allclose(
             sim_val_2, stored_ans, atol=1e-4
-        ), "Flow in the " + ex[
+        ), "Flow in the " + cases[
             1
         ] + " test problem (simulates " "viscosity) has changed,\n should be " + str(
             stored_ans
@@ -305,16 +302,16 @@ def check_output(idx, test):
         # Ensure the flow leaving model 3 is less than what leaves model 2
         assert abs(stored_ans) > abs(sim_val_3), (
             "Exit flow from model "
-            + ex[1]
+            + cases[1]
             + " should be greater than flow existing "
-            + ex[2]
+            + cases[2]
             + ", but it is not."
         )
 
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_vsc03_sfr.py
+++ b/autotest/test_gwf_vsc03_sfr.py
@@ -9,16 +9,15 @@ and more discharge of gw to the stream, compared to the same simulation
 with the VSC package inactive.
 """
 
-# Imports
-
 import os
 
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["no-vsc-sfr01", "vsc-sfr01"]
+cases = ["no-vsc-sfr01", "vsc-sfr01"]
 viscosity_on = [False, True]
 
 
@@ -90,9 +89,7 @@ K_d = C_s / (rho_water * C_p_w)  # Partitioning coefficient ($m^3/kg$)
 def build_models(idx, test):
     # Base simulation and model name and workspace
     ws = test.workspace
-    name = ex[idx]
-
-    print("Building model...{}".format(name))
+    name = cases[idx]
 
     # generate names for each model
     gwfname = "gwf-" + name
@@ -433,10 +430,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # read flow results from model
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf-" + name
 
     fname = gwfname + ".sfr.cbc"
@@ -530,7 +525,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_vsc04_lak.py
+++ b/autotest/test_gwf_vsc04_lak.py
@@ -19,9 +19,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["no-vsc04-lak", "vsc04-lak"]
+cases = ["no-vsc04-lak", "vsc04-lak"]
 viscosity_on = [False, True]
 
 # Model units
@@ -162,7 +163,7 @@ def build_models(idx, test):
     global lak_lkup_dict
 
     # Base simulation and model name and workspace
-    name = ex[idx]
+    name = cases[idx]
 
     print("Building model...{}".format(name))
 
@@ -611,10 +612,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # read flow results from model
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf-" + name
 
     fname = gwfname + ".lak.bud"
@@ -699,20 +698,20 @@ def check_output(idx, test):
         no_vsc_bud_last = np.array(outbud[-1].tolist())
         no_vsc_bud_np = np.array(no_vsc_bud_last.tolist())
 
-        for idx in np.arange(stored_ans.shape[0]):
-            k, i, j = lak_lkup_dict[idx]
+        for ii in np.arange(stored_ans.shape[0]):
+            k, i, j = lak_lkup_dict[ii]
 
             # left side of lake
             if j < 7:
-                if no_vsc_bud_np[idx, 2] > 0 and stored_ans[idx, 2] > 0:
-                    left_chk_no_vsc.append(no_vsc_bud_np[idx, 2])
-                    left_chk_ans.append(stored_ans[idx, 2])
+                if no_vsc_bud_np[ii, 2] > 0 and stored_ans[ii, 2] > 0:
+                    left_chk_no_vsc.append(no_vsc_bud_np[ii, 2])
+                    left_chk_ans.append(stored_ans[ii, 2])
 
             # right side of lake
             if j > 9:
-                if no_vsc_bud_np[idx, 2] < 0 and stored_ans[idx, 2] < 0:
-                    right_chk_no_vsc.append(no_vsc_bud_np[idx, 2])
-                    right_chk_ans.append(stored_ans[idx, 2])
+                if no_vsc_bud_np[ii, 2] < 0 and stored_ans[ii, 2] < 0:
+                    right_chk_no_vsc.append(no_vsc_bud_np[ii, 2])
+                    right_chk_ans.append(stored_ans[ii, 2])
 
         # Check that all the flows entering the lak in the 'with vsc' model are greater
         # than their 'no vsc' counterpart
@@ -737,20 +736,20 @@ def check_output(idx, test):
         with_vsc_bud_last = np.array(outbud[-1].tolist())
         with_vsc_bud_np = np.array(with_vsc_bud_last.tolist())
 
-        for idx in np.arange(stored_ans.shape[0]):
-            k, i, j = lak_lkup_dict[idx]
+        for ii in np.arange(stored_ans.shape[0]):
+            k, i, j = lak_lkup_dict[ii]
 
             # left side of lake
             if j < 7:
-                if stored_ans[idx, 2] > 0 and with_vsc_bud_np[idx, 2] > 0:
-                    left_chk_no_vsc.append(stored_ans[idx, 2])
-                    left_chk_with_vsc.append(with_vsc_bud_np[idx, 2])
+                if stored_ans[ii, 2] > 0 and with_vsc_bud_np[ii, 2] > 0:
+                    left_chk_no_vsc.append(stored_ans[ii, 2])
+                    left_chk_with_vsc.append(with_vsc_bud_np[ii, 2])
 
             # right side of lake
             if j > 9:
-                if stored_ans[idx, 2] < 0 and with_vsc_bud_np[idx, 2] < 0:
-                    right_chk_no_vsc.append(stored_ans[idx, 2])
-                    right_chk_with_vsc.append(with_vsc_bud_np[idx, 2])
+                if stored_ans[ii, 2] < 0 and with_vsc_bud_np[ii, 2] < 0:
+                    right_chk_no_vsc.append(stored_ans[ii, 2])
+                    right_chk_with_vsc.append(with_vsc_bud_np[ii, 2])
 
         # Check that all the flows entering the lak in the 'with vsc' model are greater
         # than their 'no vsc' counterpart
@@ -772,7 +771,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_vsc05_hfb.py
+++ b/autotest/test_gwf_vsc05_hfb.py
@@ -1,6 +1,4 @@
 """
-Test problem for VSC and HFB
-
 Uses constant head and general-head boundaries on the left and right
 sides of a 10 row by 10 column by 1 layer model to drive flow from left to
 right.  Tests that a horizontal flow barrier accounts for changes in
@@ -19,17 +17,16 @@ Model 3: VSC inactive, uses the lower K of model 2 and checks that flows
          to 16, etc.)
 """
 
-# Imports
-
 import os
 
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
+cases = ["no-vsc05-hfb", "vsc05-hfb", "no-vsc05-k"]
 hyd_cond = [1205.49396942506, 864.0]  # Hydraulic conductivity (m/d)
-ex = ["no-vsc05-hfb", "vsc05-hfb", "no-vsc05-k"]
 viscosity_on = [False, True, False]
 hydraulic_conductivity = [hyd_cond[0], hyd_cond[1], hyd_cond[1]]
 
@@ -71,7 +68,7 @@ hclose, rclose, relax = 1e-10, 1e-6, 0.97
 def build_models(idx, test):
     # Base simulation and model name and workspace
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     print("Building model...{}".format(name))
 
@@ -278,10 +275,8 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     # read flow results from model
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf-" + name
     sim1 = flopy.mf6.MFSimulation.load(
         sim_ws=test.workspace, load_only=["dis"]
@@ -336,7 +331,7 @@ def check_output(idx, test):
             no_vsc_bud_last[:, 2], stored_ans[:, 2], atol=1e-3
         ), (
             "Flow in models "
-            + ex[0]
+            + cases[0]
             + " and the established answer should be approximately "
             "equal, but are not."
         )
@@ -348,7 +343,7 @@ def check_output(idx, test):
             with_vsc_bud_last[:, 2], stored_ans[:, 2], atol=1e-3
         ), (
             "Flow in models "
-            + ex[1]
+            + cases[1]
             + " and the established answer should be approximately "
             "equal, but are not."
         )
@@ -361,7 +356,7 @@ def check_output(idx, test):
         assert np.less(no_vsc_low_k_bud_last[:, 2], stored_ans[:, 2]).all(), (
             "Exit flow from model the established answer "
             "should be greater than flow existing "
-            + ex[2]
+            + cases[2]
             + ", but it is not."
         )
 
@@ -369,7 +364,7 @@ def check_output(idx, test):
 # - No need to change any code below
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_wel01.py
+++ b/autotest/test_gwf_wel01.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["wel01"]
+cases = ["wel01"]
 
 # set static data
 nper = 1
@@ -31,7 +32,7 @@ hclose, rclose, relax = 1e-9, 1e-6, 1.0
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     sim = flopy.mf6.MFSimulation(
@@ -141,9 +142,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating well observations...")
-
+def check_output(idx, test):
     # MODFLOW 6 observations
     dtol = 1e-9
     for file_name in (
@@ -189,7 +188,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -197,6 +196,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwfgwf_lgr.py
+++ b/autotest/test_gwfgwf_lgr.py
@@ -36,11 +36,11 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.lgrutil import Lgr
+
 from framework import TestFramework
 
-ex = ["gwfgwf_lgr_classic", "gwfgwf_lgr_ifmod"]
+cases = ["gwfgwf_lgr_classic", "gwfgwf_lgr_ifmod"]
 ifmod = [False, True]
-
 parent_name = "parent"
 child_name = "child"
 h_left = 1.0
@@ -55,7 +55,7 @@ def get_model(idx, test):
     global child_domain
     global hclose
 
-    name = ex[idx]
+    name = cases[idx]
 
     # tdis period data
     nper = 1
@@ -242,25 +242,25 @@ def build_models(idx, exdir):
     return sim, None
 
 
-def check_output(sim):
+def check_output(idx, test):
     print("comparing heads  for child model to analytical result...")
 
-    fpth = os.path.join(sim.workspace, f"{child_name}.hds")
+    fpth = os.path.join(test.workspace, f"{child_name}.hds")
     hds_c = flopy.utils.HeadFile(fpth)
     heads_c = hds_c.get_data()
 
-    fpth = os.path.join(sim.workspace, f"{child_name}.dis.grb")
+    fpth = os.path.join(test.workspace, f"{child_name}.dis.grb")
     grb_c = flopy.mf6.utils.MfGrdFile(fpth)
 
     # check flowja residual
     for mname in [parent_name, child_name]:
         print(f"Checking flowja residual for model {mname}")
 
-        fpth = os.path.join(sim.workspace, f"{mname}.dis.grb")
+        fpth = os.path.join(test.workspace, f"{mname}.dis.grb")
         grb = flopy.mf6.utils.MfGrdFile(fpth)
         ia = grb._datadict["IA"] - 1
 
-        fpth = os.path.join(sim.workspace, f"{mname}.cbc")
+        fpth = os.path.join(test.workspace, f"{mname}.cbc")
         assert os.path.isfile(fpth)
         cbb = flopy.utils.CellBudgetFile(fpth, precision="double")
         flow_ja_face = cbb.get_data(idx=0)
@@ -277,7 +277,7 @@ def check_output(sim):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
@@ -286,6 +286,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_adv01.py
+++ b/autotest/test_gwt_adv01.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["adv01a", "adv01b", "adv01c"]
+cases = ["adv01a", "adv01b", "adv01c"]
 scheme = ["upstream", "central", "tvd"]
 
 
@@ -39,7 +40,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -239,9 +240,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -588,7 +587,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_adv01_fmi.py
+++ b/autotest/test_gwt_adv01_fmi.py
@@ -10,9 +10,10 @@ import numpy as np
 import pytest
 from flopy.utils.binaryfile import write_budget, write_head
 from flopy.utils.gridutil import uniform_flow_field
+
 from framework import TestFramework
 
-ex = ["adv01a_fmi", "adv01b_fmi", "adv01c_fmi"]
+cases = ["adv01a_fmi", "adv01b_fmi", "adv01c_fmi"]
 scheme = ["upstream", "central", "tvd"]
 
 
@@ -38,7 +39,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -215,9 +216,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -564,7 +563,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_adv01_gwtgwt.py
+++ b/autotest/test_gwt_adv01_gwtgwt.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["adv01a_gwtgwt", "adv01b_gwtgwt", "adv01c_gwtgwt"]
+cases = ["adv01a_gwtgwt", "adv01b_gwtgwt", "adv01c_gwtgwt"]
 scheme = ["upstream", "central", "tvd"]
 gdelr = 1.0
 
@@ -329,9 +330,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def eval_transport(idx, test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     gwtname = "transport1"
 
     fpth = os.path.join(test.workspace, gwtname, f"{gwtname}.ucn")
@@ -722,7 +721,7 @@ def eval_transport(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
@@ -731,6 +730,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=lambda t: eval_transport(idx, t),
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_adv02.py
+++ b/autotest/test_gwt_adv02.py
@@ -11,9 +11,10 @@ import flopy
 import flopy.utils.cvfdutil
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["adv02a", "adv02b", "adv02c"]
+cases = ["adv02a", "adv02b", "adv02c"]
 scheme = ["upstream", "central", "tvd"]
 
 
@@ -84,7 +85,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -298,9 +299,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -941,7 +940,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_adv03.py
+++ b/autotest/test_gwt_adv03.py
@@ -11,9 +11,10 @@ import flopy
 import flopy.utils.cvfdutil
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["adv03a", "adv03b", "adv03c"]
+cases = ["adv03a", "adv03b", "adv03c"]
 scheme = ["upstream", "central", "tvd"]
 
 
@@ -90,7 +91,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -329,9 +330,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -493,7 +492,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_adv04.py
+++ b/autotest/test_gwt_adv04.py
@@ -9,9 +9,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["adv04a", "adv04b", "adv04c"]
+cases = ["adv04a", "adv04b", "adv04c"]
 scheme = ["upstream", "central", "tvd"]
 
 
@@ -52,7 +53,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -226,9 +227,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -256,7 +255,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_buy_solute_heat.py
+++ b/autotest/test_gwt_buy_solute_heat.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["gwtbuy"]
+cases = ["gwtbuy"]
 
 
 def build_models(idx, test):
@@ -33,7 +34,7 @@ def build_models(idx, test):
     nouter, ninner = 100, 300
     hclose, rclose, relax = 1e-10, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -408,14 +409,12 @@ def make_plot(sim):
     return
 
 
-def check_output(sim):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     makeplot = False
     if makeplot:
-        make_plot(sim)
+        make_plot(test)
 
-    ws = sim.workspace
+    ws = test.workspace
     gwfname = "flow"
     gwtsname = "salinity"
     gwthname = "temperature"
@@ -461,7 +460,7 @@ def check_output(sim):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -469,6 +468,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_disu01.py
+++ b/autotest/test_gwt_disu01.py
@@ -10,9 +10,10 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.gridutil import get_disu_kwargs
+
 from framework import TestFramework
 
-ex = ["disu01a"]
+cases = ["disu01a"]
 
 
 def build_models(idx, test):
@@ -56,7 +57,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -217,9 +218,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -249,7 +248,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -257,6 +256,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_dsp01.py
+++ b/autotest/test_gwt_dsp01.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["dsp01a", "dsp01b"]
+cases = ["dsp01a", "dsp01b"]
 xt3d = [False, True]
 
 
@@ -37,7 +38,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -240,9 +241,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -381,13 +380,10 @@ def check_output(idx, test):
     errmsg = f"observations not equal:\n{gwtobs}\n{cncobs}"
     assert np.allclose(gwtobs["FLOW1"], -cncobs["CNC000"]), errmsg
 
-    # comment when done testing
-    # assert False
-
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dsp01_fmi.py
+++ b/autotest/test_gwt_dsp01_fmi.py
@@ -4,9 +4,10 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.binaryfile import write_budget, write_head
+
 from framework import TestFramework
 
-ex = ["dsp01a_fmi", "dsp01b_fmi"]
+cases = ["dsp01a_fmi", "dsp01b_fmi"]
 xt3d = [False, True]
 
 
@@ -38,7 +39,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -191,9 +192,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -321,7 +320,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dsp01_gwtgwt.py
+++ b/autotest/test_gwt_dsp01_gwtgwt.py
@@ -7,9 +7,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["dsp01_gwtgwt"]
+cases = ["dsp01_gwtgwt"]
 gdelr = 1.0
 
 # solver settings
@@ -266,7 +267,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
+def check_output(idx, test):
     gwtname = "transport1"
     fpth = os.path.join(test.workspace, "transport1", f"{gwtname}.ucn")
     try:
@@ -297,7 +298,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
@@ -306,6 +307,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_dsp01_noadv.py
+++ b/autotest/test_gwt_dsp01_noadv.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["dsp01a_noadv", "dsp01b_noadv"]
+cases = ["dsp01a_noadv", "dsp01b_noadv"]
 xt3d = [False, True]
 
 
@@ -37,7 +38,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -135,9 +136,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -265,7 +264,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dsp02.py
+++ b/autotest/test_gwt_dsp02.py
@@ -11,9 +11,10 @@ import flopy
 import flopy.utils.cvfdutil
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["dsp02a", "dsp02b"]
+cases = ["dsp02a", "dsp02b"]
 xt3d = [True, False]
 
 
@@ -84,7 +85,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -275,9 +276,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -712,7 +711,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dsp03.py
+++ b/autotest/test_gwt_dsp03.py
@@ -11,9 +11,10 @@ import flopy
 import flopy.utils.cvfdutil
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["dsp03a", "dsp03b"]
+cases = ["dsp03a", "dsp03b"]
 xt3d = [False, True]
 
 
@@ -90,7 +91,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -316,9 +317,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -439,7 +438,7 @@ def check_output(idx, test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dsp04.py
+++ b/autotest/test_gwt_dsp04.py
@@ -3,10 +3,11 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
 # test dispersion without and with xt3d
-ex = ["dsp04a", "dsp04b"]
+cases = ["dsp04a", "dsp04b"]
 xt3d = [None, True]
 
 
@@ -44,7 +45,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -222,9 +223,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -252,7 +251,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dsp05_noadv.py
+++ b/autotest/test_gwt_dsp05_noadv.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["dsp05a_noadv", "dsp01b_noadv"]
+cases = ["dsp05a_noadv", "dsp01b_noadv"]
 xt3d = [False, True]
 
 
@@ -33,7 +34,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -131,9 +132,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -160,7 +159,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_fmi01.py
+++ b/autotest/test_gwt_fmi01.py
@@ -5,9 +5,10 @@ import numpy as np
 import pytest
 from flopy.utils.binaryfile import write_budget, write_head
 from flopy.utils.gridutil import uniform_flow_field
+
 from framework import TestFramework
 
-ex = ["fmi01a_fc"]
+cases = ["fmi01a_fc"]
 xt3d = [False, True]
 
 
@@ -37,7 +38,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -172,9 +173,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -192,7 +191,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -200,6 +199,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_fmi02.py
+++ b/autotest/test_gwt_fmi02.py
@@ -1,4 +1,4 @@
-"""tests to ability to run flow model first followed by transport model"""
+"""Tests to ability to run flow model first followed by transport model"""
 
 import os
 

--- a/autotest/test_gwt_henry.py
+++ b/autotest/test_gwt_henry.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["henry01"]
+cases = ["henry01"]
 
 
 def build_models(idx, test):
@@ -33,7 +34,7 @@ def build_models(idx, test):
     nouter, ninner = 100, 300
     hclose, rclose, relax = 1e-10, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -229,9 +230,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -289,7 +288,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -297,6 +296,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_henry_gwtgwt.py
+++ b/autotest/test_gwt_henry_gwtgwt.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["henry01-gwtgwt-ups", "henry01-gwtgwt-cen", "henry01-gwtgwt-tvd"]
+cases = ["henry01-gwtgwt-ups", "henry01-gwtgwt-cen", "henry01-gwtgwt-tvd"]
 advection_scheme = ["UPSTREAM", "CENTRAL", "TVD"]
 
 lx = 2.0
@@ -223,7 +224,7 @@ def get_gwt_model(sim, model_shape, model_desc, adv_scheme):
 
 
 def build_models(idx, test):
-    name = ex[idx]
+    name = cases[idx]
     print("RUINNING: ", name, advection_scheme[idx])
 
     # build MODFLOW 6 files
@@ -362,9 +363,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     fpth = os.path.join(test.workspace, "gwf_ref.hds")
     hds = flopy.utils.HeadFile(fpth)
     heads = hds.get_data()
@@ -429,7 +428,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -437,6 +436,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_henry_nr.py
+++ b/autotest/test_gwt_henry_nr.py
@@ -12,9 +12,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["henrynr01"]
+cases = ["henrynr01"]
 
 # global model variables
 nlay = 20
@@ -69,7 +70,7 @@ def sinfunc(a, b, c, d, x):
 
 def build_models(idx, test):
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
 
     nrow = 1
     delr = lx / ncol
@@ -461,9 +462,7 @@ def make_plot(sim, headall, concall):
     plt.savefig(fname, bbox_inches="tight")
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     ws = test.workspace
     gwfname = "gwf_" + name
@@ -530,7 +529,7 @@ def check_output(test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -538,6 +537,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_henry_openclose.py
+++ b/autotest/test_gwt_henry_openclose.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["henry_ext"]
+cases = ["henry_ext"]
 
 
 def build_models(idx, test):
@@ -33,7 +34,7 @@ def build_models(idx, test):
     nouter, ninner = 100, 300
     hclose, rclose, relax = 1e-10, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -232,9 +233,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -292,7 +291,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -300,6 +299,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_ims_issue655.py
+++ b/autotest/test_gwt_ims_issue655.py
@@ -10,9 +10,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["issue655a", "issue655b"]
+cases = ["issue655a", "issue655b"]
 newton = [
     False,
     True,
@@ -63,7 +64,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     sim = flopy.mf6.MFSimulation(
@@ -248,9 +249,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
     gwfname = "gwf_" + name
 
@@ -292,7 +291,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_ist01.py
+++ b/autotest/test_gwt_ist01.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["ist01"]
+cases = ["ist01"]
 laytyp = [1]
 ss = [1.0e-10]
 sy = [0.1]
@@ -41,7 +42,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -219,9 +220,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
     gwfname = "gwf_" + name
@@ -266,7 +265,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -274,6 +273,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_ist02.py
+++ b/autotest/test_gwt_ist02.py
@@ -16,9 +16,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["ist02"]
+cases = ["ist02"]
 nlay, nrow, ncol = 1, 1, 300
 
 mt3d_times = np.arange(1.0, 51.0, 1.0)
@@ -97,7 +98,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -343,12 +344,8 @@ def make_plot(sim):
     fname = os.path.join(ws, gwtname + ".png")
     plt.savefig(fname)
 
-    return
 
-
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     makeplot = False
     if makeplot:
         make_plot(test)
@@ -381,7 +378,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -389,6 +386,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_lkt01.py
+++ b/autotest/test_gwt_lkt01.py
@@ -10,9 +10,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import DNODATA, TestFramework
 
-ex = ["lkt_01"]
+cases = ["lkt_01"]
 
 
 def build_models(idx, test):
@@ -46,7 +47,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -356,9 +357,7 @@ def eval_csv_information(testsim):
     ), f"Lake package does not have zero mass balance error: {result}"
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # eval csv files
     eval_csv_information(test)
 
@@ -430,13 +429,10 @@ def check_output(test):
     answer = np.ones(10) * -216.3934
     assert np.allclose(res, answer), f"{res} {answer}"
 
-    # uncomment when testing
-    # assert False
-
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -444,6 +440,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_lkt02.py
+++ b/autotest/test_gwt_lkt02.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import DNODATA, TestFramework
 
-ex = ["lkt_02"]
+cases = ["lkt_02"]
 
 
 def build_models(idx, test):
@@ -44,7 +45,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -353,9 +354,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # ensure lake concentrations were saved
     name = test.name
     gwtname = "gwt_" + name
@@ -483,13 +482,10 @@ def check_output(test):
     for dtname, dttype in dt:
         assert np.allclose(res[dtname], answer[dtname]), f"{res} {answer}"
 
-    # uncomment when testing
-    # assert False
-
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -497,6 +493,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_lkt03.py
+++ b/autotest/test_gwt_lkt03.py
@@ -8,12 +8,13 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import DNODATA, TestFramework
 
-ex = ["lkt_03"]
+cases = ["lkt_03"]
 
 
-def build_model(idx, test):
+def build_models(idx, test):
     lx = 7.0
     lz = 1.0
     nlay = 1
@@ -42,7 +43,7 @@ def build_model(idx, test):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -333,9 +334,7 @@ def build_model(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # ensure lake concentrations were saved
     name = test.name
     gwtname = "gwt_" + name
@@ -379,20 +378,17 @@ def check_output(test):
     for dtname, dttype in dt:
         assert np.allclose(res[dtname], answer[dtname]), f"{res} {answer}"
 
-    # uncomment when testing
-    # assert False
-
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_model(idx, t),
-        check=check_output,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_lkt04.py
+++ b/autotest/test_gwt_lkt04.py
@@ -11,9 +11,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import DNODATA, TestFramework
 
-ex = ["lkt_04"]
+cases = ["lkt_04"]
 
 
 def build_models(idx, test):
@@ -47,7 +48,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     sim = flopy.mf6.MFSimulation(
@@ -372,9 +373,7 @@ def eval_csv_information(testsim):
     assert success, f"One or more errors encountered in budget checks"
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # eval csv files
     eval_csv_information(test)
 
@@ -470,13 +469,10 @@ def check_output(test):
     answer = np.zeros(10)
     assert np.allclose(res, answer), f"{res} {answer}"
 
-    # uncomment when testing
-    # assert False
-
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -484,6 +480,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_moc3d01.py
+++ b/autotest/test_gwt_moc3d01.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "moc3d01a",
     "moc3d01b",
     "moc3d01c",
@@ -49,7 +50,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -271,9 +272,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -352,7 +351,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_moc3d01_zod.py
+++ b/autotest/test_gwt_moc3d01_zod.py
@@ -11,9 +11,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "moc3d01zoda",
     "moc3d01zodb",
     "moc3d01zodc",
@@ -52,7 +53,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -364,9 +365,7 @@ def make_plot_cd(cobj, fname=None):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     # get mobile domain concentration object
@@ -572,7 +571,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_moc3d02.py
+++ b/autotest/test_gwt_moc3d02.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["moc3d02a", "moc3d02b"]
+cases = ["moc3d02a", "moc3d02b"]
 xt3d = [None, True]
 
 
@@ -41,7 +42,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -240,9 +241,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -311,7 +310,7 @@ def check_output(idx, test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_moc3d03.py
+++ b/autotest/test_gwt_moc3d03.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["moc3d03"]
+cases = ["moc3d03"]
 
 
 def build_models(idx, test):
@@ -40,7 +41,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -233,9 +234,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -293,7 +292,7 @@ def check_output(test):
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -301,6 +300,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_mst01.py
+++ b/autotest/test_gwt_mst01.py
@@ -3,9 +3,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["mst01"]
+cases = ["mst01"]
 laytyp = [1]
 ss = [0.0]
 sy = [0.1]
@@ -33,7 +34,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -214,9 +215,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -233,7 +232,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -241,6 +240,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_mst02.py
+++ b/autotest/test_gwt_mst02.py
@@ -7,9 +7,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["mst02a", "mst02b"]
+cases = ["mst02a", "mst02b"]
 distcoef = [0.0, 1.0]
 nlay, nrow, ncol = 1, 1, 2
 
@@ -69,7 +70,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -226,10 +227,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    idx = idx
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -257,7 +255,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_mst03.py
+++ b/autotest/test_gwt_mst03.py
@@ -9,9 +9,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["mst03"]
+cases = ["mst03"]
 laytyp = [1]
 ss = [1.0e-10]
 sy = [0.1]
@@ -37,7 +38,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -212,9 +213,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
     gwfname = "gwf_" + name
@@ -284,7 +283,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -292,6 +291,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_mst04_noadv.py
+++ b/autotest/test_gwt_mst04_noadv.py
@@ -7,9 +7,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["mst04_noadv"]
+cases = ["mst04_noadv"]
 
 
 def build_models(idx, test):
@@ -30,7 +31,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -106,9 +107,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -124,7 +123,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -132,6 +131,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_mst05.py
+++ b/autotest/test_gwt_mst05.py
@@ -9,9 +9,10 @@ import numpy as np
 import pytest
 from flopy.utils.binaryfile import write_budget, write_head
 from flopy.utils.gridutil import uniform_flow_field
+
 from framework import TestFramework
 
-ex = ["mst05a", "mst05b"]
+cases = ["mst05a", "mst05b"]
 isotherm = ["freundlich", "langmuir"]
 distcoef = [0.3, 100.0]
 sp2 = [0.7, 0.003]
@@ -45,7 +46,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -265,9 +266,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    print("evaluating transport...")
-
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
@@ -307,7 +306,7 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_mst06_noadv.py
+++ b/autotest/test_gwt_mst06_noadv.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["mst06_noadv"]
+cases = ["mst06_noadv"]
 
 
 def build_models(idx, test):
@@ -31,7 +32,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -116,9 +117,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -164,7 +163,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -172,6 +171,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_mt3dms_p01.py
+++ b/autotest/test_gwt_mt3dms_p01.py
@@ -25,6 +25,7 @@ from typing import Tuple
 import flopy
 import numpy as np
 import pytest
+
 from conftest import try_get_target
 
 testgroup = "mt3dms_p01"

--- a/autotest/test_gwt_mvt01.py
+++ b/autotest/test_gwt_mvt01.py
@@ -11,9 +11,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["mvt_01"]
+cases = ["mvt_01"]
 
 
 def build_models(idx, test):
@@ -47,7 +48,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -482,9 +483,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # ensure lake concentrations were saved
     name = test.name
     gwtname = "gwt_" + name
@@ -544,13 +543,10 @@ def check_output(test):
     )
     assert np.allclose(d0["SFR-1_OUT"], d0["LAK-1_IN"])
 
-    # uncomment when testing so files aren't deleted
-    # assert False
-
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -558,6 +554,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_mvt02.py
+++ b/autotest/test_gwt_mvt02.py
@@ -11,9 +11,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["mvt_02"]
+cases = ["mvt_02"]
 
 
 def build_models(idx, test):
@@ -45,7 +46,7 @@ def build_models(idx, test):
     nouter, ninner = 20, 10
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -384,8 +385,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating results...")
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -474,13 +474,10 @@ def check_output(test):
     res = bobj.get_data(text="storage")[-1]
     # print(res)
 
-    # uncomment when testing so files aren't deleted
-    # assert False
-
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -488,6 +485,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_mvt02fmi.py
+++ b/autotest/test_gwt_mvt02fmi.py
@@ -13,7 +13,7 @@ import flopy
 import numpy as np
 
 testgroup = "mvt02fmi"
-ex = ["mvt02fmi"]
+cases = ["mvt02fmi"]
 
 # parameters
 lx = 7.0
@@ -392,8 +392,6 @@ def run_transport_model(dir, exe):
     errmsg = f"transport model did not terminate successfully\n{buff}"
     assert success, errmsg
 
-    print("evaluating results...")
-
     # Load csv budget and make sure names are correct
     fname = f"{gwtname}.bud.csv"
     fname = os.path.join(gwt.model_ws, fname)
@@ -472,6 +470,5 @@ def run_transport_model(dir, exe):
 
 
 def test_mvt02fmi(function_tmpdir, targets):
-    mf6 = targets.mf6
-    run_flow_model(str(function_tmpdir), mf6)
-    run_transport_model(str(function_tmpdir), mf6)
+    run_flow_model(str(function_tmpdir), targets.mf6)
+    run_transport_model(str(function_tmpdir), targets.mf6)

--- a/autotest/test_gwt_mwt01.py
+++ b/autotest/test_gwt_mwt01.py
@@ -10,9 +10,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["mwt_01"]
+cases = ["mwt_01"]
 
 
 def build_models(idx, test):
@@ -45,7 +46,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -376,9 +377,7 @@ def check_obs(sim):
     assert success, "One or more MWT obs checks did not pass"
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # ensure mwt concentrations were saved
     name = test.name
     gwtname = "gwt_" + name
@@ -396,7 +395,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -404,6 +403,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_mwt02.py
+++ b/autotest/test_gwt_mwt02.py
@@ -5,9 +5,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["mwt_02"]
+cases = ["mwt_02"]
 
 
 def build_models(idx, test):
@@ -36,7 +37,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -427,14 +428,12 @@ def make_plot(sim):
 
 
 def check_output(idx, test):
-    print("evaluating results...")
-
     makeplot = False
     if makeplot:
         make_plot(test)
 
     # ensure concentrations were saved
-    name = ex[idx]
+    name = cases[idx]
     gwtname = "gwt_" + name
     fname = gwtname + ".mwt.bin"
     fname = os.path.join(test.workspace, fname)
@@ -472,12 +471,9 @@ def check_output(idx, test):
     answer = np.ones(res.shape) * 1000.0
     assert np.allclose(res, answer), f"{res} {answer}"
 
-    # uncomment when testing
-    # assert False
-
 
 @pytest.mark.slow
-@pytest.mark.parametrize("idx, name", list(enumerate(ex)))
+@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_obs01.py
+++ b/autotest/test_gwt_obs01.py
@@ -7,9 +7,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = [
+cases = [
     "gwt_obs01a",
 ]
 scheme = ["upstream"]
@@ -40,7 +41,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -239,9 +240,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -265,7 +264,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -273,6 +272,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_prudic2004t2.py
+++ b/autotest/test_gwt_prudic2004t2.py
@@ -12,10 +12,11 @@ import sys
 import flopy
 import numpy as np
 import pytest
+
 from conftest import project_root_path
 from framework import TestFramework
 
-ex = ["prudic2004t2"]
+cases = ["prudic2004t2"]
 data_path = project_root_path / "autotest" / "data"
 model_path = data_path / "prudic2004test2"
 fname = str(model_path / "lakibd.dat")
@@ -24,7 +25,7 @@ lakibd = np.loadtxt(fname, dtype=int)
 
 def build_models(idx, test):
     ws = test.workspace
-    name = ex[idx]
+    name = cases[idx]
     gwfname = "gwf_" + name
     gwtname = "gwt_" + name
     sim = flopy.mf6.MFSimulation(
@@ -814,11 +815,9 @@ def check_obs(sim):
     assert success, "One or more SFT-LKT obs checks did not pass"
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     makeplot = False
-    for idx, arg in enumerate(sys.argv):
+    for arg in sys.argv:
         if arg.lower() == "--makeplot":
             makeplot = True
 
@@ -965,14 +964,11 @@ def check_output(test):
     # fname = os.path.join(ws, f"result_conc_sfr4.txt")
     # np.savetxt(fname, res_sfr4)
 
-    # uncomment when testing
-    # assert False
-
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -980,6 +976,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_prudic2004t2fmi.py
+++ b/autotest/test_gwt_prudic2004t2fmi.py
@@ -1,4 +1,4 @@
-"""tests to ability to run flow model first followed by transport model"""
+"""Tests to ability to run flow model first followed by transport model"""
 
 import os
 from os.path import join
@@ -6,6 +6,7 @@ from os.path import join
 import flopy
 import numpy as np
 import pytest
+
 from conftest import project_root_path
 
 data_path = project_root_path / "autotest" / "data"
@@ -784,6 +785,5 @@ def run_transport_model(dir, exe):
 
 @pytest.mark.slow
 def test_prudic2004t2fmi(function_tmpdir, targets):
-    mf6 = targets.mf6
-    run_flow_model(str(function_tmpdir), mf6)
-    run_transport_model(str(function_tmpdir), mf6)
+    run_flow_model(str(function_tmpdir), targets.mf6)
+    run_transport_model(str(function_tmpdir), targets.mf6)

--- a/autotest/test_gwt_prudic2004t2fmiats.py
+++ b/autotest/test_gwt_prudic2004t2fmiats.py
@@ -1,5 +1,5 @@
 """
-tests ats on the prudic transport model.  With these ATS settings, the
+Tests ATS on the prudic transport model.  With these ATS settings, the
 solver should fail on time step 19 in period 2, and should converge on the
 second try with a smaller time step.  This test will not pass if the states
 are not restored properly for the advanced transport packages when the
@@ -12,12 +12,12 @@ from os.path import join
 import flopy
 import numpy as np
 import pytest
+
 from conftest import project_root_path
 
 data_path = project_root_path / "autotest" / "data"
 model_path = str(data_path / "prudic2004test2")
 testgroup = "prudic2004t2fmiats"
-
 nlay = 8
 nrow = 36
 ncol = 23
@@ -853,6 +853,5 @@ def run_transport_model(dir, exe):
 
 @pytest.mark.slow
 def test_prudic2004t2fmiats(function_tmpdir, targets):
-    mf6 = targets.mf6
-    run_flow_model(dir=str(function_tmpdir), exe=mf6)
-    run_transport_model(dir=str(function_tmpdir), exe=mf6)
+    run_flow_model(dir=str(function_tmpdir), exe=targets.mf6)
+    run_transport_model(dir=str(function_tmpdir), exe=targets.mf6)

--- a/autotest/test_gwt_prudic2004t2gwtgwt.py
+++ b/autotest/test_gwt_prudic2004t2gwtgwt.py
@@ -12,12 +12,13 @@ import sys
 import flopy
 import numpy as np
 import pytest
+
 from conftest import project_root_path
 from framework import TestFramework
 
+cases = ["prudic2004t2gwtgwt"]
 data_path = project_root_path / "autotest" / "data"
 model_path = str(data_path / "prudic2004test2gwtgwt")
-ex = ["prudic2004t2gwtgwt"]
 gwfnames = ["flow1", "flow2"]
 gwtnames = ["transport1", "transport2"]
 
@@ -873,9 +874,7 @@ def make_concentration_map(sim, ws):
     plt.savefig(fname)
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # these answer files are results from autotest/prudic2004test2
     fname = os.path.join(model_path, "result_conc_lak1.txt")
     ans_lak1 = np.loadtxt(fname)
@@ -885,7 +884,7 @@ def check_output(test):
     ans_sfr4 = np.loadtxt(fname)
 
     makeplot = False
-    for idx, arg in enumerate(sys.argv):
+    for arg in sys.argv:
         if arg.lower() == "--makeplot":
             makeplot = True
 
@@ -949,14 +948,11 @@ def check_output(test):
         msg = f"{res_sfr4} {ans_sfr4} {d}"
         assert np.allclose(res_sfr4, ans_sfr4, atol=atol), msg
 
-    # uncomment when testing
-    # assert False
-
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -964,6 +960,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_sft01.py
+++ b/autotest/test_gwt_sft01.py
@@ -12,9 +12,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["sft_01"]
+cases = ["sft_01"]
 
 
 def build_models(idx, test):
@@ -47,7 +48,7 @@ def build_models(idx, test):
     nouter, ninner = 700, 300
     hclose, rclose, relax = 1e-8, 1e-6, 0.97
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -366,9 +367,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # ensure lake concentrations were saved
     name = test.name
     gwtname = "gwt_" + name
@@ -422,13 +421,10 @@ def check_output(test):
     msg = f"{qs} /= {qa}"
     assert np.allclose(qs, qa), msg
 
-    # uncomment when testing
-    # assert False
-
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -436,6 +432,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_sft01gwtgwt.py
+++ b/autotest/test_gwt_sft01gwtgwt.py
@@ -21,9 +21,10 @@ should match exactly with the gwf flows and the gwf concentrations.
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["sft01gwtgwt"]
+cases = ["sft01gwtgwt"]
 
 # properties for each model combination
 lx = 7.0
@@ -479,18 +480,16 @@ def build_gwfgwt_combo(sim, gwfname, gwtname, icombo):
     return sim, None
 
 
-def check_output(sim):
-    print("evaluating results...")
-
+def check_output(idx, test):
     # load the simulations
-    ws = sim.workspace
-    sim = flopy.mf6.MFSimulation.load(sim_ws=ws)
+    ws = test.workspace
+    test = flopy.mf6.MFSimulation.load(sim_ws=ws)
 
     # construct head and conc for combined models
-    gwf1 = sim.gwf[0]
-    gwf2 = sim.gwf[1]
-    gwt1 = sim.gwt[0]
-    gwt2 = sim.gwt[1]
+    gwf1 = test.gwf[0]
+    gwf2 = test.gwf[1]
+    gwt1 = test.gwt[0]
+    gwt2 = test.gwt[1]
     head = list(gwf1.output.head().get_data().flatten()) + list(
         gwf2.output.head().get_data().flatten()
     )
@@ -513,7 +512,7 @@ def check_output(sim):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -521,6 +520,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_src01.py
+++ b/autotest/test_gwt_src01.py
@@ -10,9 +10,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["src01a"]
+cases = ["src01a"]
 xt3d = [False]
 
 
@@ -44,7 +45,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -236,9 +237,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -256,7 +255,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -264,6 +263,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_ssm01fmi.py
+++ b/autotest/test_gwt_ssm01fmi.py
@@ -312,6 +312,5 @@ def run_transport_model(dir, exe):
 
 
 def test_ssm01fmi(function_tmpdir, targets):
-    mf6 = targets.mf6
-    run_flow_model(str(function_tmpdir), mf6)
-    run_transport_model(str(function_tmpdir), mf6)
+    run_flow_model(str(function_tmpdir), targets.mf6)
+    run_transport_model(str(function_tmpdir), targets.mf6)

--- a/autotest/test_gwt_ssm02.py
+++ b/autotest/test_gwt_ssm02.py
@@ -11,9 +11,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["ssm02"]
+cases = ["ssm02"]
 laytyp = [1]
 ss = [1.0e-10]
 sy = [0.1]
@@ -39,7 +40,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -214,9 +215,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
     gwfname = "gwf_" + name
@@ -251,7 +250,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -259,6 +258,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_ssm03.py
+++ b/autotest/test_gwt_ssm03.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["ssm03"]
+cases = ["ssm03"]
 
 
 def build_models(idx, test):
@@ -34,7 +35,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -226,9 +227,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -259,7 +258,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -267,6 +266,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_ssm04.py
+++ b/autotest/test_gwt_ssm04.py
@@ -14,9 +14,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["ssm04"]
+cases = ["ssm04"]
 
 nlay, nrow, ncol = 3, 5, 5
 idomain_lay0 = [
@@ -50,7 +51,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -416,9 +417,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -504,7 +503,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -512,6 +511,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_ssm04fmi.py
+++ b/autotest/test_gwt_ssm04fmi.py
@@ -465,7 +465,6 @@ def run_transport_model(dir, exe):
 
 
 def eval_transport(wst):
-    print("evaluating transport...")
     gwtname = "transport"
 
     # load concentration file
@@ -551,6 +550,5 @@ def eval_transport(wst):
 
 
 def test_ssm04fmi(function_tmpdir, targets):
-    mf6 = targets.mf6
-    run_flow_model(str(function_tmpdir), mf6)
-    run_transport_model(str(function_tmpdir), mf6)
+    run_flow_model(str(function_tmpdir), targets.mf6)
+    run_transport_model(str(function_tmpdir), targets.mf6)

--- a/autotest/test_gwt_ssm05.py
+++ b/autotest/test_gwt_ssm05.py
@@ -8,9 +8,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["ssm05"]
+cases = ["ssm05"]
 
 nlay, nrow, ncol = 3, 5, 5
 idomain_lay0 = [
@@ -44,7 +45,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -235,9 +236,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
-    print("evaluating transport...")
-
+def check_output(idx, test):
     name = test.name
     gwtname = "gwt_" + name
 
@@ -313,7 +312,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -321,6 +320,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwt_ssm06.py
+++ b/autotest/test_gwt_ssm06.py
@@ -18,11 +18,9 @@ delc = 10.0
 top = 100.0
 botm = 0.0
 
-#
 # Add SFR for serving as a MVR receiver (something's up when multiple packages
 # appear in SSM and MVR is active. When MVR is inactive, all seem to work well.
 # However, things break as soon as MVR is activated.
-#
 
 conns = [(0, -1), (1, 0, -2), (2, 1, -3), (3, 2, -4), (4, 3)]
 
@@ -350,5 +348,4 @@ def run_flw_and_trnprt_models(dir, exe):
 
 
 def test_ssm06(function_tmpdir, targets):
-    mf6 = targets.mf6
-    run_flw_and_trnprt_models(str(function_tmpdir), mf6)
+    run_flw_and_trnprt_models(str(function_tmpdir), targets.mf6)

--- a/autotest/test_gwt_ssm06fmi.py
+++ b/autotest/test_gwt_ssm06fmi.py
@@ -381,6 +381,5 @@ def run_transport_model(dir, exe):
 
 
 def test_ssm06fmi(function_tmpdir, targets):
-    mf6 = targets.mf6
-    run_flow_model(str(function_tmpdir), mf6)
-    run_transport_model(str(function_tmpdir), mf6)
+    run_flow_model(str(function_tmpdir), targets.mf6)
+    run_transport_model(str(function_tmpdir), targets.mf6)

--- a/autotest/test_gwt_uzt01.py
+++ b/autotest/test_gwt_uzt01.py
@@ -10,9 +10,10 @@ import os
 import flopy
 import numpy as np
 import pytest
+
 from framework import TestFramework
 
-ex = ["uzt01a"]
+cases = ["uzt01a"]
 nlay, nrow, ncol = 15, 1, 1
 
 
@@ -46,7 +47,7 @@ def build_models(idx, test):
     for id in range(nper):
         tdis_rc.append((perlen[id], nstp[id], tsmult[id]))
 
-    name = ex[idx]
+    name = cases[idx]
 
     # build MODFLOW 6 files
     ws = test.workspace
@@ -380,10 +381,10 @@ def make_plot(sim, obsvals):
 
     # shows curves for times 2.5, 7.5, 12.6, 17.7
     # which are indices 24, 74, 125, and -1
-    idx = [24, 74, 125, -1]
+    indices = [24, 74, 125, -1]
 
     obsvals = [list(row) for row in obsvals]
-    obsvals = [obsvals[i] for i in idx]
+    obsvals = [obsvals[i] for i in indices]
     obsvals = np.array(obsvals)
 
     import matplotlib.pyplot as plt
@@ -482,9 +483,7 @@ def check_obs(sim):
     assert success, "One or more UZT obs checks did not pass"
 
 
-def check_output(test):
-    print("evaluating flow...")
-
+def check_output(idx, test):
     name = test.name
     gwfname = "gwf_" + name
     gwtname = "gwt_" + name
@@ -561,7 +560,7 @@ def check_output(test):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -569,6 +568,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_gwtgwt_oldexg.py
+++ b/autotest/test_gwtgwt_oldexg.py
@@ -1,10 +1,3 @@
-import os
-
-import flopy
-import numpy as np
-import pytest
-from framework import TestFramework
-
 """
 Test compatibility of GWT-GWT with the 'classic' GWF exchange.
 It compares the result of a single reference model
@@ -28,7 +21,15 @@ specific discharges. All models are part of the same solution
 for convenience. Finally, the budget error is checked.
 """
 
-ex = ["gwtgwt_oldexg"]
+import os
+
+import flopy
+import numpy as np
+import pytest
+
+from framework import TestFramework
+
+cases = ["gwtgwt_oldexg"]
 use_ifmod = False
 
 # some global convenience...:
@@ -88,7 +89,7 @@ perlen = 100.0
 
 
 def get_model(idx, dir):
-    name = ex[idx]
+    name = cases[idx]
 
     # parameters and spd
     # tdis
@@ -580,32 +581,32 @@ def qxqyqz(fname, nlay, nrow, ncol):
     return qx, qy, qz
 
 
-def compare_to_ref(sim):
-    compare_gwf_to_ref(sim)
-    compare_gwt_to_ref(sim)
+def check_output(idx, test):
+    compare_gwf_to_ref(test)
+    compare_gwt_to_ref(test)
 
 
-def compare_gwf_to_ref(sim):
+def compare_gwf_to_ref(test):
     print("comparing heads and spec. discharge to single model reference...")
 
-    fpth = os.path.join(sim.workspace, f"{mname_ref}.hds")
+    fpth = os.path.join(test.workspace, f"{mname_ref}.hds")
     hds = flopy.utils.HeadFile(fpth)
     heads = hds.get_data()
-    fpth = os.path.join(sim.workspace, f"{mname_ref}.cbc")
+    fpth = os.path.join(test.workspace, f"{mname_ref}.cbc")
     nlay, nrow, ncol = heads.shape
     qxb, qyb, qzb = qxqyqz(fpth, nlay, nrow, ncol)
 
-    fpth = os.path.join(sim.workspace, f"{mname_left}.hds")
+    fpth = os.path.join(test.workspace, f"{mname_left}.hds")
     hds = flopy.utils.HeadFile(fpth)
     heads_left = hds.get_data()
-    fpth = os.path.join(sim.workspace, f"{mname_left}.cbc")
+    fpth = os.path.join(test.workspace, f"{mname_left}.cbc")
     nlay, nrow, ncol = heads_left.shape
     qxb_left, qyb_left, qzb_left = qxqyqz(fpth, nlay, nrow, ncol)
 
-    fpth = os.path.join(sim.workspace, f"{mname_right}.hds")
+    fpth = os.path.join(test.workspace, f"{mname_right}.hds")
     hds = flopy.utils.HeadFile(fpth)
     heads_right = hds.get_data()
-    fpth = os.path.join(sim.workspace, f"{mname_right}.cbc")
+    fpth = os.path.join(test.workspace, f"{mname_right}.cbc")
     nlay, nrow, ncol = heads_right.shape
     qxb_right, qyb_right, qzb_right = qxqyqz(fpth, nlay, nrow, ncol)
 
@@ -676,7 +677,7 @@ def compare_gwf_to_ref(sim):
 
     # check budget error from .lst file
     for mname in [mname_ref, mname_left, mname_right]:
-        fpth = os.path.join(sim.workspace, f"{mname}.lst")
+        fpth = os.path.join(test.workspace, f"{mname}.lst")
         for line in open(fpth):
             if line.lstrip().startswith("PERCENT"):
                 cumul_balance_error = float(line.split()[3])
@@ -690,11 +691,11 @@ def compare_gwf_to_ref(sim):
     for mname in [mname_ref, mname_left, mname_right]:
         print(f"Checking flowja residual for model {mname}")
 
-        fpth = os.path.join(sim.workspace, f"{mname}.dis.grb")
+        fpth = os.path.join(test.workspace, f"{mname}.dis.grb")
         grb = flopy.mf6.utils.MfGrdFile(fpth)
         ia = grb._datadict["IA"] - 1
 
-        fpth = os.path.join(sim.workspace, f"{mname}.cbc")
+        fpth = os.path.join(test.workspace, f"{mname}.cbc")
         assert os.path.isfile(fpth)
         cbb = flopy.utils.CellBudgetFile(fpth, precision="double")
         flow_ja_face = cbb.get_data(idx=0)
@@ -709,16 +710,16 @@ def compare_gwf_to_ref(sim):
             assert np.allclose(res, 0.0, atol=1.0e-6), errmsg
 
 
-def compare_gwt_to_ref(sim):
+def compare_gwt_to_ref(test):
     print("comparing concentration  to single model reference...")
 
-    fpth = os.path.join(sim.workspace, f"{mname_gwtref}.ucn")
+    fpth = os.path.join(test.workspace, f"{mname_gwtref}.ucn")
     cnc = flopy.utils.HeadFile(fpth, text="CONCENTRATION")
     conc = cnc.get_data()
-    fpth = os.path.join(sim.workspace, f"{mname_gwtleft}.ucn")
+    fpth = os.path.join(test.workspace, f"{mname_gwtleft}.ucn")
     cnc = flopy.utils.HeadFile(fpth, text="CONCENTRATION")
     conc_left = cnc.get_data()
-    fpth = os.path.join(sim.workspace, f"{mname_gwtright}.ucn")
+    fpth = os.path.join(test.workspace, f"{mname_gwtright}.ucn")
     cnc = flopy.utils.HeadFile(fpth, text="CONCENTRATION")
     conc_right = cnc.get_data()
 
@@ -735,7 +736,7 @@ def compare_gwt_to_ref(sim):
 
     # check budget error from .lst file
     for mname in [mname_gwtref, mname_gwtleft, mname_gwtright]:
-        fpth = os.path.join(sim.workspace, f"{mname}.lst")
+        fpth = os.path.join(test.workspace, f"{mname}.lst")
         for line in open(fpth):
             if line.lstrip().startswith("PERCENT"):
                 cumul_balance_error = float(line.split()[3])
@@ -750,11 +751,11 @@ def compare_gwt_to_ref(sim):
         print(f"Checking flowja residual for model {mname}")
 
         mflowname = mname.replace("gwt", "")
-        fpth = os.path.join(sim.workspace, f"{mflowname}.dis.grb")
+        fpth = os.path.join(test.workspace, f"{mflowname}.dis.grb")
         grb = flopy.mf6.utils.MfGrdFile(fpth)
         ia = grb._datadict["IA"] - 1
 
-        fpth = os.path.join(sim.workspace, f"{mname}.cbc")
+        fpth = os.path.join(test.workspace, f"{mname}.cbc")
         assert os.path.isfile(fpth)
         cbb = flopy.utils.CellBudgetFile(fpth, precision="double")
         flow_ja_face = cbb.get_data(idx=0)
@@ -771,7 +772,7 @@ def compare_gwt_to_ref(sim):
 
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -779,6 +780,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=compare_to_ref,
+        check=lambda t: check_output(idx, t),
     )
     test.run()

--- a/autotest/test_mf6_tmp_simulations.py
+++ b/autotest/test_mf6_tmp_simulations.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+
 from common_regression import get_mf6_ftypes, get_namefiles
 from framework import TestFramework
 

--- a/autotest/test_par_gwf01.py
+++ b/autotest/test_par_gwf01.py
@@ -1,10 +1,3 @@
-import os
-
-import flopy
-import numpy as np
-import pytest
-from framework import TestFramework
-
 """
 Test for parallel MODFLOW running on two cpus.
 It contains two coupled models with
@@ -17,7 +10,15 @@ constant head boundaries left=1.0, right=10.0.
 The result should be a uniform flow field.
 """
 
-ex = ["par_gwf01-1d", "par_gwf01-2d", "par_gwf01-3d"]
+import os
+
+import flopy
+import numpy as np
+import pytest
+
+from framework import TestFramework
+
+cases = ["par_gwf01-1d", "par_gwf01-2d", "par_gwf01-3d"]
 dis_shape = [(1, 1, 5), (1, 5, 5), (5, 5, 5)]
 
 # global convenience...
@@ -30,7 +31,7 @@ hclose, rclose, relax = 10e-9, 1e-3, 0.97
 
 
 def get_model(idx, dir):
-    name = ex[idx]
+    name = cases[idx]
 
     # parameters and spd
     # tdis
@@ -199,7 +200,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
+def check_output(idx, test):
     # two coupled models with a uniform flow field,
     # here we assert the known head values at the
     # cell centers
@@ -220,7 +221,7 @@ def check_output(test):
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -228,7 +229,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         compare=None,
         parallel=True,
         ncpus=2,

--- a/autotest/test_par_gwf02.py
+++ b/autotest/test_par_gwf02.py
@@ -1,11 +1,3 @@
-import os
-from decimal import Decimal
-
-import flopy
-import numpy as np
-import pytest
-from framework import TestFramework
-
 """
 Test for parallel MODFLOW running a simple
 multi-model setup with different numbers 
@@ -25,7 +17,13 @@ This constant head should reach all domains,
 no matter the topology of partitions
 """
 
-ex = [
+import flopy
+import numpy as np
+import pytest
+
+from framework import TestFramework
+
+cases = [
     "par_gwf02-a",
     "par_gwf02-b",
     "par_gwf02-c",
@@ -50,7 +48,7 @@ def get_model_name(ix, iy):
 
 
 def get_simulation(idx, ws):
-    name = ex[idx]
+    name = cases[idx]
     nr_models_x = domain_grid[idx][0]
     nr_models_y = domain_grid[idx][1]
 
@@ -230,7 +228,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
+def check_output(idx, test):
     mf6_sim = flopy.mf6.MFSimulation.load(sim_ws=test.workspace)
     for mname in mf6_sim.model_names:
         m = mf6_sim.get_model(mname)
@@ -242,7 +240,7 @@ def check_output(test):
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     ncpus = domain_grid[idx][0] * domain_grid[idx][1]
@@ -251,7 +249,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         compare=None,
         parallel=True,
         ncpus=ncpus,

--- a/autotest/test_par_gwf_idomain.py
+++ b/autotest/test_par_gwf_idomain.py
@@ -1,6 +1,3 @@
-import pytest
-from framework import TestFramework
-
 """
 This tests reuses the simulation data in test_gwf_ifmod_idomain.py
 and runs it in parallel on three cpus with
@@ -13,26 +10,30 @@ so we can compare the parallel coupling of 'leftmodel' + 'rightmodel'
 with a serial 'refmodel'
 """
 
-ex = ["par_idomain"]
+import pytest
+
+from framework import TestFramework
+
+cases = ["par_idomain"]
 
 
 def build_models(idx, test):
-    from test_gwf_ifmod_idomain import build_models as build_model_ext
+    from test_gwf_ifmod_idomain import build_models as build
 
-    sim, dummy = build_model_ext(idx, test)
+    sim, dummy = build(idx, test)
     return sim, dummy
 
 
 def check_output(test):
-    from test_gwf_ifmod_idomain import check_output
+    from test_gwf_ifmod_idomain import check_output as check
 
-    check_output(test)
+    check(test)
 
 
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -40,7 +41,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         compare=None,
         parallel=True,
         ncpus=3,

--- a/autotest/test_par_gwf_idomain.py
+++ b/autotest/test_par_gwf_idomain.py
@@ -24,10 +24,10 @@ def build_models(idx, test):
     return sim, dummy
 
 
-def check_output(test):
+def check_output(idx, test):
     from test_gwf_ifmod_idomain import check_output as check
 
-    check(test)
+    check(idx, test)
 
 
 @pytest.mark.parallel

--- a/autotest/test_par_gwf_ims_csv.py
+++ b/autotest/test_par_gwf_ims_csv.py
@@ -1,5 +1,6 @@
 import flopy
 import pytest
+
 from framework import TestFramework
 
 """
@@ -30,7 +31,7 @@ def update_ims(idx, ims):
 
 
 def build_models(idx, test):
-    from test_par_gwf01 import ex as ex_ext
+    from test_par_gwf01 import cases as ex_ext
     from test_par_gwf01 import get_model
 
     sim = get_model(idx, test.workspace)

--- a/autotest/test_par_gwf_ims_csv.py
+++ b/autotest/test_par_gwf_ims_csv.py
@@ -39,10 +39,10 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(test):
+def check_output(idx, test):
     from test_par_gwf01 import check_output as check
 
-    check(test)
+    check(idx, test)
 
 
 @pytest.mark.parallel
@@ -56,7 +56,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         compare=None,
         parallel=True,
         ncpus=2,

--- a/autotest/test_par_gwf_newton.py
+++ b/autotest/test_par_gwf_newton.py
@@ -1,6 +1,3 @@
-import pytest
-from framework import TestFramework
-
 """
 This tests reuses the simulation data in test_gwf_ifmod_newton.py
 and runs it in parallel on three cpus with
@@ -15,26 +12,30 @@ with a serial 'refmodel'.
 This test also checks that PTC works in parallel.
 """
 
-ex = ["par_newton"]
+import pytest
+
+from framework import TestFramework
+
+cases = ["par_newton"]
 
 
 def build_models(idx, test):
-    from test_gwf_ifmod_newton import build_models as build_model_ext
+    from test_gwf_ifmod_newton import build_models as build
 
-    sim, dummy = build_model_ext(idx, test)
+    sim, dummy = build(idx, test)
     return sim, dummy
 
 
 def check_output(test):
-    from test_gwf_ifmod_newton import check_output
+    from test_gwf_ifmod_newton import check_output as check
 
-    check_output(test)
+    check(test)
 
 
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -42,7 +43,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         compare=None,
         parallel=True,
         ncpus=3,

--- a/autotest/test_par_gwf_newton.py
+++ b/autotest/test_par_gwf_newton.py
@@ -26,10 +26,10 @@ def build_models(idx, test):
     return sim, dummy
 
 
-def check_output(test):
+def check_output(idx, test):
     from test_gwf_ifmod_newton import check_output as check
 
-    check(test)
+    check(idx, test)
 
 
 @pytest.mark.parallel

--- a/autotest/test_par_gwf_newton_under_relaxation.py
+++ b/autotest/test_par_gwf_newton_under_relaxation.py
@@ -1,9 +1,3 @@
-import os
-from decimal import Decimal
-
-import pytest
-from framework import TestFramework
-
 """
 This tests reuses the simulation data in test_gwf_newton_under_relaxation
 and runs it in parallel on one and two cpus with
@@ -14,7 +8,14 @@ with a serial model.
 This test also checks that Newton under_relaxation works in parallel.
 """
 
-ex = ["par_nr_ur01", "par_nr_ur02"]
+import os
+from decimal import Decimal
+
+import pytest
+
+from framework import TestFramework
+
+cases = ["par_nr_ur01", "par_nr_ur02"]
 
 
 def build_petsc_db(idx, exdir):
@@ -48,7 +49,7 @@ def check_output(idx, test):
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     ncpus = 2 if idx == 1 else 1

--- a/autotest/test_par_gwf_pakcc.py
+++ b/autotest/test_par_gwf_pakcc.py
@@ -1,10 +1,3 @@
-import pathlib as pl
-
-import flopy
-import numpy as np
-import pytest
-from framework import TestFramework
-
 """
 This tests reuses the simulation data in test_gwf_uzf_gwet
 and runs it in parallel on one and two cpus with
@@ -15,13 +8,21 @@ with a serial model.
 This test also checks that Newton under_relaxation works in parallel.
 """
 
-ex = ["par_uzf_3lay_1p", "par_uzf_3lay_2p"]
+import pathlib as pl
+
+import flopy
+import numpy as np
+import pytest
+
+from framework import TestFramework
+
+cases = ["par_uzf_3lay_1p", "par_uzf_3lay_2p"]
 
 
 def build_models(idx, test):
-    from test_gwf_uzf_gwet import build_models as build_model_ext
+    from test_gwf_uzf_gwet import build_models as build
 
-    sim, dummy = build_model_ext(idx, test)
+    sim, dummy = build(idx, test)
     if idx == 1:
         sim.set_sim_path(test.workspace / "working")
         sim.write_simulation(silent=True)
@@ -39,7 +40,7 @@ def build_models(idx, test):
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     ncpus = 2 if idx == 1 else 1

--- a/autotest/test_par_gwf_rewet.py
+++ b/autotest/test_par_gwf_rewet.py
@@ -1,6 +1,3 @@
-import pytest
-from framework import TestFramework
-
 """
 This tests reuses the simulation data in test_gwf_ifmod_rewet.py
 and runs it in parallel on three cpus with
@@ -13,26 +10,30 @@ so we can compare the parallel coupling of 'leftmodel' + 'rightmodel'
 with a serial 'refmodel'
 """
 
-ex = ["par_rewet"]
+import pytest
+
+from framework import TestFramework
+
+cases = ["par_rewet"]
 
 
 def build_models(idx, test):
-    from test_gwf_ifmod_rewet import build_models as build_model_ext
+    from test_gwf_ifmod_rewet import build_models as build
 
-    sim, dummy = build_model_ext(idx, test)
+    sim, dummy = build(idx, test)
     return sim, dummy
 
 
-def check_output(test):
-    from test_gwf_ifmod_rewet import check_output
+def check_output(idx, test):
+    from test_gwf_ifmod_rewet import check_output as check
 
-    check_output(test)
+    check(idx, test)
 
 
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -40,7 +41,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         compare=None,
         parallel=True,
         ncpus=3,

--- a/autotest/test_par_gwf_xt3d02.py
+++ b/autotest/test_par_gwf_xt3d02.py
@@ -1,38 +1,39 @@
-import os
-from decimal import Decimal
+"""
+This tests reuses the simulation data in test_gwf_ifmod_xt3d02.py
+and runs it in parallel on three cpus with
+
+cpu 0: 'refmodel'
+cpu 1: 'leftmodel'
+cpu 2: 'rightmodel'
+
+so we can compare the parallel coupling of 'leftmodel' + 'rightmodel'
+with a serial 'refmodel' in case of XT3D
+"""
 
 import pytest
+
 from framework import TestFramework
 
-# This tests reuses the simulation data in test_gwf_ifmod_xt3d02.py
-# and runs it in parallel on three cpus with
-#
-# cpu 0: 'refmodel'
-# cpu 1: 'leftmodel'
-# cpu 2: 'rightmodel'
-#
-# so we can compare the parallel coupling of 'leftmodel' + 'rightmodel'
-# with a serial 'refmodel' in case of XT3D
-ex = ["par_xt3d02"]
+cases = ["par_xt3d02"]
 
 
 def build_models(idx, test):
-    from test_gwf_ifmod_xt3d02 import build_models as build_model_ext
+    from test_gwf_ifmod_xt3d02 import build_models as build
 
-    sim, dummy = build_model_ext(idx, test)
+    sim, dummy = build(idx, test)
     return sim, dummy
 
 
-def check_output(test):
-    from test_gwf_ifmod_xt3d02 import check_output
+def check_output(idx, test):
+    from test_gwf_ifmod_xt3d02 import check_output as check
 
-    check_output(test)
+    check(idx, test)
 
 
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -40,7 +41,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         compare=None,
         parallel=True,
         ncpus=3,

--- a/autotest/test_par_gwt_adv01.py
+++ b/autotest/test_par_gwt_adv01.py
@@ -1,10 +1,13 @@
+"""
+This test reuses the simulation data and config in
+test_gwt_adv01_gwtgwt.py and runs it in parallel mode.
+"""
+
 import pytest
+
 from framework import TestFramework
 
-# This tests reuses the simulation data and config in
-# test_gwt_adv01_gwtgwt.py and runs it in parallel mode.
-
-ex = ["par_adv01a_gwtgwt", "par_adv01b_gwtgwt", "par_adv01c_gwtgwt"]
+cases = ["par_adv01a_gwtgwt", "par_adv01b_gwtgwt", "par_adv01c_gwtgwt"]
 
 
 def build_models(idx, test):
@@ -15,7 +18,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    from test_gwt_adv01_gwtgwt import eval_transport as check
+    from test_gwt_adv01_gwtgwt import check_output as check
 
     check(idx, test)
 
@@ -23,7 +26,7 @@ def check_output(idx, test):
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_par_gwt_dsp01.py
+++ b/autotest/test_par_gwt_dsp01.py
@@ -1,40 +1,40 @@
-import os
-from decimal import Decimal
+"""
+This test reuses the simulation data and config in
+test_gwt_dsp01_gwtgwt.py and runs it in parallel mode.
+"""
 
 import pytest
+
 from framework import TestFramework
 
-# This tests reuses the simulation data and config in
-# test_gwt_dsp01_gwtgwt.py and runs it in parallel mode.
-
-ex = ["par_dsp01_gwtgwt"]
+cases = ["par_dsp01_gwtgwt"]
 
 
-def build_model(idx, test):
+def build_models(idx, test):
     from test_gwt_dsp01_gwtgwt import build_models as build
 
     sim, dummy = build(idx, test)
     return sim, dummy
 
 
-def check_output(test):
+def check_output(idx, test):
     from test_gwt_dsp01_gwtgwt import check_output as check
 
-    check(test)
+    check(idx, test)
 
 
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_model(idx, t),
-        check=check_output,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
         compare=None,
         parallel=True,
         ncpus=2,

--- a/autotest/test_par_gwt_henry.py
+++ b/autotest/test_par_gwt_henry.py
@@ -1,12 +1,13 @@
-import pytest
-from framework import TestFramework
-
 """
 This test reuses the simulation data and config in
 test_gwt_henry_gwtgwt.py and runs it in parallel mode.
 """
 
-ex = ["par-henry-ups", "par-henry-cen", "par-henry-tvd"]
+import pytest
+
+from framework import TestFramework
+
+cases = ["par-henry-ups", "par-henry-cen", "par-henry-tvd"]
 
 
 def build_models(idx, test):
@@ -16,16 +17,16 @@ def build_models(idx, test):
     return sim, dummy
 
 
-def check_output(test):
+def check_output(idx, test):
     from test_gwt_henry_gwtgwt import check_output as check
 
-    check(test)
+    check(idx, test)
 
 
 @pytest.mark.parallel
 @pytest.mark.parametrize(
     "idx, name",
-    list(enumerate(ex)),
+    list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
@@ -33,7 +34,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=check_output,
+        check=lambda t: check_output(idx, t),
         compare=None,
         parallel=True,
         ncpus=2,


### PR DESCRIPTION
Fixes/cleanup for #1464

* `check` function was skipped if comparison was disabled due to lingering `return` statement
* standardize `check_output(idx, test)` signature
* rename `ex` to `cases` in test scripts
* use context manager to open files
* run black/isort