### PR TITLE
ci: revert to upload/download-artifact v3

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -189,7 +189,7 @@ jobs:
       
       - name: Upload build log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: meson-log.txt
           path: modflow6/builddir/meson-logs/meson-log.txt
@@ -248,7 +248,7 @@ jobs:
 
       - name: Upload reports
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: compat
           path: compat/*.csv
@@ -275,7 +275,7 @@ jobs:
         run: pip install tabulate pandas
 
       - name: Download reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: compat
           path: .github/compat/new
@@ -298,7 +298,7 @@ jobs:
 
       # only upload wide CSVs and Markdown tables
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: compat
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -109,7 +109,7 @@ jobs:
         run: cat run-time-comparison.md
     
       - name: Upload benchmarks
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: run-time-comparison
           path: modflow6/distribution/run-time-comparison.md
@@ -123,7 +123,7 @@ jobs:
         run: cat deprecations.md
 
       - name: Upload deprecations
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: deprecations
           path: modflow6/doc/mf6io/mf6ivar/md/deprecations.md
@@ -133,7 +133,7 @@ jobs:
         run: make html
       
       - name: Upload results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: rtd-files-for-${{ github.sha }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
           meson test --verbose --no-rebuild -C builddir
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: bin-${{ runner.os }}
           path: modflow6/bin
@@ -316,7 +316,7 @@ jobs:
         run: python update_flopy.py
 
       - name: Download pre-built binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: bin-${{ runner.os }}
           path: bin
@@ -378,7 +378,7 @@ jobs:
         run: cat deprecations.md
 
       - name: Upload deprecations
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: deprecations
           path: modflow6/doc/mf6io/mf6ivar/md/deprecations.md
@@ -397,7 +397,7 @@ jobs:
           mv "doc/ReleaseNotes.pdf" "doc/release.pdf"
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: doc
           path: doc
@@ -466,7 +466,7 @@ jobs:
           eval "$cmd"
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: ${{ needs.build.outputs.distname }}_${{ matrix.ostag }}
       
@@ -620,14 +620,14 @@ jobs:
           eval "$cmd"
 
       - name: Upload distribution
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
           path: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}.zip"
 
       - name: Upload release notes
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: release_notes
           path: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}/doc/release.pdf"


### PR DESCRIPTION
Revert `upload-artifact` and `download-artifact` from v4 to v3 for now, v4 has issues https://github.com/actions/download-artifact/issues/249