### PR TITLE
test: more autotest framework refactoring

### DIFF
--- a/autotest/common_regression.py
+++ b/autotest/common_regression.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path
+from typing import List, Tuple
 from warnings import warn
 
 COMPARE_PATTERNS = (
@@ -643,3 +644,25 @@ def get_mf6_ftypes(namefile, ftypekeys):
                 ftypes.append(ll[0])
 
     return ftypes
+
+
+def get_regression_files(
+    workspace: os.PathLike, extensions
+) -> Tuple[List[str], List[str]]:
+    if isinstance(extensions, str):
+        extensions = [extensions]
+    files = os.listdir(workspace)
+    files0 = []
+    files1 = []
+    for file_name in files:
+        fpth0 = os.path.join(workspace, file_name)
+        if os.path.isfile(fpth0):
+            for extension in extensions:
+                if file_name.lower().endswith(extension):
+                    files0.append(fpth0)
+                    fpth1 = os.path.join(
+                        workspace, "mf6_regression", file_name
+                    )
+                    files1.append(fpth1)
+                    break
+    return files0, files1

--- a/autotest/framework.py
+++ b/autotest/framework.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import time
-import traceback
 from pathlib import Path
 from subprocess import PIPE, STDOUT, Popen
 from typing import Callable, Iterable, Optional, Union
@@ -129,7 +128,7 @@ class TestFramework:
     """
     Defines a MODFLOW 6 test and drives its lifecycle. One harness
     is recommended per test function. Hooks can be configured to
-    evaluate results or compare output with other model codes:
+    evaluate results or run other model codes for comparison:
 
         - MODFLOW-2005
         - MODFLOW-NWT

--- a/autotest/framework.py
+++ b/autotest/framework.py
@@ -127,11 +127,9 @@ class TestFramework:
     __test__ = False
 
     """
-
     Defines a MODFLOW 6 test and drives its lifecycle. One harness
-    is recommended per test function. A harness consists minimally
-    of one or more MODFLOW 6 simulations. Hooks may be provided to
-    evaluate results or compare with results of other model codes:
+    is recommended per test function. Hooks can be configured to
+    evaluate results or compare output with other model codes:
 
         - MODFLOW-2005
         - MODFLOW-NWT
@@ -643,7 +641,7 @@ class TestFramework:
         """
 
         target = str(target)
-        if not (target in self.targets or shutil.which(target)):
+        if not (target in self.targets.as_dict() or shutil.which(target)):
             raise ValueError(f"Target executable not found: {target}")
 
         # needed in _compare_heads()... todo: inject explicitly?


### PR DESCRIPTION
Minor maintainability work, all non-functional changes from the tests' perspective

* fold `run_main_model` and `run_comparison_model` into `run_simulation` method
* factor methods out of framework into standalone functions
* pass more args explicitly to member methods
* remove limit on 2 simulations/models
* update docstrings and type hints

This is with a view to
- support for any number of reference/comparison simulations
- explicit workspace configuration, eliminating implicit dependencies
- further deduplication via autodiscovery of tests from named hook functions?