### PR TITLE
extend(idm): update fortran dfns for advanced and subpackages

### DIFF
--- a/src/Exchange/gwfgwfidm.f90
+++ b/src/Exchange/gwfgwfidm.f90
@@ -9,6 +9,8 @@ module ExgGwfgwfInputModule
   public exg_gwfgwf_block_definitions
   public ExgGwfgwfParamFoundType
   public exg_gwfgwf_multi_package
+  public exg_gwfgwf_advanced_package
+  public exg_gwfgwf_subpackages
 
   type ExgGwfgwfParamFoundType
     logical :: auxiliary = .false.
@@ -45,6 +47,13 @@ module ExgGwfgwfInputModule
   end type ExgGwfgwfParamFoundType
 
   logical :: exg_gwfgwf_multi_package = .true.
+  logical :: exg_gwfgwf_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    exg_gwfgwf_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     exggwfgwf_auxiliary = InputParamDefinitionType &

--- a/src/Exchange/gwfgwfidm.f90
+++ b/src/Exchange/gwfgwfidm.f90
@@ -648,19 +648,22 @@ module ExgGwfgwfInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'EXCHANGEDATA', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Exchange/gwfgwtidm.f90
+++ b/src/Exchange/gwfgwtidm.f90
@@ -9,11 +9,20 @@ module ExgGwfgwtInputModule
   public exg_gwfgwt_block_definitions
   public ExgGwfgwtParamFoundType
   public exg_gwfgwt_multi_package
+  public exg_gwfgwt_advanced_package
+  public exg_gwfgwt_subpackages
 
   type ExgGwfgwtParamFoundType
   end type ExgGwfgwtParamFoundType
 
   logical :: exg_gwfgwt_multi_package = .false.
+  logical :: exg_gwfgwt_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    exg_gwfgwt_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     exg_gwfgwt_param_definitions(*) = &

--- a/src/Exchange/gwtgwtidm.f90
+++ b/src/Exchange/gwtgwtidm.f90
@@ -9,6 +9,8 @@ module ExgGwtgwtInputModule
   public exg_gwtgwt_block_definitions
   public ExgGwtgwtParamFoundType
   public exg_gwtgwt_multi_package
+  public exg_gwtgwt_advanced_package
+  public exg_gwtgwt_subpackages
 
   type ExgGwtgwtParamFoundType
     logical :: gwfmodelname1 = .false.
@@ -41,6 +43,13 @@ module ExgGwtgwtInputModule
   end type ExgGwtgwtParamFoundType
 
   logical :: exg_gwtgwt_multi_package = .true.
+  logical :: exg_gwtgwt_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    exg_gwtgwt_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     exggwtgwt_gwfmodelname1 = InputParamDefinitionType &

--- a/src/Exchange/gwtgwtidm.f90
+++ b/src/Exchange/gwtgwtidm.f90
@@ -572,19 +572,22 @@ module ExgGwtgwtInputModule
     'OPTIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'EXCHANGEDATA', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3chd8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3chd8idm.f90
@@ -9,6 +9,8 @@ module GwfChdInputModule
   public gwf_chd_block_definitions
   public GwfChdParamFoundType
   public gwf_chd_multi_package
+  public gwf_chd_advanced_package
+  public gwf_chd_subpackages
 
   type GwfChdParamFoundType
     logical :: auxiliary = .false.
@@ -33,6 +35,13 @@ module GwfChdInputModule
   end type GwfChdParamFoundType
 
   logical :: gwf_chd_multi_package = .true.
+  logical :: gwf_chd_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_chd_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfchd_auxiliary = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3chd8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3chd8idm.f90
@@ -420,19 +420,22 @@ module GwfChdInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .true. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3dis8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3dis8idm.f90
@@ -9,6 +9,8 @@ module GwfDisInputModule
   public gwf_dis_block_definitions
   public GwfDisParamFoundType
   public gwf_dis_multi_package
+  public gwf_dis_advanced_package
+  public gwf_dis_subpackages
 
   type GwfDisParamFoundType
     logical :: length_units = .false.
@@ -27,6 +29,13 @@ module GwfDisInputModule
   end type GwfDisParamFoundType
 
   logical :: gwf_dis_multi_package = .false.
+  logical :: gwf_dis_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_dis_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfdis_length_units = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3dis8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3dis8idm.f90
@@ -303,19 +303,22 @@ module GwfDisInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'GRIDDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3disu8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3disu8idm.f90
@@ -9,6 +9,8 @@ module GwfDisuInputModule
   public gwf_disu_block_definitions
   public GwfDisuParamFoundType
   public gwf_disu_multi_package
+  public gwf_disu_advanced_package
+  public gwf_disu_subpackages
 
   type GwfDisuParamFoundType
     logical :: length_units = .false.
@@ -41,6 +43,13 @@ module GwfDisuInputModule
   end type GwfDisuParamFoundType
 
   logical :: gwf_disu_multi_package = .false.
+  logical :: gwf_disu_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_disu_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfdisu_length_units = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3disu8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3disu8idm.f90
@@ -590,37 +590,43 @@ module GwfDisuInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'GRIDDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'CONNECTIONDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'VERTICES', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'CELL2D', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3disv8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3disv8idm.f90
@@ -9,6 +9,8 @@ module GwfDisvInputModule
   public gwf_disv_block_definitions
   public GwfDisvParamFoundType
   public gwf_disv_multi_package
+  public gwf_disv_advanced_package
+  public gwf_disv_subpackages
 
   type GwfDisvParamFoundType
     logical :: length_units = .false.
@@ -33,6 +35,13 @@ module GwfDisvInputModule
   end type GwfDisvParamFoundType
 
   logical :: gwf_disv_multi_package = .false.
+  logical :: gwf_disv_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_disv_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfdisv_length_units = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3disv8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3disv8idm.f90
@@ -438,31 +438,36 @@ module GwfDisvInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'GRIDDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'VERTICES', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'CELL2D', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3drn8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3drn8idm.f90
@@ -9,6 +9,8 @@ module GwfDrnInputModule
   public gwf_drn_block_definitions
   public GwfDrnParamFoundType
   public gwf_drn_multi_package
+  public gwf_drn_advanced_package
+  public gwf_drn_subpackages
 
   type GwfDrnParamFoundType
     logical :: auxiliary = .false.
@@ -36,6 +38,13 @@ module GwfDrnInputModule
   end type GwfDrnParamFoundType
 
   logical :: gwf_drn_multi_package = .true.
+  logical :: gwf_drn_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_drn_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfdrn_auxiliary = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3drn8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3drn8idm.f90
@@ -477,19 +477,22 @@ module GwfDrnInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .true. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3evt8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3evt8idm.f90
@@ -9,6 +9,8 @@ module GwfEvtInputModule
   public gwf_evt_block_definitions
   public GwfEvtParamFoundType
   public gwf_evt_multi_package
+  public gwf_evt_advanced_package
+  public gwf_evt_subpackages
 
   type GwfEvtParamFoundType
     logical :: fixed_cell = .false.
@@ -40,6 +42,13 @@ module GwfEvtInputModule
   end type GwfEvtParamFoundType
 
   logical :: gwf_evt_multi_package = .true.
+  logical :: gwf_evt_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_evt_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfevt_fixed_cell = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3evt8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3evt8idm.f90
@@ -553,19 +553,22 @@ module GwfEvtInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .true. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3evta8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3evta8idm.f90
@@ -9,6 +9,8 @@ module GwfEvtaInputModule
   public gwf_evta_block_definitions
   public GwfEvtaParamFoundType
   public gwf_evta_multi_package
+  public gwf_evta_advanced_package
+  public gwf_evta_subpackages
 
   type GwfEvtaParamFoundType
     logical :: readasarrays = .false.
@@ -33,6 +35,13 @@ module GwfEvtaInputModule
   end type GwfEvtaParamFoundType
 
   logical :: gwf_evta_multi_package = .true.
+  logical :: gwf_evta_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_evta_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfevta_readasarrays = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3evta8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3evta8idm.f90
@@ -417,13 +417,15 @@ module GwfEvtaInputModule
     'OPTIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .true. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3ghb8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3ghb8idm.f90
@@ -9,6 +9,8 @@ module GwfGhbInputModule
   public gwf_ghb_block_definitions
   public GwfGhbParamFoundType
   public gwf_ghb_multi_package
+  public gwf_ghb_advanced_package
+  public gwf_ghb_subpackages
 
   type GwfGhbParamFoundType
     logical :: auxiliary = .false.
@@ -34,6 +36,13 @@ module GwfGhbInputModule
   end type GwfGhbParamFoundType
 
   logical :: gwf_ghb_multi_package = .true.
+  logical :: gwf_ghb_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_ghb_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfghb_auxiliary = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3ghb8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3ghb8idm.f90
@@ -439,19 +439,22 @@ module GwfGhbInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .true. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3ic8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3ic8idm.f90
@@ -9,12 +9,21 @@ module GwfIcInputModule
   public gwf_ic_block_definitions
   public GwfIcParamFoundType
   public gwf_ic_multi_package
+  public gwf_ic_advanced_package
+  public gwf_ic_subpackages
 
   type GwfIcParamFoundType
     logical :: strt = .false.
   end type GwfIcParamFoundType
 
   logical :: gwf_ic_multi_package = .false.
+  logical :: gwf_ic_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_ic_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfic_strt = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3ic8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3ic8idm.f90
@@ -75,13 +75,15 @@ module GwfIcInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'GRIDDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3idm.f90
@@ -249,13 +249,15 @@ module GwfNamInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PACKAGES', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3idm.f90
@@ -9,6 +9,8 @@ module GwfNamInputModule
   public gwf_nam_block_definitions
   public GwfNamParamFoundType
   public gwf_nam_multi_package
+  public gwf_nam_advanced_package
+  public gwf_nam_subpackages
 
   type GwfNamParamFoundType
     logical :: list = .false.
@@ -24,6 +26,13 @@ module GwfNamInputModule
   end type GwfNamParamFoundType
 
   logical :: gwf_nam_multi_package = .false.
+  logical :: gwf_nam_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_nam_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfnam_list = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3npf8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8idm.f90
@@ -9,6 +9,8 @@ module GwfNpfInputModule
   public gwf_npf_block_definitions
   public GwfNpfParamFoundType
   public gwf_npf_multi_package
+  public gwf_npf_advanced_package
+  public gwf_npf_subpackages
 
   type GwfNpfParamFoundType
     logical :: ipakcb = .false.
@@ -51,6 +53,13 @@ module GwfNpfInputModule
   end type GwfNpfParamFoundType
 
   logical :: gwf_npf_multi_package = .false.
+  logical :: gwf_npf_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_npf_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfnpf_ipakcb = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3npf8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8idm.f90
@@ -759,13 +759,15 @@ module GwfNpfInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'GRIDDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3rch8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3rch8idm.f90
@@ -9,6 +9,8 @@ module GwfRchInputModule
   public gwf_rch_block_definitions
   public GwfRchParamFoundType
   public gwf_rch_multi_package
+  public gwf_rch_advanced_package
+  public gwf_rch_subpackages
 
   type GwfRchParamFoundType
     logical :: fixed_cell = .false.
@@ -33,6 +35,13 @@ module GwfRchInputModule
   end type GwfRchParamFoundType
 
   logical :: gwf_rch_multi_package = .true.
+  logical :: gwf_rch_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_rch_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfrch_fixed_cell = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3rch8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3rch8idm.f90
@@ -420,19 +420,22 @@ module GwfRchInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .true. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3rcha8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3rcha8idm.f90
@@ -379,13 +379,15 @@ module GwfRchaInputModule
     'OPTIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .true. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3rcha8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3rcha8idm.f90
@@ -9,6 +9,8 @@ module GwfRchaInputModule
   public gwf_rcha_block_definitions
   public GwfRchaParamFoundType
   public gwf_rcha_multi_package
+  public gwf_rcha_advanced_package
+  public gwf_rcha_subpackages
 
   type GwfRchaParamFoundType
     logical :: readasarrays = .false.
@@ -31,6 +33,13 @@ module GwfRchaInputModule
   end type GwfRchaParamFoundType
 
   logical :: gwf_rcha_multi_package = .true.
+  logical :: gwf_rcha_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_rcha_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfrcha_readasarrays = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3riv8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3riv8idm.f90
@@ -9,6 +9,8 @@ module GwfRivInputModule
   public gwf_riv_block_definitions
   public GwfRivParamFoundType
   public gwf_riv_multi_package
+  public gwf_riv_advanced_package
+  public gwf_riv_subpackages
 
   type GwfRivParamFoundType
     logical :: auxiliary = .false.
@@ -35,6 +37,13 @@ module GwfRivInputModule
   end type GwfRivParamFoundType
 
   logical :: gwf_riv_multi_package = .true.
+  logical :: gwf_riv_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_riv_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfriv_auxiliary = InputParamDefinitionType &

--- a/src/Model/GroundWaterFlow/gwf3riv8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3riv8idm.f90
@@ -458,19 +458,22 @@ module GwfRivInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .true. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3wel8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3wel8idm.f90
@@ -515,19 +515,22 @@ module GwfWelInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .true. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterFlow/gwf3wel8idm.f90
+++ b/src/Model/GroundWaterFlow/gwf3wel8idm.f90
@@ -9,6 +9,8 @@ module GwfWelInputModule
   public gwf_wel_block_definitions
   public GwfWelParamFoundType
   public gwf_wel_multi_package
+  public gwf_wel_advanced_package
+  public gwf_wel_subpackages
 
   type GwfWelParamFoundType
     logical :: auxiliary = .false.
@@ -38,6 +40,13 @@ module GwfWelInputModule
   end type GwfWelParamFoundType
 
   logical :: gwf_wel_multi_package = .true.
+  logical :: gwf_wel_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwf_wel_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwfwel_auxiliary = InputParamDefinitionType &

--- a/src/Model/GroundWaterTransport/gwt1cnc1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1cnc1idm.f90
@@ -401,19 +401,22 @@ module GwtCncInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PERIOD', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .true. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterTransport/gwt1cnc1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1cnc1idm.f90
@@ -9,6 +9,8 @@ module GwtCncInputModule
   public gwt_cnc_block_definitions
   public GwtCncParamFoundType
   public gwt_cnc_multi_package
+  public gwt_cnc_advanced_package
+  public gwt_cnc_subpackages
 
   type GwtCncParamFoundType
     logical :: auxiliary = .false.
@@ -32,6 +34,13 @@ module GwtCncInputModule
   end type GwtCncParamFoundType
 
   logical :: gwt_cnc_multi_package = .true.
+  logical :: gwt_cnc_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwt_cnc_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwtcnc_auxiliary = InputParamDefinitionType &

--- a/src/Model/GroundWaterTransport/gwt1dis1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1dis1idm.f90
@@ -9,6 +9,8 @@ module GwtDisInputModule
   public gwt_dis_block_definitions
   public GwtDisParamFoundType
   public gwt_dis_multi_package
+  public gwt_dis_advanced_package
+  public gwt_dis_subpackages
 
   type GwtDisParamFoundType
     logical :: length_units = .false.
@@ -27,6 +29,13 @@ module GwtDisInputModule
   end type GwtDisParamFoundType
 
   logical :: gwt_dis_multi_package = .false.
+  logical :: gwt_dis_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwt_dis_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwtdis_length_units = InputParamDefinitionType &

--- a/src/Model/GroundWaterTransport/gwt1dis1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1dis1idm.f90
@@ -303,19 +303,22 @@ module GwtDisInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'GRIDDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterTransport/gwt1disu1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1disu1idm.f90
@@ -590,37 +590,43 @@ module GwtDisuInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'GRIDDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'CONNECTIONDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'VERTICES', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'CELL2D', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterTransport/gwt1disu1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1disu1idm.f90
@@ -9,6 +9,8 @@ module GwtDisuInputModule
   public gwt_disu_block_definitions
   public GwtDisuParamFoundType
   public gwt_disu_multi_package
+  public gwt_disu_advanced_package
+  public gwt_disu_subpackages
 
   type GwtDisuParamFoundType
     logical :: length_units = .false.
@@ -41,6 +43,13 @@ module GwtDisuInputModule
   end type GwtDisuParamFoundType
 
   logical :: gwt_disu_multi_package = .false.
+  logical :: gwt_disu_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwt_disu_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwtdisu_length_units = InputParamDefinitionType &

--- a/src/Model/GroundWaterTransport/gwt1disv1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1disv1idm.f90
@@ -9,6 +9,8 @@ module GwtDisvInputModule
   public gwt_disv_block_definitions
   public GwtDisvParamFoundType
   public gwt_disv_multi_package
+  public gwt_disv_advanced_package
+  public gwt_disv_subpackages
 
   type GwtDisvParamFoundType
     logical :: length_units = .false.
@@ -33,6 +35,13 @@ module GwtDisvInputModule
   end type GwtDisvParamFoundType
 
   logical :: gwt_disv_multi_package = .false.
+  logical :: gwt_disv_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwt_disv_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwtdisv_length_units = InputParamDefinitionType &

--- a/src/Model/GroundWaterTransport/gwt1disv1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1disv1idm.f90
@@ -438,31 +438,36 @@ module GwtDisvInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'DIMENSIONS', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'GRIDDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'VERTICES', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'CELL2D', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterTransport/gwt1dsp1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1dsp1idm.f90
@@ -208,13 +208,15 @@ module GwtDspInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'GRIDDATA', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterTransport/gwt1dsp1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1dsp1idm.f90
@@ -9,6 +9,8 @@ module GwtDspInputModule
   public gwt_dsp_block_definitions
   public GwtDspParamFoundType
   public gwt_dsp_multi_package
+  public gwt_dsp_advanced_package
+  public gwt_dsp_subpackages
 
   type GwtDspParamFoundType
     logical :: xt3d_off = .false.
@@ -22,6 +24,13 @@ module GwtDspInputModule
   end type GwtDspParamFoundType
 
   logical :: gwt_dsp_multi_package = .false.
+  logical :: gwt_dsp_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwt_dsp_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwtdsp_xt3d_off = InputParamDefinitionType &

--- a/src/Model/GroundWaterTransport/gwt1ic1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1ic1idm.f90
@@ -75,13 +75,15 @@ module GwtIcInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'GRIDDATA', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Model/GroundWaterTransport/gwt1ic1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1ic1idm.f90
@@ -9,12 +9,21 @@ module GwtIcInputModule
   public gwt_ic_block_definitions
   public GwtIcParamFoundType
   public gwt_ic_multi_package
+  public gwt_ic_advanced_package
+  public gwt_ic_subpackages
 
   type GwtIcParamFoundType
     logical :: strt = .false.
   end type GwtIcParamFoundType
 
   logical :: gwt_ic_multi_package = .false.
+  logical :: gwt_ic_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwt_ic_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwtic_strt = InputParamDefinitionType &

--- a/src/Model/GroundWaterTransport/gwt1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1idm.f90
@@ -9,6 +9,8 @@ module GwtNamInputModule
   public gwt_nam_block_definitions
   public GwtNamParamFoundType
   public gwt_nam_multi_package
+  public gwt_nam_advanced_package
+  public gwt_nam_subpackages
 
   type GwtNamParamFoundType
     logical :: list = .false.
@@ -21,6 +23,13 @@ module GwtNamInputModule
   end type GwtNamParamFoundType
 
   logical :: gwt_nam_multi_package = .false.
+  logical :: gwt_nam_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    gwt_nam_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     gwtnam_list = InputParamDefinitionType &

--- a/src/Model/GroundWaterTransport/gwt1idm.f90
+++ b/src/Model/GroundWaterTransport/gwt1idm.f90
@@ -192,13 +192,15 @@ module GwtNamInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'PACKAGES', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/Utilities/Idm/InputDefinition.f90
+++ b/src/Utilities/Idm/InputDefinition.f90
@@ -46,6 +46,7 @@ module InputDefinitionModule
     logical(LGP) :: required = .false.
     logical(LGP) :: aggregate = .false.
     logical(LGP) :: block_variable = .false.
+    logical(LGP) :: timeseries = .false.
   end type InputBlockDefinitionType
 
 end module InputDefinitionModule

--- a/src/Utilities/Idm/selector/IdmDfnSelector.f90
+++ b/src/Utilities/Idm/selector/IdmDfnSelector.f90
@@ -16,6 +16,8 @@ module IdmDfnSelectorModule
   public :: aggregate_definitions
   public :: block_definitions
   public :: idm_multi_package
+  public :: idm_advanced_package
+  public :: idm_subpackages
   public :: idm_integrated
   public :: idm_component
 
@@ -98,6 +100,48 @@ contains
     end select
     return
   end function idm_multi_package
+
+  function idm_advanced_package(component, subcomponent) result(advanced_package)
+    character(len=*), intent(in) :: component
+    character(len=*), intent(in) :: subcomponent
+    logical :: advanced_package
+    select case (component)
+    case ('GWF')
+      advanced_package = gwf_idm_advanced_package(subcomponent)
+    case ('GWT')
+      advanced_package = gwt_idm_advanced_package(subcomponent)
+    case ('EXG')
+      advanced_package = exg_idm_advanced_package(subcomponent)
+    case ('SIM')
+      advanced_package = sim_idm_advanced_package(subcomponent)
+    case default
+      call store_error('Idm selector component not found; '//&
+                       &'component="'//trim(component)//&
+                       &'", subcomponent="'//trim(subcomponent)//'".', .true.)
+    end select
+    return
+  end function idm_advanced_package
+
+  function idm_subpackages(component, subcomponent) result(subpackages)
+    character(len=*), intent(in) :: component
+    character(len=*), intent(in) :: subcomponent
+    character(len=16), dimension(:), pointer :: subpackages
+    select case (component)
+    case ('GWF')
+      subpackages => gwf_idm_subpackages(subcomponent)
+    case ('GWT')
+      subpackages => gwt_idm_subpackages(subcomponent)
+    case ('EXG')
+      subpackages => exg_idm_subpackages(subcomponent)
+    case ('SIM')
+      subpackages => sim_idm_subpackages(subcomponent)
+    case default
+      call store_error('Idm selector component not found; '//&
+                       &'component="'//trim(component)//&
+                       &'", subcomponent="'//trim(subcomponent)//'".', .true.)
+    end select
+    return
+  end function idm_subpackages
 
   function idm_integrated(component, subcomponent) result(integrated)
     character(len=*), intent(in) :: component

--- a/src/Utilities/Idm/selector/IdmExgDfnSelector.f90
+++ b/src/Utilities/Idm/selector/IdmExgDfnSelector.f90
@@ -15,6 +15,8 @@ module IdmExgDfnSelectorModule
   public :: exg_aggregate_definitions
   public :: exg_block_definitions
   public :: exg_idm_multi_package
+  public :: exg_idm_advanced_package
+  public :: exg_idm_subpackages
   public :: exg_idm_integrated
 
 contains
@@ -30,6 +32,12 @@ contains
     type(InputBlockDefinitionType), dimension(:), target :: input_dfn_target
     input_dfn => input_dfn_target
   end subroutine set_block_pointer
+
+  subroutine set_subpkg_pointer(subpkg_list, subpkg_list_target)
+    character(len=16), dimension(:), pointer :: subpkg_list
+    character(len=16), dimension(:), target :: subpkg_list_target
+    subpkg_list => subpkg_list_target
+  end subroutine set_subpkg_pointer
 
   function exg_param_definitions(subcomponent) result(input_definition)
     character(len=*), intent(in) :: subcomponent
@@ -96,6 +104,37 @@ contains
     end select
     return
   end function exg_idm_multi_package
+
+  function exg_idm_advanced_package(subcomponent) result(advanced_package)
+    character(len=*), intent(in) :: subcomponent
+    logical :: advanced_package
+    advanced_package = .false.
+    select case (subcomponent)
+    case ('GWFGWF')
+      advanced_package = exg_gwfgwf_advanced_package
+    case ('GWFGWT')
+      advanced_package = exg_gwfgwt_advanced_package
+    case ('GWTGWT')
+      advanced_package = exg_gwtgwt_advanced_package
+    case default
+    end select
+    return
+  end function exg_idm_advanced_package
+
+  function exg_idm_subpackages(subcomponent) result(subpackages)
+    character(len=*), intent(in) :: subcomponent
+    character(len=16), dimension(:), pointer :: subpackages
+    select case (subcomponent)
+    case ('GWFGWF')
+      call set_subpkg_pointer(subpackages, exg_gwfgwf_subpackages)
+    case ('GWFGWT')
+      call set_subpkg_pointer(subpackages, exg_gwfgwt_subpackages)
+    case ('GWTGWT')
+      call set_subpkg_pointer(subpackages, exg_gwtgwt_subpackages)
+    case default
+    end select
+    return
+  end function exg_idm_subpackages
 
   function exg_idm_integrated(subcomponent) result(integrated)
     character(len=*), intent(in) :: subcomponent

--- a/src/Utilities/Idm/selector/IdmGwfDfnSelector.f90
+++ b/src/Utilities/Idm/selector/IdmGwfDfnSelector.f90
@@ -27,6 +27,8 @@ module IdmGwfDfnSelectorModule
   public :: gwf_aggregate_definitions
   public :: gwf_block_definitions
   public :: gwf_idm_multi_package
+  public :: gwf_idm_advanced_package
+  public :: gwf_idm_subpackages
   public :: gwf_idm_integrated
 
 contains
@@ -42,6 +44,12 @@ contains
     type(InputBlockDefinitionType), dimension(:), target :: input_dfn_target
     input_dfn => input_dfn_target
   end subroutine set_block_pointer
+
+  subroutine set_subpkg_pointer(subpkg_list, subpkg_list_target)
+    character(len=16), dimension(:), pointer :: subpkg_list
+    character(len=16), dimension(:), target :: subpkg_list_target
+    subpkg_list => subpkg_list_target
+  end subroutine set_subpkg_pointer
 
   function gwf_param_definitions(subcomponent) result(input_definition)
     character(len=*), intent(in) :: subcomponent
@@ -204,6 +212,85 @@ contains
     end select
     return
   end function gwf_idm_multi_package
+
+  function gwf_idm_advanced_package(subcomponent) result(advanced_package)
+    character(len=*), intent(in) :: subcomponent
+    logical :: advanced_package
+    advanced_package = .false.
+    select case (subcomponent)
+    case ('CHD')
+      advanced_package = gwf_chd_advanced_package
+    case ('DIS')
+      advanced_package = gwf_dis_advanced_package
+    case ('DISU')
+      advanced_package = gwf_disu_advanced_package
+    case ('DISV')
+      advanced_package = gwf_disv_advanced_package
+    case ('DRN')
+      advanced_package = gwf_drn_advanced_package
+    case ('EVT')
+      advanced_package = gwf_evt_advanced_package
+    case ('EVTA')
+      advanced_package = gwf_evta_advanced_package
+    case ('GHB')
+      advanced_package = gwf_ghb_advanced_package
+    case ('IC')
+      advanced_package = gwf_ic_advanced_package
+    case ('NPF')
+      advanced_package = gwf_npf_advanced_package
+    case ('RCH')
+      advanced_package = gwf_rch_advanced_package
+    case ('RCHA')
+      advanced_package = gwf_rcha_advanced_package
+    case ('RIV')
+      advanced_package = gwf_riv_advanced_package
+    case ('WEL')
+      advanced_package = gwf_wel_advanced_package
+    case ('NAM')
+      advanced_package = gwf_nam_advanced_package
+    case default
+    end select
+    return
+  end function gwf_idm_advanced_package
+
+  function gwf_idm_subpackages(subcomponent) result(subpackages)
+    character(len=*), intent(in) :: subcomponent
+    character(len=16), dimension(:), pointer :: subpackages
+    select case (subcomponent)
+    case ('CHD')
+      call set_subpkg_pointer(subpackages, gwf_chd_subpackages)
+    case ('DIS')
+      call set_subpkg_pointer(subpackages, gwf_dis_subpackages)
+    case ('DISU')
+      call set_subpkg_pointer(subpackages, gwf_disu_subpackages)
+    case ('DISV')
+      call set_subpkg_pointer(subpackages, gwf_disv_subpackages)
+    case ('DRN')
+      call set_subpkg_pointer(subpackages, gwf_drn_subpackages)
+    case ('EVT')
+      call set_subpkg_pointer(subpackages, gwf_evt_subpackages)
+    case ('EVTA')
+      call set_subpkg_pointer(subpackages, gwf_evta_subpackages)
+    case ('GHB')
+      call set_subpkg_pointer(subpackages, gwf_ghb_subpackages)
+    case ('IC')
+      call set_subpkg_pointer(subpackages, gwf_ic_subpackages)
+    case ('NPF')
+      call set_subpkg_pointer(subpackages, gwf_npf_subpackages)
+    case ('RCH')
+      call set_subpkg_pointer(subpackages, gwf_rch_subpackages)
+    case ('RCHA')
+      call set_subpkg_pointer(subpackages, gwf_rcha_subpackages)
+    case ('RIV')
+      call set_subpkg_pointer(subpackages, gwf_riv_subpackages)
+    case ('WEL')
+      call set_subpkg_pointer(subpackages, gwf_wel_subpackages)
+    case ('NAM')
+      call set_subpkg_pointer(subpackages, gwf_nam_subpackages)
+    case default
+    end select
+    return
+  end function gwf_idm_subpackages
 
   function gwf_idm_integrated(subcomponent) result(integrated)
     character(len=*), intent(in) :: subcomponent

--- a/src/Utilities/Idm/selector/IdmGwtDfnSelector.f90
+++ b/src/Utilities/Idm/selector/IdmGwtDfnSelector.f90
@@ -19,6 +19,8 @@ module IdmGwtDfnSelectorModule
   public :: gwt_aggregate_definitions
   public :: gwt_block_definitions
   public :: gwt_idm_multi_package
+  public :: gwt_idm_advanced_package
+  public :: gwt_idm_subpackages
   public :: gwt_idm_integrated
 
 contains
@@ -34,6 +36,12 @@ contains
     type(InputBlockDefinitionType), dimension(:), target :: input_dfn_target
     input_dfn => input_dfn_target
   end subroutine set_block_pointer
+
+  subroutine set_subpkg_pointer(subpkg_list, subpkg_list_target)
+    character(len=16), dimension(:), pointer :: subpkg_list
+    character(len=16), dimension(:), target :: subpkg_list_target
+    subpkg_list => subpkg_list_target
+  end subroutine set_subpkg_pointer
 
   function gwt_param_definitions(subcomponent) result(input_definition)
     character(len=*), intent(in) :: subcomponent
@@ -132,6 +140,53 @@ contains
     end select
     return
   end function gwt_idm_multi_package
+
+  function gwt_idm_advanced_package(subcomponent) result(advanced_package)
+    character(len=*), intent(in) :: subcomponent
+    logical :: advanced_package
+    advanced_package = .false.
+    select case (subcomponent)
+    case ('DIS')
+      advanced_package = gwt_dis_advanced_package
+    case ('DISU')
+      advanced_package = gwt_disu_advanced_package
+    case ('DISV')
+      advanced_package = gwt_disv_advanced_package
+    case ('DSP')
+      advanced_package = gwt_dsp_advanced_package
+    case ('CNC')
+      advanced_package = gwt_cnc_advanced_package
+    case ('IC')
+      advanced_package = gwt_ic_advanced_package
+    case ('NAM')
+      advanced_package = gwt_nam_advanced_package
+    case default
+    end select
+    return
+  end function gwt_idm_advanced_package
+
+  function gwt_idm_subpackages(subcomponent) result(subpackages)
+    character(len=*), intent(in) :: subcomponent
+    character(len=16), dimension(:), pointer :: subpackages
+    select case (subcomponent)
+    case ('DIS')
+      call set_subpkg_pointer(subpackages, gwt_dis_subpackages)
+    case ('DISU')
+      call set_subpkg_pointer(subpackages, gwt_disu_subpackages)
+    case ('DISV')
+      call set_subpkg_pointer(subpackages, gwt_disv_subpackages)
+    case ('DSP')
+      call set_subpkg_pointer(subpackages, gwt_dsp_subpackages)
+    case ('CNC')
+      call set_subpkg_pointer(subpackages, gwt_cnc_subpackages)
+    case ('IC')
+      call set_subpkg_pointer(subpackages, gwt_ic_subpackages)
+    case ('NAM')
+      call set_subpkg_pointer(subpackages, gwt_nam_subpackages)
+    case default
+    end select
+    return
+  end function gwt_idm_subpackages
 
   function gwt_idm_integrated(subcomponent) result(integrated)
     character(len=*), intent(in) :: subcomponent

--- a/src/Utilities/Idm/selector/IdmSimDfnSelector.f90
+++ b/src/Utilities/Idm/selector/IdmSimDfnSelector.f90
@@ -13,6 +13,8 @@ module IdmSimDfnSelectorModule
   public :: sim_aggregate_definitions
   public :: sim_block_definitions
   public :: sim_idm_multi_package
+  public :: sim_idm_advanced_package
+  public :: sim_idm_subpackages
   public :: sim_idm_integrated
 
 contains
@@ -28,6 +30,12 @@ contains
     type(InputBlockDefinitionType), dimension(:), target :: input_dfn_target
     input_dfn => input_dfn_target
   end subroutine set_block_pointer
+
+  subroutine set_subpkg_pointer(subpkg_list, subpkg_list_target)
+    character(len=16), dimension(:), pointer :: subpkg_list
+    character(len=16), dimension(:), target :: subpkg_list_target
+    subpkg_list => subpkg_list_target
+  end subroutine set_subpkg_pointer
 
   function sim_param_definitions(subcomponent) result(input_definition)
     character(len=*), intent(in) :: subcomponent
@@ -78,6 +86,29 @@ contains
     end select
     return
   end function sim_idm_multi_package
+
+  function sim_idm_advanced_package(subcomponent) result(advanced_package)
+    character(len=*), intent(in) :: subcomponent
+    logical :: advanced_package
+    advanced_package = .false.
+    select case (subcomponent)
+    case ('NAM')
+      advanced_package = sim_nam_advanced_package
+    case default
+    end select
+    return
+  end function sim_idm_advanced_package
+
+  function sim_idm_subpackages(subcomponent) result(subpackages)
+    character(len=*), intent(in) :: subcomponent
+    character(len=16), dimension(:), pointer :: subpackages
+    select case (subcomponent)
+    case ('NAM')
+      call set_subpkg_pointer(subpackages, sim_nam_subpackages)
+    case default
+    end select
+    return
+  end function sim_idm_subpackages
 
   function sim_idm_integrated(subcomponent) result(integrated)
     character(len=*), intent(in) :: subcomponent

--- a/src/simnamidm.f90
+++ b/src/simnamidm.f90
@@ -418,31 +418,36 @@ module SimNamInputModule
     'OPTIONS', & ! blockname
     .false., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'TIMING', & ! blockname
     .true., & ! required
     .false., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'MODELS', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'EXCHANGES', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .false. & ! block_variable
+    .false., & ! block_variable
+    .false. & ! timeseries
     ), &
     InputBlockDefinitionType( &
     'SOLUTIONGROUP', & ! blockname
     .true., & ! required
     .true., & ! aggregate
-    .true. & ! block_variable
+    .true., & ! block_variable
+    .false. & ! timeseries
     ) &
     ]
 

--- a/src/simnamidm.f90
+++ b/src/simnamidm.f90
@@ -9,6 +9,8 @@ module SimNamInputModule
   public sim_nam_block_definitions
   public SimNamParamFoundType
   public sim_nam_multi_package
+  public sim_nam_advanced_package
+  public sim_nam_subpackages
 
   type SimNamParamFoundType
     logical :: continue = .false.
@@ -31,6 +33,13 @@ module SimNamInputModule
   end type SimNamParamFoundType
 
   logical :: sim_nam_multi_package = .false.
+  logical :: sim_nam_advanced_package = .false.
+
+  character(len=16), parameter :: &
+    sim_nam_subpackages(*) = &
+    [ &
+    '                ' &
+    ]
 
   type(InputParamDefinitionType), parameter :: &
     simnam_continue = InputParamDefinitionType &

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -28,6 +28,8 @@ class Dfn2F90:
         self._aggregate_varnames = []
         self._warnings = []
         self._multi_package = False
+        self._advanced_package = False
+        self._subpackage = []
 
         self.component, self.subcomponent = self._dfnfspec.stem.upper().split("-")
 
@@ -70,8 +72,28 @@ class Dfn2F90:
                 smult = ".true."
             f.write(
                 f"  logical :: {self.component.lower()}_"
-                f"{self.subcomponent.lower()}_multi_package = {smult}\n\n"
+                f"{self.subcomponent.lower()}_multi_package = {smult}\n"
             )
+
+            # advanced package
+            adv = ".false."
+            if self._advanced_package:
+                adv = ".true."
+            f.write(
+                f"  logical :: {self.component.lower()}_"
+                f"{self.subcomponent.lower()}_advanced_package = {adv}\n\n"
+            )
+
+            # subpackage
+            f.write(
+                f"  character(len=16), parameter :: &\n"
+                f"    {self.component.lower()}_{self.subcomponent.lower()}_subpackages(*) = &\n"
+            )
+            if not len(self._subpackage):
+              self._subpackage.append(''.ljust(16))
+            f.write(f"    [ &\n")
+            f.write("    '" + "', &\n    '" .join(self._subpackage) + "' &\n")
+            f.write(f"    ]\n\n")
 
             # params
             if len(self._param_varnames):
@@ -159,6 +181,14 @@ class Dfn2F90:
                 # flopy multi-package
                 if "flopy multi-package" in line.strip():
                     self._multi_package = True
+                elif "package-type" in line.strip():
+                    pkg_tags = line.strip().split()
+                    if pkg_tags[2] == "advanced-stress-package":
+                        self._advanced_package = True
+                elif "mf6 subpackage" in line.strip():
+                    sp = line.replace("# mf6 subpackage ", "").strip()
+                    sp = sp.upper()
+                    self._subpackage.append(sp.ljust(16))
                 continue
 
             ll = line.strip().split()
@@ -474,7 +504,11 @@ class Dfn2F90:
             f"  public {component.capitalize()}{subcomponent.capitalize()}"
             f"ParamFoundType\n"
             f"  public {component.lower()}_{subcomponent.lower()}_"
-            f"multi_package\n\n"
+            f"multi_package\n"
+            f"  public {component.lower()}_{subcomponent.lower()}_"
+            f"advanced_package\n"
+            f"  public {component.lower()}_{subcomponent.lower()}_"
+            f"subpackages\n\n"
         )
 
         return s
@@ -542,6 +576,8 @@ class IdmDfnSelector:
             self._write_master_defn(fh, defn="aggregate", dtype="param")
             self._write_master_defn(fh, defn="block", dtype="block")
             self._write_master_multi(fh)
+            self._write_master_adv(fh)
+            self._write_master_sub(fh)
             self._write_master_integration(fh)
             self._write_master_component(fh)
             fh.write(f"end module IdmDfnSelectorModule\n")
@@ -568,6 +604,8 @@ class IdmDfnSelector:
                     fh, component=c, sc_list=self._d[c], defn="block", dtype="block"
                 )
                 self._write_selector_multi(fh, component=c, sc_list=self._d[c])
+                self._write_selector_adv(fh, component=c, sc_list=self._d[c])
+                self._write_selector_sub(fh, component=c, sc_list=self._d[c])
                 self._write_selector_integration(fh, component=c, sc_list=self._d[c])
                 fh.write(f"end module Idm{c.title()}DfnSelectorModule\n")
 
@@ -598,6 +636,8 @@ class IdmDfnSelector:
             f"  public :: {c.lower()}_aggregate_definitions\n"
             f"  public :: {c.lower()}_block_definitions\n"
             f"  public :: {c.lower()}_idm_multi_package\n"
+            f"  public :: {c.lower()}_idm_advanced_package\n"
+            f"  public :: {c.lower()}_idm_subpackages\n"
             f"  public :: {c.lower()}_idm_integrated\n\n"
         )
         s += f"contains\n\n"
@@ -623,6 +663,16 @@ class IdmDfnSelector:
             f"target :: input_dfn_target\n"
             f"    input_dfn => input_dfn_target\n"
             f"  end subroutine set_block_pointer\n\n"
+        )
+
+        s += (
+            f"  subroutine set_subpkg_pointer(subpkg_list, subpkg_list_target)\n"
+            f"    character(len=16), dimension(:), "
+            f"pointer :: subpkg_list\n"
+            f"    character(len=16), dimension(:), "
+            f"target :: subpkg_list_target\n"
+            f"    subpkg_list => subpkg_list_target\n"
+            f"  end subroutine set_subpkg_pointer\n\n"
         )
 
         fh.write(s)
@@ -690,6 +740,61 @@ class IdmDfnSelector:
 
         fh.write(s)
 
+    def _write_selector_adv(self, fh=None, component=None, sc_list=None):
+        c = component
+
+        s = (
+            f"  function {c.lower()}_idm_advanced_package(subcomponent) "
+            f"result(advanced_package)\n"
+            f"    character(len=*), intent(in) :: subcomponent\n"
+            f"    logical :: advanced_package\n"
+            f"    advanced_package = .false.\n"
+            f"    select case (subcomponent)\n"
+        )
+
+        for sc in sc_list:
+            s += (
+                f"    case ('{sc}')\n"
+                f"      advanced_package = {c.lower()}_{sc.lower()}_"
+                f"advanced_package\n"
+            )
+
+        s += (
+            f"    case default\n"
+            f"    end select\n"
+            f"    return\n"
+            f"  end function {c.lower()}_idm_advanced_package\n\n"
+        )
+
+        fh.write(s)
+
+    def _write_selector_sub(self, fh=None, component=None, sc_list=None):
+        c = component
+
+        s = (
+            f"  function {c.lower()}_idm_subpackages(subcomponent) "
+            f"result(subpackages)\n"
+            f"    character(len=*), intent(in) :: subcomponent\n"
+            f"    character(len=16), dimension(:), pointer :: subpackages\n"
+            f"    select case (subcomponent)\n"
+        )
+
+        for sc in sc_list:
+            s += (
+                f"    case ('{sc}')\n"
+                f"      call set_subpkg_pointer(subpackages, "
+                f"{c.lower()}_{sc.lower()}_subpackages)\n"
+            )
+
+        s += (
+            f"    case default\n"
+            f"    end select\n"
+            f"    return\n"
+            f"  end function {c.lower()}_idm_subpackages\n\n"
+        )
+
+        fh.write(s)
+
     def _write_selector_integration(self, fh=None, component=None, sc_list=None):
         c = component
 
@@ -739,6 +844,8 @@ class IdmDfnSelector:
             f"  public :: aggregate_definitions\n"
             f"  public :: block_definitions\n"
             f"  public :: idm_multi_package\n"
+            f"  public :: idm_advanced_package\n"
+            f"  public :: idm_subpackages\n"
             f"  public :: idm_integrated\n"
             f"  public :: idm_component\n\n"
             f"contains\n\n"
@@ -800,6 +907,66 @@ class IdmDfnSelector:
             f"    end select\n"
             f"    return\n"
             f"  end function idm_multi_package\n\n"
+        )
+
+        fh.write(s)
+
+    def _write_master_adv(self, fh=None):
+        s = (
+            f"  function idm_advanced_package(component, subcomponent) "
+            f"result(advanced_package)\n"
+            f"    character(len=*), intent(in) :: component\n"
+            f"    character(len=*), intent(in) :: subcomponent\n"
+            f"    logical :: advanced_package\n"
+            f"    select case (component)\n"
+        )
+
+        for c in dfn_d:
+            s += (
+                f"    case ('{c}')\n"
+                f"      advanced_package = {c.lower()}_idm_advanced_"
+                f"package(subcomponent)\n"
+            )
+
+        s += (
+            f"    case default\n"
+            f"      call store_error('Idm selector component not found; '//&\n"
+            f"                       &'component=\"'//trim(component)//&\n"
+            f"                       &'\", subcomponent=\"'//trim(subcomponent)"
+            f"//'\".', .true.)\n"
+            f"    end select\n"
+            f"    return\n"
+            f"  end function idm_advanced_package\n\n"
+        )
+
+        fh.write(s)
+
+    def _write_master_sub(self, fh=None):
+        s = (
+            f"  function idm_subpackages(component, subcomponent) "
+            f"result(subpackages)\n"
+            f"    character(len=*), intent(in) :: component\n"
+            f"    character(len=*), intent(in) :: subcomponent\n"
+            f"    character(len=16), dimension(:), pointer :: subpackages\n"
+            f"    select case (component)\n"
+        )
+
+        for c in dfn_d:
+            s += (
+                f"    case ('{c}')\n"
+                f"      subpackages => {c.lower()}_idm_"
+                f"subpackages(subcomponent)\n"
+            )
+
+        s += (
+            f"    case default\n"
+            f"      call store_error('Idm selector component not found; '//&\n"
+            f"                       &'component=\"'//trim(component)//&\n"
+            f"                       &'\", subcomponent=\"'//trim(subcomponent)"
+            f"//'\".', .true.)\n"
+            f"    end select\n"
+            f"    return\n"
+            f"  end function idm_subpackages\n\n"
         )
 
         fh.write(s)

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -214,7 +214,7 @@ class Dfn2F90:
         self._var_d = vardict
 
     def _construct_f90_block_statement(
-        self, blockname, required=False, aggregate=False, block_var=False
+        self, blockname, required=False, aggregate=False, block_var=False, timeseries=False
     ):
         f90statement = f"    InputBlockDefinitionType( &\n"
         f90statement += f"    '{blockname}', & ! blockname\n"
@@ -230,9 +230,14 @@ class Dfn2F90:
             f90statement += f"    .false., & ! aggregate\n"
 
         if block_var:
-            f90statement += f"    .true. & ! block_variable\n"
+            f90statement += f"    .true., & ! block_variable\n"
         else:
-            f90statement += f"    .false. & ! block_variable\n"
+            f90statement += f"    .false., & ! block_variable\n"
+
+        if timeseries:
+            f90statement += f"    .true. & ! timeseries\n"
+        else:
+            f90statement += f"    .false. & ! timeseries\n"
 
         f90statement += f"    ), &"
 
@@ -321,6 +326,7 @@ class Dfn2F90:
         required_l = []
         has_block_var = False
         is_aggregate_blk = False
+        is_timeseries_blk = False
         aggregate_required = False
 
         # comment
@@ -419,6 +425,7 @@ class Dfn2F90:
             if "time_series" in v:
                 if v["time_series"] == "true":
                     timeseries = ".true."
+                    is_timeseries_blk = True
                 else:
                     timeseries = ".false."
 
@@ -483,6 +490,7 @@ class Dfn2F90:
                 required=required,
                 aggregate=is_aggregate_blk,
                 block_var=has_block_var,
+                timeseries=is_timeseries_blk,
             )
             + "\n"
         )


### PR DESCRIPTION
These updates are forward looking and are intended to support input loading of advanced and subpackages.  Advanced packages are marked as such with the already existing `# package-type advanced-stress-package` tagline in dfn files.  A new tag `# mf6 subpackage <subp>` identifies one subpackage- any number of these can be added to a dfn.  The subpackage identifier follows the naming convention for dfn files themselves, so to add TVK to NPF as a subpackage the entire tagline would be `# mf6 subpackage utl-tvk`.

A subpackage tagline should be added to a package only if both packages are already IDM integrated.  This means that each package does not use a parser to read it's own input file but rather sources it's input from the input context.