### PR TITLE
refactor(memory): update mem_reallocate to copy optional interface

### DIFF
--- a/src/Model/GroundWaterFlow/gwf3disu8.f90
+++ b/src/Model/GroundWaterFlow/gwf3disu8.f90
@@ -255,8 +255,8 @@ contains
         this%yc(noder) = this%cellxy(2, node)
       end do
     else
-      call mem_reallocate(this%xc, 0, 'XC', this%memoryPath)
-      call mem_reallocate(this%yc, 0, 'YC', this%memoryPath)
+      call mem_reallocate(this%xc, 0, 'XC', this%memoryPath, copy=.FALSE.)
+      call mem_reallocate(this%yc, 0, 'YC', this%memoryPath, copy=.FALSE.)
     end if
     !
     ! -- create and fill the connections object

--- a/src/Model/GroundWaterFlow/gwf3npf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8.f90
@@ -1696,13 +1696,17 @@ contains
       call mem_set_value(this%k22, 'K', this%input_mempath, map, afound(2))
     end if
     if (.not. found%wetdry) call mem_reallocate(this%wetdry, 1, 'WETDRY', &
-                                                trim(this%memoryPath))
+                                                trim(this%memoryPath), &
+                                                copy=.FALSE.)
     if (.not. found%angle1 .and. this%ixt3d == 0) &
-      call mem_reallocate(this%angle1, 0, 'ANGLE1', trim(this%memoryPath))
+      call mem_reallocate(this%angle1, 0, 'ANGLE1', trim(this%memoryPath), &
+                          copy=.FALSE.)
     if (.not. found%angle2 .and. this%ixt3d == 0) &
-      call mem_reallocate(this%angle2, 0, 'ANGLE2', trim(this%memoryPath))
+      call mem_reallocate(this%angle2, 0, 'ANGLE2', trim(this%memoryPath), &
+                          copy=.FALSE.)
     if (.not. found%angle3 .and. this%ixt3d == 0) &
-      call mem_reallocate(this%angle3, 0, 'ANGLE3', trim(this%memoryPath))
+      call mem_reallocate(this%angle3, 0, 'ANGLE3', trim(this%memoryPath), &
+                          copy=.FALSE.)
     !
     ! -- log griddata
     if (this%iout > 0) then

--- a/src/Model/GroundWaterTransport/gwt1dsp1.f90
+++ b/src/Model/GroundWaterTransport/gwt1dsp1.f90
@@ -627,7 +627,8 @@ contains
     !
     ! -- reallocate diffc if not found
     if (.not. found%diffc) then
-      call mem_reallocate(this%diffc, 0, 'DIFFC', trim(this%memoryPath))
+      call mem_reallocate(this%diffc, 0, 'DIFFC', trim(this%memoryPath), &
+                          copy=.FALSE.)
     end if
     !
     ! -- set this%idisp flag
@@ -656,11 +657,13 @@ contains
         call mem_reassignptr(this%atv, 'ATV', trim(this%memoryPath), &
                              'ATH2', trim(this%memoryPath))
     else
-      call mem_reallocate(this%alh, 0, 'ALH', trim(this%memoryPath))
-      call mem_reallocate(this%alv, 0, 'ALV', trim(this%memoryPath))
-      call mem_reallocate(this%ath1, 0, 'ATH1', trim(this%memoryPath))
-      call mem_reallocate(this%ath2, 0, 'ATH2', trim(this%memoryPath))
-      call mem_reallocate(this%atv, 0, 'ATV', trim(this%memoryPath))
+      call mem_reallocate(this%alh, 0, 'ALH', trim(this%memoryPath), copy=.FALSE.)
+      call mem_reallocate(this%alv, 0, 'ALV', trim(this%memoryPath), copy=.FALSE.)
+      call mem_reallocate(this%ath1, 0, 'ATH1', trim(this%memoryPath), &
+                          copy=.FALSE.)
+      call mem_reallocate(this%ath2, 0, 'ATH2', trim(this%memoryPath), &
+                          copy=.FALSE.)
+      call mem_reallocate(this%atv, 0, 'ATV', trim(this%memoryPath), copy=.FALSE.)
     end if
     !
     ! -- log griddata


### PR DESCRIPTION
Update:
The mem_reallocate interface has been updated to include an optional copy argument.  It has been refactored to copy by default, however, this can be overriden with the optional arg.  The interface will now throw an error if the array size has shrunk and copy is set to TRUE.  The mem_reset interface has been removed.

----------------

The MemoryManager mem_reallocate interface for the most part assumes a size increasing reallocation and then copies existing array values into the new array.  This new interface is meant to reallocate to any size (including 0) and to never copy existing values.   The existing mem_reallocate interface could probably be updated to alternatively provide this same behavior so this PR represents one way forward.

This is needed by IDM when Dynamic list based array data is loaded across periods that do not have an explicit dimension- TVK and TVS are examples.  In these cases, **maxbound** implicitly is the number of reduced nodes, however to reduce memory overhead it might preferred to reallocate these arrays to the size needed for each period.  This interface supports the idea of resetting allocated memory from the previous period.