### PR TITLE
test(framework): drop support for *.cmp file comparisons

### DIFF
--- a/autotest/test_gwf_mf6io_app2_examples_distypes.py
+++ b/autotest/test_gwf_mf6io_app2_examples_distypes.py
@@ -551,7 +551,7 @@ def check_output(idx, test):
     fpth0 = ws / f"{sim_name}.{extension}"
     # fpth1 = ws / f"mf6/{get_dis_name(name)}.{extension}"
     fpth1 = ws / f"mf6/{sim_name}.{extension}"
-    test._compare_budget_files(0, extension, fpth0, fpth1)
+    test._compare_budget_files(extension, fpth0, fpth1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* https://github.com/MODFLOW-USGS/modflow6-testmodels/pull/10
* remove support for testmodel `*.cmp` reference solution files
* support for mf2005/etc comparisons preserved
* fix default mf6 regression executable selection
* misc cleanup