### PR TITLE
test(framework): run simulations up front, tweak options

### DIFF
--- a/autotest/common_regression.py
+++ b/autotest/common_regression.py
@@ -11,6 +11,7 @@ COMPARE_PROGRAMS = (
     "mflgr",
     "libmf6",
     "mf6",
+    "mf6_regression"
     # todo: "mp7"
 )
 IGNORE_EXTENSIONS = (
@@ -306,7 +307,7 @@ def get_mf6_comparison(src):
     Determine the comparison type for a MODFLOW 6 simulation
     based on files present in the simulation workspace. Some
     files take precedence over others according to the order
-    specified in `COMPARE_PATTERNS`.
+    specified in `COMPARE_PROGRAMS`.
 
     Parameters
     ----------
@@ -319,9 +320,7 @@ def get_mf6_comparison(src):
         comparison type
 
     """
-    # Possible comparison - the order matters
 
-    # Construct src pth from namefile
     for _, dirs, _ in os.walk(src):
         dl = [d.lower() for d in dirs]
         for pattern in COMPARE_PROGRAMS:

--- a/autotest/framework.py
+++ b/autotest/framework.py
@@ -656,10 +656,11 @@ class TestFramework:
             print(f"Running {target} in {workspace}")
 
         # needed in _compare_heads()... todo: inject explicitly?
+        nf = next(iter(get_namefiles(workspace)), None)
         self.cmp_namefile = (
             None
             if "mf6" in target.name or "libmf6" in target.name
-            else os.path.basename(get_namefiles(workspace)[0])
+            else os.path.basename(nf) if nf else None
         )
 
         # run the model

--- a/autotest/test_gwf_csub_zdisp01.py
+++ b/autotest/test_gwf_csub_zdisp01.py
@@ -192,7 +192,7 @@ ds16 = [0, nper - 1, 0, nstp[-1] - 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1]
 
 
 # variant SUB package problem 3
-def build_models(idx, test):
+def build_models(idx, test, targets):
     name = cases[idx]
 
     # build MODFLOW 6 files
@@ -329,7 +329,9 @@ def build_models(idx, test):
     # build MODFLOW-NWT files
     cpth = cmppth
     ws = os.path.join(test.workspace, cpth)
-    mc = flopy.modflow.Modflow(name, model_ws=ws, version=cpth)
+    mc = flopy.modflow.Modflow(
+        name, model_ws=ws, version=cpth, exe_name=targets.mfnwt
+    )
     dis = flopy.modflow.ModflowDis(
         mc,
         nlay=nlay,
@@ -555,7 +557,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t),
+        build=lambda t: build_models(idx, t, targets),
         check=lambda t: check_output(idx, t),
         htol=htol[idx],
         verbose=False,

--- a/autotest/test_gwf_npf01_75x75.py
+++ b/autotest/test_gwf_npf01_75x75.py
@@ -13,7 +13,7 @@ ss = [0.0, 1.0e-4]
 sy = [0.1, 0.0]
 
 
-def build_models(idx, test):
+def build_models(idx, test, targets):
     nlay, nrow, ncol = 1, 75, 75
     nper = 3
     perlen = [1.0, 1000.0, 1.0]
@@ -149,7 +149,7 @@ def build_models(idx, test):
 
     # build MODFLOW-2005 files
     ws = os.path.join(test.workspace, "mf2005")
-    mc = flopy.modflow.Modflow(name, model_ws=ws)
+    mc = flopy.modflow.Modflow(name, model_ws=ws, exe_name=targets.mf2005)
     dis = flopy.modflow.ModflowDis(
         mc,
         nlay=nlay,
@@ -199,6 +199,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t),
+        build=lambda t: build_models(idx, t, targets),
     )
     test.run()

--- a/autotest/test_gwf_sfr01gwfgwf.py
+++ b/autotest/test_gwf_sfr01gwfgwf.py
@@ -310,6 +310,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         targets=targets,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
-        compare="run_only",
+        compare=None,
     )
     test.run()

--- a/autotest/test_gwf_sto01.py
+++ b/autotest/test_gwf_sto01.py
@@ -96,7 +96,7 @@ ske = [6e-4, 3e-4, 6e-4]
 
 
 # variant SUB package problem 3
-def build_models(idx, test):
+def build_models(idx, test, targets):
     name = cases[idx]
 
     # build MODFLOW 6 files
@@ -202,7 +202,9 @@ def build_models(idx, test):
     # build MODFLOW-NWT files
     cpth = cmppth
     ws = os.path.join(test.workspace, cpth)
-    mc = flopy.modflow.Modflow(name, model_ws=ws, version=cpth)
+    mc = flopy.modflow.Modflow(
+        name, model_ws=ws, version=cpth, exe_name=targets.mfnwt
+    )
     dis = flopy.modflow.ModflowDis(
         mc,
         nlay=nlay,
@@ -343,7 +345,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
-        build=lambda t: build_models(idx, t),
+        build=lambda t: build_models(idx, t, targets),
         check=lambda t: check_output(idx, t),
         targets=targets,
         htol=htol[idx],

--- a/autotest/test_gwf_utl03_obs01.py
+++ b/autotest/test_gwf_utl03_obs01.py
@@ -153,12 +153,12 @@ def build_model(idx, dir, exe):
     return sim, mc
 
 
-def build_models(dir, exe):
-    for idx, name in enumerate(cases):
-        sim, mc = build_model(idx, dir, exe)
-        sim.write_simulation()
-        mc.write_simulation()
-        hack_binary_obs(idx, dir)
+def build_models(idx, test, exe):
+    sim, mc = build_model(idx, test.workspace, exe)
+    sim.write_simulation()
+    mc.write_simulation()
+    hack_binary_obs(idx, test.workspace)
+    return sim, mc
 
 
 def hack_binary_obs(idx, dir):
@@ -218,11 +218,12 @@ def check_output(idx, test):
     list(enumerate(cases)),
 )
 def test_mf6model(idx, name, function_tmpdir, targets):
-    build_models(function_tmpdir, targets.mf6)
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t, targets.mf6),
         check=lambda t: check_output(idx, t),
         targets=targets,
+        overwrite=False,
     )
     test.run()

--- a/autotest/test_testmodels_mf6.py
+++ b/autotest/test_testmodels_mf6.py
@@ -2,7 +2,15 @@ import pytest
 
 from framework import TestFramework
 
-excluded_models = ["alt_model", "test205_gwtbuy-henrytidal"]
+excluded_models = [
+    "alt_model",
+    "test205_gwtbuy-henrytidal",
+    # todo reinstate when flopy fixed: https://github.com/modflowpy/flopy/issues/2053
+    "test001a_Tharmonic_tabs",
+    "test004_bcfss",
+    "test014_NWTP3Low_dev",
+    "test041_flowdivert_nwt_dev",
+]
 
 
 @pytest.mark.repo


### PR DESCRIPTION
* store simulations/models in `TestFramework.sims` as list, not dict
  * previously dict was keyed by workspace path &mdash; this prevented e.g. an MF6 sim and non-MF6 model from sharing the same workspace
* run all simulations registered with the framework up front
  * previously only the simulation under test ran up front, comparison simulation/model ran just before compare time
  * exceptions: mf6 regression and libmf6 (planning to clean up further soon)
  * obviates "run_only" option for `compare`, so this is removed
  * decouples registered simulations from comparisons, allows tests involving multiple simulations (e.g. for PRT where GWF runs first, then PRT consumes flows via FMI)
  * one consequence is that all non-MF6 models registered with the framework must specify `exe_name` (from `targets`)
* add `overwrite` toggle
  * whether to write inputs after build even if workspace is nonempty
  * defaults true, previously this was always done
  * setting false allows writing inputs within build function, e.g. to hack changes into a file
* try loading simulation from test workspace if no build function provided
  * revealed flopy issues loading mf6 test models https://github.com/modflowpy/flopy/issues/2053, skip them until loading fixed
* rename `COMPARE_PATTERNS` -> `COMPARE_PROGRAMS`
* fix/improve some docstrings
* minor refactoring/cleanup