### PR TITLE
test(framework): minor simplifications, cleanup

### DIFF
--- a/autotest/framework.py
+++ b/autotest/framework.py
@@ -243,6 +243,7 @@ class TestFramework:
     Defines a MODFLOW 6 test and its lifecycle, with configurable
     hooks to evaluate results or run other models for comparison:
 
+        - MODFLOW 6 (directly or via API)
         - MODFLOW-2005
         - MODFLOW-NWT
         - MODFLOW-USG

--- a/autotest/test_gwf_ats01.py
+++ b/autotest/test_gwf_ats01.py
@@ -202,10 +202,7 @@ def check_output(idx, test):
     assert v == 10.0, f"Last time should be 10.  Found {v}"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ats02.py
+++ b/autotest/test_gwf_ats02.py
@@ -228,10 +228,7 @@ def check_output(idx, test):
     ), "layer 1 should be dry for this period"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ats03.py
+++ b/autotest/test_gwf_ats03.py
@@ -204,10 +204,7 @@ def check_output(idx, test):
     assert np.allclose(answer, result), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ats_lak01.py
+++ b/autotest/test_gwf_ats_lak01.py
@@ -409,10 +409,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_auxvars.py
+++ b/autotest/test_gwf_auxvars.py
@@ -297,10 +297,7 @@ def check_output(idx, test):
         assert np.allclose(r["AUX2"], auxvar2)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_auxvars02.py
+++ b/autotest/test_gwf_auxvars02.py
@@ -117,10 +117,7 @@ def check_output(idx, test):
             assert np.allclose(r[aname], a)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_boundname01.py
+++ b/autotest/test_gwf_boundname01.py
@@ -163,10 +163,7 @@ def check_output(idx, test):
     assert np.array_equal(obs0, obs1), "observations are not identical"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_buy_lak01.py
+++ b/autotest/test_gwf_buy_lak01.py
@@ -252,10 +252,7 @@ def check_output(idx, test):
     # assert False
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_buy_lak02.py
+++ b/autotest/test_gwf_buy_lak02.py
@@ -446,7 +446,7 @@ def check_output(idx, test):
     # todo: add a better check of the lake concentrations
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, targets, function_tmpdir):
     framework = TestFramework(
         name=name,

--- a/autotest/test_gwf_buy_maw01.py
+++ b/autotest/test_gwf_buy_maw01.py
@@ -249,10 +249,7 @@ def check_output(idx, test):
             assert np.allclose(qmaw, -qgwf), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_buy_sfr01.py
+++ b/autotest/test_gwf_buy_sfr01.py
@@ -456,7 +456,7 @@ def check_output(idx, test):
         ), f"reach {n} flow {qcalc} not equal {qsim}"
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_chd01.py
+++ b/autotest/test_gwf_chd01.py
@@ -132,7 +132,7 @@ def check_output(idx, test):
     ), "simulated head do not match with known solution."
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_chd02.py
+++ b/autotest/test_gwf_chd02.py
@@ -90,7 +90,7 @@ def check_output(idx, test):
     ), "simulated head does not match with known solution."
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_db01_nr.py
+++ b/autotest/test_gwf_csub_db01_nr.py
@@ -404,10 +404,7 @@ def check_output(idx, test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_dbgeo01.py
+++ b/autotest/test_gwf_csub_dbgeo01.py
@@ -355,7 +355,7 @@ def check_output(idx, test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_distypes.py
+++ b/autotest/test_gwf_csub_distypes.py
@@ -422,10 +422,7 @@ def check_output(idx, test):
         )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     gridgen = try_get_target(targets, "gridgen")
     test = TestFramework(

--- a/autotest/test_gwf_csub_distypes.py
+++ b/autotest/test_gwf_csub_distypes.py
@@ -218,7 +218,8 @@ def build_well_data(modelgrid):
     return {1: well_spd}
 
 
-def build_models(idx, test, gridgen):
+def build_models(idx, test):
+    gridgen = try_get_target(test.targets, "gridgen")
     return build_mf6(idx, test.workspace, gridgen), None
 
 
@@ -424,13 +425,11 @@ def check_output(idx, test):
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
-    gridgen = try_get_target(targets, "gridgen")
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
-        build=lambda t: build_models(idx, t, gridgen),
+        build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
         targets=targets,
-        verbose=False,
     )
     test.run()

--- a/autotest/test_gwf_csub_inelastic.py
+++ b/autotest/test_gwf_csub_inelastic.py
@@ -245,10 +245,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_ndb01_nr.py
+++ b/autotest/test_gwf_csub_ndb01_nr.py
@@ -376,10 +376,7 @@ def check_output(idx, test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_sk01.py
+++ b/autotest/test_gwf_csub_sk01.py
@@ -448,7 +448,7 @@ def check_output(idx, test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_sk02.py
+++ b/autotest/test_gwf_csub_sk02.py
@@ -445,10 +445,7 @@ def check_output(idx, test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_sk03.py
+++ b/autotest/test_gwf_csub_sk03.py
@@ -594,10 +594,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_sk04_nr.py
+++ b/autotest/test_gwf_csub_sk04_nr.py
@@ -325,10 +325,7 @@ def check_output(idx, test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_sub01.py
+++ b/autotest/test_gwf_csub_sub01.py
@@ -370,10 +370,7 @@ def cbc_compare(test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_sub01_adjmat.py
+++ b/autotest/test_gwf_csub_sub01_adjmat.py
@@ -440,7 +440,7 @@ def cbc_compare(test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_sub01_elastic.py
+++ b/autotest/test_gwf_csub_sub01_elastic.py
@@ -334,10 +334,7 @@ def cbc_compare(test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_sub01_pch.py
+++ b/autotest/test_gwf_csub_sub01_pch.py
@@ -367,10 +367,7 @@ def cbc_compare(test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_sub02.py
+++ b/autotest/test_gwf_csub_sub02.py
@@ -207,10 +207,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_sub03.py
+++ b/autotest/test_gwf_csub_sub03.py
@@ -432,10 +432,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_subwt01.py
+++ b/autotest/test_gwf_csub_subwt01.py
@@ -395,10 +395,7 @@ def cbc_compare(test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_subwt02.py
+++ b/autotest/test_gwf_csub_subwt02.py
@@ -568,10 +568,7 @@ def cbc_compare(test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_subwt03.py
+++ b/autotest/test_gwf_csub_subwt03.py
@@ -504,10 +504,7 @@ def cbc_compare(test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_wc01.py
+++ b/autotest/test_gwf_csub_wc01.py
@@ -498,10 +498,7 @@ def cbc_compare(test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_wtgeo.py
+++ b/autotest/test_gwf_csub_wtgeo.py
@@ -624,7 +624,7 @@ def cbc_compare(test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_csub_zdisp01.py
+++ b/autotest/test_gwf_csub_zdisp01.py
@@ -192,7 +192,7 @@ ds16 = [0, nper - 1, 0, nstp[-1] - 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1]
 
 
 # variant SUB package problem 3
-def build_models(idx, test, targets):
+def build_models(idx, test):
     name = cases[idx]
 
     # build MODFLOW 6 files
@@ -330,7 +330,7 @@ def build_models(idx, test, targets):
     cpth = cmppth
     ws = os.path.join(test.workspace, cpth)
     mc = flopy.modflow.Modflow(
-        name, model_ws=ws, version=cpth, exe_name=targets.mfnwt
+        name, model_ws=ws, version=cpth, exe_name=test.targets.mfnwt
     )
     dis = flopy.modflow.ModflowDis(
         mc,
@@ -554,9 +554,8 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t, targets),
+        build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
         htol=htol[idx],
-        verbose=False,
     )
     test.run()

--- a/autotest/test_gwf_csub_zdisp01.py
+++ b/autotest/test_gwf_csub_zdisp01.py
@@ -548,10 +548,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_disu.py
+++ b/autotest/test_gwf_disu.py
@@ -77,7 +77,7 @@ def check_output(idx, test):
         assert ja.shape[0] == 126, "ja should have size of 126"
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_disv.py
+++ b/autotest/test_gwf_disv.py
@@ -83,7 +83,7 @@ def check_output(idx, test):
         assert ja.shape[0] == 126, "ja should have size of 126"
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_disv_uzf.py
+++ b/autotest/test_gwf_disv_uzf.py
@@ -381,7 +381,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_drn_ddrn01.py
+++ b/autotest/test_gwf_drn_ddrn01.py
@@ -186,10 +186,7 @@ def drain_smoothing(xdiff, xrange, newton=False):
     return f
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_drn_ddrn02.py
+++ b/autotest/test_gwf_drn_ddrn02.py
@@ -169,10 +169,7 @@ def check_output(idx, test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_evt01.py
+++ b/autotest/test_gwf_evt01.py
@@ -174,10 +174,7 @@ def check_output(idx, test):
         assert np.allclose(sim_evt_rate, cal_evt_rate), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_evt02.py
+++ b/autotest/test_gwf_evt02.py
@@ -156,10 +156,7 @@ def check_output(idx, test):
     assert os.path.isfile(fpth), "model did not run with nseg=1 in EVT input"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_henry_nr.py
+++ b/autotest/test_gwf_henry_nr.py
@@ -233,10 +233,7 @@ def build_models(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     name = "gwf-henry-nr"
     test = TestFramework(

--- a/autotest/test_gwf_ifmod_buy.py
+++ b/autotest/test_gwf_ifmod_buy.py
@@ -639,10 +639,7 @@ def check_output(idx, test):
                 )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_ifmod_idomain.py
+++ b/autotest/test_gwf_ifmod_idomain.py
@@ -373,10 +373,7 @@ def check_output(idx, test):
                 )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_ifmod_mult_exg.py
+++ b/autotest/test_gwf_ifmod_mult_exg.py
@@ -329,10 +329,7 @@ def check_output(idx, test):
     # assert maxdiff_child_south > maxdiff_child_north
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_ifmod_newton.py
+++ b/autotest/test_gwf_ifmod_newton.py
@@ -385,10 +385,7 @@ def check_output(idx, test):
                 )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_ifmod_rewet.py
+++ b/autotest/test_gwf_ifmod_rewet.py
@@ -406,10 +406,7 @@ def check_output(idx, test):
                 )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_ifmod_vert.py
+++ b/autotest/test_gwf_ifmod_vert.py
@@ -281,10 +281,7 @@ def check_output(idx, test):
             assert np.allclose(res, 0.0, atol=1.0e-6), errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_ifmod_xt3d01.py
+++ b/autotest/test_gwf_ifmod_xt3d01.py
@@ -476,10 +476,7 @@ def check_output(idx, test):
     ), "boundname observations do not match expected results"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ifmod_xt3d02.py
+++ b/autotest/test_gwf_ifmod_xt3d02.py
@@ -411,10 +411,7 @@ def check_output(idx, test):
                 )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ims_rcm_reorder.py
+++ b/autotest/test_gwf_ims_rcm_reorder.py
@@ -137,10 +137,7 @@ def check_output(idx, test):
     b1.close()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_lak_bedleak.py
+++ b/autotest/test_gwf_lak_bedleak.py
@@ -166,10 +166,7 @@ def check_output(idx, test):
             assert np.allclose(r["q"][1], -6.19237994e-12)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_lak_wetlakbedarea01.py
+++ b/autotest/test_gwf_lak_wetlakbedarea01.py
@@ -441,10 +441,7 @@ def check_output(idx, test):
     assert np.all(monotonicIncrease > 0), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_lak_wetlakbedarea02.py
+++ b/autotest/test_gwf_lak_wetlakbedarea02.py
@@ -398,10 +398,7 @@ def check_output(idx, test):
         assert np.isclose(warea, checks_out[ii], atol=1e-5), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_laket.py
+++ b/autotest/test_gwf_laket.py
@@ -292,10 +292,7 @@ def check_output(idx, test):
     assert test.success, msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_libmf6_evt01.py
+++ b/autotest/test_gwf_libmf6_evt01.py
@@ -250,10 +250,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_libmf6_ghb01.py
+++ b/autotest/test_gwf_libmf6_ghb01.py
@@ -273,10 +273,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_libmf6_ifmod01.py
+++ b/autotest/test_gwf_libmf6_ifmod01.py
@@ -303,10 +303,7 @@ def check_interface_models(mf6):
                 ), "AREA in interface model does not match"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_libmf6_ifmod02.py
+++ b/autotest/test_gwf_libmf6_ifmod02.py
@@ -401,10 +401,7 @@ def check_interface_models(mf6):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_ifmod03.py
+++ b/autotest/test_gwf_libmf6_ifmod03.py
@@ -287,10 +287,7 @@ def check_interface_models(mf6):
     assert abs(ymax - ymin) < 1e-6
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_libmf6_rch01.py
+++ b/autotest/test_gwf_libmf6_rch01.py
@@ -230,10 +230,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_libmf6_rch02.py
+++ b/autotest/test_gwf_libmf6_rch02.py
@@ -305,10 +305,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_libmf6_riv01.py
+++ b/autotest/test_gwf_libmf6_riv01.py
@@ -246,10 +246,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_libmf6_riv02.py
+++ b/autotest/test_gwf_libmf6_riv02.py
@@ -271,10 +271,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_libmf6_sto01.py
+++ b/autotest/test_gwf_libmf6_sto01.py
@@ -207,10 +207,7 @@ def api_func(exe, idx, model_ws=None):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_maw01.py
+++ b/autotest/test_gwf_maw01.py
@@ -180,7 +180,7 @@ def check_output(workspace):
     print(msg)
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     ws = str(function_tmpdir)
     sim, _ = build_model(idx, ws, targets.mf6)

--- a/autotest/test_gwf_maw02.py
+++ b/autotest/test_gwf_maw02.py
@@ -280,7 +280,7 @@ def eval_results(name, workspace):
     assert diffv < budtol, msg + f"diffv {diffv} exceeds tolerance {budtol}"
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     ws = str(function_tmpdir)
     sim, _ = build_model(idx, ws, targets.mf6)

--- a/autotest/test_gwf_maw03.py
+++ b/autotest/test_gwf_maw03.py
@@ -205,7 +205,7 @@ def eval_results(name, workspace):
         assert tc["M1RATE"].min() < 800.0 and tc["M1HEAD"].max() < 1.0, msg
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     ws = str(function_tmpdir)
     sim = build_model(idx, ws, targets.mf6)

--- a/autotest/test_gwf_maw05.py
+++ b/autotest/test_gwf_maw05.py
@@ -240,10 +240,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_maw06.py
+++ b/autotest/test_gwf_maw06.py
@@ -279,10 +279,7 @@ def check_output(idx, test):
             assert np.allclose(qmaw, -qgwf), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_maw07.py
+++ b/autotest/test_gwf_maw07.py
@@ -285,10 +285,7 @@ def check_output(idx, test):
             assert np.allclose(qmaw, -qgwf), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_maw08.py
+++ b/autotest/test_gwf_maw08.py
@@ -240,10 +240,7 @@ def eval_results(idx, test):
             assert np.allclose(qmaw, -qgwf), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_maw09.py
+++ b/autotest/test_gwf_maw09.py
@@ -305,10 +305,7 @@ def check_output(idx, test):
             assert np.allclose(qmaw, -qgwf), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_maw10.py
+++ b/autotest/test_gwf_maw10.py
@@ -261,10 +261,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_mf6io_app2_examples_distypes.py
+++ b/autotest/test_gwf_mf6io_app2_examples_distypes.py
@@ -4,6 +4,7 @@ import flopy
 import numpy as np
 import pytest
 from flopy.utils.gridgen import Gridgen
+from conftest import try_get_target
 
 from framework import TestFramework
 
@@ -253,6 +254,7 @@ def build_rch_package(gwf, list_recharge):
 
 
 def build_models(idx, test, gridgen):
+    gridgen = try_get_target(test.targets, "gridgen")
     return build_mf6(idx, test.workspace, gridgen), build_mf6(
         idx, test.workspace / "mf6", gridgen
     )
@@ -560,7 +562,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t, targets.gridgen),
+        build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
         verbose=False,
     )

--- a/autotest/test_gwf_mf6io_app2_examples_distypes.py
+++ b/autotest/test_gwf_mf6io_app2_examples_distypes.py
@@ -554,10 +554,7 @@ def check_output(idx, test):
     test._compare_budget_files(extension, fpth0, fpth1)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_mf6io_app2_examples_distypes.py
+++ b/autotest/test_gwf_mf6io_app2_examples_distypes.py
@@ -253,7 +253,7 @@ def build_rch_package(gwf, list_recharge):
     return rch
 
 
-def build_models(idx, test, gridgen):
+def build_models(idx, test):
     gridgen = try_get_target(test.targets, "gridgen")
     return build_mf6(idx, test.workspace, gridgen), build_mf6(
         idx, test.workspace / "mf6", gridgen

--- a/autotest/test_gwf_multimvr.py
+++ b/autotest/test_gwf_multimvr.py
@@ -1117,10 +1117,7 @@ def check_output(idx, test):
         )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_mvr01.py
+++ b/autotest/test_gwf_mvr01.py
@@ -444,10 +444,7 @@ def check_output(idx, test):
     assert records[24].shape == (0,)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_newton01.py
+++ b/autotest/test_gwf_newton01.py
@@ -108,10 +108,7 @@ def check_output(idx, test):
     assert np.allclose(v["H2"], 7.0), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_newton_under_relaxation.py
+++ b/autotest/test_gwf_newton_under_relaxation.py
@@ -123,10 +123,7 @@ def check_output(idx, test):
     assert np.allclose(base_heads, heads), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_noptc01.py
+++ b/autotest/test_gwf_noptc01.py
@@ -133,10 +133,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf01_75x75.py
+++ b/autotest/test_gwf_npf01_75x75.py
@@ -190,10 +190,7 @@ def build_models(idx, test, targets):
     return sim, mc
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf01_75x75.py
+++ b/autotest/test_gwf_npf01_75x75.py
@@ -13,7 +13,7 @@ ss = [0.0, 1.0e-4]
 sy = [0.1, 0.0]
 
 
-def build_models(idx, test, targets):
+def build_models(idx, test):
     nlay, nrow, ncol = 1, 75, 75
     nper = 3
     perlen = [1.0, 1000.0, 1.0]
@@ -149,7 +149,7 @@ def build_models(idx, test, targets):
 
     # build MODFLOW-2005 files
     ws = os.path.join(test.workspace, "mf2005")
-    mc = flopy.modflow.Modflow(name, model_ws=ws, exe_name=targets.mf2005)
+    mc = flopy.modflow.Modflow(name, model_ws=ws, exe_name=test.targets.mf2005)
     dis = flopy.modflow.ModflowDis(
         mc,
         nlay=nlay,
@@ -196,6 +196,6 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         name=name,
         workspace=function_tmpdir,
         targets=targets,
-        build=lambda t: build_models(idx, t, targets),
+        build=lambda t: build_models(idx, t),
     )
     test.run()

--- a/autotest/test_gwf_npf02_rewet.py
+++ b/autotest/test_gwf_npf02_rewet.py
@@ -334,10 +334,7 @@ def check_output(idx, test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf03_sfr.py
+++ b/autotest/test_gwf_npf03_sfr.py
@@ -5776,10 +5776,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf04_spdis.py
+++ b/autotest/test_gwf_npf04_spdis.py
@@ -207,10 +207,7 @@ def check_output(idx, test):
         assert np.allclose(res, 0.0, atol=1.0e-6), errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf05_anisotropy.py
+++ b/autotest/test_gwf_npf05_anisotropy.py
@@ -144,10 +144,7 @@ def check_output(idx, test):
     assert np.allclose(heads.flatten(), answer)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf_thickstrt.py
+++ b/autotest/test_gwf_npf_thickstrt.py
@@ -209,10 +209,7 @@ def check_output(idx, test):
     ), "simulated flow does not match with known solution."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf_tvk01.py
+++ b/autotest/test_gwf_npf_tvk01.py
@@ -175,10 +175,7 @@ def check_output(idx, test):
             ), f"Expected flow rate {flow_rate_calc} but found {q}"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf_tvk02.py
+++ b/autotest/test_gwf_npf_tvk02.py
@@ -197,10 +197,7 @@ def check_output(idx, test):
         ), f"Expected head {expected_result} in period {kper} but found {h}"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf_tvk03.py
+++ b/autotest/test_gwf_npf_tvk03.py
@@ -197,10 +197,7 @@ def check_output(idx, test):
         ), f"Expected head {expected_result} in period {kper} but found {h}"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf_tvk04.py
+++ b/autotest/test_gwf_npf_tvk04.py
@@ -182,10 +182,7 @@ def check_output(idx, test):
     assert 2.0 * sp_x[0][8] < sp_x[1][8], errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_npf_tvk05.py
+++ b/autotest/test_gwf_npf_tvk05.py
@@ -183,10 +183,7 @@ def check_output(idx, test):
     assert sp_x[0][8] == sp_x[1][8], errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_obs01.py
+++ b/autotest/test_gwf_obs01.py
@@ -147,10 +147,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_obs02.py
+++ b/autotest/test_gwf_obs02.py
@@ -150,10 +150,7 @@ def check_output(idx, test):
     ), "headcsv not equal head from binary file"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_pertim.py
+++ b/autotest/test_gwf_pertim.py
@@ -130,10 +130,7 @@ def check_output(idx, test):
     ), f"CHD2_OUT <> {q_out} ({q_out_sim})"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ptc01.py
+++ b/autotest/test_gwf_ptc01.py
@@ -138,10 +138,7 @@ def build_models(idx, test):
     return sim, mc
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_rch01.py
+++ b/autotest/test_gwf_rch01.py
@@ -137,10 +137,7 @@ def check_output(idx, test):
     heads = hobj.get_alldata()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_rch02.py
+++ b/autotest/test_gwf_rch02.py
@@ -129,10 +129,7 @@ def check_output(idx, test):
     heads = hobj.get_alldata()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_rch03.py
+++ b/autotest/test_gwf_rch03.py
@@ -155,10 +155,7 @@ def check_output(idx, test):
     heads = hobj.get_alldata()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sfr01gwfgwf.py
+++ b/autotest/test_gwf_sfr01gwfgwf.py
@@ -299,10 +299,7 @@ def check_output(idx, test):
     assert np.allclose(single_stage, stage), "sfr stages are not equal"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sfr_badfactor.py
+++ b/autotest/test_gwf_sfr_badfactor.py
@@ -524,7 +524,7 @@ def check_output(idx, test):
         )
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sfr_diversion.py
+++ b/autotest/test_gwf_sfr_diversion.py
@@ -167,7 +167,7 @@ def check_output(idx, test):
     ), "Large mass balance error in SFR"
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sfr_evap.py
+++ b/autotest/test_gwf_sfr_evap.py
@@ -432,10 +432,7 @@ def check_output(idx, test):
     assert np.allclose(stored_strm_evap_r, sim_evap_r, atol=1e-4), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sfr_npoint01.py
+++ b/autotest/test_gwf_sfr_npoint01.py
@@ -323,10 +323,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sfr_npoint02.py
+++ b/autotest/test_gwf_sfr_npoint02.py
@@ -239,10 +239,7 @@ def check_output(idx, test):
     ), "sfr depth not equal to calculated depth"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sfr_npoint03.py
+++ b/autotest/test_gwf_sfr_npoint03.py
@@ -295,10 +295,7 @@ def check_output(idx, test):
     ), f"upstream depths are not equal ('{test.name}')"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sfr_reorder.py
+++ b/autotest/test_gwf_sfr_reorder.py
@@ -235,10 +235,7 @@ def check_output(idx, test):
     ), "DAG did not correctly reorder reaches."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sfr_wetstrmbedarea.py
+++ b/autotest/test_gwf_sfr_wetstrmbedarea.py
@@ -375,10 +375,7 @@ def check_output(idx, test):
         assert val == 0.0, msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sto01.py
+++ b/autotest/test_gwf_sto01.py
@@ -337,10 +337,7 @@ def check_output(idx, test):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sto01.py
+++ b/autotest/test_gwf_sto01.py
@@ -96,7 +96,7 @@ ske = [6e-4, 3e-4, 6e-4]
 
 
 # variant SUB package problem 3
-def build_models(idx, test, targets):
+def build_models(idx, test):
     name = cases[idx]
 
     # build MODFLOW 6 files
@@ -203,7 +203,7 @@ def build_models(idx, test, targets):
     cpth = cmppth
     ws = os.path.join(test.workspace, cpth)
     mc = flopy.modflow.Modflow(
-        name, model_ws=ws, version=cpth, exe_name=targets.mfnwt
+        name, model_ws=ws, version=cpth, exe_name=test.targets.mfnwt
     )
     dis = flopy.modflow.ModflowDis(
         mc,
@@ -342,7 +342,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
-        build=lambda t: build_models(idx, t, targets),
+        build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
         targets=targets,
         htol=htol[idx],

--- a/autotest/test_gwf_sto02.py
+++ b/autotest/test_gwf_sto02.py
@@ -155,10 +155,7 @@ def check_output(idx, test):
     print(inc)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sto03.py
+++ b/autotest/test_gwf_sto03.py
@@ -258,10 +258,7 @@ def check_output(idx, test):
     assert max_diff.sum() == 0.0, "simulated storage is not the same"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_sto_tvs01.py
+++ b/autotest/test_gwf_sto_tvs01.py
@@ -197,10 +197,7 @@ def check_output(idx, test):
         ), f"Expected head {expected_result} in period {kper} but found {h}"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ts_lak01.py
+++ b/autotest/test_gwf_ts_lak01.py
@@ -351,10 +351,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ts_maw01.py
+++ b/autotest/test_gwf_ts_maw01.py
@@ -451,10 +451,7 @@ def check_output(idx, test):
     eval_bud_diff(fpth, cobj0, cobj1)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ts_sfr01.py
+++ b/autotest/test_gwf_ts_sfr01.py
@@ -592,10 +592,7 @@ def check_result(idx, test):
     assert np.allclose(v0, check), "FROM-MVR failed"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ts_sfr02.py
+++ b/autotest/test_gwf_ts_sfr02.py
@@ -598,10 +598,7 @@ def check_output(idx, test):
     assert np.allclose(v0, check), "TO-MVR failed"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_ts_uzf01.py
+++ b/autotest/test_gwf_ts_uzf01.py
@@ -689,10 +689,7 @@ def check_output(idx, test):
     eval_bud_diff(fpth, cobj0, cobj1)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_utl01_binaryinput.py
+++ b/autotest/test_gwf_utl01_binaryinput.py
@@ -428,10 +428,7 @@ def build_models(idx, test):
     return sim, None
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_utl02_timeseries.py
+++ b/autotest/test_gwf_utl02_timeseries.py
@@ -147,10 +147,7 @@ def build_models(idx, test):
     return sim, None
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_utl03_obs01.py
+++ b/autotest/test_gwf_utl03_obs01.py
@@ -48,13 +48,11 @@ nouter, ninner = 100, 300
 hclose, rclose, relax = 1e-6, 0.01, 1.0
 
 
-def build_mf6(idx, ws, exe, binaryobs=True):
+def build_mf6(idx, ws, binaryobs=True):
     name = cases[idx]
 
     # build MODFLOW 6 files
-    sim = flopy.mf6.MFSimulation(
-        sim_name=name, version="mf6", exe_name=exe, sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=name, version="mf6", sim_ws=ws)
     # create tdis package
     flopy.mf6.ModflowTdis(
         sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
@@ -137,14 +135,14 @@ def build_mf6(idx, ws, exe, binaryobs=True):
     return sim
 
 
-def build_model(idx, dir, exe):
+def build_model(idx, dir):
     ws = dir
     # build mf6 with ascii observation output
-    sim = build_mf6(idx, ws, exe=exe, binaryobs=False)
+    sim = build_mf6(idx, ws, binaryobs=False)
 
     # build mf6 with binary observation output
     wsc = os.path.join(ws, "mf6")
-    mc = build_mf6(idx, wsc, exe=exe, binaryobs=True)
+    mc = build_mf6(idx, wsc, binaryobs=True)
 
     sim.write_simulation()
     mc.write_simulation()
@@ -153,8 +151,8 @@ def build_model(idx, dir, exe):
     return sim, mc
 
 
-def build_models(idx, test, exe):
-    sim, mc = build_model(idx, test.workspace, exe)
+def build_models(idx, test):
+    sim, mc = build_model(idx, test.workspace)
     sim.write_simulation()
     mc.write_simulation()
     hack_binary_obs(idx, test.workspace)
@@ -218,7 +216,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
-        build=lambda t: build_models(idx, t, targets.mf6),
+        build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
         targets=targets,
         overwrite=False,

--- a/autotest/test_gwf_utl03_obs01.py
+++ b/autotest/test_gwf_utl03_obs01.py
@@ -213,10 +213,7 @@ def check_output(idx, test):
             assert np.allclose(d0[name], d1[name], rtol=1e-5), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_utl04_auxmult.py
+++ b/autotest/test_gwf_utl04_auxmult.py
@@ -173,10 +173,7 @@ def check_output(idx, test):
     assert np.allclose(qlist, answer), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_utl05_budparse.py
+++ b/autotest/test_gwf_utl05_budparse.py
@@ -155,10 +155,7 @@ def check_output(idx, test):
     assert np.allclose(inc["WEL_OUT"], 0.0)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_utl06_tas.py
+++ b/autotest/test_gwf_utl06_tas.py
@@ -360,10 +360,7 @@ def check_output(idx, test):
         assert np.allclose(q, qa), f"{q} /=\n {qa}"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_uzf01.py
+++ b/autotest/test_gwf_uzf01.py
@@ -258,10 +258,7 @@ def check_output(idx, test):
         )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_uzf02.py
+++ b/autotest/test_gwf_uzf02.py
@@ -302,10 +302,7 @@ def check_output(idx, test):
     # make_plot(sim, obsvals)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_uzf03.py
+++ b/autotest/test_gwf_uzf03.py
@@ -303,10 +303,7 @@ def check_output(idx, test):
     # make_plot(test, obsvals)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_uzf04.py
+++ b/autotest/test_gwf_uzf04.py
@@ -253,10 +253,7 @@ def check_output(idx, test):
     ), "Simulated mobile water volume in aux does not match known result"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_uzf05.py
+++ b/autotest/test_gwf_uzf05.py
@@ -235,10 +235,7 @@ def check_output(idx, test):
     assert np.isclose(q, -4.0), "Flow from UZF to node 1 should be -4."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_uzf_wc_output.py
+++ b/autotest/test_gwf_uzf_wc_output.py
@@ -536,10 +536,7 @@ def check_output(idx, test):
     print("Finished running checks")
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_vsc01.py
+++ b/autotest/test_gwf_vsc01.py
@@ -320,10 +320,7 @@ def check_output(idx, test):
             print("Binary viscosity output file was not read successfully")
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_vsc02.py
+++ b/autotest/test_gwf_vsc02.py
@@ -309,10 +309,7 @@ def check_output(idx, test):
         )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_vsc03_sfr.py
+++ b/autotest/test_gwf_vsc03_sfr.py
@@ -523,10 +523,7 @@ def check_output(idx, test):
             )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_vsc04_lak.py
+++ b/autotest/test_gwf_vsc04_lak.py
@@ -769,10 +769,7 @@ def check_output(idx, test):
         )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_vsc05_hfb.py
+++ b/autotest/test_gwf_vsc05_hfb.py
@@ -362,10 +362,7 @@ def check_output(idx, test):
 
 
 # - No need to change any code below
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_wel01.py
+++ b/autotest/test_gwf_wel01.py
@@ -186,10 +186,7 @@ def check_output(idx, test):
     assert np.allclose(a1, a2), errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwf_zb01.py
+++ b/autotest/test_gwf_zb01.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import flopy
 import numpy as np
@@ -217,7 +216,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(idx, test, zb6):
+def check_output(idx, test):
     # build zonebudget files
     zones = [-1000000, 1000000, 9999999]
     nzones = len(zones)
@@ -240,7 +239,7 @@ def check_output(idx, test, zb6):
 
     # run zonebudget
     success, buff = flopy.run_model(
-        zb6,
+        test.targets.zb6,
         "zonebudget.nam",
         model_ws=test.workspace,
         silent=False,
@@ -392,7 +391,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=lambda t: check_output(idx, t, targets.zbud6),
+        check=lambda t: check_output(idx, t),
         htol=htol[idx],
     )
     test.run()

--- a/autotest/test_gwf_zb01.py
+++ b/autotest/test_gwf_zb01.py
@@ -239,7 +239,7 @@ def check_output(idx, test):
 
     # run zonebudget
     success, buff = flopy.run_model(
-        test.targets.zb6,
+        test.targets.zbud6,
         "zonebudget.nam",
         model_ws=test.workspace,
         silent=False,

--- a/autotest/test_gwf_zb01.py
+++ b/autotest/test_gwf_zb01.py
@@ -385,10 +385,7 @@ def check_output(idx, test, zb6):
         print("    " + msg)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwfgwf_lgr.py
+++ b/autotest/test_gwfgwf_lgr.py
@@ -275,10 +275,7 @@ def check_output(idx, test):
             assert np.allclose(res, 0.0, atol=1.0e-6), errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_adv01.py
+++ b/autotest/test_gwt_adv01.py
@@ -585,10 +585,7 @@ def check_output(idx, test):
     ), "simulated concentrations do not match with known solution."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_adv01_fmi.py
+++ b/autotest/test_gwt_adv01_fmi.py
@@ -561,10 +561,7 @@ def check_output(idx, test):
     ), "simulated concentrations do not match with known solution."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_adv01_gwtgwt.py
+++ b/autotest/test_gwt_adv01_gwtgwt.py
@@ -719,10 +719,7 @@ def check_output(idx, test):
             # assert np.allclose(res, 0.0, atol=1.0e-6), errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_adv02.py
+++ b/autotest/test_gwt_adv02.py
@@ -938,10 +938,7 @@ def check_output(idx, test):
     ), "simulated concentrations do not match with known solution."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_adv03.py
+++ b/autotest/test_gwt_adv03.py
@@ -490,10 +490,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_adv04.py
+++ b/autotest/test_gwt_adv04.py
@@ -253,10 +253,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_buy_solute_heat.py
+++ b/autotest/test_gwt_buy_solute_heat.py
@@ -458,10 +458,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_disu01.py
+++ b/autotest/test_gwt_disu01.py
@@ -246,10 +246,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_dsp01.py
+++ b/autotest/test_gwt_dsp01.py
@@ -381,10 +381,7 @@ def check_output(idx, test):
     assert np.allclose(gwtobs["FLOW1"], -cncobs["CNC000"]), errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_dsp01_fmi.py
+++ b/autotest/test_gwt_dsp01_fmi.py
@@ -318,10 +318,7 @@ def check_output(idx, test):
     ), "simulated concentrations do not match with known solution."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_dsp01_gwtgwt.py
+++ b/autotest/test_gwt_dsp01_gwtgwt.py
@@ -296,10 +296,7 @@ def check_output(idx, test):
     assert abs(np.sum(conc1) + np.sum(conc2) - 100.0) < 1e-6
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwt_dsp01_noadv.py
+++ b/autotest/test_gwt_dsp01_noadv.py
@@ -262,10 +262,7 @@ def check_output(idx, test):
     ), "simulated concentrations do not match with known solution."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_dsp02.py
+++ b/autotest/test_gwt_dsp02.py
@@ -709,10 +709,7 @@ def check_output(idx, test):
     ), "simulated concentrations do not match with known solution."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_dsp03.py
+++ b/autotest/test_gwt_dsp03.py
@@ -436,10 +436,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_dsp04.py
+++ b/autotest/test_gwt_dsp04.py
@@ -249,10 +249,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_dsp05_noadv.py
+++ b/autotest/test_gwt_dsp05_noadv.py
@@ -157,10 +157,7 @@ def check_output(idx, test):
     assert np.allclose(cres, conc.flatten()), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_fmi01.py
+++ b/autotest/test_gwt_fmi01.py
@@ -189,10 +189,7 @@ def check_output(idx, test):
     assert np.allclose(cres, conc), errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_henry.py
+++ b/autotest/test_gwt_henry.py
@@ -286,10 +286,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_henry_gwtgwt.py
+++ b/autotest/test_gwt_henry_gwtgwt.py
@@ -426,10 +426,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_henry_nr.py
+++ b/autotest/test_gwt_henry_nr.py
@@ -527,10 +527,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_henry_openclose.py
+++ b/autotest/test_gwt_henry_openclose.py
@@ -289,10 +289,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_ims_issue655.py
+++ b/autotest/test_gwt_ims_issue655.py
@@ -289,10 +289,7 @@ def check_output(idx, test):
     #     vold = v
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_ist01.py
+++ b/autotest/test_gwt_ist01.py
@@ -263,10 +263,7 @@ def check_output(idx, test):
         assert np.allclose(rate_sim, rate_calc), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_ist02.py
+++ b/autotest/test_gwt_ist02.py
@@ -376,10 +376,7 @@ def check_output(idx, test):
     assert success, "Conc difference between mf6 and mt3d > 0.05"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_lkt01.py
+++ b/autotest/test_gwt_lkt01.py
@@ -430,10 +430,7 @@ def check_output(idx, test):
     assert np.allclose(res, answer), f"{res} {answer}"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_lkt02.py
+++ b/autotest/test_gwt_lkt02.py
@@ -483,10 +483,7 @@ def check_output(idx, test):
         assert np.allclose(res[dtname], answer[dtname]), f"{res} {answer}"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_lkt03.py
+++ b/autotest/test_gwt_lkt03.py
@@ -379,10 +379,7 @@ def check_output(idx, test):
         assert np.allclose(res[dtname], answer[dtname]), f"{res} {answer}"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_lkt04.py
+++ b/autotest/test_gwt_lkt04.py
@@ -470,10 +470,7 @@ def check_output(idx, test):
     assert np.allclose(res, answer), f"{res} {answer}"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_moc3d01.py
+++ b/autotest/test_gwt_moc3d01.py
@@ -349,10 +349,7 @@ def check_output(idx, test):
         ), "simulated concentrations do not match with known solution."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_moc3d01_zod.py
+++ b/autotest/test_gwt_moc3d01_zod.py
@@ -569,10 +569,7 @@ def check_output(idx, test):
         assert np.allclose(tsres, tssim), errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_moc3d02.py
+++ b/autotest/test_gwt_moc3d02.py
@@ -308,10 +308,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_moc3d03.py
+++ b/autotest/test_gwt_moc3d03.py
@@ -290,10 +290,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_mst01.py
+++ b/autotest/test_gwt_mst01.py
@@ -230,10 +230,7 @@ def check_output(idx, test):
     )
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_mst02.py
+++ b/autotest/test_gwt_mst02.py
@@ -253,10 +253,7 @@ def check_output(idx, test):
         assert False, f'could not load data from "{fpth}"'
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_mst03.py
+++ b/autotest/test_gwt_mst03.py
@@ -281,10 +281,7 @@ def check_output(idx, test):
     assert np.allclose(conc, canswer, atol=1.0e-8), errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_mst04_noadv.py
+++ b/autotest/test_gwt_mst04_noadv.py
@@ -121,10 +121,7 @@ def check_output(idx, test):
     assert np.allclose(cres, conc.flatten()), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_mst05.py
+++ b/autotest/test_gwt_mst05.py
@@ -304,10 +304,7 @@ def check_output(idx, test):
         plt.savefig(fname)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_mst06_noadv.py
+++ b/autotest/test_gwt_mst06_noadv.py
@@ -161,10 +161,7 @@ def check_output(idx, test):
     assert np.allclose(decay_rate, decay_rate_answer), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_mvt01.py
+++ b/autotest/test_gwt_mvt01.py
@@ -544,10 +544,7 @@ def check_output(idx, test):
     assert np.allclose(d0["SFR-1_OUT"], d0["LAK-1_IN"])
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_mvt02.py
+++ b/autotest/test_gwt_mvt02.py
@@ -475,10 +475,7 @@ def check_output(idx, test):
     # print(res)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_mwt01.py
+++ b/autotest/test_gwt_mwt01.py
@@ -393,10 +393,7 @@ def check_output(idx, test):
     check_obs(test)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_mwt02.py
+++ b/autotest/test_gwt_mwt02.py
@@ -473,7 +473,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_obs01.py
+++ b/autotest/test_gwt_obs01.py
@@ -262,10 +262,7 @@ def check_output(idx, test):
     ), "obs concentrations do not match oc concentrations."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_prudic2004t2.py
+++ b/autotest/test_gwt_prudic2004t2.py
@@ -966,10 +966,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_prudic2004t2gwtgwt.py
+++ b/autotest/test_gwt_prudic2004t2gwtgwt.py
@@ -950,10 +950,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_sft01.py
+++ b/autotest/test_gwt_sft01.py
@@ -422,10 +422,7 @@ def check_output(idx, test):
     assert np.allclose(qs, qa), msg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_sft01gwtgwt.py
+++ b/autotest/test_gwt_sft01gwtgwt.py
@@ -510,10 +510,7 @@ def check_output(idx, test):
     ), "aquifer concentration does not equal sfr concentration"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_src01.py
+++ b/autotest/test_gwt_src01.py
@@ -253,10 +253,7 @@ def check_output(idx, test):
     ), "simulated concentrations do not match with known solution."
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_ssm02.py
+++ b/autotest/test_gwt_ssm02.py
@@ -248,10 +248,7 @@ def check_output(idx, test):
         vold = v
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_ssm03.py
+++ b/autotest/test_gwt_ssm03.py
@@ -256,10 +256,7 @@ def check_output(idx, test):
         assert q < 0.0, "mass flux for chd must be less than zero"
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_ssm04.py
+++ b/autotest/test_gwt_ssm04.py
@@ -501,10 +501,7 @@ def check_output(idx, test):
             istart = istop
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_ssm05.py
+++ b/autotest/test_gwt_ssm05.py
@@ -310,10 +310,7 @@ def check_output(idx, test):
             istart = istop
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_uzt01.py
+++ b/autotest/test_gwt_uzt01.py
@@ -558,10 +558,7 @@ def check_output(idx, test):
     # make_plot(sim, obsvals)
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_zb01.py
+++ b/autotest/test_gwt_zb01.py
@@ -415,7 +415,7 @@ def check_output(idx, test, zb6):
         print("    " + msg)
 
 
-@pytest.mark.parametrize("idx, name", list(enumerate(cases)))
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_zb01.py
+++ b/autotest/test_gwt_zb01.py
@@ -273,7 +273,7 @@ def check_output(idx, test):
 
     # run zonebudget
     success, buff = flopy.run_model(
-        test.targets.zb6,
+        test.targets.zbud6,
         "zonebudget.nam",
         model_ws=ws,
         silent=False,

--- a/autotest/test_gwt_zb01.py
+++ b/autotest/test_gwt_zb01.py
@@ -247,7 +247,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def check_output(idx, test, zb6):
+def check_output(idx, test):
     ws = Path(test.workspace)
 
     # build zonebudget files
@@ -273,7 +273,7 @@ def check_output(idx, test, zb6):
 
     # run zonebudget
     success, buff = flopy.run_model(
-        zb6,
+        test.targets.zb6,
         "zonebudget.nam",
         model_ws=ws,
         silent=False,
@@ -422,7 +422,7 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
-        check=lambda t: check_output(idx, t, targets.zbud6),
+        check=lambda t: check_output(idx, t),
         htol=htol,
     )
     test.run()

--- a/autotest/test_gwtgwt_oldexg.py
+++ b/autotest/test_gwtgwt_oldexg.py
@@ -770,10 +770,7 @@ def compare_gwt_to_ref(test):
             assert np.allclose(res, 0.0, atol=1.0e-6), errmsg
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_mf6_tmp_simulations.py
+++ b/autotest/test_mf6_tmp_simulations.py
@@ -108,10 +108,7 @@ def run_mf6(sim, ws):
     sim.compare()
 
 
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(get_mf6_models())),
-)
+@pytest.mark.parametrize("idx, name", enumerate(get_mf6_models()))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_par_gwf01.py
+++ b/autotest/test_par_gwf01.py
@@ -219,10 +219,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_par_gwf02.py
+++ b/autotest/test_par_gwf02.py
@@ -238,10 +238,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     ncpus = domain_grid[idx][0] * domain_grid[idx][1]
     test = TestFramework(

--- a/autotest/test_par_gwf03.py
+++ b/autotest/test_par_gwf03.py
@@ -231,10 +231,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_par_gwf_idomain.py
+++ b/autotest/test_par_gwf_idomain.py
@@ -31,10 +31,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_par_gwf_ims_csv.py
+++ b/autotest/test_par_gwf_ims_csv.py
@@ -13,7 +13,7 @@ constant head boundaries left=1.0, right=10.0.
 The result should be a uniform flow field.
 """
 
-ex = ["par_gwf_csv"]
+cases = ["par_gwf_csv"]
 dis_shape = [(1, 1, 5)]
 
 # global convenience...
@@ -24,7 +24,7 @@ name_right = "rightmodel"
 def update_ims(idx, ims):
     from test_par_gwf01 import hclose, ninner, nouter, rclose
 
-    name = ex[idx]
+    name = cases[idx]
     ims.csv_outer_output_filerecord.set_data(f"{name}.outer.csv")
     ims.csv_inner_output_filerecord.set_data(f"{name}.inner.csv")
     return
@@ -46,10 +46,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(ex)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_par_gwf_newton.py
+++ b/autotest/test_par_gwf_newton.py
@@ -33,10 +33,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_par_gwf_newton_under_relaxation.py
+++ b/autotest/test_par_gwf_newton_under_relaxation.py
@@ -47,10 +47,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     ncpus = 2 if idx == 1 else 1
     test = TestFramework(

--- a/autotest/test_par_gwf_pakcc.py
+++ b/autotest/test_par_gwf_pakcc.py
@@ -38,10 +38,7 @@ def build_models(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     ncpus = 2 if idx == 1 else 1
     test = TestFramework(

--- a/autotest/test_par_gwf_rewet.py
+++ b/autotest/test_par_gwf_rewet.py
@@ -31,10 +31,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_par_gwf_xt3d02.py
+++ b/autotest/test_par_gwf_xt3d02.py
@@ -31,10 +31,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_par_gwt_adv01.py
+++ b/autotest/test_par_gwt_adv01.py
@@ -24,10 +24,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_par_gwt_dsp01.py
+++ b/autotest/test_par_gwt_dsp01.py
@@ -24,10 +24,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_par_gwt_henry.py
+++ b/autotest/test_par_gwt_henry.py
@@ -24,10 +24,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "idx, name",
-    list(enumerate(cases)),
-)
+@pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,


### PR DESCRIPTION
* mention that test framework supports mf6-mf6 comparisons too
* simplify parametrization syntax, no need for wrapping with `list(...)`
* remove unneeded params in `build_models()` and `check_output()` functions