### PR TITLE
fix(FlowModelInterface.f90): re-install if statement for proper messaging

### DIFF
--- a/src/Model/ModelUtilities/FlowModelInterface.f90
+++ b/src/Model/ModelUtilities/FlowModelInterface.f90
@@ -87,15 +87,17 @@ contains
                     &' VERSION 2, 8/17/2023')"
 
     ! --print a message identifying the FMI package.
-    if (this%inunit /= 0) then
-      write (this%iout, fmtfmi) this%inunit
-    else
-      write (this%iout, fmtfmi0)
-      if (this%flows_from_file) then
-        write (this%iout, '(a)') '  FLOWS ARE ASSUMED TO BE ZERO.'
+    if (this%iout > 0) then
+      if (this%inunit /= 0) then
+        write (this%iout, fmtfmi) this%inunit
       else
-        write (this%iout, '(a)') '  FLOWS PROVIDED BY A GWF MODEL IN THIS &
-          &SIMULATION'
+        write (this%iout, fmtfmi0)
+        if (this%flows_from_file) then
+          write (this%iout, '(a)') '  FLOWS ARE ASSUMED TO BE ZERO.'
+        else
+          write (this%iout, '(a)') '  FLOWS PROVIDED BY A GWF MODEL IN THIS &
+            &SIMULATION'
+        end if
       end if
     end if
     !


### PR DESCRIPTION
In #1332, wherein some code originally appearing in `tsp1fmi1.f90` was moved to `FlowModelInterface.f90`, the line of code pointed to in the screen grabs below didn't survive the move.  As a result, I was getting some messaging printed to console that was throwing me for a loop while debugging GWE.  That is, when some code in an exchange was being defined it was being reported that "FLOWS ARE ASSUMED TO BE ZERO."  However, that's not the case.  This PR seeks to restore the `if` statement indicated in the screen grabs which should lead to better messaging.  I may be missing something, though?  Also interested in see what the ci comes back with.  This change shouldn't impact any of the autotests.

Original code (prior to #1332):
![fmi1](https://github.com/MODFLOW-USGS/modflow6/assets/3236576/25b537b3-800e-439b-aac6-70c182ce9e37)

New code (after #1332) is missing the line in question:
![fmi2](https://github.com/MODFLOW-USGS/modflow6/assets/3236576/4795ef0a-588b-46f5-97bb-61096e7daa75)
