### PR TITLE
refactor(model): lift properties, use base in virtual model

### DIFF
--- a/src/Distributed/VirtualGwfModel.f90
+++ b/src/Distributed/VirtualGwfModel.f90
@@ -4,7 +4,7 @@ module VirtualGwfModelModule
   use VirtualDataContainerModule, only: VDC_GWFMODEL_TYPE
   use VirtualModelModule
   use SimStagesModule
-  use NumericalModelModule, only: NumericalModelType
+  use BaseModelModule, only: BaseModelType
   implicit none
   private
 
@@ -45,7 +45,7 @@ contains
     use VirtualDataListsModule, only: virtual_model_list
     integer(I4B) :: model_id !< global model id
     character(len=*) :: model_name !< model name
-    class(NumericalModelType), pointer :: model !< the actual model (can be null() when remote)
+    class(BaseModelType), pointer :: model !< the actual model (can be null() when remote)
     ! local
     class(VirtualGwfModelType), pointer :: virtual_gwf_model
     class(*), pointer :: obj
@@ -62,7 +62,7 @@ contains
     class(VirtualGwfModelType) :: this
     character(len=*) :: name
     integer(I4B) :: id
-    class(NumericalModelType), pointer :: model
+    class(BaseModelType), pointer :: model
 
     ! create base
     call this%VirtualModelType%create(name, id, model)

--- a/src/Distributed/VirtualGwtModel.f90
+++ b/src/Distributed/VirtualGwtModel.f90
@@ -4,7 +4,7 @@ module VirtualGwtModelModule
   use VirtualBaseModule
   use VirtualDataContainerModule, only: VDC_GWTMODEL_TYPE
   use VirtualModelModule
-  use NumericalModelModule, only: NumericalModelType
+  use BaseModelModule, only: BaseModelType
   implicit none
   private
 
@@ -47,7 +47,7 @@ contains
     use VirtualDataListsModule, only: virtual_model_list
     integer(I4B) :: model_id !< global model id
     character(len=*) :: model_name !< model name
-    class(NumericalModelType), pointer :: model !< the actual model (can be null() when remote)
+    class(BaseModelType), pointer :: model !< the actual model (can be null() when remote)
     ! local
     class(VirtualGwtModelType), pointer :: virtual_gwt_model
     class(*), pointer :: obj
@@ -64,7 +64,7 @@ contains
     class(VirtualGwtModelType) :: this
     character(len=*) :: name
     integer(I4B) :: id
-    class(NumericalModelType), pointer :: model
+    class(BaseModelType), pointer :: model
 
     ! create base
     call this%VirtualModelType%create(name, id, model)

--- a/src/Distributed/VirtualModel.f90
+++ b/src/Distributed/VirtualModel.f90
@@ -5,7 +5,7 @@ module VirtualModelModule
   use KindModule, only: I4B, LGP
   use ListModule, only: ListType
   use SimStagesModule
-  use NumericalModelModule, only: NumericalModelType
+  use BaseModelModule, only: BaseModelType
   implicit none
   private
 
@@ -14,7 +14,7 @@ module VirtualModelModule
   public :: get_virtual_model
 
   type, public, extends(VirtualDataContainerType) :: VirtualModelType
-    class(NumericalModelType), pointer :: local_model
+    class(BaseModelType), pointer :: local_model
     ! CON
     type(VirtualIntType), pointer :: con_ianglex => null()
     type(VirtualInt1dType), pointer :: con_ia => null()
@@ -69,7 +69,7 @@ contains
     class(VirtualModelType) :: this
     character(len=*) :: name
     integer(I4B) :: id
-    class(NumericalModelType), pointer :: model
+    class(BaseModelType), pointer :: model
     ! local
     logical(LGP) :: is_local
 
@@ -324,7 +324,7 @@ contains
 
   function eq_numerical_model(this, num_model) result(is_equal)
     class(VirtualModelType), intent(in) :: this
-    class(NumericalModelType), intent(in) :: num_model
+    class(BaseModelType), intent(in) :: num_model
     logical(LGP) :: is_equal
 
     is_equal = (this%id == num_model%id)

--- a/src/Model/ExplicitModel.f90
+++ b/src/Model/ExplicitModel.f90
@@ -5,7 +5,6 @@ module ExplicitModelModule
   use ConstantsModule, only: LINELENGTH
   use ListModule, only: ListType
   use BaseModelModule, only: BaseModelType
-  use BaseDisModule, only: DisBaseType
   use MemoryManagerModule, only: mem_allocate, mem_deallocate
 
   implicit none
@@ -22,9 +21,6 @@ module ExplicitModelModule
   !<
   type, extends(BaseModelType) :: ExplicitModelType
     character(len=LINELENGTH), pointer :: filename => null() !< input file name
-    integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !< ibound array
-    type(ListType), pointer :: bndlist => null() !< array of boundary packages
-    class(DisBaseType), pointer :: dis => null() !< discretization object
   contains
     ! -- Overridden methods
     procedure :: model_ad
@@ -76,17 +72,6 @@ contains
     ! -- deallocate scalars
     deallocate (this%filename)
 
-    ! -- deallocate arrays
-    call mem_deallocate(this%ibound)
-
-    ! -- nullify pointers
-    if (associated(this%ibound)) &
-      call mem_deallocate(this%ibound, 'IBOUND', this%memoryPath)
-
-    ! -- member derived types
-    call this%bndlist%Clear()
-    deallocate (this%bndlist)
-
     ! -- deallocate base tpye
     call this%BaseModelType%model_da()
   end subroutine model_da
@@ -98,7 +83,6 @@ contains
     character(len=*), intent(in) :: modelname
 
     call this%BaseModelType%allocate_scalars(modelname)
-    allocate (this%bndlist)
     allocate (this%filename)
     this%filename = ''
   end subroutine allocate_scalars
@@ -107,12 +91,8 @@ contains
   !<
   subroutine allocate_arrays(this)
     class(ExplicitModelType) :: this
-    integer(I4B) :: i
 
-    call mem_allocate(this%ibound, this%dis%nodes, 'IBOUND', this%memoryPath)
-    do i = 1, this%dis%nodes
-      this%ibound(i) = 1 ! active by default
-    end do
+    call this%BaseModelType%allocate_arrays()
   end subroutine allocate_arrays
 
   !> @ brief Cast a generic object into an explicit model

--- a/src/Model/NumericalModel.f90
+++ b/src/Model/NumericalModel.f90
@@ -29,12 +29,6 @@ module NumericalModelModule
     integer(I4B), dimension(:), pointer, contiguous :: idxglo => null() !pointer to position in solution matrix
     real(DP), dimension(:), pointer, contiguous :: xold => null() !dependent variable for previous timestep
     real(DP), dimension(:), pointer, contiguous :: flowja => null() !intercell flows
-    integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !ibound array
-    !
-    ! -- Derived types
-    type(ListType), pointer :: bndlist => null() !array of boundary packages for this model
-    class(DisBaseType), pointer :: dis => null() !discretization object
-
   contains
     !
     ! -- Required for all models (override procedures defined in BaseModelType)
@@ -229,18 +223,12 @@ contains
     call mem_deallocate(this%flowja)
     call mem_deallocate(this%idxglo)
     !
-    ! -- derived types
-    call this%bndlist%Clear()
-    deallocate (this%bndlist)
-    !
     ! -- nullify pointers
     call mem_deallocate(this%x, 'X', this%memoryPath)
     call mem_deallocate(this%rhs, 'RHS', this%memoryPath)
-    call mem_deallocate(this%ibound, 'IBOUND', this%memoryPath)
     !
     ! -- BaseModelType
     call this%BaseModelType%model_da()
-    !
     !
     ! -- Return
     return
@@ -280,7 +268,6 @@ contains
     call mem_allocate(this%icnvg, 'ICNVG', this%memoryPath)
     call mem_allocate(this%moffset, 'MOFFSET', this%memoryPath)
     allocate (this%filename)
-    allocate (this%bndlist)
     !
     this%filename = ''
     this%neq = 0

--- a/src/SimulationCreate.f90
+++ b/src/SimulationCreate.f90
@@ -217,7 +217,7 @@ contains
     use SimVariablesModule, only: idm_context
     use GwfModule, only: gwf_cr
     use GwtModule, only: gwt_cr
-    use NumericalModelModule, only: NumericalModelType, GetNumericalModelFromList
+    use BaseModelModule, only: BaseModelType, GetBaseModelFromList
     use VirtualGwfModelModule, only: add_virtual_gwf_model
     use VirtualGwtModelModule, only: add_virtual_gwt_model
     use ConstantsModule, only: LENMODELNAME
@@ -231,7 +231,7 @@ contains
     type(CharacterStringType), dimension(:), contiguous, &
       pointer :: mnames !< model names
     integer(I4B) :: im
-    class(NumericalModelType), pointer :: num_model
+    class(BaseModelType), pointer :: num_model
     character(len=LINELENGTH) :: model_type
     character(len=LINELENGTH) :: fname, model_name
     character(len=LINELENGTH) :: errmsg
@@ -282,7 +282,7 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
             n, ' will be created'
           call gwf_cr(fname, n, model_names(n))
-          num_model => GetNumericalModelFromList(basemodellist, im)
+          num_model => GetBaseModelFromList(basemodellist, im)
           model_loc_idx(n) = im
         end if
         call add_virtual_gwf_model(n, model_names(n), num_model)
@@ -292,7 +292,7 @@ contains
           write (iout, '(4x,2a,i0,a)') trim(model_type), ' model ', &
             n, ' will be created'
           call gwt_cr(fname, n, model_names(n))
-          num_model => GetNumericalModelFromList(basemodellist, im)
+          num_model => GetBaseModelFromList(basemodellist, im)
           model_loc_idx(n) = im
         end if
         call add_virtual_gwt_model(n, model_names(n), num_model)


### PR DESCRIPTION
* move `bndlist`, `dis`, `ibound` from `Numerical/ExplicitModel` to `BaseModel`
* allows using `BaseModel` instead of `NumericalModel` in base virtual model type, eventually supporting explicit virtual models, also simpler templating
* update usage in `SimulationCreate`