### PR TITLE
fix(idm): reset auxvar 2d arrray in array input loader each period

### DIFF
--- a/src/Utilities/Idm/mf6blockfile/StressGridInput.f90
+++ b/src/Utilities/Idm/mf6blockfile/StressGridInput.f90
@@ -249,18 +249,17 @@ contains
                                   this%mf6_input%mempath, this%sourcename)
     end if
     !
-    ! -- reset input context memory for parameters
     do n = 1, this%nparam
       if (this%param_reads(n)%invar /= 0) then
         !
-        ! -- set definition
-        idt => this%mf6_input%param_dfns(this%idt_idxs(n))
-        !
         ! -- reset read state
         this%param_reads(n)%invar = 0
-
+        !
       end if
     end do
+    !
+    ! -- reset auxvar array each period
+    this%bndctx%auxvar = DZERO
     !
     ! -- return
     return


### PR DESCRIPTION
The Modflow6 input/output guide describes the input aux parameter for EVT and RCH Array-Based Input, which includes the line:

```
If an array is not specified for an auxiliary variable, then a value of zero is assigned.
```

When the input specifies a TAS for the aux parameter it is already reset because the TAS manager is reset.  However, the parameter is not currently explicitly reset to zero when not associated with a TAS.