### PR TITLE
chore(InputOutput.f90): cleanup docstrings in IO utility

### DIFF
--- a/.github/common/fortran_format_check.py
+++ b/.github/common/fortran_format_check.py
@@ -18,7 +18,7 @@ excludedirs = [
 ]
 
 # Exclude these files from checks
-excludefiles = []  # excluded until refactored # NOTE: as of 1/18/2024 "src/Utilities/InputOutput.f90" no longer needs to be excluded
+excludefiles = []  # add excluded files here   # NOTE: as of 1/18/2024 "src/Utilities/InputOutput.f90" no longer needs to be excluded
 
 
 class FortranFormatCheck:

--- a/.github/common/fortran_format_check.py
+++ b/.github/common/fortran_format_check.py
@@ -18,7 +18,8 @@ excludedirs = [
 ]
 
 # Exclude these files from checks
-excludefiles = ["src/Utilities/InputOutput.f90"]  # excluded until refactored
+# (the following line commented out on 1/18/2024)
+# excludefiles = ["src/Utilities/InputOutput.f90"]  # excluded until refactored
 
 
 class FortranFormatCheck:

--- a/.github/common/fortran_format_check.py
+++ b/.github/common/fortran_format_check.py
@@ -18,7 +18,7 @@ excludedirs = [
 ]
 
 # Exclude these files from checks
-excludefiles = []  # add excluded files here   # NOTE: as of 1/18/2024 "src/Utilities/InputOutput.f90" no longer needs to be excluded
+excludefiles = []  # add excluded files here
 
 
 class FortranFormatCheck:

--- a/.github/common/fortran_format_check.py
+++ b/.github/common/fortran_format_check.py
@@ -18,8 +18,7 @@ excludedirs = [
 ]
 
 # Exclude these files from checks
-# (the following line commented out on 1/18/2024)
-# excludefiles = ["src/Utilities/InputOutput.f90"]  # excluded until refactored
+excludefiles = []  # excluded until refactored # NOTE: as of 1/18/2024 "src/Utilities/InputOutput.f90" no longer needs to be excluded
 
 
 class FortranFormatCheck:

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -595,27 +595,28 @@ contains
     ! -- constant
     character(len=1) DASH(400)
     data DASH/400*'-'/
+    ! -- formats
+    character(len=*), parameter :: fmtmsgout1 = "(1x, a)"
+    character(len=*), parameter :: fmtmsgout2 = "(1x, 400a)"
     !
     ! -- Construct the complete label in BUF.  Start with BUF=LABEL.
-    buf=label
+    buf = label
     !
     ! -- Add auxiliary data names if there are any.
     nbuf = len(label) + 9
-    if(naux > 0) then
-       do 10 i=1, naux
-         n1 = nbuf + 1
-         nbuf = nbuf + 16
-         buf(n1:nbuf) = caux(i)
-10     continue
+    if (naux > 0) then
+      do i = 1, naux
+        n1 = nbuf + 1
+        nbuf = nbuf + 16
+        buf(n1:nbuf) = caux(i)
+      end do
     end if
     !
     ! -- Write the label.
-    write(iout, 103) buf(1:nbuf)
-103 format(1x, a)
+    write (iout, fmtmsgout1) buf(1:nbuf)
     !
     ! -- Add a line of dashes.
-    write(iout, 104) (DASH(j), j=1, nbuf)
-104 format(1x,400a)
+    write (iout, fmtmsgout2) (DASH(j), j=1, nbuf)
     !
     ! -- Return
     return
@@ -628,22 +629,22 @@ contains
   !<
   subroutine UBDSV4(kstp, kper, text, naux, auxtxt, ibdchn, &
      &              ncol, nrow, nlay, nlist, iout, delt, pertim, totim)
-    ! -- dummy 
+    ! -- dummy
     character(len=16) :: text
     character(len=16), dimension(:) :: auxtxt
-    real(DP),intent(in) :: delt, pertim, totim
+    real(DP), intent(in) :: delt, pertim, totim
     ! -- formats
     character(len=*), parameter :: fmt = &
-      "(1X,'UBDSV4 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
-      "', STRESS PERIOD',I7)"
+      & "(1X,'UBDSV4 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
+      & "', STRESS PERIOD',I7)"
     !
     ! -- Write unformatted records identifying data
-    if(iout > 0) write(iout, fmt) text, ibdchn, kstp, kper
-    write(ibdchn) kstp, kper, text, ncol, nrow, -nlay
-    write(ibdchn) 5, delt, pertim, totim
-    write(ibdchn) naux + 1
-    if(naux > 0) write(ibdchn) (auxtxt(n), n=1, naux)
-    write(ibdchn) nlist
+    if (iout > 0) write (iout, fmt) text, ibdchn, kstp, kper
+    write (ibdchn) kstp, kper, text, ncol, nrow, -nlay
+    write (ibdchn) 5, delt, pertim, totim
+    write (ibdchn) naux + 1
+    if (naux > 0) write (ibdchn) (auxtxt(n), n=1, naux)
+    write (ibdchn) nlist
     !
     ! -- Return
     return
@@ -651,18 +652,18 @@ contains
 
   !> @brief Write one value of cell-by-cell flow plus auxiliary data using a
   !! list structure
-  !< 
+  !<
   subroutine UBDSVB(ibdchn, icrl, q, val, nvl, naux, laux)
     ! -- dummy
     real(DP), dimension(nvl) :: val
     real(DP) :: q
     !
     ! -- Write cell number and flow rate
-    IF(naux > 0) then
+    IF (naux > 0) then
       n2 = laux + naux - 1
-      write(ibdchn) icrl, q, (val(n), n=laux, n2)
+      write (ibdchn) icrl, q, (val(n), n=laux, n2)
     else
-      write(ibdchn) icrl, q
+      write (ibdchn) icrl, q
     end if
     !
     ! -- Return
@@ -682,34 +683,37 @@ contains
     ! -- local
     character(len=1) :: DOT, SPACE, DG, BF
     dimension :: BF(1000), DG(10)
-    !
-    data DG(1),DG(2),DG(3),DG(4),DG(5),DG(6),DG(7),DG(8),DG(9),DG(10)/ &
-       & '0','1','2','3','4','5','6','7','8','9'/
-    data DOT,SPACE/'.',' '/
+    ! -- constants
+    data DG(1), DG(2), DG(3), DG(4), DG(5), DG(6), DG(7), DG(8), DG(9), DG(10)/ &
+       & '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'/
+    data DOT, SPACE/'.', ' '/
+    ! -- formats
+    character(len=*), parameter :: fmtmsgout1 = "(1x)"
+    character(len=*), parameter :: fmtmsgout2 = "(1x, 1000a1)"
     !
     ! -- Calculate # of columns to be printed (nlbl), width
     !    of a line (ntot), number of lines (nwrap).
     if (iout <= 0) return
-    write(iout, 1)
-  1 format(1x)
+    write (iout, fmtmsgout1)
+    !
     nlbl = nlbl2 - nlbl1 + 1
     n = nlbl
     !
-    if(nlbl < ncpl) n = ncpl
+    if (nlbl < ncpl) n = ncpl
     ntot = nspace + n * ndig
     !
-    if(ntot > 1000) go to 50
-    nwrap = (nlbl-1) / ncpl + 1
+    if (ntot > 1000) go to 50
+    nwrap = (nlbl - 1) / ncpl + 1
     j1 = nlbl1 - ncpl
     j2 = nlbl1 - 1
     !
     ! -- Build and print each line
-    do 40 n=1, nwrap
+    do n = 1, nwrap
       !
       ! -- Clear the buffer (BF)
-      do 20 i=1, 1000
+      do i = 1, 1000
         BF(i) = SPACE
- 20   continue
+      end do
       nbf = nspace
       !
       ! -- Determine first (j1) and last (j2) column # for this line.
@@ -717,40 +721,38 @@ contains
       j2 = j2 + ncpl
       if (j2 > nlbl2) j2 = nlbl2
       !
-      !-- Load the column #'s into the buffer.
-      do 30 j=j1, j2
+      ! -- Load the column #'s into the buffer.
+      do j = j1, j2
         nbf = nbf + ndig
         i2 = j / 10
         i1 = j - i2 * 10 + 1
         BF(nbf) = DG(i1)
-        if(i2 == 0) go to 30
+        if (i2 == 0) go to 30
         i3 = i2 / 10
         i2 = i2 - i3 * 10 + 1
-        BF(nbf-1) = DG(i2)
-        if(i3 == 0) go to 30
+        BF(nbf - 1) = DG(i2)
+        if (i3 == 0) go to 30
         i4 = i3 / 10
         i3 = i3 - i4 * 10 + 1
-        BF(nbf-2) = DG(i3)
+        BF(nbf - 2) = DG(i3)
         if (I4 == 0) go to 30
         if (I4 > 9) then
           ! -- If more than 4 digits, use "X" for 4th digit.
-          BF(nbf-3) = 'X'
+          BF(nbf - 3) = 'X'
         else
-          BF(nbf-3) = DG(i4+1)
+          BF(nbf - 3) = DG(i4 + 1)
         end if
- 30   continue
+30    end do
       !
       ! -- Print the contents of the buffer (i.e. print the line).
-      write(iout, 31) (BF(i), i=1, nbf)
- 31   format(1x,1000A1)
+      write (iout, fmtmsgout2) (BF(i), i=1, nbf)
       !
- 40 continue
+    end do
     !
     ! -- Print a line of dots (for aesthetic purposes only).
- 50 ntot = ntot
-    if (ntot > 1000) ntot=1000
-    write(iout, 51) (DOT,i=1,ntot)
- 51 format(1x,1000A1)
+50  ntot = ntot
+    if (ntot > 1000) ntot = 1000
+    write (iout, fmtmsgout2) (DOT, i=1, ntot)
     !
     ! -- Return
     return
@@ -977,17 +979,17 @@ contains
     real(DP), intent(in) :: totim
     ! -- format
     character(len=*), parameter :: fmt = &
-      "(1X,'UBDSV1 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
-      "', STRESS PERIOD',I7)"
+      & "(1X,'UBDSV1 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
+      & "', STRESS PERIOD',I7)"
     !
     ! -- Write records
-    if(iout > 0) write(iout, fmt) text, ibdchn, kstp, kper
-    write(ibdchn) kstp,kper,text,ncol,nrow,-nlay
-    write(ibdchn) 1,delt,pertim,totim
-    write(ibdchn) buff
+    if (iout > 0) write (iout, fmt) text, ibdchn, kstp, kper
+    write (ibdchn) kstp, kper, text, ncol, nrow, -nlay
+    write (ibdchn) 1, delt, pertim, totim
+    write (ibdchn) buff
     !
     ! -- flush file
-    flush(ibdchn)
+    flush (ibdchn)
     !
     ! -- Return
     return
@@ -1025,9 +1027,9 @@ contains
     integer(I4B) :: n
     ! -- format
     character(len=*), parameter :: fmt = &
-      "(1X,'UBDSV06 SAVING ',A16,' IN MODEL ',A16,' PACKAGE ',A16,"//&
-      "'CONNECTED TO MODEL ',A16,' PACKAGE ',A16,"//&
-      "' ON UNIT',I7,' AT TIME STEP',I7,', STRESS PERIOD',I7)"
+      & "(1X,'UBDSV06 SAVING ',A16,' IN MODEL ',A16,' PACKAGE ',A16,"// &
+      & "'CONNECTED TO MODEL ',A16,' PACKAGE ',A16,"// &
+      & "' ON UNIT',I7,' AT TIME STEP',I7,', STRESS PERIOD',I7)"
     !
     ! -- Write unformatted records identifying data.
     if (iout > 0) write (iout, fmt) text, modelnam1, paknam1, modelnam2, &

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -1471,7 +1471,7 @@ contains
     character(len=len(linein)) :: line
     character(len=20), dimension(:), allocatable :: words
     character(len=100) :: ermsg
-    integer(I4B) :: ndigits=0, nwords=0
+    integer(I4B) :: ndigits = 0, nwords = 0
     integer(I4B) :: i, ierr
     logical :: isint
     !
@@ -1481,17 +1481,17 @@ contains
     ierr = 0
     i = 0
     isint = .false.
-    if(editdesc == 'I') isint = .true.
+    if (editdesc == 'I') isint = .true.
     !
     ! -- Check array name
     if (nwords < 1) then
-      ermsg = 'Could not build PRINT_FORMAT from line' // trim(line)
+      ermsg = 'Could not build PRINT_FORMAT from line'//trim(line)
       call store_error(trim(ermsg))
       ermsg = 'Syntax is: COLUMNS <columns> WIDTH <width> DIGITS &
               &<digits> <format>'
       call store_error(trim(ermsg))
       call store_error_unit(inunit)
-    endif
+    end if
     !
     ermsg = 'Error setting PRINT_FORMAT. Syntax is incorrect in line:'
     if (nwords >= 4) then
@@ -1499,14 +1499,14 @@ contains
       if (.not. same_word(words(3), 'WIDTH')) ierr = 1
       ! -- Read nvalues and nwidth
       if (ierr == 0) then
-        read(words(2), *, iostat=ierr) nvaluesp
-      endif
+        read (words(2), *, iostat=ierr) nvaluesp
+      end if
       if (ierr == 0) then
-        read(words(4), *, iostat=ierr) nwidthp
-      endif
+        read (words(4), *, iostat=ierr) nwidthp
+      end if
     else
       ierr = 1
-    endif
+    end if
     if (ierr /= 0) then
       call store_error(ermsg)
       call store_error(line)
@@ -1514,7 +1514,7 @@ contains
               &DIGITS <digits> <format>'
       call store_error(trim(ermsg))
       call store_error_unit(inunit)
-    endif
+    end if
     i = 4
     !
     if (.not. isint) then
@@ -1522,12 +1522,12 @@ contains
       if (nwords >= 5) then
         if (.not. same_word(words(5), 'DIGITS')) ierr = 1
         ! -- Read ndigits
-        read(words(6), *, iostat=ierr) ndigits
+        read (words(6), *, iostat=ierr) ndigits
       else
         ierr = 1
-      endif
+      end if
       i = i + 2
-    endif
+    end if
     !
     ! -- Check for EXPONENTIAL | FIXED | GENERAL | SCIENTIFIC option.
     ! -- Check for LABEL, WRAP, and STRIP options.
@@ -1549,7 +1549,7 @@ contains
           editdesc = 'S'
           if (isint) ierr = 1
         case default
-          ermsg = 'Error in format specification. Unrecognized option: ' // words(i)
+          ermsg = 'Error in format specification. Unrecognized option: '//words(i)
           call store_error(ermsg)
           ermsg = 'Valid values are EXPONENTIAL, FIXED, GENERAL, or SCIENTIFIC.'
           call store_error(ermsg)
@@ -1557,13 +1557,13 @@ contains
         end select
       else
         exit
-      endif
-    enddo
+      end if
+    end do
     if (ierr /= 0) then
       call store_error(ermsg)
       call store_error(line)
       call store_error_unit(inunit)
-    endif
+    end if
     !
     ! -- Build the output format.
     select case (editdesc)
@@ -1586,47 +1586,47 @@ contains
     ! -- dummy
     integer(I4B), intent(in) :: nvalsp, nwidp, ndig
     character(len=*), intent(inout) :: outfmt
-    logical, intent(in), optional :: prowcolnum  ! default true
+    logical, intent(in), optional :: prowcolnum ! default true
     ! -- local
-    character(len=8)   :: cvalues, cwidth, cdigits
-    character(len=60)  :: ufmt
+    character(len=8) :: cvalues, cwidth, cdigits
+    character(len=60) :: ufmt
     logical :: prowcolnumlocal
     ! -- formats
-    10 format(i8)
+    character(len=*), parameter :: fmtndig = "(i8)"
     !
     if (present(prowcolnum)) then
       prowcolnumlocal = prowcolnum
     else
       prowcolnumlocal = .true.
-    endif
+    end if
     !
     ! -- Convert integers to characters and left-adjust
-    write(cdigits,10) ndig
+    write (cdigits, fmtndig) ndig
     cdigits = adjustl(cdigits)
     !
     ! -- Build format for printing to the list file in wrap format
-    write(cvalues,10) nvalsp
+    write (cvalues, fmtndig) nvalsp
     cvalues = adjustl(cvalues)
-    write(cwidth,10) nwidp
+    write (cwidth, fmtndig) nwidp
     cwidth = adjustl(cwidth)
     if (prowcolnumlocal) then
       ufmt = '(1x,i3,1x,'
     else
       ufmt = '(5x,'
-    endif
+    end if
     !
-    ufmt = trim(ufmt) // cvalues
-    ufmt = trim(ufmt) // '(1x,f'
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // '.'
-    ufmt = trim(ufmt) // cdigits
-    ufmt = trim(ufmt) // '):/(5x,'
-    ufmt = trim(ufmt) // cvalues
-    ufmt = trim(ufmt) // '(1x,f'
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // '.'
-    ufmt = trim(ufmt) // cdigits
-    ufmt = trim(ufmt) // ')))'
+    ufmt = trim(ufmt)//cvalues
+    ufmt = trim(ufmt)//'(1x,f'
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//'.'
+    ufmt = trim(ufmt)//cdigits
+    ufmt = trim(ufmt)//'):/(5x,'
+    ufmt = trim(ufmt)//cvalues
+    ufmt = trim(ufmt)//'(1x,f'
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//'.'
+    ufmt = trim(ufmt)//cdigits
+    ufmt = trim(ufmt)//')))'
     outfmt = ufmt
     !
     ! -- Return
@@ -1641,58 +1641,58 @@ contains
     integer(I4B), intent(in) :: nvalsp, nwidp, ndig
     character(len=*), intent(in) :: editdesc
     character(len=*), intent(inout) :: outfmt
-    logical, intent(in), optional :: prowcolnum  ! default true
+    logical, intent(in), optional :: prowcolnum ! default true
     ! -- local
-    character(len=8)   :: cvalues,  cwidth, cdigits
-    character(len=60)  :: ufmt
+    character(len=8) :: cvalues, cwidth, cdigits
+    character(len=60) :: ufmt
     logical :: prowcolnumlocal
     ! -- formats
-    10 format(i8)
+    character(len=*), parameter :: fmtndig = "(i8)"
     !
     if (present(prowcolnum)) then
       prowcolnumlocal = prowcolnum
     else
       prowcolnumlocal = .true.
-    endif
+    end if
     !
     ! -- Build the format
-    write(cdigits,10) ndig
+    write (cdigits, fmtndig) ndig
     cdigits = adjustl(cdigits)
     ! -- Convert integers to characters and left-adjust
-    write(cwidth,10) nwidp
+    write (cwidth, fmtndig) nwidp
     cwidth = adjustl(cwidth)
     ! -- Build format for printing to the list file
-    write(cvalues, 10) (nvalsp - 1)
+    write (cvalues, fmtndig) (nvalsp - 1)
     cvalues = adjustl(cvalues)
     if (prowcolnumlocal) then
-      ufmt = '(1x,i3,2x,1p,' // editdesc
+      ufmt = '(1x,i3,2x,1p,'//editdesc
     else
-      ufmt = '(6x,1p,' // editdesc
-    endif
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // '.'
-    ufmt = trim(ufmt) // cdigits
-    if (nvalsp>1) then
-      ufmt = trim(ufmt) // ','
-      ufmt = trim(ufmt) // cvalues
-      ufmt = trim(ufmt) // '(1x,'
-      ufmt = trim(ufmt) // editdesc
-      ufmt = trim(ufmt) // cwidth
-      ufmt = trim(ufmt) // '.'
-      ufmt = trim(ufmt) // cdigits
-      ufmt = trim(ufmt) // ')'
-    endif
+      ufmt = '(6x,1p,'//editdesc
+    end if
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//'.'
+    ufmt = trim(ufmt)//cdigits
+    if (nvalsp > 1) then
+      ufmt = trim(ufmt)//','
+      ufmt = trim(ufmt)//cvalues
+      ufmt = trim(ufmt)//'(1x,'
+      ufmt = trim(ufmt)//editdesc
+      ufmt = trim(ufmt)//cwidth
+      ufmt = trim(ufmt)//'.'
+      ufmt = trim(ufmt)//cdigits
+      ufmt = trim(ufmt)//')'
+    end if
     !
-    ufmt = trim(ufmt) // ':/(5x,'
-    write(cvalues, 10) nvalsp
+    ufmt = trim(ufmt)//':/(5x,'
+    write (cvalues, fmtndig) nvalsp
     cvalues = adjustl(cvalues)
-    ufmt = trim(ufmt) // cvalues
-    ufmt = trim(ufmt) // '(1x,'
-    ufmt = trim(ufmt) // editdesc
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // '.'
-    ufmt = trim(ufmt) // cdigits
-    ufmt = trim(ufmt) // ')))'
+    ufmt = trim(ufmt)//cvalues
+    ufmt = trim(ufmt)//'(1x,'
+    ufmt = trim(ufmt)//editdesc
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//'.'
+    ufmt = trim(ufmt)//cdigits
+    ufmt = trim(ufmt)//')))'
     outfmt = ufmt
     !
     ! -- Return
@@ -1706,38 +1706,38 @@ contains
     ! -- dummy
     integer(I4B), intent(in) :: nvalsp, nwidp
     character(len=*), intent(inout) :: outfmt
-    logical, intent(in), optional :: prowcolnum  ! default true
+    logical, intent(in), optional :: prowcolnum ! default true
     ! -- local
-    character(len=8)   :: cvalues, cwidth
-    character(len=60)  :: ufmt
+    character(len=8) :: cvalues, cwidth
+    character(len=60) :: ufmt
     logical :: prowcolnumlocal
     ! -- formats
-    10 format(i8)
+    character(len=*), parameter :: fmtndig = "(i8)"
     !
     if (present(prowcolnum)) then
       prowcolnumlocal = prowcolnum
     else
       prowcolnumlocal = .true.
-    endif
+    end if
     !
     ! -- Build format for printing to the list file in wrap format
-    write(cvalues,10)nvalsp
+    write (cvalues, fmtndig) nvalsp
     cvalues = adjustl(cvalues)
-    write(cwidth,10)nwidp
+    write (cwidth, fmtndig) nwidp
     cwidth = adjustl(cwidth)
     if (prowcolnumlocal) then
       ufmt = '(1x,i3,1x,'
     else
       ufmt = '(5x,'
-    endif
-    ufmt = trim(ufmt) // cvalues
-    ufmt = trim(ufmt) // '(1x,i'
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // '):/(5x,'
-    ufmt = trim(ufmt) // cvalues
-    ufmt = trim(ufmt) // '(1x,i'
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // ')))'
+    end if
+    ufmt = trim(ufmt)//cvalues
+    ufmt = trim(ufmt)//'(1x,i'
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//'):/(5x,'
+    ufmt = trim(ufmt)//cvalues
+    ufmt = trim(ufmt)//'(1x,i'
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//')))'
     outfmt = ufmt
     !
     ! -- Return
@@ -1750,7 +1750,7 @@ contains
     ! -- return
     integer(I4B) :: get_nwords !< number of words in a string
     ! -- dummy
-    character(len=*), intent(in) :: line  !< line
+    character(len=*), intent(in) :: line !< line
     ! -- local
     integer(I4B) :: linelen
     integer(I4B) :: lloc
@@ -1777,7 +1777,7 @@ contains
 
   !> @brief Move the file pointer.
   !!
-  !! Patterned after fseek, which is not supported as part of the fortran 
+  !! Patterned after fseek, which is not supported as part of the fortran
   !! standard.  For this subroutine to work the file must have been opened with
   !! access='stream' and action='readwrite'.
   !<
@@ -1790,34 +1790,34 @@ contains
     ! -- local
     integer(I8B) :: ipos
     !
-    inquire(unit=iu, size=ipos)
+    inquire (unit=iu, size=ipos)
     !
-    select case(whence)
-    case(0)
+    select case (whence)
+    case (0)
       !
       ! -- whence = 0, offset is relative to start of file
       ipos = 0 + offset
-    case(1)
+    case (1)
       !
       ! -- whence = 1, offset is relative to current pointer position
-      inquire(unit=iu, pos=ipos)
+      inquire (unit=iu, pos=ipos)
       ipos = ipos + offset
-    case(2)
+    case (2)
       !
       ! -- whence = 2, offset is relative to end of file
-      inquire(unit=iu, size=ipos)
+      inquire (unit=iu, size=ipos)
       ipos = ipos + offset
     end select
     !
     ! -- position the file pointer to ipos
-    write(iu, pos=ipos, iostat=status)
-    inquire(unit=iu, pos=ipos)
+    write (iu, pos=ipos, iostat=status)
+    inquire (unit=iu, pos=ipos)
     !
     ! -- Return
     return
   end subroutine fseek_stream
 
-  !> @brief Read until non-comment line found and then return line. 
+  !> @brief Read until non-comment line found and then return line.
   !!
   !! Different from u8rdcom in that line is a deferred length character string,
   !! which allows any length lines to be read using the get_line subroutine.
@@ -1827,14 +1827,14 @@ contains
     use, intrinsic :: iso_fortran_env, only: IOSTAT_END
     implicit none
     ! -- dummy
-    integer(I4B),         intent(in) :: iin
-    integer(I4B),         intent(in) :: iout
-    character (len=:), allocatable, intent(inout) :: line
-    integer(I4B),        intent(out) :: ierr
+    integer(I4B), intent(in) :: iin
+    integer(I4B), intent(in) :: iout
+    character(len=:), allocatable, intent(inout) :: line
+    integer(I4B), intent(out) :: ierr
     ! -- local
-    character (len=:), allocatable :: linetemp
-    character (len=2), parameter :: comment = '//'
-    character(len=1), parameter  :: tab = CHAR(9)
+    character(len=:), allocatable :: linetemp
+    character(len=2), parameter :: comment = '//'
+    character(len=1), parameter :: tab = CHAR(9)
     logical :: iscomment
     integer(I4B) :: i, j, l, istart, lsize
     !
@@ -1850,9 +1850,9 @@ contains
       elseif (ierr /= 0) then
         ! -- Other error...report it
         call unitinquire(iin)
-        write(errmsg, *) 'u9rdcom: Could not read from unit: ',iin
+        write (errmsg, *) 'u9rdcom: Could not read from unit: ', iin
         call store_error(errmsg, terminate=.TRUE.)
-      endif
+      end if
       if (len_trim(line) < 1) then
         line = comment
         cycle
@@ -1864,9 +1864,10 @@ contains
         ! -- adjustl manually to avoid stack overflow
         lsize = len(line)
         istart = 1
-        allocate(character(len=lsize) :: linetemp)
+        allocate (character(len=lsize) :: linetemp)
         do j = 1, lsize
-          if (line(j:j) /= ' ' .and. line(j:j) /= ',' .and. line(j:j) /= char(9)) then
+          if (line(j:j) /= ' ' .and. line(j:j) /= ',' .and. &
+              line(j:j) /= char(9)) then
             istart = j
             exit
           end if
@@ -1874,40 +1875,40 @@ contains
         linetemp(:) = ' '
         linetemp(:) = line(istart:)
         line(:) = linetemp(:)
-        deallocate(linetemp)
+        deallocate (linetemp)
         !
         ! -- check for comment
         iscomment = .false.
         select case (line(1:1))
-          case ('#')
-            iscomment = .true.
-            exit cleartabs
-          case ('!')
-            iscomment = .true.
-            exit cleartabs
-          case (tab)
-            line(1:1) = ' '
-            cycle cleartabs
-          case default
-            if (line(1:2) == comment) iscomment = .true.
-            if (len_trim(line) < 1) iscomment = .true.
-            exit cleartabs
+        case ('#')
+          iscomment = .true.
+          exit cleartabs
+        case ('!')
+          iscomment = .true.
+          exit cleartabs
+        case (tab)
+          line(1:1) = ' '
+          cycle cleartabs
+        case default
+          if (line(1:2) == comment) iscomment = .true.
+          if (len_trim(line) < 1) iscomment = .true.
+          exit cleartabs
         end select
       end do cleartabs
       !
-      if (.not.iscomment) then
+      if (.not. iscomment) then
         exit pcomments
       else
         if (iout > 0) then
           !find the last non-blank character.
           l = len(line)
           do i = l, 1, -1
-            if(line(i:i) /= ' ') then
+            if (line(i:i) /= ' ') then
               exit
             end if
           end do
           ! -- print the line up to the last non-blank character.
-          write(iout,'(1x,a)') line(1:i)
+          write (iout, '(1x,a)') line(1:i)
         end if
       end if
     end do pcomments
@@ -1917,9 +1918,9 @@ contains
   end subroutine u9rdcom
 
   !> @brief Read an unlimited length line from unit number lun into a deferred-
-  !! length character string (line).  
+  !! length character string (line).
   !!
-  !! Tack on a single space to the end so that routines like URWORD continue to 
+  !! Tack on a single space to the end so that routines like URWORD continue to
   !! function as before.
   !<
   subroutine get_line(lun, line, iostat)
@@ -1942,30 +1943,30 @@ contains
       read (lun, '(A)', iostat=iostat, advance='no', size=size_read) buffer
       if (is_iostat_eor(iostat)) then
         linesize = len(line)
-        deallocate(linetemp)
-        allocate(character(len=linesize) :: linetemp)
+        deallocate (linetemp)
+        allocate (character(len=linesize) :: linetemp)
         linetemp(:) = line(:)
-        deallocate(line)
-        allocate(character(len=linesize + size_read + 1) :: line)
+        deallocate (line)
+        allocate (character(len=linesize + size_read + 1) :: line)
         line(:) = linetemp(:)
-        line(linesize+1:) = buffer(:size_read)
+        line(linesize + 1:) = buffer(:size_read)
         linesize = len(line)
         line(linesize:linesize) = ' '
         iostat = 0
         exit
       else if (iostat == 0) then
         linesize = len(line)
-        deallocate(linetemp)
-        allocate(character(len=linesize) :: linetemp)
+        deallocate (linetemp)
+        allocate (character(len=linesize) :: linetemp)
         linetemp(:) = line(:)
-        deallocate(line)
-        allocate(character(len=linesize + size_read) :: line)
+        deallocate (line)
+        allocate (character(len=linesize + size_read) :: line)
         line(:) = linetemp(:)
-        line(linesize+1:) = buffer(:size_read)
+        line(linesize + 1:) = buffer(:size_read)
       else
         exit
       end if
     end do
-  end subroutine get_line  
+  end subroutine get_line
 
 end module InputOutputModule

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -52,8 +52,8 @@ module InputOutputModule
 50  format(1x,/1x,'OPENED ',a,/ &
                  1x,'FILE TYPE:',a,'   UNIT ',I4,3x,'STATUS:',a,/ &
                  1x,'FORMAT:',a,3x,'ACCESS:',a/ &
-                 1X,'ACTION:',A/)
-60  FORMAT(1X,/1X,'DID NOT OPEN ',A,/)
+                 1x,'ACTION:',a/)
+60  format(1x,/1x,'DID NOT OPEN ',a,/)
     !
     ! -- Process mode_opt
     if (present(mode_opt)) then
@@ -314,49 +314,49 @@ module InputOutputModule
     if (present(fmt)) then
       cfmt = fmt
     else
-      select case(NCODE)
+      select case(ncode)
         case(TABSTRING, TABUCSTRING)
-          write(cfmt, '(A,I0,A)') '(A', ILEN, ')'
+          write(cfmt, '(a,I0,a)') '(a', ilen, ')'
         case(TABINTEGER)
-          write(cfmt, '(A,I0,A)') '(I', ILEN, ')'
+          write(cfmt, '(a,I0,a)') '(I', ilen, ')'
         case(TABREAL)
           ireal = 1
-          i = ILEN - 7
-          write(cfmt, '(A,I0,A,I0,A)') '(1PG', ILEN, '.', i, ')'
+          i = ilen - 7
+          write(cfmt, '(a,I0,a,I0,a)') '(1PG', ilen, '.', i, ')'
           if (R >= DZERO) then
             ipad = 1
           end if
       end select
     end if
-    write(cffmt, '(A,I0,A)') '(A', ILEN, ')'
+    write(cffmt, '(a,I0,a)') '(a', ilen, ')'
     !
-    if (present(ALIGNMENT)) then
-      ialign = ALIGNMENT
+    if (present(alignment)) then
+      ialign = alignment
     else
       ialign = TABRIGHT
     end if
     !
     ! -- 
-    if (NCODE == TABSTRING .or. NCODE == TABUCSTRING) then
+    if (ncode == TABSTRING .or. ncode == TABUCSTRING) then
       cval = C
-      if (NCODE == TABUCSTRING) then
-        call UPCASE(cval)
+      if (ncode == TABUCSTRING) then
+        call UPcase(cval)
       end if
-    else if (NCODE == TABINTEGER) then
-      write(cval, cfmt) N
-    else if (NCODE == TABREAL) then
-      write(cval, cfmt) R
+    else if (ncode == TABINTEGER) then
+      write(cval, cfmt) n
+    else if (ncode == TABREAL) then
+      write(cval, cfmt) r
     end if
     !
-    ! -- apply alignment to cval
-    if (len_trim(adjustl(cval)) > ILEN) then
+    ! -- Apply alignment to cval
+    if (len_trim(adjustl(cval)) > ilen) then
       cval = adjustl(cval)
     else
       cval = trim(adjustl(cval))
     end if
     if (ialign == TABCENTER) then
       i = len_trim(cval)
-      ispace = (ILEN - i) / 2
+      ispace = (ilen - i) / 2
       if (ireal > 0) then
         if (ipad > 0) then
           cval = ' ' //trim(adjustl(cval))
@@ -374,23 +374,23 @@ module InputOutputModule
     else
       cval = adjustr(cval)
     end if
-    if (NCODE == TABUCSTRING) then
-      call UPCASE(cval)
+    if (ncode == TABUCSTRING) then
+      call UPcase(cval)
     end if
     !
-    ! -- increment istop to the end of the column
-    istop = ICOL + ILEN - 1
+    ! -- Increment istop to the end of the column
+    istop = icol + ilen - 1
     !
-    ! -- write final string to line
-    write(LINE(ICOL:istop), cffmt) cval
+    ! -- Write final string to line
+    write(line(icol:istop), cffmt) cval
     !
-    ICOL = istop + 1
+    icoL = istop + 1
     !
-    if (present(SEP)) then
-      i = len(SEP)
-      istop = ICOL + i
-      write(LINE(ICOL:istop), '(A)') SEP
-      ICOL = istop
+    if (present(sep)) then
+      i = len(sep)
+      istop = icol + i
+      write(line(icol:istop), '(a)') sep
+      icol = istop
     end if
     !
     ! -- Return
@@ -437,13 +437,13 @@ module InputOutputModule
     integer(I4B), intent(in) :: in !< input file unit number
     ! -- local
     character(len=20) string                
-    CHARACTER(len=30) RW
-    CHARACTER(len=1) TAB
-    CHARACTER(len=1) CHAREND
+    character(len=30) rw
+    character(len=1) tab
+    character(len=1) charend
     character(len=200) :: msg
-    character(len=LINELENGTH) :: msg_line
+    character(len=linelength) :: msg_line
     !
-    TAB=CHAR(9)
+    tab=char(9)
     !
     ! -- Set last char in LINE to blank and set ISTART and ISTOP to point
     !    to this blank as a default situation when no word is found.  If
@@ -460,33 +460,33 @@ module InputOutputModule
     do 10 i=icol, linlen
       if(line(i:i) /= ' ' .and. line(i:i) /= ',' .and. &
          line(i:i) /= tab) go to 20
-10  CONTINUE
+10  continue
     icol = linlen + 1
-    GO TO 100
+    go to 100
     !
     ! -- Found start of word.  Look for end.
     !    When word is quoted, only a quote can terminate it.
-    !    SEARCH FOR A SINGLE (CHAR(39)) OR DOUBLE (CHAR(34)) QUOTE
+    !    search for a single (char(39)) or double (char(34)) quote
 20  if(line(i:i)==char(34) .or. line(i:i)==char(39)) then
       if (line(i:i) == char(34)) then
-        CHAREND = CHAR(34)
-      ELSE
-        CHAREND = CHAR(39)
-      END IF
+        charend = char(34)
+      else
+        charend = char(39)
+      end if
       i = i + 1
       if(i <= linlen) then
         do 25 j=i, linlen
           if(line(j:j)==charend) go to 40
-25      CONTINUE
-      END IF
+25      continue
+      end if
     !
     ! -- When word is not quoted, space, comma, or tab will terminate.
-    ELSE
+    else
       do 30 j=i, linlen
         if(line(j:j)==' ' .or. line(j:j)==',' .or. &
            line(j:j)==tab) go to 40
-30    CONTINUE
-    END IF
+30    continue
+    end if
     !
     ! -- End of line without finding end of word; set end of word to
     !    end of line.
@@ -506,9 +506,9 @@ module InputOutputModule
       do 50 k=istart, istop
         if(line(k:k) >= 'a' .and. line(k:k) <= 'z') &
            line(k:k) = char(ichar(line(k:k)) - idiff)
-50    CONTINUE
-      RETURN
-    END IF
+50    continue
+      return
+    end if
     !
     ! -- Convert word to a number if requested.
 100 if(ncode==2 .or. ncode==3) then
@@ -518,49 +518,49 @@ module InputOutputModule
       rw(l:30) = line(istart:istop)
       if(ncode == 2) read(rw,'(i30)',err=200) n
       if(ncode == 3) read(rw,'(f30.0)',err=200) r
-    END IF
-    RETURN
+    end if
+    return
     !
     ! -- Number conversion error.
 200 if(ncode == 3) then
       string = 'a real number'
       l = 13
-    ELSE
+    else
       string = 'an integer'
       l = 10
-    END IF
+    end if
     !
     ! -- If output unit is negative, set last character of string to 'E'.
     if (iout < 0) then
       n = 0
       r = 0.
       line(linlen+1:linlen+1) = 'E'
-      RETURN
+      return
     !
     ! -- If output unit is positive; write a message to output unit.
     else if(iout > 0) then
       if(in > 0) then
         write(msg_line,201) in, line(istart:istop), string(1:l)
-      ELSE
+      else
         write(msg_line,202) line(istart:istop), string(1:l)
-      END IF
+      end if
       call write_message(msg_line, iunit=IOUT, skipbefore=1)
-      call write_message(LINE, iunit=IOUT, fmt='(1x,a)')
-201   FORMAT(1X,'FILE UNIT ',I4,' : ERROR CONVERTING "',A, &
-             '" TO ',A,' IN LINE:')
-202   FORMAT(1X,'KEYBOARD INPUT : ERROR CONVERTING "',A, &
-             '" TO ',A,' IN LINE:')
+      call write_message(line, iunit=IOUT, fmt='(1x,a)')
+201   format(1x,'FILE UNIT ',I4,' : ERROR CONVERTING "',a, &
+             '" TO ',a,' IN LINE:')
+202   format(1x,'KEYBOARD INPUT : ERROR CONVERTING "',a, &
+             '" TO ',a,' IN LINE:')
     !
     ! -- If output unit is 0; write a message to default output.
-    ELSE
+    else
       if(in > 0) then
         write(msg_line,201) in, line(istart:istop), string(1:l)
-      ELSE
+      else
         write(msg_line,202) line(istart:istop), string(1:l)
-      END IF
-      call write_message(msg_line, iunit=IOUT, skipbefore=1)
-      call write_message(LINE, iunit=IOUT, fmt='(1x,a)')
-    END IF
+      end if
+      call write_message(msg_line, iunit=iout, skipbefore=1)
+      call write_message(LINE, iunit=iout, fmt='(1x,a)')
+    end if
     !
     ! -- STOP after storing error message.
     call lowcase(string)
@@ -569,9 +569,9 @@ module InputOutputModule
     else
       write(msg,207) line(istart:istop), trim(string)
     endif
-205 format('File unit ',I0,': Error converting "',A, &
+205 format('File unit ',I0,': Error converting "',a, &
            '" to ',A,' in following line:')
-207 format('Keyboard input: Error converting "',A, &
+207 format('Keyboard input: Error converting "',a, &
            '" to ',A,' in following line:')
     call store_error(msg)
     call store_error(trim(line))
@@ -768,7 +768,7 @@ module InputOutputModule
             & ' IN STRESS PERIOD ',I4/2x,75('-'))
       else if (ilay < 0) then
         write(iout,2) text, kstp, kper
-    2    FORMAT('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
+    2    format('1',/1x,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
             & ' IN STRESS PERIOD ',I4/1x,79('-'))
     end if
     !
@@ -789,112 +789,112 @@ module InputOutputModule
     ! 
     ! -- Loop through the rows printing each one in its entirety.
     do i=1,nrow
-      SELECT CASE(IP)
+      select case(ip)
       !
-      CASE(1)
+      case(1)
       ! -- format 11G10.3
       write(iout, 11) i,(buf(j, i), j=1, ncol)
-11    FORMAT(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))
+11    format(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))
       !
-      CASE(2)
+      case(2)
       ! -- format 9G13.6
       write(iout, 21) i, (buf(j, i), j=1, ncol)
-21    FORMAT(1X,I3,2X,1PG13.6,8(1X,G13.6):/(5X,9(1X,G13.6)))
+21    format(1x,I3,2x,1PG13.6,8(1x,G13.6):/(5x,9(1x,G13.6)))
       !
-      CASE(3)
+      case(3)
       ! -- format 15F7.1
       write(iout, 31) i, (buf(j, i), j=1, ncol)
-31    FORMAT(1X,I3,1X,15(1X,F7.1):/(5X,15(1X,F7.1)))
+31    format(1x,I3,1x,15(1x,F7.1):/(5x,15(1x,F7.1)))
       !
-      CASE(4)
+      case(4)
       ! -- format 15F7.2
-      WRITE(IOUT,41) I,(BUF(J,I),J=1,NCOL)
-41    FORMAT(1X,I3,1X,15(1X,F7.2):/(5X,15(1X,F7.2)))
+      write(iout,41) i,(buf(j,i),j=1,ncol)
+41    format(1x,I3,1x,15(1x,F7.2):/(5x,15(1x,F7.2)))
       !
-      CASE(5)
+      case(5)
       ! -- format 15F7.3
       write(iout, 51) i, (buf(j, i), j=1, ncol)
-51    FORMAT(1X,I3,1X,15(1X,F7.3):/(5X,15(1X,F7.3)))
+51    format(1x,I3,1x,15(1x,F7.3):/(5x,15(1x,F7.3)))
       !
-      CASE(6)
+      case(6)
       ! -- format 15F7.4
       write(iout, 61) i, (buf(j, i), j=1, ncol)
-61    FORMAT(1X,I3,1X,15(1X,F7.4):/(5X,15(1X,F7.4)))
+61    format(1x,I3,1x,15(1x,F7.4):/(5x,15(1x,F7.4)))
       !
-      CASE(7)
+      case(7)
       ! -- format 20F5.0
       write(iout, 71) i, (buf(j, i), j=1, ncol)
-71    FORMAT(1X,I3,1X,20(1X,F5.0):/(5X,20(1X,F5.0)))
+71    format(1x,I3,1x,20(1x,F5.0):/(5x,20(1x,F5.0)))
       !
-      CASE(8)
+      case(8)
       ! -- format 20F5.1
       write(iout, 81) i, (buf(j, i), j=1, ncol)
-81    FORMAT(1X,I3,1X,20(1X,F5.1):/(5X,20(1X,F5.1)))
+81    format(1x,I3,1x,20(1x,F5.1):/(5x,20(1x,F5.1)))
       !
-      CASE(9)
+      case(9)
       ! -- format 20F5.2
       write(iout, 91) i, (buf(j, i), j=1, ncol)
-91    FORMAT(1X,I3,1X,20(1X,F5.2):/(5X,20(1X,F5.2)))
+91    format(1x,I3,1x,20(1x,F5.2):/(5x,20(1x,F5.2)))
       !
-      CASE(10)
+      case(10)
       ! -- format 20F5.3
       write(iout, 101) i, (buf(j, i), j=1, ncol)
-101   FORMAT(1X,I3,1X,20(1X,F5.3):/(5X,20(1X,F5.3)))
+101   format(1x,I3,1x,20(1x,F5.3):/(5x,20(1x,F5.3)))
       !
-      CASE(11)
+      case(11)
       ! -- format 20F5.4
       write(iout, 111) i, (buf(j, i), j=1, ncol)
-111   FORMAT(1X,I3,1X,20(1X,F5.4):/(5X,20(1X,F5.4)))
+111   format(1x,I3,1x,20(1x,F5.4):/(5x,20(1x,F5.4)))
       !
-      CASE(12)
+      case(12)
       ! -- format 10G11.4
       write(iout,121) i, (buf(j, i), j=1, ncol)
-121   FORMAT(1X,I3,2X,1PG11.4,9(1X,G11.4):/(5X,10(1X,G11.4)))
+121   format(1x,I3,2x,1PG11.4,9(1x,G11.4):/(5x,10(1x,G11.4)))
       !
-      CASE(13)
+      case(13)
       ! -- format 10F6.0
       write(iout, 131) i, (buf(j, i), j=1, ncol)
-131   FORMAT(1X,I3,1X,10(1X,F6.0):/(5X,10(1X,F6.0)))
+131   format(1x,I3,1x,10(1x,F6.0):/(5X,10(1x,F6.0)))
       !
-      CASE(14)
+      case(14)
       ! -- format 10F6.1
       write(iout, 141) i, (buf(j, i), j=1, ncol)
-141   FORMAT(1X,I3,1X,10(1X,F6.1):/(5X,10(1X,F6.1)))
+141   format(1x,I3,1x,10(1x,F6.1):/(5x,10(1x,F6.1)))
       !
-      CASE(15)
+      case(15)
       ! -- format 10F6.2
       write(iout, 151) i, (buf(j, i), j=1, ncol)
-151   FORMAT(1X,I3,1X,10(1X,F6.2):/(5X,10(1X,F6.2)))
+151   format(1x,I3,1x,10(1x,F6.2):/(5x,10(1x,F6.2)))
       !
-      CASE(16)
+      case(16)
       ! -- format 10F6.3
       write(iout, 161) i, (buf(j, i), j=1, ncol)
-161   FORMAT(1X,I3,1X,10(1X,F6.3):/(5X,10(1X,F6.3)))
+161   format(1x,I3,1x,10(1x,F6.3):/(5x,10(1x,F6.3)))
       !
-      CASE(17)
+      case(17)
       ! -- format 10F6.4
       write(iout, 171) i, (buf(j, i), j=1, ncol)
-171   FORMAT(1X,I3,1X,10(1X,F6.4):/(5X,10(1X,F6.4)))
+171   format(1x,I3,1x,10(1x,F6.4):/(5x,10(1x,F6.4)))
       !
-      CASE(18)
+      case(18)
       ! -- format 10F6.5
       write(iout, 181) i, (buf(j, i), j=1, ncol)
-181   FORMAT(1X,I3,1X,10(1X,F6.5):/(5X,10(1X,F6.5)))
+181   format(1x,I3,1x,10(1x,F6.5):/(5x,10(1x,F6.5)))
       !
-      CASE(19)
+      case(19)
       ! -- format 5G12.5
       write(iout, 191) i, (buf(j, i), j=1, ncol)
-191   FORMAT(1X,I3,2X,1PG12.5,4(1X,G12.5):/(5X,5(1X,G12.5)))
+191   format(1x,I3,2x,1PG12.5,4(1x,G12.5):/(5x,5(1x,G12.5)))
       !
-      CASE(20)
+      case(20)
       ! -- format 6G11.4
       write(iout, 201) i, (buf(j, i), j=1, ncol)
-201   FORMAT(1X,I3,2X,1PG11.4,5(1X,G11.4):/(5X,6(1X,G11.4)))
+201   format(1x,I3,2x,1PG11.4,5(1x,G11.4):/(5x,6(1x,G11.4)))
       !
-      CASE(21)
+      case(21)
       ! -- format 7G9.2
       write(iout, 211) i, (buf(j, i), j=1, ncol)
-211   FORMAT(1X,I3,2X,1PG9.2,6(1X,G9.2):/(5X,7(1X,G9.2)))
+211   format(1x,I3,2x,1PG9.2,6(1x,G9.2):/(5x,7(1x,G9.2)))
       !
       end select
     end do
@@ -962,7 +962,7 @@ module InputOutputModule
     ! -- flush file
     flush(ibdchn)
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ubdsv1
 
@@ -1015,7 +1015,7 @@ module InputOutputModule
     if (naux > 0) write(ibdchn) (auxtxt(n),n=1,naux)
     write(ibdchn) nlist
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ubdsv06
 
@@ -1041,7 +1041,7 @@ module InputOutputModule
         write(ibdchn) n,q
     end if
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ubdsvc
 
@@ -1068,7 +1068,7 @@ module InputOutputModule
         write(ibdchn) n,n2,q
     end if
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ubdsvd
 
@@ -1129,7 +1129,7 @@ module InputOutputModule
     write(line,fmtb) trim(fm), trim(seq), trim(unf), trim(frm)
     call write_message(line)
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine unitinquire
 
@@ -1170,7 +1170,7 @@ module InputOutputModule
       words(i) = line(istart:istop)
     end do
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ParseLine
 
@@ -1215,7 +1215,7 @@ module InputOutputModule
     ! -- flush file
     flush(IOUT)
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ulaprufw
 
@@ -1741,7 +1741,7 @@ module InputOutputModule
       get_nwords = get_nwords + 1
     end do
     !
-    ! -- return
+    ! -- Return
     return
   end function get_nwords
 
@@ -1783,7 +1783,7 @@ module InputOutputModule
     write(iu, pos=ipos, iostat=status)
     inquire(unit=iu, pos=ipos)
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine fseek_stream
 
@@ -1938,4 +1938,4 @@ module InputOutputModule
     end do
   end subroutine get_line  
 
-END MODULE InputOutputModule
+end module InputOutputModule

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -49,11 +49,11 @@ contains
     integer(I4B) :: ivar
     integer(I4B) :: iuop
     ! -- formats
-50  format(1x,/1x,'OPENED ',a,/ &
-                 1x,'FILE TYPE:',a,'   UNIT ',I4,3x,'STATUS:',a,/ &
-                 1x,'FORMAT:',a,3x,'ACCESS:',a/ &
-                 1x,'ACTION:',a/)
-60  format(1x,/1x,'DID NOT OPEN ',a,/)
+    character(len=*), parameter :: fmtmsg = &
+      "(1x,/1x,'OPENED ',a,/1x,'FILE TYPE:',a,'   UNIT ',I4,3x,'STATUS:',a,/ &
+      & 1x,'FORMAT:',a,3x,'ACCESS:',a/1x,'ACTION:',a/)"
+    character(len=*), parameter :: fmtmsg2 = &
+                                   "(1x,/1x,'DID NOT OPEN ',a,/)"
     !
     ! -- Process mode_opt
     if (present(mode_opt)) then
@@ -64,8 +64,8 @@ contains
     !
     ! -- Evaluate if the file should be opened
     if (isim_mode < imode) then
-      if(iout > 0) then
-        write(iout, 60) trim(fname)
+      if (iout > 0) then
+        write (iout, fmtmsg2) trim(fname)
       end if
     else
       !
@@ -75,49 +75,49 @@ contains
       filstat = 'OLD'
       !
       ! -- Override defaults
-      if(present(fmtarg_opt)) then
+      if (present(fmtarg_opt)) then
         fmtarg = fmtarg_opt
         call upcase(fmtarg)
-      endif
-      if(present(accarg_opt)) then
+      end if
+      if (present(accarg_opt)) then
         accarg = accarg_opt
         call upcase(accarg)
-      endif
-      if(present(filstat_opt)) then
+      end if
+      if (present(filstat_opt)) then
         filstat = filstat_opt
         call upcase(filstat)
-      endif
-      if(filstat == 'OLD') then
+      end if
+      if (filstat == 'OLD') then
         filact = action(1)
       else
         filact = action(2)
-      endif
+      end if
       !
       ! -- size of fname
       iflen = len_trim(fname)
       !
       ! -- Get a free unit number
-      if(iu <= 0) then
+      if (iu <= 0) then
         call freeunitnumber(iu)
-      endif
+      end if
       !
       ! -- Check to see if file is already open, if not then open the file
-      inquire(file=fname(1:iflen), number=iuop)
-      if(iuop > 0) then
+      inquire (file=fname(1:iflen), number=iuop)
+      if (iuop > 0) then
         ivar = -1
       else
-        open(unit=iu, file=fname(1:iflen), form=fmtarg, access=accarg,           &
-           status=filstat, action=filact, iostat=ivar)
-      endif
+        open (unit=iu, file=fname(1:iflen), form=fmtarg, access=accarg, &
+              status=filstat, action=filact, iostat=ivar)
+      end if
       !
       ! -- Check for an error
-      if(ivar /= 0) then
+      if (ivar /= 0) then
         write (errmsg, '(3a,1x,i0,a)') &
           'Could not open "', fname(1:iflen), '" on unit', iu, '.'
-        if(iuop > 0) then
+        if (iuop > 0) then
           write (errmsg, '(a,1x,a,1x,i0,a)') &
             trim(errmsg), 'File already open on unit', iuop, '.'
-        endif
+        end if
         write (errmsg, '(a,1x,a,1x,a,a)') &
           trim(errmsg), 'Specified file status', trim(filstat), '.'
         write (errmsg, '(a,1x,a,1x,a,a)') &
@@ -131,12 +131,12 @@ contains
         write (errmsg, '(a,1x,a)') &
           trim(errmsg), 'STOP EXECUTION in subroutine openfile().'
         call store_error(errmsg, terminate=.TRUE.)
-      endif
+      end if
       !
       ! -- Write a message
       if (iout > 0) then
-        write(iout, 50) fname(1:iflen), ftype, iu, filstat, fmtarg, accarg, &
-                        filact
+        write (iout, fmtmsg) fname(1:iflen), ftype, iu, filstat, fmtarg, &
+          accarg, filact
       end if
     end if
     !
@@ -152,15 +152,15 @@ contains
     ! -- modules
     implicit none
     ! -- dummy
-    integer(I4B), intent(inout) :: iu  !< next free file unit number
+    integer(I4B), intent(inout) :: iu !< next free file unit number
     ! -- local
     integer(I4B) :: i
     logical :: opened
     !
     do i = iunext, iulast
-      inquire(unit=i, opened=opened)
+      inquire (unit=i, opened=opened)
       if (.not. opened) exit
-    enddo
+    end do
     iu = i
     iunext = iu + 1
     !
@@ -176,7 +176,7 @@ contains
     ! -- modules
     implicit none
     ! -- return
-    integer(I4B) :: getunit  !< free unit number
+    integer(I4B) :: getunit !< free unit number
     ! -- local
     integer(I4B) :: iunit
     !
@@ -187,15 +187,15 @@ contains
     ! -- Return
     return
   end function getunit
-  
+
   !> @brief Convert to upper case
   !!
   !! Subroutine to convert a character string to upper case.
   !<
   subroutine upcase(word)
     implicit none
-    ! -- dummy  
-    character (len=*), intent(inout) :: word  !< word to convert to upper case
+    ! -- dummy
+    character(len=*), intent(inout) :: word !< word to convert to upper case
     ! -- local
     integer(I4B) :: l
     integer(I4B) :: idiff
@@ -232,10 +232,10 @@ contains
     !
     ! -- Loop through the string and convert any uppercase characters.
     do k = 1, l
-      if(word(k:k) >= 'A' .and. word(k:k) <= 'Z') then
-        word(k:k)=char(ichar(word(k:k))+idiff)
-      endif
-    enddo
+      if (word(k:k) >= 'A' .and. word(k:k) <= 'Z') then
+        word(k:k) = char(ichar(word(k:k)) + idiff)
+      end if
+    end do
     !
     ! -- Return
     return
@@ -249,8 +249,8 @@ contains
   !<
   subroutine append_processor_id(name, proc_id)
     ! -- dummy
-    character(len=LINELENGTH), intent(inout) :: name  !< file name
-    integer(I4B), intent(in) :: proc_id  !< processor id
+    character(len=LINELENGTH), intent(inout) :: name !< file name
+    integer(I4B), intent(in) :: proc_id !< processor id
     ! -- local
     character(len=LINELENGTH) :: name_local
     character(len=LINELENGTH) :: name_processor
@@ -263,13 +263,13 @@ contains
     ipos0 = index(name_local, ".", back=.TRUE.)
     ipos1 = len_trim(name)
     if (ipos0 > 0) then
-      write(extension_local, '(a)') name(ipos0:ipos1)
+      write (extension_local, '(a)') name(ipos0:ipos1)
     else
       ipos0 = ipos1
       extension_local = ''
     end if
-    write(name_processor, '(a,a,i0,a)') &
-      name(1:ipos0-1), '.p', proc_id, trim(adjustl(extension_local))
+    write (name_processor, '(a,a,i0,a)') &
+      name(1:ipos0 - 1), '.p', proc_id, trim(adjustl(extension_local))
     name = name_processor
     !
     ! -- Return
@@ -279,26 +279,26 @@ contains
   !> @brief Create a formatted line
   !!
   !! Subroutine to create a formatted line with specified alignment and column
-  !! separators. Like URWORD, UWWORD works with strings, integers, and floats. 
+  !! separators. Like URWORD, UWWORD works with strings, integers, and floats.
   !! Can pass an optional format statement, alignment, and column separator.
   !<
   subroutine UWWORD(line, icol, ilen, ncode, c, n, r, fmt, alignment, sep)
     implicit none
     ! -- dummy
-    character (len=*), intent(inout) :: line !< line
+    character(len=*), intent(inout) :: line !< line
     integer(I4B), intent(inout) :: icol !< column to write to line
     integer(I4B), intent(in) :: ilen !< current length of line
     integer(I4B), intent(in) :: ncode !< code for data type to write
-    character (len=*), intent(in) :: c !< character data type
+    character(len=*), intent(in) :: c !< character data type
     integer(I4B), intent(in) :: n !< integer data type
     real(DP), intent(in) :: r !< float data type
-    character (len=*), optional, intent(in) :: fmt !< format statement
+    character(len=*), optional, intent(in) :: fmt !< format statement
     integer(I4B), optional, intent(in) :: alignment !< alignment specifier
-    character (len=*), optional, intent(in) :: sep !< column separator
-    ! -- local 
-    character (len=16) :: cfmt
-    character (len=16) :: cffmt
-    character (len=ILEN) :: cval
+    character(len=*), optional, intent(in) :: sep !< column separator
+    ! -- local
+    character(len=16) :: cfmt
+    character(len=16) :: cffmt
+    character(len=ILEN) :: cval
     integer(I4B) :: ialign
     integer(I4B) :: i
     integer(I4B) :: ispace
@@ -314,21 +314,21 @@ contains
     if (present(fmt)) then
       cfmt = fmt
     else
-      select case(ncode)
-        case(TABSTRING, TABUCSTRING)
-          write(cfmt, '(a,I0,a)') '(a', ilen, ')'
-        case(TABINTEGER)
-          write(cfmt, '(a,I0,a)') '(I', ilen, ')'
-        case(TABREAL)
-          ireal = 1
-          i = ilen - 7
-          write(cfmt, '(a,I0,a,I0,a)') '(1PG', ilen, '.', i, ')'
-          if (R >= DZERO) then
-            ipad = 1
-          end if
+      select case (ncode)
+      case (TABSTRING, TABUCSTRING)
+        write (cfmt, '(a,I0,a)') '(a', ilen, ')'
+      case (TABINTEGER)
+        write (cfmt, '(a,I0,a)') '(I', ilen, ')'
+      case (TABREAL)
+        ireal = 1
+        i = ilen - 7
+        write (cfmt, '(a,I0,a,I0,a)') '(1PG', ilen, '.', i, ')'
+        if (R >= DZERO) then
+          ipad = 1
+        end if
       end select
     end if
-    write(cffmt, '(a,I0,a)') '(a', ilen, ')'
+    write (cffmt, '(a,I0,a)') '(a', ilen, ')'
     !
     if (present(alignment)) then
       ialign = alignment
@@ -336,16 +336,15 @@ contains
       ialign = TABRIGHT
     end if
     !
-    ! -- 
     if (ncode == TABSTRING .or. ncode == TABUCSTRING) then
       cval = C
       if (ncode == TABUCSTRING) then
         call UPcase(cval)
       end if
     else if (ncode == TABINTEGER) then
-      write(cval, cfmt) n
+      write (cval, cfmt) n
     else if (ncode == TABREAL) then
-      write(cval, cfmt) r
+      write (cval, cfmt) r
     end if
     !
     ! -- Apply alignment to cval
@@ -359,17 +358,17 @@ contains
       ispace = (ilen - i) / 2
       if (ireal > 0) then
         if (ipad > 0) then
-          cval = ' ' //trim(adjustl(cval))
+          cval = ' '//trim(adjustl(cval))
         else
           cval = trim(adjustl(cval))
         end if
       else
-        cval = repeat(' ', ispace) // trim(cval)
+        cval = repeat(' ', ispace)//trim(cval)
       end if
     else if (ialign == TABLEFT) then
       cval = trim(adjustl(cval))
       if (ipad > 0) then
-        cval = ' ' //trim(adjustl(cval))
+        cval = ' '//trim(adjustl(cval))
       end if
     else
       cval = adjustr(cval)
@@ -382,14 +381,14 @@ contains
     istop = icol + ilen - 1
     !
     ! -- Write final string to line
-    write(line(icol:istop), cffmt) cval
+    write (line(icol:istop), cffmt) cval
     !
     icoL = istop + 1
     !
     if (present(sep)) then
       i = len(sep)
       istop = icol + i
-      write(line(icol:istop), '(a)') sep
+      write (line(icol:istop), '(a)') sep
       icol = istop
     end if
     !
@@ -400,9 +399,9 @@ contains
   !> @brief Extract a word from a string
   !!
   !! Subroutine to extract a word from a line of text, and optionally
-  !! convert the word to a number. The last character in the line is 
-  !! set to blank so that if any problems occur with finding a word, 
-  !! istart and istop will point to this blank character. Thus, a word 
+  !! convert the word to a number. The last character in the line is
+  !! set to blank so that if any problems occur with finding a word,
+  !! istart and istop will point to this blank character. Thus, a word
   !! will always be returned unless there is a numeric conversion error.
   !! Be sure that the last character in line is not an important character
   !! because it will always be set to blank.
@@ -413,19 +412,19 @@ contains
   !! commas separated by one or more spaces as a null word.
   !!
   !! For a word that begins with "'" or '"', the word starts with
-  !! the character after the quote and ends with the character preceding 
+  !! the character after the quote and ends with the character preceding
   !! a subsequent quote. Thus, a quoted word can include spaces and commas.
-  !! The quoted word cannot contain a quote character of the same type 
-  !! within the word but can contain a different quote character. For 
+  !! The quoted word cannot contain a quote character of the same type
+  !! within the word but can contain a different quote character. For
   !! example, "WORD'S" or 'WORD"S'.
   !!
-  !! Number conversion error is written to unit iout if iout is positive; 
-  !! error is written to default output if iout is 0; no error message is 
+  !! Number conversion error is written to unit iout if iout is positive;
+  !! error is written to default output if iout is 0; no error message is
   !! written if iout is negative.
   !!
   !<
   subroutine URWORD(line, icol, istart, istop, ncode, n, r, iout, in)
-    ! -- dummy  
+    ! -- dummy
     character(len=*) :: line !< line to parse
     integer(I4B), intent(inout) :: icol !< current column in line
     integer(I4B), intent(inout) :: istart !< starting character position of the word
@@ -436,14 +435,25 @@ contains
     integer(I4B), intent(in) :: iout !< output listing file unit
     integer(I4B), intent(in) :: in !< input file unit number
     ! -- local
-    character(len=20) string                
+    character(len=20) string
     character(len=30) rw
     character(len=1) tab
     character(len=1) charend
     character(len=200) :: msg
     character(len=linelength) :: msg_line
+    ! -- formats
+    character(len=*), parameter :: fmtmsgout1 = &
+      "(1X,'FILE UNIT ',I4,' : ERROR CONVERTING ""',A, &
+      & '"" TO ',A,' IN LINE:')"
+    character(len=*), parameter :: fmtmsgout2 = "(1x, &
+      & 'KEYBOARD INPUT : ERROR CONVERTING ""',a,'"" TO ',a,' IN LINE:')"
+    character(len=*), parameter :: fmtmsgout3 = "('File unit ', &
+      & I0,': Error converting ""',a,'"" to ',A,' in following line:')"
+    character(len=*), parameter :: fmtmsgout4 = &
+      "('Keyboard input: Error converting ""',a, &
+      & '"" to ',A,' in following line:')"
     !
-    tab=char(9)
+    tab = char(9)
     !
     ! -- Set last char in LINE to blank and set ISTART and ISTOP to point
     !    to this blank as a default situation when no word is found.  If
@@ -453,39 +463,39 @@ contains
     istart = linlen
     istop = linlen
     linlen = linlen - 1
-    if(icol < 1 .or. icol > linlen) go to 100
+    if (icol < 1 .or. icol > linlen) go to 100
     !
     ! -- Find start of word, which is indicated by first character that
     !    is not a blank, a comma, or a tab.
-    do 10 i=icol, linlen
-      if(line(i:i) /= ' ' .and. line(i:i) /= ',' .and. &
-         line(i:i) /= tab) go to 20
-10  continue
+    do i = icol, linlen
+      if (line(i:i) /= ' ' .and. line(i:i) /= ',' .and. &
+          line(i:i) /= tab) go to 20
+    end do
     icol = linlen + 1
     go to 100
     !
     ! -- Found start of word.  Look for end.
     !    When word is quoted, only a quote can terminate it.
     !    search for a single (char(39)) or double (char(34)) quote
-20  if(line(i:i)==char(34) .or. line(i:i)==char(39)) then
+20  if (line(i:i) == char(34) .or. line(i:i) == char(39)) then
       if (line(i:i) == char(34)) then
         charend = char(34)
       else
         charend = char(39)
       end if
       i = i + 1
-      if(i <= linlen) then
-        do 25 j=i, linlen
-          if(line(j:j)==charend) go to 40
-25      continue
+      if (i <= linlen) then
+        do j = i, linlen
+          if (line(j:j) == charend) go to 40
+        end do
       end if
-    !
-    ! -- When word is not quoted, space, comma, or tab will terminate.
+      !
+      ! -- When word is not quoted, space, comma, or tab will terminate.
     else
-      do 30 j=i, linlen
-        if(line(j:j)==' ' .or. line(j:j)==',' .or. &
-           line(j:j)==tab) go to 40
-30    continue
+      do j = i, linlen
+        if (line(j:j) == ' ' .or. line(j:j) == ',' .or. &
+            line(j:j) == tab) go to 40
+      end do
     end if
     !
     ! -- End of line without finding end of word; set end of word to
@@ -496,33 +506,33 @@ contains
     !    set ICOL to point to location for scanning for another word.
 40  icol = j + 1
     j = j - 1
-    if(j < i) go to 100
+    if (j < i) go to 100
     istart = i
     istop = j
     !
     ! -- Convert word to upper case and RETURN if NCODE is 1.
-    if(ncode==1) then
+    if (ncode == 1) then
       idiff = ichar('a') - ichar('A')
-      do 50 k=istart, istop
-        if(line(k:k) >= 'a' .and. line(k:k) <= 'z') &
-           line(k:k) = char(ichar(line(k:k)) - idiff)
-50    continue
+      do k = istart, istop
+        if (line(k:k) >= 'a' .and. line(k:k) <= 'z') &
+          line(k:k) = char(ichar(line(k:k)) - idiff)
+      end do
       return
     end if
     !
     ! -- Convert word to a number if requested.
-100 if(ncode==2 .or. ncode==3) then
+100 if (ncode == 2 .or. ncode == 3) then
       rw = ' '
-      l = 30-istop+istart
+      l = 30 - istop + istart
       if (l < 1) go to 200
       rw(l:30) = line(istart:istop)
-      if(ncode == 2) read(rw,'(i30)',err=200) n
-      if(ncode == 3) read(rw,'(f30.0)',err=200) r
+      if (ncode == 2) read (rw, '(i30)', err=200) n
+      if (ncode == 3) read (rw, '(f30.0)', err=200) r
     end if
     return
     !
     ! -- Number conversion error.
-200 if(ncode == 3) then
+200 if (ncode == 3) then
       string = 'a real number'
       l = 13
     else
@@ -534,29 +544,25 @@ contains
     if (iout < 0) then
       n = 0
       r = 0.
-      line(linlen+1:linlen+1) = 'E'
+      line(linlen + 1:linlen + 1) = 'E'
       return
-    !
-    ! -- If output unit is positive; write a message to output unit.
-    else if(iout > 0) then
-      if(in > 0) then
-        write(msg_line,201) in, line(istart:istop), string(1:l)
+      !
+      ! -- If output unit is positive; write a message to output unit.
+    else if (iout > 0) then
+      if (in > 0) then
+        write (msg_line, fmtmsgout1) in, line(istart:istop), string(1:l)
       else
-        write(msg_line,202) line(istart:istop), string(1:l)
+        write (msg_line, fmtmsgout2) line(istart:istop), string(1:l)
       end if
       call write_message(msg_line, iunit=IOUT, skipbefore=1)
       call write_message(line, iunit=IOUT, fmt='(1x,a)')
-201   format(1x,'FILE UNIT ',I4,' : ERROR CONVERTING "',a, &
-             '" TO ',a,' IN LINE:')
-202   format(1x,'KEYBOARD INPUT : ERROR CONVERTING "',a, &
-             '" TO ',a,' IN LINE:')
-    !
-    ! -- If output unit is 0; write a message to default output.
+      !
+      ! -- If output unit is 0; write a message to default output.
     else
-      if(in > 0) then
-        write(msg_line,201) in, line(istart:istop), string(1:l)
+      if (in > 0) then
+        write (msg_line, fmtmsgout1) in, line(istart:istop), string(1:l)
       else
-        write(msg_line,202) line(istart:istop), string(1:l)
+        write (msg_line, fmtmsgout2) line(istart:istop), string(1:l)
       end if
       call write_message(msg_line, iunit=iout, skipbefore=1)
       call write_message(LINE, iunit=iout, fmt='(1x,a)')
@@ -565,14 +571,11 @@ contains
     ! -- STOP after storing error message.
     call lowcase(string)
     if (in > 0) then
-      write(msg,205) in,line(istart:istop), trim(string)
+      write (msg, fmtmsgout3) in, line(istart:istop), trim(string)
     else
-      write(msg,207) line(istart:istop), trim(string)
-    endif
-205 format('File unit ',I0,': Error converting "',a, &
-           '" to ',A,' in following line:')
-207 format('Keyboard input: Error converting "',a, &
-           '" to ',A,' in following line:')
+      write (msg, fmtmsgout4) line(istart:istop), trim(string)
+    end if
+    !
     call store_error(msg)
     call store_error(trim(line))
     call store_error_unit(in)

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -933,27 +933,27 @@ contains
   !> @brief Save 1 layer array on disk
   !<
   subroutine ulasav(buf, text, kstp, kper, pertim, totim, ncol, nrow, &
-                     ilay, ichn)
+                    ilay, ichn)
     ! -- dummy
     character(len=16) :: text
     real(DP), dimension(ncol, nrow) :: buf
     real(DP) :: pertim, totim
     !
     ! -- Write an unformatted record containing identifying information
-    write(ichn) kstp, kper, pertim, totim, text, ncol, nrow, ilay
+    write (ichn) kstp, kper, pertim, totim, text, ncol, nrow, ilay
     !
     ! -- Write an unformatted record containing array values. The array is
     !    dimensioned (ncol,nrow)
-    write(ichn) ((buf(ic, ir), ic=1, ncol), ir=1, nrow)
+    write (ichn) ((buf(ic, ir), ic=1, ncol), ir=1, nrow)
     !
     ! -- flush file
-    flush(ICHN)
+    flush (ICHN)
     !
     ! -- Return
     return
   end subroutine ulasav
 
-  !> @brief Record cell-by-cell flow terms for one component of flow as a 3-D 
+  !> @brief Record cell-by-cell flow terms for one component of flow as a 3-D
   !! array with extra record to indicate delt, pertim, and totim
   !<
   subroutine ubdsv1(kstp, kper, text, ibdchn, buff, ncol, nrow, nlay, iout, &
@@ -991,7 +991,7 @@ contains
   end subroutine ubdsv1
 
   !> @brief Write header records for cell-by-cell flow terms for one component
-  !! of flow.  
+  !! of flow.
   !!
   !! Each item in the list is written by module ubdsvc
   !<
@@ -1027,17 +1027,17 @@ contains
       "' ON UNIT',I7,' AT TIME STEP',I7,', STRESS PERIOD',I7)"
     !
     ! -- Write unformatted records identifying data.
-    if (iout > 0) write(iout,fmt) text, modelnam1, paknam1, modelnam2, &
-                                  paknam2, ibdchn, kstp, kper
-    write(ibdchn) kstp, kper, text, ncol, nrow, -nlay
-    write(ibdchn) 6, delt, pertim, totim
-    write(ibdchn) modelnam1
-    write(ibdchn) paknam1
-    write(ibdchn) modelnam2
-    write(ibdchn) paknam2
-    write(ibdchn) naux+1
-    if (naux > 0) write(ibdchn) (auxtxt(n),n=1,naux)
-    write(ibdchn) nlist
+    if (iout > 0) write (iout, fmt) text, modelnam1, paknam1, modelnam2, &
+      paknam2, ibdchn, kstp, kper
+    write (ibdchn) kstp, kper, text, ncol, nrow, -nlay
+    write (ibdchn) 6, delt, pertim, totim
+    write (ibdchn) modelnam1
+    write (ibdchn) paknam1
+    write (ibdchn) modelnam2
+    write (ibdchn) paknam2
+    write (ibdchn) naux + 1
+    if (naux > 0) write (ibdchn) (auxtxt(n), n=1, naux)
+    write (ibdchn) nlist
     !
     ! -- Return
     return
@@ -1060,9 +1060,9 @@ contains
     !
     ! -- Write record
     if (naux > 0) then
-        write(ibdchn) n,q,(aux(nn),nn=1,naux)
+      write (ibdchn) n, q, (aux(nn), nn=1, naux)
     else
-        write(ibdchn) n,q
+      write (ibdchn) n, q
     end if
     !
     ! -- Return
@@ -1087,9 +1087,9 @@ contains
     !
     ! -- Write record
     if (naux > 0) then
-        write(ibdchn) n,n2,q,(aux(nn),nn=1,naux)
+      write (ibdchn) n, n2, q, (aux(nn), nn=1, naux)
     else
-        write(ibdchn) n,n2,q
+      write (ibdchn) n, n2, q
     end if
     !
     ! -- Return
@@ -1098,7 +1098,7 @@ contains
 
   !> @brief Perform a case-insensitive comparison of two words
   !<
-  logical function same_word(word1, word2) 
+  logical function same_word(word1, word2)
     implicit none
     ! -- dummy
     character(len=*), intent(in) :: word1, word2
@@ -1109,7 +1109,7 @@ contains
     call upcase(upword1)
     upword2 = word2
     call upcase(upword2)
-    same_word = (upword1==upword2)
+    same_word = (upword1 == upword2)
     !
     ! -- Return
     return
@@ -1144,27 +1144,27 @@ contains
        &"('    formatted:',a,'  sequential:',a,'  unformatted:',a,'  form:',a)"
     !
     ! -- set strings using inquire statement
-    inquire(unit=iu, name=fname, access=ac, action=act, formatted=fm, &
-            sequential=seq, unformatted=unf, form=frm)
+    inquire (unit=iu, name=fname, access=ac, action=act, formatted=fm, &
+             sequential=seq, unformatted=unf, form=frm)
     !
     ! -- write the results of the inquire statement
-    write(line,fmta) iu, trim(fname), trim(ac), trim(act)
+    write (line, fmta) iu, trim(fname), trim(ac), trim(act)
     call write_message(line)
-    write(line,fmtb) trim(fm), trim(seq), trim(unf), trim(frm)
+    write (line, fmtb) trim(fm), trim(seq), trim(unf), trim(frm)
     call write_message(line)
     !
     ! -- Return
     return
   end subroutine unitinquire
 
-  !> @brief Parse a line into words. 
+  !> @brief Parse a line into words.
   !!
-  !! Blanks and commas are recognized as delimiters. Multiple blanks between 
-  !! words is OK, but multiple commas between words is treated as an error. 
+  !! Blanks and commas are recognized as delimiters. Multiple blanks between
+  !! words is OK, but multiple commas between words is treated as an error.
   !! Quotation marks are not recognized as delimiters.
-  !< 
+  !<
   subroutine ParseLine(line, nwords, words, inunit, filename)
-    ! -- modules 
+    ! -- modules
     use ConstantsModule, only: LINELENGTH
     implicit none
     ! -- dummy
@@ -1179,13 +1179,13 @@ contains
     !
     nwords = 0
     if (allocated(words)) then
-      deallocate(words)
-    endif
+      deallocate (words)
+    end if
     linelen = len(line)
     !
     ! -- get the number of words in a line and allocate words array
     nwords = get_nwords(line)
-    allocate(words(nwords))
+    allocate (words(nwords))
     !
     ! -- Populate words array and return
     lloc = 1
@@ -1205,7 +1205,7 @@ contains
     implicit none
     ! -- dummy
     integer(I4B), intent(in) :: ncol, nrow, kstp, kper, ilay, iout
-    real(DP),dimension(ncol,nrow), intent(in) :: buf
+    real(DP), dimension(ncol, nrow), intent(in) :: buf
     character(len=*), intent(in) :: text
     character(len=*), intent(in) :: userfmt
     integer(I4B), intent(in) :: nvalues, nwidth
@@ -1213,31 +1213,33 @@ contains
     ! -- local
     integer(I4B) :: i, j, nspaces
     ! -- formats
-    1 format('1',/2X,A,' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
-          ' IN STRESS PERIOD ',I4/2X,75('-'))
-    2 format('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
-          ' IN STRESS PERIOD ',I4/1X,79('-'))
+    character(len=*), parameter :: fmtmsgout1 = &
+      "('1',/2X,A,' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
+&        ' IN STRESS PERIOD ',I4/2X,75('-'))"
+    character(len=*), parameter :: fmtmsgout2 = &
+      "('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
+&        ' IN STRESS PERIOD ',I4/1X,79('-'))"
     !
-    if (iout<=0) return
+    if (iout <= 0) return
     ! -- Print a header depending on ILAY
     if (ilay > 0) then
-       write(iout,1) trim(text), ilay, kstp, kper
-    else if(ilay < 0) then
-       write(iout,2) trim(text), kstp, kper
+      write (iout, fmtmsgout1) trim(text), ilay, kstp, kper
+    else if (ilay < 0) then
+      write (iout, fmtmsgout2) trim(text), kstp, kper
     end if
     !
     ! -- Print column numbers.
     nspaces = 0
     if (editdesc == 'F') nspaces = 3
-    call ucolno(1, ncol, nspaces, nvalues, nwidth+1, iout)
+    call ucolno(1, ncol, nspaces, nvalues, nwidth + 1, iout)
     !
     ! -- Loop through the rows, printing each one in its entirety.
-    do i=1,nrow
-      write(iout,userfmt) i,(buf(j,i),j=1,ncol)
+    do i = 1, nrow
+      write (iout, userfmt) i, (buf(j, i), j=1, ncol)
     end do
     !
     ! -- flush file
-    flush(IOUT)
+    flush (IOUT)
     !
     ! -- Return
     return
@@ -1245,7 +1247,7 @@ contains
 
   !> @breif This function reads a line of arbitrary length and returns it.
   !!
-  !! The returned string can be stored in a deferred-length character variable, 
+  !! The returned string can be stored in a deferred-length character variable,
   !! for example:
   !!
   !!   integer(I4B) :: iu
@@ -1255,7 +1257,7 @@ contains
   !!   open(iu,file='my_file')
   !!   my_string = read_line(iu, eof)
   !<
-  function read_line(iu, eof) result (astring)
+  function read_line(iu, eof) result(astring)
     !
     implicit none
     ! -- dummy
@@ -1268,41 +1270,44 @@ contains
     character(len=1000) :: ermsg, fname
     character(len=7) :: fmtd
     logical :: lop
-    ! -- format
-20  format('Error in read_line: File ',i0,' is not open.')
-30  format('Error in read_line: Attempting to read text ' // &
-              'from unformatted file: "',a,'"')
-40  format('Error reading from file "',a,'" opened on unit ',i0, &
-              ' in read_line.')
+    ! -- formats
+    character(len=*), parameter :: fmterrmsg1 = &
+      & "('Error in read_line: File ',i0,' is not open.')"
+    character(len=*), parameter :: fmterrmsg2 = &
+      & "('Error in read_line: Attempting to read text ' // &
+      & 'from unformatted file: ""',a,'""')"
+    character(len=*), parameter :: fmterrmsg3 = &
+      & "('Error reading from file ""',a,'"" opened on unit ',i0, &
+      & ' in read_line.')"
     !
     astring = ''
     eof = .false.
     do
-      read(iu, '(a)', advance='NO', iostat=istat, size=isize, end=99) buffer
+      read (iu, '(a)', advance='NO', iostat=istat, size=isize, end=99) buffer
       if (istat > 0) then
         ! Determine error if possible, report it, and stop.
         if (iu <= 0) then
-          ermsg = 'Programming error in call to read_line: ' // &
+          ermsg = 'Programming error in call to read_line: '// &
                   'Attempt to read from unit number <= 0'
         else
-          inquire(unit=iu,opened=lop,name=fname,formatted=fmtd)
+          inquire (unit=iu, opened=lop, name=fname, formatted=fmtd)
           if (.not. lop) then
-            write(ermsg,20) iu
+            write (ermsg, fmterrmsg1) iu
           elseif (fmtd == 'NO' .or. fmtd == 'UNKNOWN') then
-            write(ermsg, 30) trim(fname)
+            write (ermsg, fmterrmsg2) trim(fname)
           else
-            write(ermsg,40) trim(fname), iu
-          endif
-        endif
+            write (ermsg, fmterrmsg3) trim(fname), iu
+          end if
+        end if
         call store_error(ermsg)
         call store_error_unit(iu)
-      endif
-      astring = astring // buffer(:isize)
+      end if
+      astring = astring//buffer(:isize)
       ! -- An end-of-record condition stops the loop.
       if (istat < 0) then
         return
-      endif
-    enddo
+      end if
+    end do
     !
     return
 99  continue
@@ -1328,19 +1333,19 @@ contains
     lenpath = len_trim(pathname)
     istart = 1
     istop = lenpath
-    loop: do i=lenpath,1,-1
+    loop: do i = lenpath, 1, -1
       if (pathname(i:i) == fs .or. pathname(i:i) == bs) then
         if (i == istop) then
           istop = istop - 1
         else
           istart = i + 1
           exit loop
-        endif
-      endif
-    enddo loop
+        end if
+      end if
+    end do loop
     if (istop >= istart) then
       filename = pathname(istart:istop)
-    endif
+    end if
     !
     ! -- Return
     return
@@ -1348,8 +1353,8 @@ contains
 
   !> @brief Starting at position icol, define string as line(istart:istop).
   !!
-  !! If string can be interpreted as an integer(I4B), return integer in idnum 
-  !! argument. If token is not an integer(I4B), assume it is a boundary name, 
+  !! If string can be interpreted as an integer(I4B), return integer in idnum
+  !! argument. If token is not an integer(I4B), assume it is a boundary name,
   !! return NAMEDBOUNDFLAG in idnum, convert string to uppercase and return it
   !! in bndname.
   !<
@@ -1360,12 +1365,12 @@ contains
     integer(I4B), intent(inout) :: icol, istart, istop
     integer(I4B), intent(out) :: idnum
     character(len=LENBOUNDNAME), intent(out) :: bndname
-    ! -- local 
-    integer(I4B) :: istat, ndum, ncode=0
+    ! -- local
+    integer(I4B) :: istat, ndum, ncode = 0
     real(DP) :: rdum
     !
     call urword(line, icol, istart, istop, ncode, ndum, rdum, 0, 0)
-    read(line(istart:istop),*,iostat=istat) ndum
+    read (line(istart:istop), *, iostat=istat) ndum
     if (istat == 0) then
       idnum = ndum
       bndname = ''
@@ -1373,7 +1378,7 @@ contains
       idnum = NAMEDBOUNDFLAG
       bndname = line(istart:istop)
       call upcase(bndname)
-    endif
+    end if
     !
     ! -- Return
     return
@@ -1384,7 +1389,7 @@ contains
   subroutine urdaux(naux, inunit, iout, lloc, istart, istop, auxname, line, text)
     ! -- modules
     use ArrayHandlersModule, only: ExpandArray
-    use ConstantsModule,     only: LENAUXNAME
+    use ConstantsModule, only: LENAUXNAME
     ! -- implicit
     implicit none
     ! -- dummy
@@ -1403,12 +1408,13 @@ contains
     real(DP) :: rval
     !
     linelen = len(line)
-    if(naux > 0) then
-      write(errmsg,'(a)') 'Auxiliary variables already specified. Auxiliary ' // &
-        'variables must be specified on one line in the options block.'
+    if (naux > 0) then
+      write (errmsg, '(a)') 'Auxiliary variables already specified. '// &
+        & 'Auxiliary variables must be specified on one line in the '// &
+        & 'options block.'
       call store_error(errmsg)
       call store_error_unit(inunit)
-    endif
+    end if
     auxloop: do
       call urword(line, lloc, istart, istop, 1, n, rval, iout, inunit)
       if (istart >= linelen) exit auxloop
@@ -1421,15 +1427,15 @@ contains
           & to ', LENAUXNAME, ' characters.'
         call store_error(errmsg)
         call store_error_unit(inunit)
-      end if      
+      end if
       naux = naux + 1
       call ExpandArray(auxname)
       auxname(naux) = line(istart:istop)
-      if(iout > 0) then
-        write(iout, "(4X,'AUXILIARY ',a,' VARIABLE: ',A)")                     &
+      if (iout > 0) then
+        write (iout, "(4X,'AUXILIARY ',a,' VARIABLE: ',A)") &
           trim(adjustl(text)), auxname(naux)
-      endif
-    enddo auxloop
+      end if
+    end do auxloop
     !
     ! -- Return
     return

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -19,7 +19,7 @@ module InputOutputModule
             BuildFloatFormat, BuildIntFormat, fseek_stream, get_nwords, &
             u9rdcom, append_processor_id
 
-contains
+  contains
 
   !> @brief Open a file
   !!
@@ -52,17 +52,17 @@ contains
 50  format(1x,/1x,'OPENED ',a,/ &
                  1x,'FILE TYPE:',a,'   UNIT ',I4,3x,'STATUS:',a,/ &
                  1x,'FORMAT:',a,3x,'ACCESS:',a/ &
-                 1x,'ACTION:',a/)
-60  format(1x,/1x,'DID NOT OPEN ',a,/)
+                 1X,'ACTION:',A/)
+60  FORMAT(1X,/1X,'DID NOT OPEN ',A,/)
     !
-    ! -- Process mode_opt
+    ! -- process mode_opt
     if (present(mode_opt)) then
       imode = mode_opt
     else
       imode = isim_mode
     end if
     !
-    ! -- Evaluate if the file should be opened
+    ! -- evaluate if the file should be opened
     if (isim_mode < imode) then
       if(iout > 0) then
         write(iout, 60) trim(fname)
@@ -140,7 +140,7 @@ contains
       end if
     end if
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine openfile
 
@@ -164,7 +164,7 @@ contains
     iu = i
     iunext = iu + 1
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine freeunitnumber
 
@@ -226,11 +226,11 @@ contains
     ! -- local
     integer(I4B) :: idiff, k, l
     !
-    ! -- Compute the difference between lowercase and uppercase.
+    ! -- compute the difference between lowercase and uppercase.
     l = len(word)
     idiff = ichar('a') - ichar('A')
     !
-    ! -- Loop through the string and convert any uppercase characters.
+    ! -- loop through the string and convert any uppercase characters.
     do k = 1, l
       if(word(k:k) >= 'A' .and. word(k:k) <= 'Z') then
         word(k:k)=char(ichar(word(k:k))+idiff)
@@ -249,12 +249,12 @@ contains
   !<
   subroutine append_processor_id(name, proc_id)
     ! -- dummy
-    character(len=LINELENGTH), intent(inout) :: name  !< file name
+    character(len=linelength), intent(inout) :: name  !< file name
     integer(I4B), intent(in) :: proc_id  !< processor id
     ! -- local
-    character(len=LINELENGTH) :: name_local
-    character(len=LINELENGTH) :: name_processor
-    character(len=LINELENGTH) :: extension_local
+    character(len=linelength) :: name_local
+    character(len=linelength) :: name_processor
+    character(len=linelength) :: extension_local
     integer(I4B) :: ipos0
     integer(I4B) :: ipos1
     !
@@ -272,7 +272,7 @@ contains
       name(1:ipos0-1), '.p', proc_id, trim(adjustl(extension_local))
     name = name_processor
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine append_processor_id
 
@@ -311,52 +311,52 @@ contains
     ireal = 0
     !
     ! -- process dummy variables
-    if (present(fmt)) then
-      cfmt = fmt
+    if (present(FMT)) then
+      CFMT = FMT
     else
-      select case(ncode)
+      select case(NCODE)
         case(TABSTRING, TABUCSTRING)
-          write(cfmt, '(a,I0,a)') '(a', ilen, ')'
+          write(cfmt, '(A,I0,A)') '(A', ILEN, ')'
         case(TABINTEGER)
-          write(cfmt, '(a,I0,a)') '(I', ilen, ')'
+          write(cfmt, '(A,I0,A)') '(I', ILEN, ')'
         case(TABREAL)
           ireal = 1
-          i = ilen - 7
-          write(cfmt, '(a,I0,a,I0,a)') '(1PG', ilen, '.', i, ')'
+          i = ILEN - 7
+          write(cfmt, '(A,I0,A,I0,A)') '(1PG', ILEN, '.', i, ')'
           if (R >= DZERO) then
             ipad = 1
           end if
       end select
     end if
-    write(cffmt, '(a,I0,a)') '(a', ilen, ')'
+    write(cffmt, '(A,I0,A)') '(A', ILEN, ')'
     !
-    if (present(alignment)) then
-      ialign = alignment
+    if (present(ALIGNMENT)) then
+      ialign = ALIGNMENT
     else
       ialign = TABRIGHT
     end if
     !
     ! -- 
-    if (ncode == TABSTRING .or. ncode == TABUCSTRING) then
+    if (NCODE == TABSTRING .or. NCODE == TABUCSTRING) then
       cval = C
-      if (ncode == TABUCSTRING) then
-        call UPcase(cval)
+      if (NCODE == TABUCSTRING) then
+        call UPCASE(cval)
       end if
-    else if (ncode == TABINTEGER) then
-      write(cval, cfmt) n
-    else if (ncode == TABREAL) then
-      write(cval, cfmt) r
+    else if (NCODE == TABINTEGER) then
+      write(cval, cfmt) N
+    else if (NCODE == TABREAL) then
+      write(cval, cfmt) R
     end if
     !
-    ! -- Apply alignment to cval
-    if (len_trim(adjustl(cval)) > ilen) then
+    ! -- apply alignment to cval
+    if (len_trim(adjustl(cval)) > ILEN) then
       cval = adjustl(cval)
     else
       cval = trim(adjustl(cval))
     end if
     if (ialign == TABCENTER) then
       i = len_trim(cval)
-      ispace = (ilen - i) / 2
+      ispace = (ILEN - i) / 2
       if (ireal > 0) then
         if (ipad > 0) then
           cval = ' ' //trim(adjustl(cval))
@@ -374,23 +374,23 @@ contains
     else
       cval = adjustr(cval)
     end if
-    if (ncode == TABUCSTRING) then
-      call UPcase(cval)
+    if (NCODE == TABUCSTRING) then
+      call UPCASE(cval)
     end if
     !
-    ! -- Increment istop to the end of the column
-    istop = icol + ilen - 1
+    ! -- increment istop to the end of the column
+    istop = ICOL + ILEN - 1
     !
-    ! -- Write final string to line
-    write(line(icol:istop), cffmt) cval
+    ! -- write final string to line
+    write(LINE(ICOL:istop), cffmt) cval
     !
-    icoL = istop + 1
+    ICOL = istop + 1
     !
-    if (present(sep)) then
-      i = len(sep)
-      istop = icol + i
-      write(line(icol:istop), '(a)') sep
-      icol = istop
+    if (present(SEP)) then
+      i = len(SEP)
+      istop = ICOL + i
+      write(LINE(ICOL:istop), '(A)') SEP
+      ICOL = istop
     end if
     !
     ! -- Return
@@ -437,13 +437,13 @@ contains
     integer(I4B), intent(in) :: in !< input file unit number
     ! -- local
     character(len=20) string                
-    character(len=30) rw
-    character(len=1) tab
-    character(len=1) charend
+    CHARACTER(len=30) RW
+    CHARACTER(len=1) TAB
+    CHARACTER(len=1) CHAREND
     character(len=200) :: msg
-    character(len=linelength) :: msg_line
+    character(len=LINELENGTH) :: msg_line
     !
-    tab=char(9)
+    TAB=CHAR(9)
     !
     ! -- Set last char in LINE to blank and set ISTART and ISTOP to point
     !    to this blank as a default situation when no word is found.  If
@@ -460,33 +460,33 @@ contains
     do 10 i=icol, linlen
       if(line(i:i) /= ' ' .and. line(i:i) /= ',' .and. &
          line(i:i) /= tab) go to 20
-10  continue
+10  CONTINUE
     icol = linlen + 1
-    go to 100
+    GO TO 100
     !
     ! -- Found start of word.  Look for end.
     !    When word is quoted, only a quote can terminate it.
-    !    search for a single (char(39)) or double (char(34)) quote
+    !    SEARCH FOR A SINGLE (CHAR(39)) OR DOUBLE (CHAR(34)) QUOTE
 20  if(line(i:i)==char(34) .or. line(i:i)==char(39)) then
       if (line(i:i) == char(34)) then
-        charend = char(34)
-      else
-        charend = char(39)
-      end if
+        CHAREND = CHAR(34)
+      ELSE
+        CHAREND = CHAR(39)
+      END IF
       i = i + 1
       if(i <= linlen) then
         do 25 j=i, linlen
           if(line(j:j)==charend) go to 40
-25      continue
-      end if
+25      CONTINUE
+      END IF
     !
     ! -- When word is not quoted, space, comma, or tab will terminate.
-    else
+    ELSE
       do 30 j=i, linlen
         if(line(j:j)==' ' .or. line(j:j)==',' .or. &
            line(j:j)==tab) go to 40
-30    continue
-    end if
+30    CONTINUE
+    END IF
     !
     ! -- End of line without finding end of word; set end of word to
     !    end of line.
@@ -506,9 +506,9 @@ contains
       do 50 k=istart, istop
         if(line(k:k) >= 'a' .and. line(k:k) <= 'z') &
            line(k:k) = char(ichar(line(k:k)) - idiff)
-50    continue
-      return
-    end if
+50    CONTINUE
+      RETURN
+    END IF
     !
     ! -- Convert word to a number if requested.
 100 if(ncode==2 .or. ncode==3) then
@@ -518,49 +518,49 @@ contains
       rw(l:30) = line(istart:istop)
       if(ncode == 2) read(rw,'(i30)',err=200) n
       if(ncode == 3) read(rw,'(f30.0)',err=200) r
-    end if
-    return
+    END IF
+    RETURN
     !
     ! -- Number conversion error.
 200 if(ncode == 3) then
       string = 'a real number'
       l = 13
-    else
+    ELSE
       string = 'an integer'
       l = 10
-    end if
+    END IF
     !
     ! -- If output unit is negative, set last character of string to 'E'.
     if (iout < 0) then
       n = 0
       r = 0.
       line(linlen+1:linlen+1) = 'E'
-      return
+      RETURN
     !
     ! -- If output unit is positive; write a message to output unit.
     else if(iout > 0) then
       if(in > 0) then
         write(msg_line,201) in, line(istart:istop), string(1:l)
-      else
+      ELSE
         write(msg_line,202) line(istart:istop), string(1:l)
-      end if
+      END IF
       call write_message(msg_line, iunit=IOUT, skipbefore=1)
-      call write_message(line, iunit=IOUT, fmt='(1x,a)')
-201   format(1x,'FILE UNIT ',I4,' : ERROR CONVERTING "',a, &
-             '" TO ',a,' IN LINE:')
-202   format(1x,'KEYBOARD INPUT : ERROR CONVERTING "',a, &
-             '" TO ',a,' IN LINE:')
+      call write_message(LINE, iunit=IOUT, fmt='(1x,a)')
+201   FORMAT(1X,'FILE UNIT ',I4,' : ERROR CONVERTING "',A, &
+             '" TO ',A,' IN LINE:')
+202   FORMAT(1X,'KEYBOARD INPUT : ERROR CONVERTING "',A, &
+             '" TO ',A,' IN LINE:')
     !
     ! -- If output unit is 0; write a message to default output.
-    else
+    ELSE
       if(in > 0) then
         write(msg_line,201) in, line(istart:istop), string(1:l)
-      else
+      ELSE
         write(msg_line,202) line(istart:istop), string(1:l)
-      end if
-      call write_message(msg_line, iunit=iout, skipbefore=1)
-      call write_message(LINE, iunit=iout, fmt='(1x,a)')
-    end if
+      END IF
+      call write_message(msg_line, iunit=IOUT, skipbefore=1)
+      call write_message(LINE, iunit=IOUT, fmt='(1x,a)')
+    END IF
     !
     ! -- STOP after storing error message.
     call lowcase(string)
@@ -569,9 +569,9 @@ contains
     else
       write(msg,207) line(istart:istop), trim(string)
     endif
-205 format('File unit ',I0,': Error converting "',a, &
+205 format('File unit ',I0,': Error converting "',A, &
            '" to ',A,' in following line:')
-207 format('Keyboard input: Error converting "',a, &
+207 format('Keyboard input: Error converting "',A, &
            '" to ',A,' in following line:')
     call store_error(msg)
     call store_error(trim(line))
@@ -768,7 +768,7 @@ contains
             & ' IN STRESS PERIOD ',I4/2x,75('-'))
       else if (ilay < 0) then
         write(iout,2) text, kstp, kper
-    2    format('1',/1x,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
+    2    FORMAT('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
             & ' IN STRESS PERIOD ',I4/1x,79('-'))
     end if
     !
@@ -789,153 +789,161 @@ contains
     ! 
     ! -- Loop through the rows printing each one in its entirety.
     do i=1,nrow
-      select case(ip)
+      SELECT CASE(IP)
       !
-      case(1)
-      ! -- format 11G10.3
-      write(iout, 11) i,(buf(j, i), j=1, ncol)
-11    format(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))
-      !
-      case(2)
-      ! -- format 9G13.6
-      write(iout, 21) i, (buf(j, i), j=1, ncol)
-21    format(1x,I3,2x,1PG13.6,8(1x,G13.6):/(5x,9(1x,G13.6)))
-      !
-      case(3)
-      ! -- format 15F7.1
-      write(iout, 31) i, (buf(j, i), j=1, ncol)
-31    format(1x,I3,1x,15(1x,F7.1):/(5x,15(1x,F7.1)))
-      !
-      case(4)
-      ! -- format 15F7.2
-      write(iout,41) i,(buf(j,i),j=1,ncol)
-41    format(1x,I3,1x,15(1x,F7.2):/(5x,15(1x,F7.2)))
-      !
-      case(5)
-      ! -- format 15F7.3
-      write(iout, 51) i, (buf(j, i), j=1, ncol)
-51    format(1x,I3,1x,15(1x,F7.3):/(5x,15(1x,F7.3)))
-      !
-      case(6)
-      ! -- format 15F7.4
-      write(iout, 61) i, (buf(j, i), j=1, ncol)
-61    format(1x,I3,1x,15(1x,F7.4):/(5x,15(1x,F7.4)))
-      !
-      case(7)
-      ! -- format 20F5.0
-      write(iout, 71) i, (buf(j, i), j=1, ncol)
-71    format(1x,I3,1x,20(1x,F5.0):/(5x,20(1x,F5.0)))
-      !
-      case(8)
-      ! -- format 20F5.1
-      write(iout, 81) i, (buf(j, i), j=1, ncol)
-81    format(1x,I3,1x,20(1x,F5.1):/(5x,20(1x,F5.1)))
-      !
-      case(9)
-      ! -- format 20F5.2
-      write(iout, 91) i, (buf(j, i), j=1, ncol)
-91    format(1x,I3,1x,20(1x,F5.2):/(5x,20(1x,F5.2)))
-      !
-      case(10)
-      ! -- format 20F5.3
-      write(iout, 101) i, (buf(j, i), j=1, ncol)
-101   format(1x,I3,1x,20(1x,F5.3):/(5x,20(1x,F5.3)))
-      !
-      case(11)
-      ! -- format 20F5.4
-      write(iout, 111) i, (buf(j, i), j=1, ncol)
-111   format(1x,I3,1x,20(1x,F5.4):/(5x,20(1x,F5.4)))
-      !
-      case(12)
-      ! -- format 10G11.4
-      write(iout,121) i, (buf(j, i), j=1, ncol)
-121   format(1x,I3,2x,1PG11.4,9(1x,G11.4):/(5x,10(1x,G11.4)))
-      !
-      case(13)
-      ! -- format 10F6.0
-      write(iout, 131) i, (buf(j, i), j=1, ncol)
-131   format(1x,I3,1x,10(1x,F6.0):/(5X,10(1x,F6.0)))
-      !
-      case(14)
-      ! -- format 10F6.1
-      write(iout, 141) i, (buf(j, i), j=1, ncol)
-141   format(1x,I3,1x,10(1x,F6.1):/(5x,10(1x,F6.1)))
-      !
-      case(15)
-      ! -- format 10F6.2
-      write(iout, 151) i, (buf(j, i), j=1, ncol)
-151   format(1x,I3,1x,10(1x,F6.2):/(5x,10(1x,F6.2)))
-      !
-      case(16)
-      ! -- format 10F6.3
-      write(iout, 161) i, (buf(j, i), j=1, ncol)
-161   format(1x,I3,1x,10(1x,F6.3):/(5x,10(1x,F6.3)))
-      !
-      case(17)
-      ! -- format 10F6.4
-      write(iout, 171) i, (buf(j, i), j=1, ncol)
-171   format(1x,I3,1x,10(1x,F6.4):/(5x,10(1x,F6.4)))
-      !
-      case(18)
-      ! -- format 10F6.5
-      write(iout, 181) i, (buf(j, i), j=1, ncol)
-181   format(1x,I3,1x,10(1x,F6.5):/(5x,10(1x,F6.5)))
-      !
-      case(19)
-      ! -- format 5G12.5
-      write(iout, 191) i, (buf(j, i), j=1, ncol)
-191   format(1x,I3,2x,1PG12.5,4(1x,G12.5):/(5x,5(1x,G12.5)))
-      !
-      case(20)
-      ! -- format 6G11.4
-      write(iout, 201) i, (buf(j, i), j=1, ncol)
-201   format(1x,I3,2x,1PG11.4,5(1x,G11.4):/(5x,6(1x,G11.4)))
-      !
-      case(21)
-      ! -- format 7G9.2
-      write(iout, 211) i, (buf(j, i), j=1, ncol)
-211   format(1x,I3,2x,1PG9.2,6(1x,G9.2):/(5x,7(1x,G9.2)))
-      !
-      end select
-    end do
-    !
-    ! -- Flush file
-    flush(iout)
-    !
-    ! -- Return
-    return
-  end subroutine ULAPRW
+      CASE(1)
+!C------------ FORMAT 11G10.3
+      WRITE(IOUT,11) I,(BUF(J,I),J=1,NCOL)
+11    FORMAT(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))
 
-  !> @brief Save 1 layer array on disk
-  !<
-  subroutine ulasav(buf, text, kstp, kper, pertim, totim, ncol, nrow, &
-                     ilay, ichn)
-    ! -- dummy
-    character(len=16) :: text
-    real(DP), dimension(ncol, nrow) :: buf
-    real(DP) :: pertim, totim
-    !
-    ! -- Write an unformatted record containing identifying information
-    write(ichn) kstp, kper, pertim, totim, text, ncol, nrow, ilay
-    !
-    ! -- Write an unformatted record containing array values. The array is
-    !    dimensioned (ncol,nrow)
-    write(ichn) ((buf(ic, ir), ic=1, ncol), ir=1, nrow)
-    !
-    ! -- flush file
-    flush(ICHN)
-    !
-    ! -- Return
-    return
-  end subroutine ulasav
+      CASE(2)
+!C------------ FORMAT 9G13.6
+      WRITE(IOUT,21) I,(BUF(J,I),J=1,NCOL)
+21    FORMAT(1X,I3,2X,1PG13.6,8(1X,G13.6):/(5X,9(1X,G13.6)))
 
-  !> @brief Record cell-by-cell flow terms for one component of flow as a 3-D 
-  !! array with extra record to indicate delt, pertim, and totim
-  !<
+      CASE(3)
+!C------------ FORMAT 15F7.1
+      WRITE(IOUT,31) I,(BUF(J,I),J=1,NCOL)
+31    FORMAT(1X,I3,1X,15(1X,F7.1):/(5X,15(1X,F7.1)))
+
+      CASE(4)
+!C------------ FORMAT 15F7.2
+      WRITE(IOUT,41) I,(BUF(J,I),J=1,NCOL)
+41    FORMAT(1X,I3,1X,15(1X,F7.2):/(5X,15(1X,F7.2)))
+
+      CASE(5)
+!C------------ FORMAT 15F7.3
+      WRITE(IOUT,51) I,(BUF(J,I),J=1,NCOL)
+51    FORMAT(1X,I3,1X,15(1X,F7.3):/(5X,15(1X,F7.3)))
+
+      CASE(6)
+!C------------ FORMAT 15F7.4
+      WRITE(IOUT,61) I,(BUF(J,I),J=1,NCOL)
+61    FORMAT(1X,I3,1X,15(1X,F7.4):/(5X,15(1X,F7.4)))
+
+      CASE(7)
+!C------------ FORMAT 20F5.0
+      WRITE(IOUT,71) I,(BUF(J,I),J=1,NCOL)
+71    FORMAT(1X,I3,1X,20(1X,F5.0):/(5X,20(1X,F5.0)))
+
+      CASE(8)
+!C------------ FORMAT 20F5.1
+      WRITE(IOUT,81) I,(BUF(J,I),J=1,NCOL)
+81    FORMAT(1X,I3,1X,20(1X,F5.1):/(5X,20(1X,F5.1)))
+
+      CASE(9)
+!C------------ FORMAT 20F5.2
+      WRITE(IOUT,91) I,(BUF(J,I),J=1,NCOL)
+91    FORMAT(1X,I3,1X,20(1X,F5.2):/(5X,20(1X,F5.2)))
+
+      CASE(10)
+!C------------ FORMAT 20F5.3
+      WRITE(IOUT,101) I,(BUF(J,I),J=1,NCOL)
+101   FORMAT(1X,I3,1X,20(1X,F5.3):/(5X,20(1X,F5.3)))
+
+      CASE(11)
+!C------------ FORMAT 20F5.4
+      WRITE(IOUT,111) I,(BUF(J,I),J=1,NCOL)
+111   FORMAT(1X,I3,1X,20(1X,F5.4):/(5X,20(1X,F5.4)))
+
+      CASE(12)
+!C------------ FORMAT 10G11.4
+      WRITE(IOUT,121) I,(BUF(J,I),J=1,NCOL)
+121   FORMAT(1X,I3,2X,1PG11.4,9(1X,G11.4):/(5X,10(1X,G11.4)))
+
+      CASE(13)
+!C------------ FORMAT 10F6.0
+      WRITE(IOUT,131) I,(BUF(J,I),J=1,NCOL)
+131   FORMAT(1X,I3,1X,10(1X,F6.0):/(5X,10(1X,F6.0)))
+
+      CASE(14)
+!C------------ FORMAT 10F6.1
+      WRITE(IOUT,141) I,(BUF(J,I),J=1,NCOL)
+141   FORMAT(1X,I3,1X,10(1X,F6.1):/(5X,10(1X,F6.1)))
+
+      CASE(15)
+!C------------ FORMAT 10F6.2
+      WRITE(IOUT,151) I,(BUF(J,I),J=1,NCOL)
+151   FORMAT(1X,I3,1X,10(1X,F6.2):/(5X,10(1X,F6.2)))
+
+      CASE(16)
+!C------------ FORMAT 10F6.3
+      WRITE(IOUT,161) I,(BUF(J,I),J=1,NCOL)
+161   FORMAT(1X,I3,1X,10(1X,F6.3):/(5X,10(1X,F6.3)))
+
+      CASE(17)
+!C------------ FORMAT 10F6.4
+      WRITE(IOUT,171) I,(BUF(J,I),J=1,NCOL)
+171   FORMAT(1X,I3,1X,10(1X,F6.4):/(5X,10(1X,F6.4)))
+
+      CASE(18)
+!C------------ FORMAT 10F6.5
+      WRITE(IOUT,181) I,(BUF(J,I),J=1,NCOL)
+181   FORMAT(1X,I3,1X,10(1X,F6.5):/(5X,10(1X,F6.5)))
+
+      CASE(19)
+!C------------FORMAT 5G12.5
+      WRITE(IOUT,191) I,(BUF(J,I),J=1,NCOL)
+191   FORMAT(1X,I3,2X,1PG12.5,4(1X,G12.5):/(5X,5(1X,G12.5)))
+
+      CASE(20)
+!C------------FORMAT 6G11.4
+      WRITE(IOUT,201) I,(BUF(J,I),J=1,NCOL)
+201   FORMAT(1X,I3,2X,1PG11.4,5(1X,G11.4):/(5X,6(1X,G11.4)))
+
+      CASE(21)
+!C------------FORMAT 7G9.2
+      WRITE(IOUT,211) I,(BUF(J,I),J=1,NCOL)
+211   FORMAT(1X,I3,2X,1PG9.2,6(1X,G9.2):/(5X,7(1X,G9.2)))
+
+      END SELECT
+      END DO
+      !
+      ! -- flush file
+      flush(IOUT)
+      !
+      ! -- return
+      RETURN
+      END SUBROUTINE ULAPRW
+
+     SUBROUTINE ULASAV(BUF,TEXT,KSTP,KPER,PERTIM,TOTIM,NCOL, &
+     &                   NROW,ILAY,ICHN)
+!C     ******************************************************************
+!C     SAVE 1 LAYER ARRAY ON DISK
+!C     ******************************************************************
+!C
+!C        SPECIFICATIONS:
+!C     ------------------------------------------------------------------
+      CHARACTER(len=16) TEXT
+      real(DP),dimension(ncol,nrow) :: buf
+      real(DP) :: pertim,totim
+!C     ------------------------------------------------------------------
+!C
+!C1------WRITE AN UNFORMATTED RECORD CONTAINING IDENTIFYING
+!C1------INFORMATION.
+      WRITE(ICHN) KSTP,KPER,PERTIM,TOTIM,TEXT,NCOL,NROW,ILAY
+!C
+!C2------WRITE AN UNFORMATTED RECORD CONTAINING ARRAY VALUES
+!C2------THE ARRAY IS DIMENSIONED (NCOL,NROW)
+      WRITE(ICHN) ((BUF(IC,IR),IC=1,NCOL),IR=1,NROW)
+      !
+      ! -- flush file
+      flush(ICHN)
+!C
+!C3------RETURN
+      RETURN
+     END SUBROUTINE ULASAV
+
   subroutine ubdsv1(kstp, kper, text, ibdchn, buff, ncol, nrow, nlay, iout, &
                     delt, pertim, totim)
+! ******************************************************************************
+! Record cell-by-cell flow terms for one component of flow as a 3-D array with
+!   extra record to indicate delt, pertim, and totim
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
     implicit none
-    ! -- dummy
     integer(I4B), intent(in) :: kstp
     integer(I4B), intent(in) :: kper
     character(len=*), intent(in) :: text
@@ -952,6 +960,7 @@ contains
     character(len=*), parameter :: fmt = &
       "(1X,'UBDSV1 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
       "', STRESS PERIOD',I7)"
+! ------------------------------------------------------------------------------
     !
     ! -- Write records
     if(iout > 0) write(iout, fmt) text, ibdchn, kstp, kper
@@ -962,20 +971,22 @@ contains
     ! -- flush file
     flush(ibdchn)
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine ubdsv1
 
-  !> @brief Write header records for cell-by-cell flow terms for one component
-  !! of flow.  
-  !!
-  !! Each item in the list is written by module ubdsvc
-  !<
-  subroutine ubdsv06(kstp, kper, text, modelnam1, paknam1, modelnam2, paknam2, &
-                     ibdchn, naux, auxtxt, ncol, nrow, nlay, nlist, iout, &
-                     delt, pertim, totim)
+  subroutine ubdsv06(kstp,kper,text,                                 &
+                     modelnam1,paknam1,modelnam2,paknam2,            &
+                     ibdchn,naux,auxtxt,                             &
+                     ncol,nrow,nlay,nlist,iout,delt,pertim,totim)
+! ******************************************************************
+! write header records for cell-by-cell flow terms for one component
+! of flow.  each item in the list is written by module ubdsvc
+! ******************************************************************
+!
+!     specifications:
+! ------------------------------------------------------------------
     implicit none
-    ! -- dummy
     integer(I4B), intent(in) :: kstp
     integer(I4B), intent(in) :: kper
     character(len=*), intent(in) :: text
@@ -994,19 +1005,21 @@ contains
     real(DP), intent(in) :: delt
     real(DP), intent(in) :: pertim
     real(DP), intent(in) :: totim
-    ! -- local
+    ! -- local variables
     integer(I4B) :: n
     ! -- format
     character(len=*), parameter :: fmt = &
       "(1X,'UBDSV06 SAVING ',A16,' IN MODEL ',A16,' PACKAGE ',A16,"//&
-      "'CONNECTED TO MODEL ',A16,' PACKAGE ',A16,"//&
+      "'CONNECTED TO MODEL ',A16,' PACKAGE ',A16,"//                 &
       "' ON UNIT',I7,' AT TIME STEP',I7,', STRESS PERIOD',I7)"
-    !
-    ! -- Write unformatted records identifying data.
-    if (iout > 0) write(iout,fmt) text, modelnam1, paknam1, modelnam2, paknam2,&
-                                  modelnam2, paknam2, ibdchn, kstp, kper
-    write(ibdchn) kstp, kper, text, ncol, nrow, -nlay
-    write(ibdchn) 6, delt, pertim, totim
+! ------------------------------------------------------------------
+!
+! write unformatted records identifying data.
+    if (iout > 0) write(iout,fmt) text, modelnam1, paknam1,          &
+                                  modelnam2, paknam2,                &
+                                  ibdchn, kstp, kper
+    write(ibdchn) kstp,kper,text,ncol,nrow,-nlay
+    write(ibdchn) 6,delt,pertim,totim
     write(ibdchn) modelnam1
     write(ibdchn) paknam1
     write(ibdchn) modelnam2
@@ -1015,24 +1028,27 @@ contains
     if (naux > 0) write(ibdchn) (auxtxt(n),n=1,naux)
     write(ibdchn) nlist
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine ubdsv06
 
-  !> @brief Write one value of cell-by-cell flow using a list structure.
-  !!
-  !! From node (n) and to node (n2) are written to the file
-  !<
   subroutine ubdsvc(ibdchn, n, q, naux, aux)
+! ******************************************************************************
+! Write one value of cell-by-cell flow using a list structure. From node (n)
+! and to node (n2) are written to the file
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
     implicit none
-    ! -- dummy
     integer(I4B), intent(in) :: ibdchn
     integer(I4B), intent(in) :: n
     real(DP), intent(in) :: q
     integer(I4B), intent(in) :: naux
     real(DP), dimension(naux), intent(in) :: aux
-    ! -- local
+    ! -- local variables
     integer(I4B) :: nn
+! ------------------------------------------------------------------------------
     !
     ! -- Write record
     if (naux > 0) then
@@ -1041,25 +1057,28 @@ contains
         write(ibdchn) n,q
     end if
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine ubdsvc
 
-  !> @brief Write one value of cell-by-cell flow using a list structure.
-  !!
-  !! From node (n) and to node (n2) are written to the file
-  !<
   subroutine ubdsvd(ibdchn, n, n2, q, naux, aux)
+! ******************************************************************************
+! Write one value of cell-by-cell flow using a list structure. From node (n)
+! and to node (n2) are written to the file
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
     implicit none
-    ! -- dummy
     integer(I4B), intent(in) :: ibdchn
     integer(I4B), intent(in) :: n
     integer(I4B), intent(in) :: n2
     real(DP), intent(in) :: q
     integer(I4B), intent(in) :: naux
     real(DP), dimension(naux), intent(in) :: aux
-    ! -- local
+    ! -- local variables
     integer(I4B) :: nn
+! ------------------------------------------------------------------------------
     !
     ! -- Write record
     if (naux > 0) then
@@ -1068,17 +1087,16 @@ contains
         write(ibdchn) n,n2,q
     end if
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine ubdsvd
 
-  !> @brief Perform a case-insensitive comparison of two words
-  !<
-  logical function same_word(word1, word2) 
+  logical function same_word(word1, word2)
+    ! Perform a case-insensitive comparison of two words
     implicit none
-    ! -- dummy
+    ! -- dummy variables variables
     character(len=*), intent(in) :: word1, word2
-    ! -- local
+    ! -- local variables
     character(len=200) :: upword1, upword2
     !
     upword1 = word1
@@ -1086,8 +1104,6 @@ contains
     upword2 = word2
     call upcase(upword2)
     same_word = (upword1==upword2)
-    !
-    ! -- Return
     return
   end function same_word
 
@@ -1108,19 +1124,20 @@ contains
   end function
 
   subroutine unitinquire(iu)
-    ! -- dummy
+    ! -- dummy variables
     integer(I4B) :: iu
-    ! -- local
+    ! -- local variables
     character(len=LINELENGTH) :: line
     character(len=100) :: fname, ac, act, fm, frm, seq, unf
     ! -- format
-    character(len=*), parameter :: fmta = &
-       &"('unit:',i4,'  name:',a,'  access:',a,'  action:',a)"
-    character(len=*), parameter :: fmtb = &
-       &"('    formatted:',a,'  sequential:',a,'  unformatted:',a,'  form:',a)"
+    character(len=*), parameter :: fmta =                                        &
+       &"('unit:',i4,'  name:',a,'  access:',a,'  action:',a)"                                  
+    character(len=*), parameter :: fmtb =                                        &
+       &"('    formatted:',a,'  sequential:',a,'  unformatted:',a,'  form:',a)"                                  
+    ! -- code
     !
     ! -- set strings using inquire statement
-    inquire(unit=iu, name=fname, access=ac, action=act, formatted=fm, &
+    inquire(unit=iu, name=fname, access=ac, action=act, formatted=fm,            &
             sequential=seq, unformatted=unf, form=frm)
     !
     ! -- write the results of the inquire statement
@@ -1129,27 +1146,24 @@ contains
     write(line,fmtb) trim(fm), trim(seq), trim(unf), trim(frm)
     call write_message(line)
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine unitinquire
 
-  !> @brief Parse a line into words. 
-  !!
-  !! Blanks and commas are recognized as delimiters. Multiple blanks between 
-  !! words is OK, but multiple commas between words is treated as an error. 
-  !! Quotation marks are not recognized as delimiters.
-  !< 
   subroutine ParseLine(line, nwords, words, inunit, filename)
-    ! -- modules 
+    ! Parse a line into words. Blanks and commas are recognized as
+    ! delimiters. Multiple blanks between words is OK, but multiple
+    ! commas between words is treated as an error. Quotation marks
+    ! are not recognized as delimiters.
     use ConstantsModule, only: LINELENGTH
     implicit none
-    ! -- dummy
+    ! -- dummy variables
     character(len=*), intent(in) :: line
     integer(I4B), intent(inout) :: nwords
     character(len=*), allocatable, dimension(:), intent(inout) :: words
     integer(I4B), intent(in), optional :: inunit
     character(len=*), intent(in), optional :: filename
-    ! -- local
+    ! -- local variables
     integer(I4B) :: i, idum, istart, istop, linelen, lloc
     real(DP) :: rdum
     !
@@ -1170,29 +1184,34 @@ contains
       words(i) = line(istart:istop)
     end do
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine ParseLine
 
-  !> @brief Print 1 layer array with user formatting in wrap format
-  !<
   subroutine ulaprufw(ncol, nrow, kstp, kper, ilay, iout, buf, text, userfmt, &
                       nvalues, nwidth, editdesc)
+    ! **************************************************************************
+    ! Print 1 layer array with user formatting in wrap format
+    ! **************************************************************************
+    !
+    !    Specifications:
+    ! --------------------------------------------------------------------------
     implicit none
-    ! -- dummy
+    ! -- dummy variables
     integer(I4B), intent(in) :: ncol, nrow, kstp, kper, ilay, iout
     real(DP),dimension(ncol,nrow), intent(in) :: buf
     character(len=*), intent(in) :: text
     character(len=*), intent(in) :: userfmt
     integer(I4B), intent(in) :: nvalues, nwidth
     character(len=1), intent(in) :: editdesc
-    ! -- local
+    ! -- local variables
     integer(I4B) :: i, j, nspaces
-    ! -- formats
+    ! formats
     1 format('1',/2X,A,' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
           ' IN STRESS PERIOD ',I4/2X,75('-'))
     2 format('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
           ' IN STRESS PERIOD ',I4/1X,79('-'))
+    ! ------------------------------------------------------------------
     !
     if (iout<=0) return
     ! -- Print a header depending on ILAY
@@ -1215,35 +1234,33 @@ contains
     ! -- flush file
     flush(IOUT)
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine ulaprufw
 
-  !> @breif This function reads a line of arbitrary length and returns it.
-  !!
-  !! The returned string can be stored in a deferred-length character variable, 
-  !! for example:
-  !!
-  !!   integer(I4B) :: iu
-  !!   character(len=:), allocatable :: my_string
-  !!   logical :: eof
-  !!   iu = 8
-  !!   open(iu,file='my_file')
-  !!   my_string = read_line(iu, eof)
-  !<
   function read_line(iu, eof) result (astring)
+    ! This function reads a line of arbitrary length and returns
+    ! it.  The returned string can be stored in a deferred-length
+    ! character variable, for example:
+    !
+    !    integer(I4B) :: iu
+    !    character(len=:), allocatable :: my_string
+    !    logical :: eof
+    !    iu = 8
+    !    open(iu,file='my_file')
+    !    my_string = read_line(iu, eof)
     !
     implicit none
-    ! -- dummy
-    integer(I4B), intent(in) :: iu
-    logical, intent(out) :: eof
+    ! -- dummy variables
+    integer(I4B), intent(in)           :: iu
+    logical, intent(out)          :: eof
     character(len=:), allocatable :: astring
-    ! -- local
-    integer(I4B) :: isize, istat
-    character(len=256) :: buffer
+    ! -- local variables
+    integer(I4B)        :: isize, istat
+    character(len=256)  :: buffer
     character(len=1000) :: ermsg, fname
-    character(len=7) :: fmtd
-    logical :: lop
+    character(len=7)    :: fmtd
+    logical             :: lop
     ! -- format
 20  format('Error in read_line: File ',i0,' is not open.')
 30  format('Error in read_line: Attempting to read text ' // &
@@ -1274,7 +1291,7 @@ contains
         call store_error_unit(iu)
       endif
       astring = astring // buffer(:isize)
-      ! -- An end-of-record condition stops the loop.
+      ! An end-of-record condition stops the loop.
       if (istat < 0) then
         return
       endif
@@ -1282,20 +1299,18 @@ contains
     !
     return
 99  continue
-    !
     ! An end-of-file condition returns an empty string.
     eof = .true.
-    !
-    ! -- Return
     return
+    !
   end function read_line
 
   subroutine GetFileFromPath(pathname, filename)
     implicit none
-    ! -- dummy
+    ! -- dummy variables
     character(len=*), intent(in) :: pathname
     character(len=*), intent(out) :: filename
-    ! -- local
+    ! -- local variables
     integer(I4B) :: i, istart, istop, lenpath
     character(len=1) :: fs = '/'
     character(len=1) :: bs = '\'
@@ -1318,25 +1333,21 @@ contains
       filename = pathname(istart:istop)
     endif
     !
-    ! -- Return
     return
   end subroutine GetFileFromPath
 
-  !> @brief Starting at position icol, define string as line(istart:istop).
-  !!
-  !! If string can be interpreted as an integer(I4B), return integer in idnum 
-  !! argument. If token is not an integer(I4B), assume it is a boundary name, 
-  !! return NAMEDBOUNDFLAG in idnum, convert string to uppercase and return it
-  !! in bndname.
-  !<
   subroutine extract_idnum_or_bndname(line, icol, istart, istop, idnum, bndname)
+    ! Starting at position icol, define string as line(istart:istop).
+    ! If string can be interpreted as an integer(I4B), return integer in idnum argument.
+    ! If token is not an integer(I4B), assume it is a boundary name, return NAMEDBOUNDFLAG
+    ! in idnum, convert string to uppercase and return it in bndname.
     implicit none
-    ! -- dummy
-    character(len=*), intent(inout) :: line
-    integer(I4B), intent(inout) :: icol, istart, istop
-    integer(I4B), intent(out) :: idnum
-    character(len=LENBOUNDNAME), intent(out) :: bndname
-    ! -- local 
+    ! -- dummy variables
+    character(len=*),            intent(inout) :: line
+    integer(I4B),                     intent(inout) :: icol, istart, istop
+    integer(I4B),                     intent(out)   :: idnum
+    character(len=LENBOUNDNAME), intent(out)   :: bndname
+    ! -- local variables
     integer(I4B) :: istat, ndum, ncode=0
     real(DP) :: rdum
     !
@@ -1351,19 +1362,22 @@ contains
       call upcase(bndname)
     endif
     !
-    ! -- Return
     return
   end subroutine extract_idnum_or_bndname
 
-  !> @brief Read auxiliary variables from an input line
-  !<
   subroutine urdaux(naux, inunit, iout, lloc, istart, istop, auxname, line, text)
+! ******************************************************************************
+! Read auxiliary variables from an input line
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
     ! -- modules
     use ArrayHandlersModule, only: ExpandArray
     use ConstantsModule,     only: LENAUXNAME
     ! -- implicit
     implicit none
-    ! -- dummy
+    ! -- dummy variables
     integer(I4B), intent(inout) :: naux
     integer(I4B), intent(in) :: inunit
     integer(I4B), intent(in) :: iout
@@ -1373,11 +1387,11 @@ contains
     character(len=LENAUXNAME), allocatable, dimension(:), intent(inout) :: auxname
     character(len=*), intent(inout) :: line
     character(len=*), intent(in) :: text
-    ! -- local
+    ! -- local variables
     integer(I4B) :: n, linelen
     integer(I4B) :: iauxlen
     real(DP) :: rval
-    !
+! ------------------------------------------------------------------------------
     linelen = len(line)
     if(naux > 0) then
       write(errmsg,'(a)') 'Auxiliary variables already specified. Auxiliary ' // &
@@ -1407,43 +1421,47 @@ contains
       endif
     enddo auxloop
     !
-    ! -- Return
     return
   end subroutine urdaux
 
-  !> @brief Define the print or save format
-  !!
-  !! Define cdatafmp as a Fortran output format based on user input. Also define
-  !! nvalues, nwidth, and editdesc.
-  !!
-  !! Syntax for linein:
-  !!   COLUMNS nval WIDTH nwid [DIGITS ndig [options]]
-  !!
-  !! Where:
-  !!   nval = Number of values per line.
-  !!   nwid = Number of character places to be used for each value.
-  !!   ndig = Number of digits to the right of the decimal point (required
-  !!          for real array).
-  !!   options are:
-  !!          editoption: One of [EXPONENTIAL, FIXED, GENERAL, SCIENTIFIC]
-  !! A default value should be passed in for editdesc as G, I, E, F, or S.
-  !! If I is passed in, then the fortran format will be for an integer variable.
-  !<
   subroutine print_format(linein, cdatafmp, editdesc, nvaluesp, nwidthp, inunit)
-    ! -- dummy
+! ******************************************************************************
+! print_format -- define the print or save format
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+! Define cdatafmp as a Fortran output format based on user input.  Also define
+! nvalues, nwidth, and editdesc.
+!
+!   Syntax for linein:
+!     COLUMNS nval WIDTH nwid [DIGITS ndig [options]]
+!
+! Where:
+!     nval = Number of values per line.
+!     nwid = Number of character places to be used for each value.
+!     ndig = Number of digits to the right of the decimal point (required
+!            for real array).
+!     options are:
+!            editoption: One of [EXPONENTIAL, FIXED, GENERAL, SCIENTIFIC]
+! A default value should be passed in for editdesc as G, I, E, F, or S.
+! If I is passed in, then the fortran format will be for an integer variable.
+! ------------------------------------------------------------------------------
+    ! -- dummy variables
     character(len=*), intent(in) :: linein
     character(len=*), intent(inout) :: cdatafmp
     character(len=*), intent(inout) :: editdesc
     integer(I4B), intent(inout) :: nvaluesp
     integer(I4B), intent(inout) :: nwidthp
     integer(I4B), intent(in) :: inunit
-    ! -- local
+    ! -- local variables
     character(len=len(linein)) :: line
     character(len=20), dimension(:), allocatable :: words
     character(len=100) :: ermsg
     integer(I4B) :: ndigits=0, nwords=0
     integer(I4B) :: i, ierr
     logical :: isint
+! ------------------------------------------------------------------------------
     !
     ! -- Parse line and initialize values
     line(:) = linein(:)
@@ -1545,23 +1563,21 @@ contains
       call BuildFloatFormat(nvaluesp, nwidthp, ndigits, editdesc, cdatafmp)
     end select
     !
-    ! -- Return
     return
   end subroutine print_format
 
-  !> @brief Build a fixed format for printing or saving a real array
-  !<
   subroutine BuildFixedFormat(nvalsp, nwidp, ndig, outfmt, prowcolnum)
+    ! Build a fixed format for printing or saving a real array
     implicit none
-    ! -- dummy
+    ! -- dummy variables
     integer(I4B), intent(in) :: nvalsp, nwidp, ndig
     character(len=*), intent(inout) :: outfmt
     logical, intent(in), optional :: prowcolnum  ! default true
-    ! -- local
+    ! -- local variables
     character(len=8)   :: cvalues, cwidth, cdigits
     character(len=60)  :: ufmt
     logical :: prowcolnumlocal
-    ! -- formats
+    ! formats
     10 format(i8)
     !
     if (present(prowcolnum)) then
@@ -1584,7 +1600,6 @@ contains
     else
       ufmt = '(5x,'
     endif
-    !
     ufmt = trim(ufmt) // cvalues
     ufmt = trim(ufmt) // '(1x,f'
     ufmt = trim(ufmt) // cwidth
@@ -1599,24 +1614,22 @@ contains
     ufmt = trim(ufmt) // ')))'
     outfmt = ufmt
     !
-    ! -- Return
     return
   end subroutine BuildFixedFormat
 
-  !> @brief Build a floating-point format for printing or saving a real array
-  !<
   subroutine BuildFloatFormat(nvalsp, nwidp, ndig, editdesc, outfmt, prowcolnum)
+    ! Build a floating-point format for printing or saving a real array
     implicit none
-    ! -- dummy
+    ! -- dummy variables
     integer(I4B), intent(in) :: nvalsp, nwidp, ndig
     character(len=*), intent(in) :: editdesc
     character(len=*), intent(inout) :: outfmt
     logical, intent(in), optional :: prowcolnum  ! default true
-    ! -- local
+    ! -- local variables
     character(len=8)   :: cvalues,  cwidth, cdigits
     character(len=60)  :: ufmt
     logical :: prowcolnumlocal
-    ! -- formats
+    ! formats
     10 format(i8)
     !
     if (present(prowcolnum)) then
@@ -1652,7 +1665,6 @@ contains
       ufmt = trim(ufmt) // cdigits
       ufmt = trim(ufmt) // ')'
     endif
-    !
     ufmt = trim(ufmt) // ':/(5x,'
     write(cvalues, 10) nvalsp
     cvalues = adjustl(cvalues)
@@ -1665,23 +1677,21 @@ contains
     ufmt = trim(ufmt) // ')))'
     outfmt = ufmt
     !
-    ! -- Return
     return
   end subroutine BuildFloatFormat
 
-  !> @brief Build a format for printing or saving an integer array
-  !<
   subroutine BuildIntFormat(nvalsp, nwidp, outfmt, prowcolnum)
+    ! Build a format for printing or saving an integer array
     implicit none
-    ! -- dummy
+    ! -- dummy variables
     integer(I4B), intent(in) :: nvalsp, nwidp
     character(len=*), intent(inout) :: outfmt
     logical, intent(in), optional :: prowcolnum  ! default true
-    ! -- local
+    ! -- local variables
     character(len=8)   :: cvalues, cwidth
     character(len=60)  :: ufmt
     logical :: prowcolnumlocal
-    ! -- formats
+    ! formats
     10 format(i8)
     !
     if (present(prowcolnum)) then
@@ -1710,18 +1720,21 @@ contains
     ufmt = trim(ufmt) // ')))'
     outfmt = ufmt
     !
-    ! -- Return
     return
   end subroutine BuildIntFormat
 
+
   !> @brief Get the number of words in a string
+  !!
+  !! Function to get the number of words in a string
+  !!
   !<
   function get_nwords(line)
-    ! -- return
-    integer(I4B) :: get_nwords !< number of words in a string
-    ! -- dummy
+    ! -- return variable
+    integer(I4B) :: get_nwords            !< number of words in a string
+    ! -- dummy variables
     character(len=*), intent(in) :: line  !< line
-    ! -- local
+    ! -- local variables
     integer(I4B) :: linelen
     integer(I4B) :: lloc
     integer(I4B) :: istart
@@ -1741,27 +1754,28 @@ contains
       get_nwords = get_nwords + 1
     end do
     !
-    ! -- Return
+    ! -- return
     return
   end function get_nwords
 
-  !> @brief Move the file pointer.
-  !!
-  !! Patterned after fseek, which is not supported as part of the fortran 
-  !! standard.  For this subroutine to work the file must have been opened with
-  !! access='stream' and action='readwrite'.
-  !<
   subroutine fseek_stream(iu, offset, whence, status)
-    ! -- dummy
+! ******************************************************************************
+! Move the file pointer.  Patterned after fseek, which is not 
+! supported as part of the fortran standard.  For this subroutine to work
+! the file must have been opened with access='stream' and action='readwrite'.
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
     integer(I4B), intent(in) :: iu
     integer(I4B), intent(in) :: offset
     integer(I4B), intent(in) :: whence
     integer(I4B), intent(inout) :: status
-    ! -- local
     integer(I8B) :: ipos
+! ------------------------------------------------------------------------------
     !
     inquire(unit=iu, size=ipos)
-    !
+    
     select case(whence)
     case(0)
       !
@@ -1783,30 +1797,34 @@ contains
     write(iu, pos=ipos, iostat=status)
     inquire(unit=iu, pos=ipos)
     !
-    ! -- Return
+    ! -- return
     return
   end subroutine fseek_stream
-
-  !> @brief Read until non-comment line found and then return line. 
-  !!
-  !! Different from u8rdcom in that line is a deferred length character string,
-  !! which allows any length lines to be read using the get_line subroutine.
-  !<
+  
   subroutine u9rdcom(iin, iout, line, ierr)
-    ! -- module
+! ******************************************************************************
+! Read until non-comment line found and then return line.  Different from
+! u8rdcom in that line is a deferred length character string, which allows
+! any length lines to be read using the get_line subroutine.
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
     use, intrinsic :: iso_fortran_env, only: IOSTAT_END
     implicit none
-    ! -- dummy
+    ! -- dummy variables
     integer(I4B),         intent(in) :: iin
     integer(I4B),         intent(in) :: iout
     character (len=:), allocatable, intent(inout) :: line
     integer(I4B),        intent(out) :: ierr
-    ! -- local
+    ! -- local variables
     character (len=:), allocatable :: linetemp
     character (len=2), parameter :: comment = '//'
     character(len=1), parameter  :: tab = CHAR(9)
     logical :: iscomment
     integer(I4B) :: i, j, l, istart, lsize
+! ------------------------------------------------------------------------------
+    !code
     !
     !readerrmsg = ''
     line = comment
@@ -1823,12 +1841,12 @@ contains
         write(errmsg, *) 'u9rdcom: Could not read from unit: ',iin
         call store_error(errmsg, terminate=.TRUE.)
       endif
-      if (len_trim(line) < 1) then
+      if (len_trim(line).lt.1) then
         line = comment
         cycle
       end if
       !
-      ! -- Ensure that any initial tab characters are treated as spaces
+      ! Ensure that any initial tab characters are treated as spaces
       cleartabs: do
         !
         ! -- adjustl manually to avoid stack overflow
@@ -1859,7 +1877,7 @@ contains
             line(1:1) = ' '
             cycle cleartabs
           case default
-            if (line(1:2) == comment) iscomment = .true.
+            if (line(1:2).eq.comment) iscomment = .true.
             if (len_trim(line) < 1) iscomment = .true.
             exit cleartabs
         end select
@@ -1870,38 +1888,39 @@ contains
       else
         if (iout > 0) then
           !find the last non-blank character.
-          l = len(line)
+          l=len(line)
           do i = l, 1, -1
-            if(line(i:i) /= ' ') then
+            if(line(i:i).ne.' ') then
               exit
             end if
           end do
-          ! -- print the line up to the last non-blank character.
+          !print the line up to the last non-blank character.
           write(iout,'(1x,a)') line(1:i)
         end if
       end if
     end do pcomments
-    !
-    ! -- Return
     return
   end subroutine u9rdcom
 
-  !> @brief Read an unlimited length line from unit number lun into a deferred-
-  !! length character string (line).  
-  !!
-  !! Tack on a single space to the end so that routines like URWORD continue to 
-  !! function as before.
-  !<
   subroutine get_line(lun, line, iostat)
-    ! -- dummy
+! ******************************************************************************
+! Read an unlimited length line from unit number lun into a deferred-length
+! character string (line).  Tack on a single space to the end so that 
+! routines like URWORD continue to function as before.
+! ******************************************************************************
+!
+!    SPECIFICATIONS:
+! ------------------------------------------------------------------------------
+    ! -- dummy variables
     integer(I4B), intent(in) :: lun
     character(len=:), intent(out), allocatable :: line
     integer(I4B), intent(out) :: iostat
-    ! -- local
+    ! -- local variables
     integer(I4B), parameter :: buffer_len = MAXCHARLEN
     character(len=buffer_len) :: buffer
     character(len=:), allocatable :: linetemp
     integer(I4B) :: size_read, linesize
+! ------------------------------------------------------------------------------
     !
     ! -- initialize
     line = ''
@@ -1909,7 +1928,10 @@ contains
     !
     ! -- process
     do
-      read (lun, '(A)', iostat=iostat, advance='no', size=size_read) buffer
+      read ( lun, '(A)',  &
+          iostat = iostat,  &
+          advance = 'no',  &
+          size = size_read ) buffer
       if (is_iostat_eor(iostat)) then
         linesize = len(line)
         deallocate(linetemp)
@@ -1938,4 +1960,4 @@ contains
     end do
   end subroutine get_line  
 
-end module InputOutputModule
+END MODULE InputOutputModule

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -55,14 +55,14 @@ module InputOutputModule
                  1X,'ACTION:',A/)
 60  FORMAT(1X,/1X,'DID NOT OPEN ',A,/)
     !
-    ! -- process mode_opt
+    ! -- Process mode_opt
     if (present(mode_opt)) then
       imode = mode_opt
     else
       imode = isim_mode
     end if
     !
-    ! -- evaluate if the file should be opened
+    ! -- Evaluate if the file should be opened
     if (isim_mode < imode) then
       if(iout > 0) then
         write(iout, 60) trim(fname)
@@ -140,7 +140,7 @@ module InputOutputModule
       end if
     end if
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine openfile
 
@@ -164,7 +164,7 @@ module InputOutputModule
     iu = i
     iunext = iu + 1
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine freeunitnumber
 
@@ -226,11 +226,11 @@ module InputOutputModule
     ! -- local
     integer(I4B) :: idiff, k, l
     !
-    ! -- compute the difference between lowercase and uppercase.
+    ! -- Compute the difference between lowercase and uppercase.
     l = len(word)
     idiff = ichar('a') - ichar('A')
     !
-    ! -- loop through the string and convert any uppercase characters.
+    ! -- Loop through the string and convert any uppercase characters.
     do k = 1, l
       if(word(k:k) >= 'A' .and. word(k:k) <= 'Z') then
         word(k:k)=char(ichar(word(k:k))+idiff)
@@ -249,12 +249,12 @@ module InputOutputModule
   !<
   subroutine append_processor_id(name, proc_id)
     ! -- dummy
-    character(len=linelength), intent(inout) :: name  !< file name
+    character(len=LINELENGTH), intent(inout) :: name  !< file name
     integer(I4B), intent(in) :: proc_id  !< processor id
     ! -- local
-    character(len=linelength) :: name_local
-    character(len=linelength) :: name_processor
-    character(len=linelength) :: extension_local
+    character(len=LINELENGTH) :: name_local
+    character(len=LINELENGTH) :: name_processor
+    character(len=LINELENGTH) :: extension_local
     integer(I4B) :: ipos0
     integer(I4B) :: ipos1
     !
@@ -272,7 +272,7 @@ module InputOutputModule
       name(1:ipos0-1), '.p', proc_id, trim(adjustl(extension_local))
     name = name_processor
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine append_processor_id
 
@@ -311,8 +311,8 @@ module InputOutputModule
     ireal = 0
     !
     ! -- process dummy variables
-    if (present(FMT)) then
-      CFMT = FMT
+    if (present(fmt)) then
+      cfmt = fmt
     else
       select case(NCODE)
         case(TABSTRING, TABUCSTRING)
@@ -1003,8 +1003,8 @@ module InputOutputModule
       "' ON UNIT',I7,' AT TIME STEP',I7,', STRESS PERIOD',I7)"
     !
     ! -- Write unformatted records identifying data.
-    if (iout > 0) write(iout,fmt) text, modelnam1, paknam1, modelnam2, paknam2,&
-                                  modelnam2, paknam2, ibdchn, kstp, kper
+    if (iout > 0) write(iout,fmt) text, modelnam1, paknam1, modelnam2, &
+                                  paknam2, ibdchn, kstp, kper
     write(ibdchn) kstp, kper, text, ncol, nrow, -nlay
     write(ibdchn) 6, delt, pertim, totim
     write(ibdchn) modelnam1

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -19,7 +19,7 @@ module InputOutputModule
             BuildFloatFormat, BuildIntFormat, fseek_stream, get_nwords, &
             u9rdcom, append_processor_id
 
-  contains
+contains
 
   !> @brief Open a file
   !!
@@ -755,21 +755,66 @@ module InputOutputModule
 
   !> @brief Print 1 layer array
   !<
-  subroutine ULAPRW(buf,text,kstp,kper,ncol,nrow,ilay,iprn,iout)
+  subroutine ULAPRW(buf, text, kstp, kper, ncol, nrow, ilay, iprn, iout)
     ! -- dummy
     character(len=16) :: text
-    real(DP), dimension(ncol,nrow) :: buf
+    real(DP), dimension(ncol, nrow) :: buf
+    ! -- formats
+    character(len=*), parameter :: fmtmsgout1 = &
+      & "('1', /2x, a, ' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
+      & ' IN STRESS PERIOD ',I4/2x,75('-'))"
+    character(len=*), parameter :: fmtmsgout2 = &
+      & "('1',/1x,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
+      & ' IN STRESS PERIOD ',I4/1x,79('-'))"
+    character(len=*), parameter :: fmtg10 = &
+      & "(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))"
+    character(len=*), parameter :: fmtg13 = &
+      & "(1x,I3,2x,1PG13.6,8(1x,G13.6):/(5x,9(1x,G13.6)))"
+    character(len=*), parameter :: fmtf7pt1 = &
+      & "(1x,I3,1x,15(1x,F7.1):/(5x,15(1x,F7.1)))"
+    character(len=*), parameter :: fmtf7pt2 = &
+      & "(1x,I3,1x,15(1x,F7.2):/(5x,15(1x,F7.2)))"
+    character(len=*), parameter :: fmtf7pt3 = &
+      & "(1x,I3,1x,15(1x,F7.3):/(5x,15(1x,F7.3)))"
+    character(len=*), parameter :: fmtf7pt4 = &
+      & "(1x,I3,1x,15(1x,F7.4):/(5x,15(1x,F7.4)))"
+    character(len=*), parameter :: fmtf5pt0 = &
+      & "(1x,I3,1x,20(1x,F5.0):/(5x,20(1x,F5.0)))"
+    character(len=*), parameter :: fmtf5pt1 = &
+      & "(1x,I3,1x,20(1x,F5.1):/(5x,20(1x,F5.1)))"
+    character(len=*), parameter :: fmtf5pt2 = &
+      & "(1x,I3,1x,20(1x,F5.2):/(5x,20(1x,F5.2)))"
+    character(len=*), parameter :: fmtf5pt3 = &
+      & "(1x,I3,1x,20(1x,F5.3):/(5x,20(1x,F5.3)))"
+    character(len=*), parameter :: fmtf5pt4 = &
+      & "(1x,I3,1x,20(1x,F5.4):/(5x,20(1x,F5.4)))"
+    character(len=*), parameter :: fmtg11 = &
+      & "(1x,I3,2x,1PG11.4,9(1x,G11.4):/(5x,10(1x,G11.4)))"
+    character(len=*), parameter :: fmtf6pt0 = &
+      & "(1x,I3,1x,10(1x,F6.0):/(5X,10(1x,F6.0)))"
+    character(len=*), parameter :: fmtf6pt1 = &
+      & "(1x,I3,1x,10(1x,F6.1):/(5x,10(1x,F6.1)))"
+    character(len=*), parameter :: fmtf6pt2 = &
+      & "(1x,I3,1x,10(1x,F6.2):/(5x,10(1x,F6.2)))"
+    character(len=*), parameter :: fmtf6pt3 = &
+      & "(1x,I3,1x,10(1x,F6.3):/(5x,10(1x,F6.3)))"
+    character(len=*), parameter :: fmtf6pt4 = &
+      & "(1x,I3,1x,10(1x,F6.4):/(5x,10(1x,F6.4)))"
+    character(len=*), parameter :: fmtf6pt5 = &
+      & "(1x,I3,1x,10(1x,F6.5):/(5x,10(1x,F6.5)))"
+    character(len=*), parameter :: fmtg12 = &
+      & "(1x,I3,2x,1PG12.5,4(1x,G12.5):/(5x,5(1x,G12.5)))"
+    character(len=*), parameter :: fmtg11pt4 = &
+      & "(1x,I3,2x,1PG11.4,5(1x,G11.4):/(5x,6(1x,G11.4)))"
+    character(len=*), parameter :: fmtg9pt2 = &
+      & "(1x,I3,2x,1PG9.2,6(1x,G9.2):/(5x,7(1x,G9.2)))"
     !
     if (iout <= 0) return
     ! -- Print a header depending on ilay
     if (ilay > 0) then
-      write(iout, 1) text, ilay, kstp, kper
-    1 format('1', /2x, a, ' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
-            & ' IN STRESS PERIOD ',I4/2x,75('-'))
-      else if (ilay < 0) then
-        write(iout,2) text, kstp, kper
-    2    format('1',/1x,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
-            & ' IN STRESS PERIOD ',I4/1x,79('-'))
+      write (iout, fmtmsgout1) text, ilay, kstp, kper
+    else if (ilay < 0) then
+      write (iout, fmtmsgout2) text, kstp, kper
     end if
     !
     ! -- Make sure the format code (ip or iprn) is between 1 and 21
@@ -786,121 +831,100 @@ module InputOutputModule
     if (ip == 19) call ucolno(1, ncol, 0, 5, 13, iout)
     if (ip == 20) call ucolno(1, ncol, 0, 6, 12, iout)
     if (ip == 21) call ucolno(1, ncol, 0, 7, 10, iout)
-    ! 
+    !
     ! -- Loop through the rows printing each one in its entirety.
-    do i=1,nrow
-      select case(ip)
-      !
-      case(1)
-      ! -- format 11G10.3
-      write(iout, 11) i,(buf(j, i), j=1, ncol)
-11    format(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))
-      !
-      case(2)
-      ! -- format 9G13.6
-      write(iout, 21) i, (buf(j, i), j=1, ncol)
-21    format(1x,I3,2x,1PG13.6,8(1x,G13.6):/(5x,9(1x,G13.6)))
-      !
-      case(3)
-      ! -- format 15F7.1
-      write(iout, 31) i, (buf(j, i), j=1, ncol)
-31    format(1x,I3,1x,15(1x,F7.1):/(5x,15(1x,F7.1)))
-      !
-      case(4)
-      ! -- format 15F7.2
-      write(iout,41) i,(buf(j,i),j=1,ncol)
-41    format(1x,I3,1x,15(1x,F7.2):/(5x,15(1x,F7.2)))
-      !
-      case(5)
-      ! -- format 15F7.3
-      write(iout, 51) i, (buf(j, i), j=1, ncol)
-51    format(1x,I3,1x,15(1x,F7.3):/(5x,15(1x,F7.3)))
-      !
-      case(6)
-      ! -- format 15F7.4
-      write(iout, 61) i, (buf(j, i), j=1, ncol)
-61    format(1x,I3,1x,15(1x,F7.4):/(5x,15(1x,F7.4)))
-      !
-      case(7)
-      ! -- format 20F5.0
-      write(iout, 71) i, (buf(j, i), j=1, ncol)
-71    format(1x,I3,1x,20(1x,F5.0):/(5x,20(1x,F5.0)))
-      !
-      case(8)
-      ! -- format 20F5.1
-      write(iout, 81) i, (buf(j, i), j=1, ncol)
-81    format(1x,I3,1x,20(1x,F5.1):/(5x,20(1x,F5.1)))
-      !
-      case(9)
-      ! -- format 20F5.2
-      write(iout, 91) i, (buf(j, i), j=1, ncol)
-91    format(1x,I3,1x,20(1x,F5.2):/(5x,20(1x,F5.2)))
-      !
-      case(10)
-      ! -- format 20F5.3
-      write(iout, 101) i, (buf(j, i), j=1, ncol)
-101   format(1x,I3,1x,20(1x,F5.3):/(5x,20(1x,F5.3)))
-      !
-      case(11)
-      ! -- format 20F5.4
-      write(iout, 111) i, (buf(j, i), j=1, ncol)
-111   format(1x,I3,1x,20(1x,F5.4):/(5x,20(1x,F5.4)))
-      !
-      case(12)
-      ! -- format 10G11.4
-      write(iout,121) i, (buf(j, i), j=1, ncol)
-121   format(1x,I3,2x,1PG11.4,9(1x,G11.4):/(5x,10(1x,G11.4)))
-      !
-      case(13)
-      ! -- format 10F6.0
-      write(iout, 131) i, (buf(j, i), j=1, ncol)
-131   format(1x,I3,1x,10(1x,F6.0):/(5X,10(1x,F6.0)))
-      !
-      case(14)
-      ! -- format 10F6.1
-      write(iout, 141) i, (buf(j, i), j=1, ncol)
-141   format(1x,I3,1x,10(1x,F6.1):/(5x,10(1x,F6.1)))
-      !
-      case(15)
-      ! -- format 10F6.2
-      write(iout, 151) i, (buf(j, i), j=1, ncol)
-151   format(1x,I3,1x,10(1x,F6.2):/(5x,10(1x,F6.2)))
-      !
-      case(16)
-      ! -- format 10F6.3
-      write(iout, 161) i, (buf(j, i), j=1, ncol)
-161   format(1x,I3,1x,10(1x,F6.3):/(5x,10(1x,F6.3)))
-      !
-      case(17)
-      ! -- format 10F6.4
-      write(iout, 171) i, (buf(j, i), j=1, ncol)
-171   format(1x,I3,1x,10(1x,F6.4):/(5x,10(1x,F6.4)))
-      !
-      case(18)
-      ! -- format 10F6.5
-      write(iout, 181) i, (buf(j, i), j=1, ncol)
-181   format(1x,I3,1x,10(1x,F6.5):/(5x,10(1x,F6.5)))
-      !
-      case(19)
-      ! -- format 5G12.5
-      write(iout, 191) i, (buf(j, i), j=1, ncol)
-191   format(1x,I3,2x,1PG12.5,4(1x,G12.5):/(5x,5(1x,G12.5)))
-      !
-      case(20)
-      ! -- format 6G11.4
-      write(iout, 201) i, (buf(j, i), j=1, ncol)
-201   format(1x,I3,2x,1PG11.4,5(1x,G11.4):/(5x,6(1x,G11.4)))
-      !
-      case(21)
-      ! -- format 7G9.2
-      write(iout, 211) i, (buf(j, i), j=1, ncol)
-211   format(1x,I3,2x,1PG9.2,6(1x,G9.2):/(5x,7(1x,G9.2)))
-      !
+    do i = 1, nrow
+      select case (ip)
+        !
+      case (1)
+        ! -- format 11G10.3
+        write (iout, fmtg10) i, (buf(j, i), j=1, ncol)
+        !
+      case (2)
+        ! -- format 9G13.6
+        write (iout, fmtg13) i, (buf(j, i), j=1, ncol)
+        !
+      case (3)
+        ! -- format 15F7.1
+        write (iout, fmtf7pt1) i, (buf(j, i), j=1, ncol)
+        !
+      case (4)
+        ! -- format 15F7.2
+        write (iout, fmtf7pt2) i, (buf(j, i), j=1, ncol)
+        !
+      case (5)
+        ! -- format 15F7.3
+        write (iout, fmtf7pt3) i, (buf(j, i), j=1, ncol)
+        !
+      case (6)
+        ! -- format 15F7.4
+        write (iout, fmtf7pt4) i, (buf(j, i), j=1, ncol)
+        !
+      case (7)
+        ! -- format 20F5.0
+        write (iout, fmtf5pt0) i, (buf(j, i), j=1, ncol)
+        !
+      case (8)
+        ! -- format 20F5.1
+        write (iout, fmtf5pt1) i, (buf(j, i), j=1, ncol)
+        !
+      case (9)
+        ! -- format 20F5.2
+        write (iout, fmtf5pt2) i, (buf(j, i), j=1, ncol)
+        !
+      case (10)
+        ! -- format 20F5.3
+        write (iout, fmtf5pt3) i, (buf(j, i), j=1, ncol)
+        !
+      case (11)
+        ! -- format 20F5.4
+        write (iout, fmtf5pt4) i, (buf(j, i), j=1, ncol)
+        !
+      case (12)
+        ! -- format 10G11.4
+        write (iout, fmtg11) i, (buf(j, i), j=1, ncol)
+        !
+      case (13)
+        ! -- format 10F6.0
+        write (iout, fmtf6pt0) i, (buf(j, i), j=1, ncol)
+        !
+      case (14)
+        ! -- format 10F6.1
+        write (iout, fmtf6pt1) i, (buf(j, i), j=1, ncol)
+        !
+      case (15)
+        ! -- format 10F6.2
+        write (iout, fmtf6pt2) i, (buf(j, i), j=1, ncol)
+        !
+      case (16)
+        ! -- format 10F6.3
+        write (iout, fmtf6pt3) i, (buf(j, i), j=1, ncol)
+        !
+      case (17)
+        ! -- format 10F6.4
+        write (iout, fmtf6pt4) i, (buf(j, i), j=1, ncol)
+        !
+      case (18)
+        ! -- format 10F6.5
+        write (iout, fmtf6pt5) i, (buf(j, i), j=1, ncol)
+        !
+      case (19)
+        ! -- format 5G12.5
+        write (iout, fmtg12) i, (buf(j, i), j=1, ncol)
+        !
+      case (20)
+        ! -- format 6G11.4
+        write (iout, fmtg11pt4) i, (buf(j, i), j=1, ncol)
+        !
+      case (21)
+        ! -- format 7G9.2
+        write (iout, fmtg9pt2) i, (buf(j, i), j=1, ncol)
+        !
       end select
     end do
     !
     ! -- Flush file
-    flush(iout)
+    flush (iout)
     !
     ! -- Return
     return

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -792,158 +792,150 @@ module InputOutputModule
       SELECT CASE(IP)
       !
       CASE(1)
-!C------------ FORMAT 11G10.3
-      WRITE(IOUT,11) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 11G10.3
+      write(iout, 11) i,(buf(j, i), j=1, ncol)
 11    FORMAT(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))
-
+      !
       CASE(2)
-!C------------ FORMAT 9G13.6
-      WRITE(IOUT,21) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 9G13.6
+      write(iout, 21) i, (buf(j, i), j=1, ncol)
 21    FORMAT(1X,I3,2X,1PG13.6,8(1X,G13.6):/(5X,9(1X,G13.6)))
-
+      !
       CASE(3)
-!C------------ FORMAT 15F7.1
-      WRITE(IOUT,31) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 15F7.1
+      write(iout, 31) i, (buf(j, i), j=1, ncol)
 31    FORMAT(1X,I3,1X,15(1X,F7.1):/(5X,15(1X,F7.1)))
-
+      !
       CASE(4)
-!C------------ FORMAT 15F7.2
+      ! -- format 15F7.2
       WRITE(IOUT,41) I,(BUF(J,I),J=1,NCOL)
 41    FORMAT(1X,I3,1X,15(1X,F7.2):/(5X,15(1X,F7.2)))
-
+      !
       CASE(5)
-!C------------ FORMAT 15F7.3
-      WRITE(IOUT,51) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 15F7.3
+      write(iout, 51) i, (buf(j, i), j=1, ncol)
 51    FORMAT(1X,I3,1X,15(1X,F7.3):/(5X,15(1X,F7.3)))
-
+      !
       CASE(6)
-!C------------ FORMAT 15F7.4
-      WRITE(IOUT,61) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 15F7.4
+      write(iout, 61) i, (buf(j, i), j=1, ncol)
 61    FORMAT(1X,I3,1X,15(1X,F7.4):/(5X,15(1X,F7.4)))
-
+      !
       CASE(7)
-!C------------ FORMAT 20F5.0
-      WRITE(IOUT,71) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 20F5.0
+      write(iout, 71) i, (buf(j, i), j=1, ncol)
 71    FORMAT(1X,I3,1X,20(1X,F5.0):/(5X,20(1X,F5.0)))
-
+      !
       CASE(8)
-!C------------ FORMAT 20F5.1
-      WRITE(IOUT,81) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 20F5.1
+      write(iout, 81) i, (buf(j, i), j=1, ncol)
 81    FORMAT(1X,I3,1X,20(1X,F5.1):/(5X,20(1X,F5.1)))
-
+      !
       CASE(9)
-!C------------ FORMAT 20F5.2
-      WRITE(IOUT,91) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 20F5.2
+      write(iout, 91) i, (buf(j, i), j=1, ncol)
 91    FORMAT(1X,I3,1X,20(1X,F5.2):/(5X,20(1X,F5.2)))
-
+      !
       CASE(10)
-!C------------ FORMAT 20F5.3
-      WRITE(IOUT,101) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 20F5.3
+      write(iout, 101) i, (buf(j, i), j=1, ncol)
 101   FORMAT(1X,I3,1X,20(1X,F5.3):/(5X,20(1X,F5.3)))
-
+      !
       CASE(11)
-!C------------ FORMAT 20F5.4
-      WRITE(IOUT,111) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 20F5.4
+      write(iout, 111) i, (buf(j, i), j=1, ncol)
 111   FORMAT(1X,I3,1X,20(1X,F5.4):/(5X,20(1X,F5.4)))
-
+      !
       CASE(12)
-!C------------ FORMAT 10G11.4
-      WRITE(IOUT,121) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 10G11.4
+      write(iout,121) i, (buf(j, i), j=1, ncol)
 121   FORMAT(1X,I3,2X,1PG11.4,9(1X,G11.4):/(5X,10(1X,G11.4)))
-
+      !
       CASE(13)
-!C------------ FORMAT 10F6.0
-      WRITE(IOUT,131) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 10F6.0
+      write(iout, 131) i, (buf(j, i), j=1, ncol)
 131   FORMAT(1X,I3,1X,10(1X,F6.0):/(5X,10(1X,F6.0)))
-
+      !
       CASE(14)
-!C------------ FORMAT 10F6.1
-      WRITE(IOUT,141) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 10F6.1
+      write(iout, 141) i, (buf(j, i), j=1, ncol)
 141   FORMAT(1X,I3,1X,10(1X,F6.1):/(5X,10(1X,F6.1)))
-
+      !
       CASE(15)
-!C------------ FORMAT 10F6.2
-      WRITE(IOUT,151) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 10F6.2
+      write(iout, 151) i, (buf(j, i), j=1, ncol)
 151   FORMAT(1X,I3,1X,10(1X,F6.2):/(5X,10(1X,F6.2)))
-
+      !
       CASE(16)
-!C------------ FORMAT 10F6.3
-      WRITE(IOUT,161) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 10F6.3
+      write(iout, 161) i, (buf(j, i), j=1, ncol)
 161   FORMAT(1X,I3,1X,10(1X,F6.3):/(5X,10(1X,F6.3)))
-
+      !
       CASE(17)
-!C------------ FORMAT 10F6.4
-      WRITE(IOUT,171) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 10F6.4
+      write(iout, 171) i, (buf(j, i), j=1, ncol)
 171   FORMAT(1X,I3,1X,10(1X,F6.4):/(5X,10(1X,F6.4)))
-
+      !
       CASE(18)
-!C------------ FORMAT 10F6.5
-      WRITE(IOUT,181) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 10F6.5
+      write(iout, 181) i, (buf(j, i), j=1, ncol)
 181   FORMAT(1X,I3,1X,10(1X,F6.5):/(5X,10(1X,F6.5)))
-
+      !
       CASE(19)
-!C------------FORMAT 5G12.5
-      WRITE(IOUT,191) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 5G12.5
+      write(iout, 191) i, (buf(j, i), j=1, ncol)
 191   FORMAT(1X,I3,2X,1PG12.5,4(1X,G12.5):/(5X,5(1X,G12.5)))
-
+      !
       CASE(20)
-!C------------FORMAT 6G11.4
-      WRITE(IOUT,201) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 6G11.4
+      write(iout, 201) i, (buf(j, i), j=1, ncol)
 201   FORMAT(1X,I3,2X,1PG11.4,5(1X,G11.4):/(5X,6(1X,G11.4)))
-
+      !
       CASE(21)
-!C------------FORMAT 7G9.2
-      WRITE(IOUT,211) I,(BUF(J,I),J=1,NCOL)
+      ! -- format 7G9.2
+      write(iout, 211) i, (buf(j, i), j=1, ncol)
 211   FORMAT(1X,I3,2X,1PG9.2,6(1X,G9.2):/(5X,7(1X,G9.2)))
-
-      END SELECT
-      END DO
       !
-      ! -- flush file
-      flush(IOUT)
-      !
-      ! -- return
-      RETURN
-      END SUBROUTINE ULAPRW
+      end select
+    end do
+    !
+    ! -- Flush file
+    flush(iout)
+    !
+    ! -- Return
+    return
+  end subroutine ULAPRW
 
-     SUBROUTINE ULASAV(BUF,TEXT,KSTP,KPER,PERTIM,TOTIM,NCOL, &
-     &                   NROW,ILAY,ICHN)
-!C     ******************************************************************
-!C     SAVE 1 LAYER ARRAY ON DISK
-!C     ******************************************************************
-!C
-!C        SPECIFICATIONS:
-!C     ------------------------------------------------------------------
-      CHARACTER(len=16) TEXT
-      real(DP),dimension(ncol,nrow) :: buf
-      real(DP) :: pertim,totim
-!C     ------------------------------------------------------------------
-!C
-!C1------WRITE AN UNFORMATTED RECORD CONTAINING IDENTIFYING
-!C1------INFORMATION.
-      WRITE(ICHN) KSTP,KPER,PERTIM,TOTIM,TEXT,NCOL,NROW,ILAY
-!C
-!C2------WRITE AN UNFORMATTED RECORD CONTAINING ARRAY VALUES
-!C2------THE ARRAY IS DIMENSIONED (NCOL,NROW)
-      WRITE(ICHN) ((BUF(IC,IR),IC=1,NCOL),IR=1,NROW)
-      !
-      ! -- flush file
-      flush(ICHN)
-!C
-!C3------RETURN
-      RETURN
-     END SUBROUTINE ULASAV
+  !> @brief Save 1 layer array on disk
+  !<
+  subroutine ulasav(buf, text, kstp, kper, pertim, totim, ncol, nrow, &
+                     ilay, ichn)
+    ! -- dummy
+    character(len=16) :: text
+    real(DP), dimension(ncol, nrow) :: buf
+    real(DP) :: pertim, totim
+    !
+    ! -- Write an unformatted record containing identifying information
+    write(ichn) kstp, kper, pertim, totim, text, ncol, nrow, ilay
+    !
+    ! -- Write an unformatted record containing array values. The array is
+    !    dimensioned (ncol,nrow)
+    write(ichn) ((buf(ic, ir), ic=1, ncol), ir=1, nrow)
+    !
+    ! -- flush file
+    flush(ICHN)
+    !
+    ! -- Return
+    return
+  end subroutine ulasav
 
+  !> @brief Record cell-by-cell flow terms for one component of flow as a 3-D 
+  !! array with extra record to indicate delt, pertim, and totim
+  !<
   subroutine ubdsv1(kstp, kper, text, ibdchn, buff, ncol, nrow, nlay, iout, &
                     delt, pertim, totim)
-! ******************************************************************************
-! Record cell-by-cell flow terms for one component of flow as a 3-D array with
-!   extra record to indicate delt, pertim, and totim
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
+    ! -- dummy
     integer(I4B), intent(in) :: kstp
     integer(I4B), intent(in) :: kper
     character(len=*), intent(in) :: text
@@ -960,7 +952,6 @@ module InputOutputModule
     character(len=*), parameter :: fmt = &
       "(1X,'UBDSV1 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
       "', STRESS PERIOD',I7)"
-! ------------------------------------------------------------------------------
     !
     ! -- Write records
     if(iout > 0) write(iout, fmt) text, ibdchn, kstp, kper
@@ -975,18 +966,16 @@ module InputOutputModule
     return
   end subroutine ubdsv1
 
-  subroutine ubdsv06(kstp,kper,text,                                 &
-                     modelnam1,paknam1,modelnam2,paknam2,            &
-                     ibdchn,naux,auxtxt,                             &
-                     ncol,nrow,nlay,nlist,iout,delt,pertim,totim)
-! ******************************************************************
-! write header records for cell-by-cell flow terms for one component
-! of flow.  each item in the list is written by module ubdsvc
-! ******************************************************************
-!
-!     specifications:
-! ------------------------------------------------------------------
+  !> @brief Write header records for cell-by-cell flow terms for one component
+  !! of flow.  
+  !!
+  !! Each item in the list is written by module ubdsvc
+  !<
+  subroutine ubdsv06(kstp, kper, text, modelnam1, paknam1, modelnam2, paknam2, &
+                     ibdchn, naux, auxtxt, ncol, nrow, nlay, nlist, iout, &
+                     delt, pertim, totim)
     implicit none
+    ! -- dummy
     integer(I4B), intent(in) :: kstp
     integer(I4B), intent(in) :: kper
     character(len=*), intent(in) :: text
@@ -1005,21 +994,19 @@ module InputOutputModule
     real(DP), intent(in) :: delt
     real(DP), intent(in) :: pertim
     real(DP), intent(in) :: totim
-    ! -- local variables
+    ! -- local
     integer(I4B) :: n
     ! -- format
     character(len=*), parameter :: fmt = &
       "(1X,'UBDSV06 SAVING ',A16,' IN MODEL ',A16,' PACKAGE ',A16,"//&
-      "'CONNECTED TO MODEL ',A16,' PACKAGE ',A16,"//                 &
+      "'CONNECTED TO MODEL ',A16,' PACKAGE ',A16,"//&
       "' ON UNIT',I7,' AT TIME STEP',I7,', STRESS PERIOD',I7)"
-! ------------------------------------------------------------------
-!
-! write unformatted records identifying data.
-    if (iout > 0) write(iout,fmt) text, modelnam1, paknam1,          &
-                                  modelnam2, paknam2,                &
-                                  ibdchn, kstp, kper
-    write(ibdchn) kstp,kper,text,ncol,nrow,-nlay
-    write(ibdchn) 6,delt,pertim,totim
+    !
+    ! -- Write unformatted records identifying data.
+    if (iout > 0) write(iout,fmt) text, modelnam1, paknam1, modelnam2, paknam2,&
+                                  modelnam2, paknam2, ibdchn, kstp, kper
+    write(ibdchn) kstp, kper, text, ncol, nrow, -nlay
+    write(ibdchn) 6, delt, pertim, totim
     write(ibdchn) modelnam1
     write(ibdchn) paknam1
     write(ibdchn) modelnam2
@@ -1032,23 +1019,20 @@ module InputOutputModule
     return
   end subroutine ubdsv06
 
+  !> @brief Write one value of cell-by-cell flow using a list structure.
+  !!
+  !! From node (n) and to node (n2) are written to the file
+  !<
   subroutine ubdsvc(ibdchn, n, q, naux, aux)
-! ******************************************************************************
-! Write one value of cell-by-cell flow using a list structure. From node (n)
-! and to node (n2) are written to the file
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
+    ! -- dummy
     integer(I4B), intent(in) :: ibdchn
     integer(I4B), intent(in) :: n
     real(DP), intent(in) :: q
     integer(I4B), intent(in) :: naux
     real(DP), dimension(naux), intent(in) :: aux
-    ! -- local variables
+    ! -- local
     integer(I4B) :: nn
-! ------------------------------------------------------------------------------
     !
     ! -- Write record
     if (naux > 0) then
@@ -1061,24 +1045,21 @@ module InputOutputModule
     return
   end subroutine ubdsvc
 
+  !> @brief Write one value of cell-by-cell flow using a list structure.
+  !!
+  !! From node (n) and to node (n2) are written to the file
+  !<
   subroutine ubdsvd(ibdchn, n, n2, q, naux, aux)
-! ******************************************************************************
-! Write one value of cell-by-cell flow using a list structure. From node (n)
-! and to node (n2) are written to the file
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
+    ! -- dummy
     integer(I4B), intent(in) :: ibdchn
     integer(I4B), intent(in) :: n
     integer(I4B), intent(in) :: n2
     real(DP), intent(in) :: q
     integer(I4B), intent(in) :: naux
     real(DP), dimension(naux), intent(in) :: aux
-    ! -- local variables
+    ! -- local
     integer(I4B) :: nn
-! ------------------------------------------------------------------------------
     !
     ! -- Write record
     if (naux > 0) then
@@ -1091,12 +1072,13 @@ module InputOutputModule
     return
   end subroutine ubdsvd
 
-  logical function same_word(word1, word2)
-    ! Perform a case-insensitive comparison of two words
+  !> @brief Perform a case-insensitive comparison of two words
+  !<
+  logical function same_word(word1, word2) 
     implicit none
-    ! -- dummy variables variables
+    ! -- dummy
     character(len=*), intent(in) :: word1, word2
-    ! -- local variables
+    ! -- local
     character(len=200) :: upword1, upword2
     !
     upword1 = word1
@@ -1104,6 +1086,8 @@ module InputOutputModule
     upword2 = word2
     call upcase(upword2)
     same_word = (upword1==upword2)
+    !
+    ! -- Return
     return
   end function same_word
 
@@ -1124,20 +1108,19 @@ module InputOutputModule
   end function
 
   subroutine unitinquire(iu)
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B) :: iu
-    ! -- local variables
+    ! -- local
     character(len=LINELENGTH) :: line
     character(len=100) :: fname, ac, act, fm, frm, seq, unf
     ! -- format
-    character(len=*), parameter :: fmta =                                        &
-       &"('unit:',i4,'  name:',a,'  access:',a,'  action:',a)"                                  
-    character(len=*), parameter :: fmtb =                                        &
-       &"('    formatted:',a,'  sequential:',a,'  unformatted:',a,'  form:',a)"                                  
-    ! -- code
+    character(len=*), parameter :: fmta = &
+       &"('unit:',i4,'  name:',a,'  access:',a,'  action:',a)"
+    character(len=*), parameter :: fmtb = &
+       &"('    formatted:',a,'  sequential:',a,'  unformatted:',a,'  form:',a)"
     !
     ! -- set strings using inquire statement
-    inquire(unit=iu, name=fname, access=ac, action=act, formatted=fm,            &
+    inquire(unit=iu, name=fname, access=ac, action=act, formatted=fm, &
             sequential=seq, unformatted=unf, form=frm)
     !
     ! -- write the results of the inquire statement
@@ -1150,20 +1133,23 @@ module InputOutputModule
     return
   end subroutine unitinquire
 
+  !> @brief Parse a line into words. 
+  !!
+  !! Blanks and commas are recognized as delimiters. Multiple blanks between 
+  !! words is OK, but multiple commas between words is treated as an error. 
+  !! Quotation marks are not recognized as delimiters.
+  !< 
   subroutine ParseLine(line, nwords, words, inunit, filename)
-    ! Parse a line into words. Blanks and commas are recognized as
-    ! delimiters. Multiple blanks between words is OK, but multiple
-    ! commas between words is treated as an error. Quotation marks
-    ! are not recognized as delimiters.
+    ! -- modules 
     use ConstantsModule, only: LINELENGTH
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     character(len=*), intent(in) :: line
     integer(I4B), intent(inout) :: nwords
     character(len=*), allocatable, dimension(:), intent(inout) :: words
     integer(I4B), intent(in), optional :: inunit
     character(len=*), intent(in), optional :: filename
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i, idum, istart, istop, linelen, lloc
     real(DP) :: rdum
     !
@@ -1188,30 +1174,25 @@ module InputOutputModule
     return
   end subroutine ParseLine
 
+  !> @brief Print 1 layer array with user formatting in wrap format
+  !<
   subroutine ulaprufw(ncol, nrow, kstp, kper, ilay, iout, buf, text, userfmt, &
                       nvalues, nwidth, editdesc)
-    ! **************************************************************************
-    ! Print 1 layer array with user formatting in wrap format
-    ! **************************************************************************
-    !
-    !    Specifications:
-    ! --------------------------------------------------------------------------
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(in) :: ncol, nrow, kstp, kper, ilay, iout
     real(DP),dimension(ncol,nrow), intent(in) :: buf
     character(len=*), intent(in) :: text
     character(len=*), intent(in) :: userfmt
     integer(I4B), intent(in) :: nvalues, nwidth
     character(len=1), intent(in) :: editdesc
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i, j, nspaces
-    ! formats
+    ! -- formats
     1 format('1',/2X,A,' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
           ' IN STRESS PERIOD ',I4/2X,75('-'))
     2 format('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
           ' IN STRESS PERIOD ',I4/1X,79('-'))
-    ! ------------------------------------------------------------------
     !
     if (iout<=0) return
     ! -- Print a header depending on ILAY
@@ -1238,29 +1219,31 @@ module InputOutputModule
     return
   end subroutine ulaprufw
 
+  !> @breif This function reads a line of arbitrary length and returns it.
+  !!
+  !! The returned string can be stored in a deferred-length character variable, 
+  !! for example:
+  !!
+  !!   integer(I4B) :: iu
+  !!   character(len=:), allocatable :: my_string
+  !!   logical :: eof
+  !!   iu = 8
+  !!   open(iu,file='my_file')
+  !!   my_string = read_line(iu, eof)
+  !<
   function read_line(iu, eof) result (astring)
-    ! This function reads a line of arbitrary length and returns
-    ! it.  The returned string can be stored in a deferred-length
-    ! character variable, for example:
-    !
-    !    integer(I4B) :: iu
-    !    character(len=:), allocatable :: my_string
-    !    logical :: eof
-    !    iu = 8
-    !    open(iu,file='my_file')
-    !    my_string = read_line(iu, eof)
     !
     implicit none
-    ! -- dummy variables
-    integer(I4B), intent(in)           :: iu
-    logical, intent(out)          :: eof
+    ! -- dummy
+    integer(I4B), intent(in) :: iu
+    logical, intent(out) :: eof
     character(len=:), allocatable :: astring
-    ! -- local variables
-    integer(I4B)        :: isize, istat
-    character(len=256)  :: buffer
+    ! -- local
+    integer(I4B) :: isize, istat
+    character(len=256) :: buffer
     character(len=1000) :: ermsg, fname
-    character(len=7)    :: fmtd
-    logical             :: lop
+    character(len=7) :: fmtd
+    logical :: lop
     ! -- format
 20  format('Error in read_line: File ',i0,' is not open.')
 30  format('Error in read_line: Attempting to read text ' // &
@@ -1291,7 +1274,7 @@ module InputOutputModule
         call store_error_unit(iu)
       endif
       astring = astring // buffer(:isize)
-      ! An end-of-record condition stops the loop.
+      ! -- An end-of-record condition stops the loop.
       if (istat < 0) then
         return
       endif
@@ -1299,18 +1282,20 @@ module InputOutputModule
     !
     return
 99  continue
+    !
     ! An end-of-file condition returns an empty string.
     eof = .true.
-    return
     !
+    ! -- Return
+    return
   end function read_line
 
   subroutine GetFileFromPath(pathname, filename)
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     character(len=*), intent(in) :: pathname
     character(len=*), intent(out) :: filename
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i, istart, istop, lenpath
     character(len=1) :: fs = '/'
     character(len=1) :: bs = '\'
@@ -1333,21 +1318,25 @@ module InputOutputModule
       filename = pathname(istart:istop)
     endif
     !
+    ! -- Return
     return
   end subroutine GetFileFromPath
 
+  !> @brief Starting at position icol, define string as line(istart:istop).
+  !!
+  !! If string can be interpreted as an integer(I4B), return integer in idnum 
+  !! argument. If token is not an integer(I4B), assume it is a boundary name, 
+  !! return NAMEDBOUNDFLAG in idnum, convert string to uppercase and return it
+  !! in bndname.
+  !<
   subroutine extract_idnum_or_bndname(line, icol, istart, istop, idnum, bndname)
-    ! Starting at position icol, define string as line(istart:istop).
-    ! If string can be interpreted as an integer(I4B), return integer in idnum argument.
-    ! If token is not an integer(I4B), assume it is a boundary name, return NAMEDBOUNDFLAG
-    ! in idnum, convert string to uppercase and return it in bndname.
     implicit none
-    ! -- dummy variables
-    character(len=*),            intent(inout) :: line
-    integer(I4B),                     intent(inout) :: icol, istart, istop
-    integer(I4B),                     intent(out)   :: idnum
-    character(len=LENBOUNDNAME), intent(out)   :: bndname
-    ! -- local variables
+    ! -- dummy
+    character(len=*), intent(inout) :: line
+    integer(I4B), intent(inout) :: icol, istart, istop
+    integer(I4B), intent(out) :: idnum
+    character(len=LENBOUNDNAME), intent(out) :: bndname
+    ! -- local 
     integer(I4B) :: istat, ndum, ncode=0
     real(DP) :: rdum
     !
@@ -1362,22 +1351,19 @@ module InputOutputModule
       call upcase(bndname)
     endif
     !
+    ! -- Return
     return
   end subroutine extract_idnum_or_bndname
 
+  !> @brief Read auxiliary variables from an input line
+  !<
   subroutine urdaux(naux, inunit, iout, lloc, istart, istop, auxname, line, text)
-! ******************************************************************************
-! Read auxiliary variables from an input line
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use ArrayHandlersModule, only: ExpandArray
     use ConstantsModule,     only: LENAUXNAME
     ! -- implicit
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(inout) :: naux
     integer(I4B), intent(in) :: inunit
     integer(I4B), intent(in) :: iout
@@ -1387,11 +1373,11 @@ module InputOutputModule
     character(len=LENAUXNAME), allocatable, dimension(:), intent(inout) :: auxname
     character(len=*), intent(inout) :: line
     character(len=*), intent(in) :: text
-    ! -- local variables
+    ! -- local
     integer(I4B) :: n, linelen
     integer(I4B) :: iauxlen
     real(DP) :: rval
-! ------------------------------------------------------------------------------
+    !
     linelen = len(line)
     if(naux > 0) then
       write(errmsg,'(a)') 'Auxiliary variables already specified. Auxiliary ' // &
@@ -1421,47 +1407,43 @@ module InputOutputModule
       endif
     enddo auxloop
     !
+    ! -- Return
     return
   end subroutine urdaux
 
+  !> @brief Define the print or save format
+  !!
+  !! Define cdatafmp as a Fortran output format based on user input. Also define
+  !! nvalues, nwidth, and editdesc.
+  !!
+  !! Syntax for linein:
+  !!   COLUMNS nval WIDTH nwid [DIGITS ndig [options]]
+  !!
+  !! Where:
+  !!   nval = Number of values per line.
+  !!   nwid = Number of character places to be used for each value.
+  !!   ndig = Number of digits to the right of the decimal point (required
+  !!          for real array).
+  !!   options are:
+  !!          editoption: One of [EXPONENTIAL, FIXED, GENERAL, SCIENTIFIC]
+  !! A default value should be passed in for editdesc as G, I, E, F, or S.
+  !! If I is passed in, then the fortran format will be for an integer variable.
+  !<
   subroutine print_format(linein, cdatafmp, editdesc, nvaluesp, nwidthp, inunit)
-! ******************************************************************************
-! print_format -- define the print or save format
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-! Define cdatafmp as a Fortran output format based on user input.  Also define
-! nvalues, nwidth, and editdesc.
-!
-!   Syntax for linein:
-!     COLUMNS nval WIDTH nwid [DIGITS ndig [options]]
-!
-! Where:
-!     nval = Number of values per line.
-!     nwid = Number of character places to be used for each value.
-!     ndig = Number of digits to the right of the decimal point (required
-!            for real array).
-!     options are:
-!            editoption: One of [EXPONENTIAL, FIXED, GENERAL, SCIENTIFIC]
-! A default value should be passed in for editdesc as G, I, E, F, or S.
-! If I is passed in, then the fortran format will be for an integer variable.
-! ------------------------------------------------------------------------------
-    ! -- dummy variables
+    ! -- dummy
     character(len=*), intent(in) :: linein
     character(len=*), intent(inout) :: cdatafmp
     character(len=*), intent(inout) :: editdesc
     integer(I4B), intent(inout) :: nvaluesp
     integer(I4B), intent(inout) :: nwidthp
     integer(I4B), intent(in) :: inunit
-    ! -- local variables
+    ! -- local
     character(len=len(linein)) :: line
     character(len=20), dimension(:), allocatable :: words
     character(len=100) :: ermsg
     integer(I4B) :: ndigits=0, nwords=0
     integer(I4B) :: i, ierr
     logical :: isint
-! ------------------------------------------------------------------------------
     !
     ! -- Parse line and initialize values
     line(:) = linein(:)
@@ -1563,21 +1545,23 @@ module InputOutputModule
       call BuildFloatFormat(nvaluesp, nwidthp, ndigits, editdesc, cdatafmp)
     end select
     !
+    ! -- Return
     return
   end subroutine print_format
 
+  !> @brief Build a fixed format for printing or saving a real array
+  !<
   subroutine BuildFixedFormat(nvalsp, nwidp, ndig, outfmt, prowcolnum)
-    ! Build a fixed format for printing or saving a real array
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(in) :: nvalsp, nwidp, ndig
     character(len=*), intent(inout) :: outfmt
     logical, intent(in), optional :: prowcolnum  ! default true
-    ! -- local variables
+    ! -- local
     character(len=8)   :: cvalues, cwidth, cdigits
     character(len=60)  :: ufmt
     logical :: prowcolnumlocal
-    ! formats
+    ! -- formats
     10 format(i8)
     !
     if (present(prowcolnum)) then
@@ -1600,6 +1584,7 @@ module InputOutputModule
     else
       ufmt = '(5x,'
     endif
+    !
     ufmt = trim(ufmt) // cvalues
     ufmt = trim(ufmt) // '(1x,f'
     ufmt = trim(ufmt) // cwidth
@@ -1614,22 +1599,24 @@ module InputOutputModule
     ufmt = trim(ufmt) // ')))'
     outfmt = ufmt
     !
+    ! -- Return
     return
   end subroutine BuildFixedFormat
 
+  !> @brief Build a floating-point format for printing or saving a real array
+  !<
   subroutine BuildFloatFormat(nvalsp, nwidp, ndig, editdesc, outfmt, prowcolnum)
-    ! Build a floating-point format for printing or saving a real array
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(in) :: nvalsp, nwidp, ndig
     character(len=*), intent(in) :: editdesc
     character(len=*), intent(inout) :: outfmt
     logical, intent(in), optional :: prowcolnum  ! default true
-    ! -- local variables
+    ! -- local
     character(len=8)   :: cvalues,  cwidth, cdigits
     character(len=60)  :: ufmt
     logical :: prowcolnumlocal
-    ! formats
+    ! -- formats
     10 format(i8)
     !
     if (present(prowcolnum)) then
@@ -1665,6 +1652,7 @@ module InputOutputModule
       ufmt = trim(ufmt) // cdigits
       ufmt = trim(ufmt) // ')'
     endif
+    !
     ufmt = trim(ufmt) // ':/(5x,'
     write(cvalues, 10) nvalsp
     cvalues = adjustl(cvalues)
@@ -1677,21 +1665,23 @@ module InputOutputModule
     ufmt = trim(ufmt) // ')))'
     outfmt = ufmt
     !
+    ! -- Return
     return
   end subroutine BuildFloatFormat
 
+  !> @brief Build a format for printing or saving an integer array
+  !<
   subroutine BuildIntFormat(nvalsp, nwidp, outfmt, prowcolnum)
-    ! Build a format for printing or saving an integer array
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(in) :: nvalsp, nwidp
     character(len=*), intent(inout) :: outfmt
     logical, intent(in), optional :: prowcolnum  ! default true
-    ! -- local variables
+    ! -- local
     character(len=8)   :: cvalues, cwidth
     character(len=60)  :: ufmt
     logical :: prowcolnumlocal
-    ! formats
+    ! -- formats
     10 format(i8)
     !
     if (present(prowcolnum)) then
@@ -1720,21 +1710,18 @@ module InputOutputModule
     ufmt = trim(ufmt) // ')))'
     outfmt = ufmt
     !
+    ! -- Return
     return
   end subroutine BuildIntFormat
 
-
   !> @brief Get the number of words in a string
-  !!
-  !! Function to get the number of words in a string
-  !!
   !<
   function get_nwords(line)
-    ! -- return variable
-    integer(I4B) :: get_nwords            !< number of words in a string
-    ! -- dummy variables
+    ! -- return
+    integer(I4B) :: get_nwords !< number of words in a string
+    ! -- dummy
     character(len=*), intent(in) :: line  !< line
-    ! -- local variables
+    ! -- local
     integer(I4B) :: linelen
     integer(I4B) :: lloc
     integer(I4B) :: istart
@@ -1758,24 +1745,23 @@ module InputOutputModule
     return
   end function get_nwords
 
+  !> @brief Move the file pointer.
+  !!
+  !! Patterned after fseek, which is not supported as part of the fortran 
+  !! standard.  For this subroutine to work the file must have been opened with
+  !! access='stream' and action='readwrite'.
+  !<
   subroutine fseek_stream(iu, offset, whence, status)
-! ******************************************************************************
-! Move the file pointer.  Patterned after fseek, which is not 
-! supported as part of the fortran standard.  For this subroutine to work
-! the file must have been opened with access='stream' and action='readwrite'.
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
+    ! -- dummy
     integer(I4B), intent(in) :: iu
     integer(I4B), intent(in) :: offset
     integer(I4B), intent(in) :: whence
     integer(I4B), intent(inout) :: status
+    ! -- local
     integer(I8B) :: ipos
-! ------------------------------------------------------------------------------
     !
     inquire(unit=iu, size=ipos)
-    
+    !
     select case(whence)
     case(0)
       !
@@ -1800,31 +1786,27 @@ module InputOutputModule
     ! -- return
     return
   end subroutine fseek_stream
-  
+
+  !> @brief Read until non-comment line found and then return line. 
+  !!
+  !! Different from u8rdcom in that line is a deferred length character string,
+  !! which allows any length lines to be read using the get_line subroutine.
+  !<
   subroutine u9rdcom(iin, iout, line, ierr)
-! ******************************************************************************
-! Read until non-comment line found and then return line.  Different from
-! u8rdcom in that line is a deferred length character string, which allows
-! any length lines to be read using the get_line subroutine.
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
+    ! -- module
     use, intrinsic :: iso_fortran_env, only: IOSTAT_END
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B),         intent(in) :: iin
     integer(I4B),         intent(in) :: iout
     character (len=:), allocatable, intent(inout) :: line
     integer(I4B),        intent(out) :: ierr
-    ! -- local variables
+    ! -- local
     character (len=:), allocatable :: linetemp
     character (len=2), parameter :: comment = '//'
     character(len=1), parameter  :: tab = CHAR(9)
     logical :: iscomment
     integer(I4B) :: i, j, l, istart, lsize
-! ------------------------------------------------------------------------------
-    !code
     !
     !readerrmsg = ''
     line = comment
@@ -1841,12 +1823,12 @@ module InputOutputModule
         write(errmsg, *) 'u9rdcom: Could not read from unit: ',iin
         call store_error(errmsg, terminate=.TRUE.)
       endif
-      if (len_trim(line).lt.1) then
+      if (len_trim(line) < 1) then
         line = comment
         cycle
       end if
       !
-      ! Ensure that any initial tab characters are treated as spaces
+      ! -- Ensure that any initial tab characters are treated as spaces
       cleartabs: do
         !
         ! -- adjustl manually to avoid stack overflow
@@ -1877,7 +1859,7 @@ module InputOutputModule
             line(1:1) = ' '
             cycle cleartabs
           case default
-            if (line(1:2).eq.comment) iscomment = .true.
+            if (line(1:2) == comment) iscomment = .true.
             if (len_trim(line) < 1) iscomment = .true.
             exit cleartabs
         end select
@@ -1888,39 +1870,38 @@ module InputOutputModule
       else
         if (iout > 0) then
           !find the last non-blank character.
-          l=len(line)
+          l = len(line)
           do i = l, 1, -1
-            if(line(i:i).ne.' ') then
+            if(line(i:i) /= ' ') then
               exit
             end if
           end do
-          !print the line up to the last non-blank character.
+          ! -- print the line up to the last non-blank character.
           write(iout,'(1x,a)') line(1:i)
         end if
       end if
     end do pcomments
+    !
+    ! -- Return
     return
   end subroutine u9rdcom
 
+  !> @brief Read an unlimited length line from unit number lun into a deferred-
+  !! length character string (line).  
+  !!
+  !! Tack on a single space to the end so that routines like URWORD continue to 
+  !! function as before.
+  !<
   subroutine get_line(lun, line, iostat)
-! ******************************************************************************
-! Read an unlimited length line from unit number lun into a deferred-length
-! character string (line).  Tack on a single space to the end so that 
-! routines like URWORD continue to function as before.
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(in) :: lun
     character(len=:), intent(out), allocatable :: line
     integer(I4B), intent(out) :: iostat
-    ! -- local variables
+    ! -- local
     integer(I4B), parameter :: buffer_len = MAXCHARLEN
     character(len=buffer_len) :: buffer
     character(len=:), allocatable :: linetemp
     integer(I4B) :: size_read, linesize
-! ------------------------------------------------------------------------------
     !
     ! -- initialize
     line = ''
@@ -1928,10 +1909,7 @@ module InputOutputModule
     !
     ! -- process
     do
-      read ( lun, '(A)',  &
-          iostat = iostat,  &
-          advance = 'no',  &
-          size = size_read ) buffer
+      read (lun, '(A)', iostat=iostat, advance='no', size=size_read) buffer
       if (is_iostat_eor(iostat)) then
         linesize = len(line)
         deallocate(linetemp)

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -1250,7 +1250,7 @@ contains
     return
   end subroutine ulaprufw
 
-  !> @breif This function reads a line of arbitrary length and returns it.
+  !> @brief This function reads a line of arbitrary length and returns it.
   !!
   !! The returned string can be stored in a deferred-length character variable,
   !! for example:

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -5,50 +5,41 @@ module InputOutputModule
   use KindModule, only: DP, I4B, I8B
   use SimVariablesModule, only: iunext, isim_mode, errmsg
   use SimModule, only: store_error, store_error_unit
-  use ConstantsModule, only: IUSTART, IULAST,                                  &
-                             LINELENGTH, LENBIGLINE, LENBOUNDNAME,             &
-                             NAMEDBOUNDFLAG, MAXCHARLEN,                       &
-                             TABLEFT, TABCENTER, TABRIGHT,                     &
-                             TABSTRING, TABUCSTRING, TABINTEGER, TABREAL,      &
-                             DZERO
+  use ConstantsModule, only: IUSTART, IULAST, LINELENGTH, LENBIGLINE, &
+                             LENBOUNDNAME, NAMEDBOUNDFLAG, MAXCHARLEN, &
+                             TABLEFT, TABCENTER, TABRIGHT, TABSTRING, &
+                             TABUCSTRING, TABINTEGER, TABREAL, DZERO
   use MessageModule, only: write_message
   private
-  public :: GetUnit,                                                           &
-            UPCASE, URWORD, ULSTLB, UBDSV4,                                    &
-            ubdsv06, UBDSVB, UCOLNO, ULAPRW,                                   &
-            ULASAV, ubdsv1, ubdsvc, ubdsvd, UWWORD,                            &
-            same_word, str_pad_left, unitinquire,           &
-            ParseLine, ulaprufw, openfile,                                     &
-            linear_interpolate, lowcase,                                       &
-            read_line,                                                         &
-            GetFileFromPath, extract_idnum_or_bndname, urdaux,                 &
-            print_format, BuildFixedFormat,                            &
-            BuildFloatFormat, BuildIntFormat, fseek_stream,                    &
-            get_nwords, u9rdcom,                                               &
-            append_processor_id
+  public :: GetUnit, UPCASE, URWORD, ULSTLB, UBDSV4, ubdsv06, UBDSVB, UCOLNO, &
+            ULAPRW, ULASAV, ubdsv1, ubdsvc, ubdsvd, UWWORD, same_word, &
+            str_pad_left, unitinquire, ParseLine, ulaprufw, openfile, &
+            linear_interpolate, lowcase, read_line, GetFileFromPath, &
+            extract_idnum_or_bndname, urdaux, print_format, BuildFixedFormat, &
+            BuildFloatFormat, BuildIntFormat, fseek_stream, get_nwords, &
+            u9rdcom, append_processor_id
 
-  contains
+contains
 
   !> @brief Open a file
   !!
   !! Subroutine to open a file using the specified arguments
-  !!
   !<
-  subroutine openfile(iu, iout, fname, ftype, fmtarg_opt, accarg_opt,          &
+  subroutine openfile(iu, iout, fname, ftype, fmtarg_opt, accarg_opt, &
                       filstat_opt, mode_opt)
     ! -- modules
     use OpenSpecModule, only: action
     implicit none
-    ! -- dummy variables
-    integer(I4B), intent(inout)       :: iu                 !< unit number
-    integer(I4B), intent(in)          :: iout               !< output unit number to write a message (iout=0 does not print)
-    character(len=*), intent(in) :: fname                   !< name of the file
-    character(len=*), intent(in) :: ftype                   !< file type (e.g. WEL)
-    character(len=*), intent(in), optional :: fmtarg_opt    !< file format, default is 'formatted'
-    character(len=*), intent(in), optional :: accarg_opt    !< file access, default is 'sequential'
-    character(len=*), intent(in), optional :: filstat_opt   !< file status, default is 'old'. Use 'REPLACE' for output file.
-    integer(I4B), intent(in), optional :: mode_opt          !< simulation mode that is evaluated to determine if the file should be opened
-    ! -- local variables
+    ! -- dummy
+    integer(I4B), intent(inout) :: iu !< unit number
+    integer(I4B), intent(in) :: iout !< output unit number to write a message (iout=0 does not print)
+    character(len=*), intent(in) :: fname !< name of the file
+    character(len=*), intent(in) :: ftype !< file type (e.g. WEL)
+    character(len=*), intent(in), optional :: fmtarg_opt !< file format, default is 'formatted'
+    character(len=*), intent(in), optional :: accarg_opt !< file access, default is 'sequential'
+    character(len=*), intent(in), optional :: filstat_opt !< file status, default is 'old'. Use 'REPLACE' for output file.
+    integer(I4B), intent(in), optional :: mode_opt !< simulation mode that is evaluated to determine if the file should be opened
+    ! -- local
     character(len=20) :: fmtarg
     character(len=20) :: accarg
     character(len=20) :: filstat
@@ -58,23 +49,23 @@ module InputOutputModule
     integer(I4B) :: ivar
     integer(I4B) :: iuop
     ! -- formats
-50  FORMAT(1X,/1X,'OPENED ',A,/                                                &
-                 1X,'FILE TYPE:',A,'   UNIT ',I4,3X,'STATUS:',A,/              &
-                 1X,'FORMAT:',A,3X,'ACCESS:',A/                                &
-                 1X,'ACTION:',A/)
-60  FORMAT(1X,/1X,'DID NOT OPEN ',A,/)
+    character(len=*), parameter :: fmtmsg = &
+      "(1x,/1x,'OPENED ',a,/1x,'FILE TYPE:',a,'   UNIT ',I4,3x,'STATUS:',a,/ &
+&        1x,'FORMAT:',a,3x,'ACCESS:',a/1x,'ACTION:',a/)"
+    character(len=*), parameter :: fmtmsg2 = &
+                                   "(1x,/1x,'DID NOT OPEN ',a,/)"
     !
-    ! -- process mode_opt
+    ! -- Process mode_opt
     if (present(mode_opt)) then
       imode = mode_opt
     else
       imode = isim_mode
     end if
     !
-    ! -- evaluate if the file should be opened
+    ! -- Evaluate if the file should be opened
     if (isim_mode < imode) then
-      if(iout > 0) then
-        write(iout, 60) trim(fname)
+      if (iout > 0) then
+        write (iout, fmtmsg2) trim(fname)
       end if
     else
       !
@@ -84,49 +75,49 @@ module InputOutputModule
       filstat = 'OLD'
       !
       ! -- Override defaults
-      if(present(fmtarg_opt)) then
+      if (present(fmtarg_opt)) then
         fmtarg = fmtarg_opt
         call upcase(fmtarg)
-      endif
-      if(present(accarg_opt)) then
+      end if
+      if (present(accarg_opt)) then
         accarg = accarg_opt
         call upcase(accarg)
-      endif
-      if(present(filstat_opt)) then
+      end if
+      if (present(filstat_opt)) then
         filstat = filstat_opt
         call upcase(filstat)
-      endif
-      if(filstat == 'OLD') then
+      end if
+      if (filstat == 'OLD') then
         filact = action(1)
       else
         filact = action(2)
-      endif
+      end if
       !
       ! -- size of fname
       iflen = len_trim(fname)
       !
       ! -- Get a free unit number
-      if(iu <= 0) then
+      if (iu <= 0) then
         call freeunitnumber(iu)
-      endif
+      end if
       !
       ! -- Check to see if file is already open, if not then open the file
-      inquire(file=fname(1:iflen), number=iuop)
-      if(iuop > 0) then
+      inquire (file=fname(1:iflen), number=iuop)
+      if (iuop > 0) then
         ivar = -1
       else
-        open(unit=iu, file=fname(1:iflen), form=fmtarg, access=accarg,           &
-           status=filstat, action=filact, iostat=ivar)
-      endif
+        open (unit=iu, file=fname(1:iflen), form=fmtarg, access=accarg, &
+              status=filstat, action=filact, iostat=ivar)
+      end if
       !
       ! -- Check for an error
-      if(ivar /= 0) then
+      if (ivar /= 0) then
         write (errmsg, '(3a,1x,i0,a)') &
           'Could not open "', fname(1:iflen), '" on unit', iu, '.'
-        if(iuop > 0) then
+        if (iuop > 0) then
           write (errmsg, '(a,1x,a,1x,i0,a)') &
             trim(errmsg), 'File already open on unit', iuop, '.'
-        endif
+        end if
         write (errmsg, '(a,1x,a,1x,a,a)') &
           trim(errmsg), 'Specified file status', trim(filstat), '.'
         write (errmsg, '(a,1x,a,1x,a,a)') &
@@ -140,58 +131,53 @@ module InputOutputModule
         write (errmsg, '(a,1x,a)') &
           trim(errmsg), 'STOP EXECUTION in subroutine openfile().'
         call store_error(errmsg, terminate=.TRUE.)
-      endif
+      end if
       !
       ! -- Write a message
-      if(iout > 0) then
-        write(iout, 50) fname(1:iflen),                                          &
-                       ftype, iu, filstat,                                       &
-                       fmtarg, accarg,                                           &
-                       filact
+      if (iout > 0) then
+        write (iout, fmtmsg) fname(1:iflen), ftype, iu, filstat, fmtarg, &
+          accarg, filact
       end if
     end if
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine openfile
 
   !> @brief Assign a free unopened unit number
   !!
   !! Subroutine to assign a free unopened unit number to the iu dummy argument
-  !!
   !<
   subroutine freeunitnumber(iu)
     ! -- modules
     implicit none
-    ! -- dummy variables
-    integer(I4B),intent(inout) :: iu  !< next free file unit number
-    ! -- local variables
+    ! -- dummy
+    integer(I4B), intent(inout) :: iu !< next free file unit number
+    ! -- local
     integer(I4B) :: i
     logical :: opened
     !
-    ! -- code
     do i = iunext, iulast
-      inquire(unit=i, opened=opened)
-      if(.not. opened) exit
-    enddo
+      inquire (unit=i, opened=opened)
+      if (.not. opened) exit
+    end do
     iu = i
     iunext = iu + 1
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine freeunitnumber
 
   !> @brief Get a free unit number
   !!
   !! Function to get a free unit number that hasn't been used
-  !!
   !<
   function getunit()
     ! -- modules
     implicit none
     ! -- return
-    integer(I4B) :: getunit  !< free unit number
-    ! -- local variables
+    integer(I4B) :: getunit !< free unit number
+    ! -- local
     integer(I4B) :: iunit
     !
     ! -- code
@@ -201,17 +187,16 @@ module InputOutputModule
     ! -- Return
     return
   end function getunit
-  
+
   !> @brief Convert to upper case
   !!
   !! Subroutine to convert a character string to upper case.
-  !!
   !<
   subroutine upcase(word)
     implicit none
-    ! -- dummy variables  
-    character (len=*), intent(inout) :: word  !< word to convert to upper case
-    ! -- local variables
+    ! -- dummy
+    character(len=*), intent(inout) :: word !< word to convert to upper case
+    ! -- local
     integer(I4B) :: l
     integer(I4B) :: idiff
     integer(I4B) :: k
@@ -226,54 +211,50 @@ module InputOutputModule
         word(k:k) = char(ichar(word(k:k)) - idiff)
     end do
     !
-    ! -- return.
+    ! -- Return
     return
-    end subroutine upcase
+  end subroutine upcase
 
   !> @brief Convert to lower case
   !!
   !! Subroutine to convert a character string to lower case.
-  !!
   !<
   subroutine lowcase(word)
     implicit none
-    ! -- dummy variables
-    character(len=*) :: word  !< 
-    ! -- local variables
+    ! -- dummy
+    character(len=*) :: word
+    ! -- local
     integer(I4B) :: idiff, k, l
     !
-    ! -- compute the difference between lowercase and uppercase.
+    ! -- Compute the difference between lowercase and uppercase.
     l = len(word)
     idiff = ichar('a') - ichar('A')
     !
-    ! -- loop through the string and convert any uppercase characters.
+    ! -- Loop through the string and convert any uppercase characters.
     do k = 1, l
-      if(word(k:k) >= 'A' .and. word(k:k) <= 'Z') then
-        word(k:k)=char(ichar(word(k:k))+idiff)
-      endif
-    enddo
+      if (word(k:k) >= 'A' .and. word(k:k) <= 'Z') then
+        word(k:k) = char(ichar(word(k:k)) + idiff)
+      end if
+    end do
     !
-    ! -- return.
+    ! -- Return
     return
   end subroutine lowcase
 
   !> @brief Append processor id to a string
   !!
-  !! Subroutine to append the processor id to a string 
-  !! before the file extension (extension is the 
-  !! string after the last '.' in the string. If there
-  !! is no '.' in the string the processor id is appended 
-  !! to the end of the string.
-  !!
+  !! Subroutine to append the processor id to a string before the file extension
+  !! (extension is the string after the last '.' in the string. If there is
+  !! no '.' in the string the processor id is appended to the end of the string.
   !<
   subroutine append_processor_id(name, proc_id)
-    ! -- dummy variables
-    character(len=linelength), intent(inout) :: name  !< file name
-    integer(I4B), intent(in) :: proc_id  !< processor id
-    ! -- local variables
-    character(len=linelength) :: name_local
-    character(len=linelength) :: name_processor
-    character(len=linelength) :: extension_local
+    ! -- dummy
+    character(len=LINELENGTH), intent(inout) :: name !< file name
+    integer(I4B), intent(in) :: proc_id !< processor id
+    ! -- local
+    character(len=LINELENGTH) :: name_local
+    character(len=LINELENGTH) :: name_processor
+    character(len=LINELENGTH) :: extension_local
     integer(I4B) :: ipos0
     integer(I4B) :: ipos1
     !
@@ -282,149 +263,146 @@ module InputOutputModule
     ipos0 = index(name_local, ".", back=.TRUE.)
     ipos1 = len_trim(name)
     if (ipos0 > 0) then
-      write(extension_local, '(a)') name(ipos0:ipos1)
+      write (extension_local, '(a)') name(ipos0:ipos1)
     else
       ipos0 = ipos1
       extension_local = ''
     end if
-    write(name_processor, '(a,a,i0,a)') &
-      name(1:ipos0-1), '.p', proc_id, trim(adjustl(extension_local))
+    write (name_processor, '(a,a,i0,a)') &
+      name(1:ipos0 - 1), '.p', proc_id, trim(adjustl(extension_local))
     name = name_processor
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine append_processor_id
 
   !> @brief Create a formatted line
   !!
-  !! Subroutine to create a formatted line with specified alignment
-  !! and column separators. Like URWORD, UWWORD works with strings,
-  !! integers, and floats. Can pass an optional format statement,
-  !! alignment, and column separator.
-  !!
+  !! Subroutine to create a formatted line with specified alignment and column
+  !! separators. Like URWORD, UWWORD works with strings, integers, and floats.
+  !! Can pass an optional format statement, alignment, and column separator.
   !<
-  subroutine UWWORD(LINE,ICOL,ILEN,NCODE,C,N,R,FMT,ALIGNMENT,SEP)
+  subroutine UWWORD(line, icol, ilen, ncode, c, n, r, fmt, alignment, sep)
     implicit none
-    ! -- dummy variables
-    character (len=*), intent(inout) :: LINE         !< line
-    integer(I4B), intent(inout) :: ICOL              !< column to write to line
-    integer(I4B), intent(in) :: ILEN                 !< current length of line
-    integer(I4B), intent(in) :: NCODE                !< code for data type to write
-    character (len=*), intent(in) :: C               !< character data type
-    integer(I4B), intent(in) :: N                    !< integer data type
-    real(DP), intent(in) :: R                        !< float data type
-    character (len=*), optional, intent(in) :: FMT   !< format statement
-    integer(I4B), optional, intent(in) :: ALIGNMENT  !< alignment specifier
-    character (len=*), optional, intent(in) :: SEP   !< column separator
-    ! -- local variables
-    character (len=16) :: cfmt
-    character (len=16) :: cffmt
-    character (len=ILEN) :: cval
+    ! -- dummy
+    character(len=*), intent(inout) :: line !< line
+    integer(I4B), intent(inout) :: icol !< column to write to line
+    integer(I4B), intent(in) :: ilen !< current length of line
+    integer(I4B), intent(in) :: ncode !< code for data type to write
+    character(len=*), intent(in) :: c !< character data type
+    integer(I4B), intent(in) :: n !< integer data type
+    real(DP), intent(in) :: r !< float data type
+    character(len=*), optional, intent(in) :: fmt !< format statement
+    integer(I4B), optional, intent(in) :: alignment !< alignment specifier
+    character(len=*), optional, intent(in) :: sep !< column separator
+    ! -- local
+    character(len=16) :: cfmt
+    character(len=16) :: cffmt
+    character(len=ILEN) :: cval
     integer(I4B) :: ialign
     integer(I4B) :: i
     integer(I4B) :: ispace
     integer(I4B) :: istop
     integer(I4B) :: ipad
     integer(I4B) :: ireal
-    ! -- code
     !
     ! -- initialize locals
     ipad = 0
     ireal = 0
     !
     ! -- process dummy variables
-    if (present(FMT)) then
-      CFMT = FMT
+    if (present(fmt)) then
+      cfmt = fmt
     else
-      select case(NCODE)
-        case(TABSTRING, TABUCSTRING)
-          write(cfmt, '(A,I0,A)') '(A', ILEN, ')'
-        case(TABINTEGER)
-          write(cfmt, '(A,I0,A)') '(I', ILEN, ')'
-        case(TABREAL)
-          ireal = 1
-          i = ILEN - 7
-          write(cfmt, '(A,I0,A,I0,A)') '(1PG', ILEN, '.', i, ')'
-          if (R >= DZERO) then
-            ipad = 1
-          end if
+      select case (ncode)
+      case (TABSTRING, TABUCSTRING)
+        write (cfmt, '(a,I0,a)') '(a', ilen, ')'
+      case (TABINTEGER)
+        write (cfmt, '(a,I0,a)') '(I', ilen, ')'
+      case (TABREAL)
+        ireal = 1
+        i = ilen - 7
+        write (cfmt, '(a,I0,a,I0,a)') '(1PG', ilen, '.', i, ')'
+        if (R >= DZERO) then
+          ipad = 1
+        end if
       end select
     end if
-    write(cffmt, '(A,I0,A)') '(A', ILEN, ')'
-
-    if (present(ALIGNMENT)) then
-      ialign = ALIGNMENT
+    write (cffmt, '(a,I0,a)') '(a', ilen, ')'
+    !
+    if (present(alignment)) then
+      ialign = alignment
     else
       ialign = TABRIGHT
     end if
     !
-    ! -- 
-    if (NCODE == TABSTRING .or. NCODE == TABUCSTRING) then
+    ! --
+    if (ncode == TABSTRING .or. ncode == TABUCSTRING) then
       cval = C
-      if (NCODE == TABUCSTRING) then
-        call UPCASE(cval)
+      if (ncode == TABUCSTRING) then
+        call UPcase(cval)
       end if
-    else if (NCODE == TABINTEGER) then
-      write(cval, cfmt) N
-    else if (NCODE == TABREAL) then
-      write(cval, cfmt) R
+    else if (ncode == TABINTEGER) then
+      write (cval, cfmt) n
+    else if (ncode == TABREAL) then
+      write (cval, cfmt) r
     end if
     !
-    ! -- apply alignment to cval
-    if (len_trim(adjustl(cval)) > ILEN) then
+    ! -- Apply alignment to cval
+    if (len_trim(adjustl(cval)) > ilen) then
       cval = adjustl(cval)
     else
       cval = trim(adjustl(cval))
     end if
     if (ialign == TABCENTER) then
       i = len_trim(cval)
-      ispace = (ILEN - i) / 2
+      ispace = (ilen - i) / 2
       if (ireal > 0) then
         if (ipad > 0) then
-          cval = ' ' //trim(adjustl(cval))
+          cval = ' '//trim(adjustl(cval))
         else
           cval = trim(adjustl(cval))
         end if
       else
-        cval = repeat(' ', ispace) // trim(cval)
+        cval = repeat(' ', ispace)//trim(cval)
       end if
     else if (ialign == TABLEFT) then
       cval = trim(adjustl(cval))
       if (ipad > 0) then
-        cval = ' ' //trim(adjustl(cval))
+        cval = ' '//trim(adjustl(cval))
       end if
     else
       cval = adjustr(cval)
     end if
-    if (NCODE == TABUCSTRING) then
-      call UPCASE(cval)
+    if (ncode == TABUCSTRING) then
+      call UPcase(cval)
     end if
     !
-    ! -- increment istop to the end of the column
-    istop = ICOL + ILEN - 1
+    ! -- Increment istop to the end of the column
+    istop = icol + ilen - 1
     !
-    ! -- write final string to line
-    write(LINE(ICOL:istop), cffmt) cval
-
-    ICOL = istop + 1
-
-    if (present(SEP)) then
-      i = len(SEP)
-      istop = ICOL + i
-      write(LINE(ICOL:istop), '(A)') SEP
-      ICOL = istop
+    ! -- Write final string to line
+    write (line(icol:istop), cffmt) cval
+    !
+    icoL = istop + 1
+    !
+    if (present(sep)) then
+      i = len(sep)
+      istop = icol + i
+      write (line(icol:istop), '(a)') sep
+      icol = istop
     end if
     !
-    !-- return
+    ! -- Return
     return
   end subroutine UWWORD
 
   !> @brief Extract a word from a string
   !!
   !! Subroutine to extract a word from a line of text, and optionally
-  !! convert the word to a number. The last character in the line is 
-  !! set to blank so that if any problems occur with finding a word, 
-  !! istart and istop will point to this blank character. Thus, a word 
+  !! convert the word to a number. The last character in the line is
+  !! set to blank so that if any problems occur with finding a word,
+  !! istart and istop will point to this blank character. Thus, a word
   !! will always be returned unless there is a numeric conversion error.
   !! Be sure that the last character in line is not an important character
   !! because it will always be set to blank.
@@ -435,552 +413,559 @@ module InputOutputModule
   !! commas separated by one or more spaces as a null word.
   !!
   !! For a word that begins with "'" or '"', the word starts with
-  !! the character after the quote and ends with the character preceding 
+  !! the character after the quote and ends with the character preceding
   !! a subsequent quote. Thus, a quoted word can include spaces and commas.
-  !! The quoted word cannot contain a quote character of the same type 
-  !! within the word but can contain a different quote character. For 
+  !! The quoted word cannot contain a quote character of the same type
+  !! within the word but can contain a different quote character. For
   !! example, "WORD'S" or 'WORD"S'.
   !!
-  !! Number conversion error is written to unit iout if iout is positive; 
-  !! error is written to default output if iout is 0; no error message is 
+  !! Number conversion error is written to unit iout if iout is positive;
+  !! error is written to default output if iout is 0; no error message is
   !! written if iout is negative.
   !!
   !<
-  SUBROUTINE URWORD(LINE,ICOL,ISTART,ISTOP,NCODE,N,R,IOUT,IN)
-    ! -- dummy variables  
-    character(len=*) :: LINE                 !< line to parse
-    integer(I4B), intent(inout) :: icol      !< current column in line
-    integer(I4B), intent(inout) :: istart    !< starting character position of the word
-    integer(I4B), intent(inout) :: istop     !< ending character position of the word
-    integer(I4B), intent(in) :: ncode        !< word conversion flag (1) upper case, (2) integer, (3) real number
-    integer(I4B), intent(inout) :: n         !< integer data type
-    real(DP), intent(inout) :: r             !< float data type
-    integer(I4B), intent(in) :: iout         !< output listing file unit
-    integer(I4B), intent(in) :: in           !< input file unit number
-    ! -- local variables
-    CHARACTER(len=20) STRING                
-    CHARACTER(len=30) RW
-    CHARACTER(len=1) TAB
-    CHARACTER(len=1) CHAREND
+  subroutine URWORD(line, icol, istart, istop, ncode, n, r, iout, in)
+    ! -- dummy
+    character(len=*) :: line !< line to parse
+    integer(I4B), intent(inout) :: icol !< current column in line
+    integer(I4B), intent(inout) :: istart !< starting character position of the word
+    integer(I4B), intent(inout) :: istop !< ending character position of the word
+    integer(I4B), intent(in) :: ncode !< word conversion flag (1) upper case, (2) integer, (3) real number
+    integer(I4B), intent(inout) :: n !< integer data type
+    real(DP), intent(inout) :: r !< float data type
+    integer(I4B), intent(in) :: iout !< output listing file unit
+    integer(I4B), intent(in) :: in !< input file unit number
+    ! -- local
+    character(len=20) string
+    character(len=30) rw
+    character(len=1) tab
+    character(len=1) charend
     character(len=200) :: msg
-    character(len=LINELENGTH) :: msg_line
+    character(len=linelength) :: msg_line
+    ! -- formats
+    character(len=*), parameter :: fmtmsgout1 = &
+      "(1X,'FILE UNIT ',I4,' : ERROR CONVERTING ""',A, &
+      & '"" TO ',A,' IN LINE:')"
+    character(len=*), parameter :: fmtmsgout2 = "(1x, &
+      & 'KEYBOARD INPUT : ERROR CONVERTING ""',a,'"" TO ',a,' IN LINE:')"
+    character(len=*), parameter :: fmtmsgout3 = "('File unit ', &
+      & I0,': Error converting ""',a,'"" to ',A,' in following line:')"
+    character(len=*), parameter :: fmtmsgout4 = &
+      "('Keyboard input: Error converting ""',a, &
+      & '"" to ',A,' in following line:')"
     !
-    ! -- code
-    TAB=CHAR(9)
+    tab = char(9)
     !
     ! -- Set last char in LINE to blank and set ISTART and ISTOP to point
     !    to this blank as a default situation when no word is found.  If
     !    starting location in LINE is out of bounds, do not look for a word.
-    LINLEN=LEN(LINE)
-    LINE(LINLEN:LINLEN)=' '
-    ISTART=LINLEN
-    ISTOP=LINLEN
-    LINLEN=LINLEN-1
-    IF(ICOL.LT.1 .OR. ICOL.GT.LINLEN) GO TO 100
+    linlen = len(line)
+    line(linlen:linlen) = ' '
+    istart = linlen
+    istop = linlen
+    linlen = linlen - 1
+    if (icol < 1 .or. icol > linlen) go to 100
     !
     ! -- Find start of word, which is indicated by first character that
     !    is not a blank, a comma, or a tab.
-    DO 10 I=ICOL,LINLEN
-      IF(LINE(I:I).NE.' ' .AND. LINE(I:I).NE.',' .AND. &
-         LINE(I:I).NE.TAB) GO TO 20
-10  CONTINUE
-    ICOL=LINLEN+1
-    GO TO 100
+    do i = icol, linlen
+      if (line(i:i) /= ' ' .and. line(i:i) /= ',' .and. &
+          line(i:i) /= tab) go to 20
+    end do
+    icol = linlen + 1
+    go to 100
     !
     ! -- Found start of word.  Look for end.
     !    When word is quoted, only a quote can terminate it.
-    !    SEARCH FOR A SINGLE (CHAR(39)) OR DOUBLE (CHAR(34)) QUOTE
-20  IF(LINE(I:I).EQ.CHAR(34) .OR. LINE(I:I).EQ.CHAR(39)) THEN
-      IF (LINE(I:I).EQ.CHAR(34)) THEN
-        CHAREND = CHAR(34)
-      ELSE
-        CHAREND = CHAR(39)
-      END IF
-      I=I+1
-      IF(I.LE.LINLEN) THEN
-        DO 25 J=I,LINLEN
-          IF(LINE(J:J).EQ.CHAREND) GO TO 40
-25      CONTINUE
-      END IF
-    !
-    ! -- When word is not quoted, space, comma, or tab will terminate.
-    ELSE
-      DO 30 J=I,LINLEN
-        IF(LINE(J:J).EQ.' ' .OR. LINE(J:J).EQ.',' .OR. &
-           LINE(J:J).EQ.TAB) GO TO 40
-30    CONTINUE
-    END IF
+    !    search for a single (char(39)) or double (char(34)) quote
+20  if (line(i:i) == char(34) .or. line(i:i) == char(39)) then
+      if (line(i:i) == char(34)) then
+        charend = char(34)
+      else
+        charend = char(39)
+      end if
+      i = i + 1
+      if (i <= linlen) then
+        do j = i, linlen
+          if (line(j:j) == charend) go to 40
+        end do
+      end if
+      !
+      ! -- When word is not quoted, space, comma, or tab will terminate.
+    else
+      do j = i, linlen
+        if (line(j:j) == ' ' .or. line(j:j) == ',' .or. &
+            line(j:j) == tab) go to 40
+      end do
+    end if
     !
     ! -- End of line without finding end of word; set end of word to
     !    end of line.
-    J=LINLEN+1
+    j = linlen + 1
     !
     ! -- Found end of word; set J to point to last character in WORD and
     !    set ICOL to point to location for scanning for another word.
-40  ICOL=J+1
-    J=J-1
-    IF(J.LT.I) GO TO 100
-    ISTART=I
-    ISTOP=J
+40  icol = j + 1
+    j = j - 1
+    if (j < i) go to 100
+    istart = i
+    istop = j
     !
     ! -- Convert word to upper case and RETURN if NCODE is 1.
-    IF(NCODE.EQ.1) THEN
-      IDIFF=ICHAR('a')-ICHAR('A')
-      DO 50 K=ISTART,ISTOP
-        IF(LINE(K:K).GE.'a' .AND. LINE(K:K).LE.'z') &
-           LINE(K:K)=CHAR(ICHAR(LINE(K:K))-IDIFF)
-50    CONTINUE
-      RETURN
-    END IF
+    if (ncode == 1) then
+      idiff = ichar('a') - ichar('A')
+      do k = istart, istop
+        if (line(k:k) > 'a' .and. line(k:k) < 'z') &
+          line(k:k) = char(ichar(line(k:k)) - idiff)
+      end do
+      return
+    end if
     !
     ! -- Convert word to a number if requested.
-100 IF(NCODE.EQ.2 .OR. NCODE.EQ.3) THEN
-      RW=' '
-      L=30-ISTOP+ISTART
-      IF(L.LT.1) GO TO 200
-      RW(L:30)=LINE(ISTART:ISTOP)
-      IF(NCODE.EQ.2) READ(RW,'(I30)',ERR=200) N
-      IF(NCODE.EQ.3) READ(RW,'(F30.0)',ERR=200) R
-    END IF
-    RETURN
+100 if (ncode == 2 .or. ncode == 3) then
+      rw = ' '
+      l = 30 - istop + istart
+      if (l < 1) go to 200
+      rw(l:30) = line(istart:istop)
+      if (ncode == 2) read (rw, '(i30)', err=200) n
+      if (ncode == 3) read (rw, '(f30.0)', err=200) r
+    end if
+    return
     !
     ! -- Number conversion error.
-200 IF(NCODE.EQ.3) THEN
-      STRING= 'A REAL NUMBER'
-      L=13
-    ELSE
-      STRING= 'AN INTEGER'
-      L=10
-    END IF
+200 if (ncode == 3) then
+      string = 'a real number'
+      l = 13
+    else
+      string = 'an integer'
+      l = 10
+    end if
     !
     ! -- If output unit is negative, set last character of string to 'E'.
-    IF(IOUT.LT.0) THEN
-      N=0
-      R=0.
-      LINE(LINLEN+1:LINLEN+1)='E'
-      RETURN
-    !
-    ! -- If output unit is positive; write a message to output unit.
-    ELSE IF(IOUT.GT.0) THEN
-      IF(IN.GT.0) THEN
-        write(msg_line,201) IN,LINE(ISTART:ISTOP),STRING(1:L)
-      ELSE
-        WRITE(msg_line,202) LINE(ISTART:ISTOP),STRING(1:L)
-      END IF
+    if (iout < 0) then
+      n = 0
+      r = 0.
+      line(linlen + 1:linlen + 1) = 'E'
+      return
+      !
+      ! -- If output unit is positive; write a message to output unit.
+    else if (iout == 0) then
+      if (in > 0) then
+        write (msg_line, fmtmsgout1) in, line(istart:istop), string(1:l)
+      else
+        write (msg_line, fmtmsgout2) line(istart:istop), string(1:l)
+      end if
       call write_message(msg_line, iunit=IOUT, skipbefore=1)
-      call write_message(LINE, iunit=IOUT, fmt='(1x,a)')
-201   FORMAT(1X,'FILE UNIT ',I4,' : ERROR CONVERTING "',A, &
-             '" TO ',A,' IN LINE:')
-202   FORMAT(1X,'KEYBOARD INPUT : ERROR CONVERTING "',A, &
-             '" TO ',A,' IN LINE:')
-    !
-    ! -- If output unit is 0; write a message to default output.
-    ELSE
-      IF(IN.GT.0) THEN
-        write(msg_line,201) IN,LINE(ISTART:ISTOP),STRING(1:L)
-      ELSE
-        WRITE(msg_line,202) LINE(ISTART:ISTOP),STRING(1:L)
-      END IF
-      call write_message(msg_line, iunit=IOUT, skipbefore=1)
-      call write_message(LINE, iunit=IOUT, fmt='(1x,a)')
-    END IF
+      call write_message(line, iunit=IOUT, fmt='(1x,a)')
+      !
+      ! -- If output unit is 0; write a message to default output.
+    else
+      if (in > 0) then
+        write (msg_line, fmtmsgout1) in, line(istart:istop), string(1:l)
+      else
+        write (msg_line, fmtmsgout2) line(istart:istop), string(1:l)
+      end if
+      call write_message(msg_line, iunit=iout, skipbefore=1)
+      call write_message(LINE, iunit=iout, fmt='(1x,a)')
+    end if
     !
     ! -- STOP after storing error message.
     call lowcase(string)
     if (in > 0) then
-      write(msg,205) in,line(istart:istop),trim(string)
+      write (msg, fmtmsgout3) in, line(istart:istop), trim(string)
     else
-      write(msg,207) line(istart:istop),trim(string)
-    endif
-205 format('File unit ',I0,': Error converting "',A, &
-           '" to ',A,' in following line:')
-207 format('Keyboard input: Error converting "',A, &
-           '" to ',A,' in following line:')
+      write (msg, fmtmsgout4) line(istart:istop), trim(string)
+    end if
+    !
     call store_error(msg)
     call store_error(trim(line))
     call store_error_unit(in)
     !
-    ! -- return
-END SUBROUTINE URWORD
+    ! -- Return
+    return
+  end subroutine URWORD
 
-      SUBROUTINE ULSTLB(IOUT,LABEL,CAUX,NCAUX,NAUX)
-!C     ******************************************************************
-!C     PRINT A LABEL FOR A LIST
-!C     ******************************************************************
-!C
-!C        SPECIFICATIONS:
-!C     ------------------------------------------------------------------
-      CHARACTER(len=*) LABEL
-      CHARACTER(len=16) CAUX(NCAUX)
-      CHARACTER(len=400) BUF
-      CHARACTER(len=1) DASH(400)
-      DATA DASH/400*'-'/
-!C     ------------------------------------------------------------------
-!C
-!C1------Construct the complete label in BUF.  Start with BUF=LABEL.
-      BUF=LABEL
-!C
-!C2------Add auxiliary data names if there are any.
-      NBUF=LEN(LABEL)+9
-      IF(NAUX.GT.0) THEN
-         DO 10 I=1,NAUX
-         N1=NBUF+1
-         NBUF=NBUF+16
-         BUF(N1:NBUF)=CAUX(I)
-10       CONTINUE
-      END IF
-!C
-!C3------Write the label.
-      WRITE(IOUT,103) BUF(1:NBUF)
-  103 FORMAT(1X,A)
-!C
-!C4------Add a line of dashes.
-      WRITE(IOUT,104) (DASH(J),J=1,NBUF)
-  104 FORMAT(1X,400A)
-!C
-!C5------Return.
-      RETURN
-      END SUBROUTINE ULSTLB
-!
+  !> @brief Print a label for a list
+  !<
+  subroutine ULSTLB(iout, label, caux, ncaux, naux)
+    ! -- dummy
+    character(len=*) :: label
+    character(len=16) :: caux(ncaux)
+    ! -- local
+    character(len=400) buf
+    ! -- constant
+    character(len=1) DASH(400)
+    data DASH/400*'-'/
+    ! -- formats
+    character(len=*), parameter :: fmtmsgout1 = "(1x, a)"
+    character(len=*), parameter :: fmtmsgout2 = "(1x,400a)"
+    !
+    ! -- Construct the complete label in BUF.  Start with BUF=LABEL.
+    buf = label
+    !
+    ! -- Add auxiliary data names if there are any.
+    nbuf = len(label) + 9
+    if (naux > 0) then
+      do i = 1, naux
+        n1 = nbuf + 1
+        nbuf = nbuf + 16
+        buf(n1:nbuf) = caux(i)
+      end do
+    end if
+    !
+    ! -- Write the label.
+    write (iout, fmtmsgout1) buf(1:nbuf)
+    !
+    ! -- Add a line of dashes.
+    write (iout, fmtmsgout2) (DASH(j), j=1, nbuf)
+    !
+    ! -- Return
+    return
+  end subroutine ULSTLB
 
-      SUBROUTINE UBDSV4(KSTP,KPER,TEXT,NAUX,AUXTXT,IBDCHN, &
-     &          NCOL,NROW,NLAY,NLIST,IOUT,DELT,PERTIM,TOTIM)
-!C     ******************************************************************
-!C     WRITE HEADER RECORDS FOR CELL-BY-CELL FLOW TERMS FOR ONE COMPONENT
-!C     OF FLOW PLUS AUXILIARY DATA USING A LIST STRUCTURE.  EACH ITEM IN
-!C     THE LIST IS WRITTEN BY MODULE UBDSVB
-!C     ******************************************************************
-!C
-!C        SPECIFICATIONS:
-!C     ------------------------------------------------------------------
-      CHARACTER(len=16) :: TEXT
-      character(len=16), dimension(:) :: AUXTXT
-      real(DP),intent(in) :: delt,pertim,totim
-      character(len=*), parameter :: fmt = &
-      "(1X,'UBDSV4 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
-      "', STRESS PERIOD',I7)"
-!C     ------------------------------------------------------------------
-!C
-!C1------WRITE UNFORMATTED RECORDS IDENTIFYING DATA.
-      IF(IOUT.GT.0) WRITE(IOUT,fmt) TEXT,IBDCHN,KSTP,KPER
-      WRITE(IBDCHN) KSTP,KPER,TEXT,NCOL,NROW,-NLAY
-      WRITE(IBDCHN) 5,DELT,PERTIM,TOTIM
-      WRITE(IBDCHN) NAUX+1
-      IF(NAUX.GT.0) WRITE(IBDCHN) (AUXTXT(N),N=1,NAUX)
-      WRITE(IBDCHN) NLIST
-!C
-!C2------RETURN
-      RETURN
-      END SUBROUTINE UBDSV4
+  !> @brief Write header records for cell-by-cell flow terms for one component
+  !! of flow plus auxiliary data using a list structure
+  !!
+  !! Each item in the list is written by module UBDSVB
+  !<
+  subroutine UBDSV4(kstp, kper, text, naux, auxtxt, ibdchn, &
+     &              ncol, nrow, nlay, nlist, iout, delt, pertim, totim)
+    ! -- dummy
+    character(len=16) :: text
+    character(len=16), dimension(:) :: auxtxt
+    real(DP), intent(in) :: delt, pertim, totim
+    ! -- formats
+    character(len=*), parameter :: fmt = &
+      & "(1X,'UBDSV4 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
+      & "', STRESS PERIOD',I7)"
+    !
+    ! -- Write unformatted records identifying data
+    if (iout > 0) write (iout, fmt) text, ibdchn, kstp, kper
+    write (ibdchn) kstp, kper, text, ncol, nrow, -nlay
+    write (ibdchn) 5, delt, pertim, totim
+    write (ibdchn) naux + 1
+    if (naux > 0) write (ibdchn) (auxtxt(n), n=1, naux)
+    write (ibdchn) nlist
+    !
+    ! -- Return
+    return
+  end subroutine UBDSV4
 
-      SUBROUTINE UBDSVB(IBDCHN,ICRL,Q,VAL,NVL,NAUX,LAUX)
-!C     ******************************************************************
-!C     WRITE ONE VALUE OF CELL-BY-CELL FLOW PLUS AUXILIARY DATA USING
-!C     A LIST STRUCTURE.
-!C     ******************************************************************
-!C
-!C        SPECIFICATIONS:
-!C     ------------------------------------------------------------------
-      real(DP), DIMENSION(nvl) :: VAL
-      real(DP) :: q
-!C     ------------------------------------------------------------------
-!C
-!C1------WRITE CELL NUMBER AND FLOW RATE
-      IF(NAUX.GT.0) THEN
-         N2=LAUX+NAUX-1
-         WRITE(IBDCHN) ICRL,Q,(VAL(N),N=LAUX,N2)
-      ELSE
-         WRITE(IBDCHN) ICRL,Q
-      END IF
-!C
-!C2------RETURN
-      RETURN
-      END SUBROUTINE UBDSVB
+  !> @brief Write one value of cell-by-cell flow plus auxiliary data using a
+  !! list structure
+  !<
+  subroutine UBDSVB(ibdchn, icrl, q, val, nvl, naux, laux)
+    ! -- dummy
+    real(DP), dimension(nvl) :: val
+    real(DP) :: q
+    !
+    ! -- Write cell number and flow rate
+    IF (naux > 0) then
+      n2 = laux + naux - 1
+      write (ibdchn) icrl, q, (val(n), n=laux, n2)
+    else
+      write (ibdchn) icrl, q
+    end if
+    !
+    ! -- Return
+    return
+  end subroutine UBDSVB
 
-  SUBROUTINE UCOLNO(NLBL1,NLBL2,NSPACE,NCPL,NDIG,IOUT)
-!C     ******************************************************************
-!C     OUTPUT COLUMN NUMBERS ABOVE A MATRIX PRINTOUT
-!C        NLBL1 IS THE START COLUMN LABEL (NUMBER)
-!C        NLBL2 IS THE STOP COLUMN LABEL (NUMBER)
-!C        NSPACE IS NUMBER OF BLANK SPACES TO LEAVE AT START OF LINE
-!C        NCPL IS NUMBER OF COLUMN NUMBERS PER LINE
-!C        NDIG IS NUMBER OF CHARACTERS IN EACH COLUMN FIELD
-!C        IOUT IS OUTPUT CHANNEL
-!C     ******************************************************************
-!C
-!C        SPECIFICATIONS:
-!C     ------------------------------------------------------------------
-      CHARACTER(len=1) DOT,SPACE,DG,BF
-      DIMENSION BF(1000),DG(10)
-!C
-      DATA DG(1),DG(2),DG(3),DG(4),DG(5),DG(6),DG(7),DG(8),DG(9),DG(10)/ &
-     &         '0','1','2','3','4','5','6','7','8','9'/
-      DATA DOT,SPACE/'.',' '/
-!C     ------------------------------------------------------------------
-!C
-!C1------CALCULATE # OF COLUMNS TO BE PRINTED (NLBL), WIDTH
-!C1------OF A LINE (NTOT), NUMBER OF LINES (NWRAP).
-      if (iout<=0) return
-      WRITE(IOUT,1)
-    1 FORMAT(1X)
-      NLBL=NLBL2-NLBL1+1
-      N=NLBL
-      IF(NLBL.GT.NCPL) N=NCPL
-      NTOT=NSPACE+N*NDIG
-      IF(NTOT.GT.1000) GO TO 50
-      NWRAP=(NLBL-1)/NCPL + 1
-      J1=NLBL1-NCPL
-      J2=NLBL1-1
-!C
-!C2------BUILD AND PRINT EACH LINE
-      DO 40 N=1,NWRAP
-!C
-!C3------CLEAR THE BUFFER (BF).
-      DO 20 I=1,1000
-      BF(I)=SPACE
-   20 CONTINUE
-      NBF=NSPACE
-!C
-!C4------DETERMINE FIRST (J1) AND LAST (J2) COLUMN # FOR THIS LINE.
-      J1=J1+NCPL
-      J2=J2+NCPL
-      IF(J2.GT.NLBL2) J2=NLBL2
-!C
-!C5------LOAD THE COLUMN #'S INTO THE BUFFER.
-      DO 30 J=J1,J2
-      NBF=NBF+NDIG
-      I2=J/10
-      I1=J-I2*10+1
-      BF(NBF)=DG(I1)
-      IF(I2.EQ.0) GO TO 30
-      I3=I2/10
-      I2=I2-I3*10+1
-      BF(NBF-1)=DG(I2)
-      IF(I3.EQ.0) GO TO 30
-      I4=I3/10
-      I3=I3-I4*10+1
-      BF(NBF-2)=DG(I3)
-      IF(I4.EQ.0) GO TO 30
-      IF(I4.GT.9) THEN
-!C5A-----If more than 4 digits, use "X" for 4th digit.
-         BF(NBF-3)='X'
-      ELSE
-         BF(NBF-3)=DG(I4+1)
-      END IF
-   30 CONTINUE
-!C
-!C6------PRINT THE CONTENTS OF THE BUFFER (I.E. PRINT THE LINE).
-      WRITE(IOUT,31) (BF(I),I=1,NBF)
-   31 FORMAT(1X,1000A1)
-!C
-   40 CONTINUE
-!C
-!C7------PRINT A LINE OF DOTS (FOR AESTHETIC PURPOSES ONLY).
-   50 NTOT=NTOT
-      IF(NTOT.GT.1000) NTOT=1000
-      WRITE(IOUT,51) (DOT,I=1,NTOT)
-   51 FORMAT(1X,1000A1)
-!C
-!C8------RETURN
-      RETURN
-      END SUBROUTINE UCOLNO
-
-      SUBROUTINE ULAPRW(BUF,TEXT,KSTP,KPER,NCOL,NROW,ILAY,IPRN,IOUT)
-!C     ******************************************************************
-!C     PRINT 1 LAYER ARRAY
-!C     ******************************************************************
-!C
-!C        SPECIFICATIONS:
-!C     ------------------------------------------------------------------
-      CHARACTER(len=16) TEXT
-      real(DP),dimension(ncol,nrow) :: buf
-!C     ------------------------------------------------------------------
-!C
-      if (iout<=0) return
-!C1------PRINT A HEADER DEPENDING ON ILAY
-      IF(ILAY.GT.0) THEN
-         WRITE(IOUT,1) TEXT,ILAY,KSTP,KPER
-    1    FORMAT('1',/2X,A,' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
-     &     ' IN STRESS PERIOD ',I4/2X,75('-'))
-      ELSE IF(ILAY.LT.0) THEN
-         WRITE(IOUT,2) TEXT,KSTP,KPER
-    2    FORMAT('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
-     &     ' IN STRESS PERIOD ',I4/1X,79('-'))
-      END IF
-!C
-!C2------MAKE SURE THE FORMAT CODE (IP OR IPRN) IS
-!C2------BETWEEN 1 AND 21.
-      IP=IPRN
-      IF(IP.LT.1 .OR. IP.GT.21) IP=12
-!C
-!C3------CALL THE UTILITY MODULE UCOLNO TO PRINT COLUMN NUMBERS.
-      IF(IP.EQ.1) CALL UCOLNO(1,NCOL,0,11,11,IOUT)
-      IF(IP.EQ.2) CALL UCOLNO(1,NCOL,0,9,14,IOUT)
-      IF(IP.GE.3 .AND. IP.LE.6) CALL UCOLNO(1,NCOL,3,15,8,IOUT)
-      IF(IP.GE.7 .AND. IP.LE.11) CALL UCOLNO(1,NCOL,3,20,6,IOUT)
-      IF(IP.EQ.12) CALL UCOLNO(1,NCOL,0,10,12,IOUT)
-      IF(IP.GE.13 .AND. IP.LE.18) CALL UCOLNO(1,NCOL,3,10,7,IOUT)
-      IF(IP.EQ.19) CALL UCOLNO(1,NCOL,0,5,13,IOUT)
-      IF(IP.EQ.20) CALL UCOLNO(1,NCOL,0,6,12,IOUT)
-      IF(IP.EQ.21) CALL UCOLNO(1,NCOL,0,7,10,IOUT)
-!C
-!C4------LOOP THROUGH THE ROWS PRINTING EACH ONE IN ITS ENTIRETY.
-      DO I=1,NROW
-      SELECT CASE(IP)
-
-      CASE(1)
-!C------------ FORMAT 11G10.3
-      WRITE(IOUT,11) I,(BUF(J,I),J=1,NCOL)
-11    FORMAT(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))
-
-      CASE(2)
-!C------------ FORMAT 9G13.6
-      WRITE(IOUT,21) I,(BUF(J,I),J=1,NCOL)
-21    FORMAT(1X,I3,2X,1PG13.6,8(1X,G13.6):/(5X,9(1X,G13.6)))
-
-      CASE(3)
-!C------------ FORMAT 15F7.1
-      WRITE(IOUT,31) I,(BUF(J,I),J=1,NCOL)
-31    FORMAT(1X,I3,1X,15(1X,F7.1):/(5X,15(1X,F7.1)))
-
-      CASE(4)
-!C------------ FORMAT 15F7.2
-      WRITE(IOUT,41) I,(BUF(J,I),J=1,NCOL)
-41    FORMAT(1X,I3,1X,15(1X,F7.2):/(5X,15(1X,F7.2)))
-
-      CASE(5)
-!C------------ FORMAT 15F7.3
-      WRITE(IOUT,51) I,(BUF(J,I),J=1,NCOL)
-51    FORMAT(1X,I3,1X,15(1X,F7.3):/(5X,15(1X,F7.3)))
-
-      CASE(6)
-!C------------ FORMAT 15F7.4
-      WRITE(IOUT,61) I,(BUF(J,I),J=1,NCOL)
-61    FORMAT(1X,I3,1X,15(1X,F7.4):/(5X,15(1X,F7.4)))
-
-      CASE(7)
-!C------------ FORMAT 20F5.0
-      WRITE(IOUT,71) I,(BUF(J,I),J=1,NCOL)
-71    FORMAT(1X,I3,1X,20(1X,F5.0):/(5X,20(1X,F5.0)))
-
-      CASE(8)
-!C------------ FORMAT 20F5.1
-      WRITE(IOUT,81) I,(BUF(J,I),J=1,NCOL)
-81    FORMAT(1X,I3,1X,20(1X,F5.1):/(5X,20(1X,F5.1)))
-
-      CASE(9)
-!C------------ FORMAT 20F5.2
-      WRITE(IOUT,91) I,(BUF(J,I),J=1,NCOL)
-91    FORMAT(1X,I3,1X,20(1X,F5.2):/(5X,20(1X,F5.2)))
-
-      CASE(10)
-!C------------ FORMAT 20F5.3
-      WRITE(IOUT,101) I,(BUF(J,I),J=1,NCOL)
-101   FORMAT(1X,I3,1X,20(1X,F5.3):/(5X,20(1X,F5.3)))
-
-      CASE(11)
-!C------------ FORMAT 20F5.4
-      WRITE(IOUT,111) I,(BUF(J,I),J=1,NCOL)
-111   FORMAT(1X,I3,1X,20(1X,F5.4):/(5X,20(1X,F5.4)))
-
-      CASE(12)
-!C------------ FORMAT 10G11.4
-      WRITE(IOUT,121) I,(BUF(J,I),J=1,NCOL)
-121   FORMAT(1X,I3,2X,1PG11.4,9(1X,G11.4):/(5X,10(1X,G11.4)))
-
-      CASE(13)
-!C------------ FORMAT 10F6.0
-      WRITE(IOUT,131) I,(BUF(J,I),J=1,NCOL)
-131   FORMAT(1X,I3,1X,10(1X,F6.0):/(5X,10(1X,F6.0)))
-
-      CASE(14)
-!C------------ FORMAT 10F6.1
-      WRITE(IOUT,141) I,(BUF(J,I),J=1,NCOL)
-141   FORMAT(1X,I3,1X,10(1X,F6.1):/(5X,10(1X,F6.1)))
-
-      CASE(15)
-!C------------ FORMAT 10F6.2
-      WRITE(IOUT,151) I,(BUF(J,I),J=1,NCOL)
-151   FORMAT(1X,I3,1X,10(1X,F6.2):/(5X,10(1X,F6.2)))
-
-      CASE(16)
-!C------------ FORMAT 10F6.3
-      WRITE(IOUT,161) I,(BUF(J,I),J=1,NCOL)
-161   FORMAT(1X,I3,1X,10(1X,F6.3):/(5X,10(1X,F6.3)))
-
-      CASE(17)
-!C------------ FORMAT 10F6.4
-      WRITE(IOUT,171) I,(BUF(J,I),J=1,NCOL)
-171   FORMAT(1X,I3,1X,10(1X,F6.4):/(5X,10(1X,F6.4)))
-
-      CASE(18)
-!C------------ FORMAT 10F6.5
-      WRITE(IOUT,181) I,(BUF(J,I),J=1,NCOL)
-181   FORMAT(1X,I3,1X,10(1X,F6.5):/(5X,10(1X,F6.5)))
-
-      CASE(19)
-!C------------FORMAT 5G12.5
-      WRITE(IOUT,191) I,(BUF(J,I),J=1,NCOL)
-191   FORMAT(1X,I3,2X,1PG12.5,4(1X,G12.5):/(5X,5(1X,G12.5)))
-
-      CASE(20)
-!C------------FORMAT 6G11.4
-      WRITE(IOUT,201) I,(BUF(J,I),J=1,NCOL)
-201   FORMAT(1X,I3,2X,1PG11.4,5(1X,G11.4):/(5X,6(1X,G11.4)))
-
-      CASE(21)
-!C------------FORMAT 7G9.2
-      WRITE(IOUT,211) I,(BUF(J,I),J=1,NCOL)
-211   FORMAT(1X,I3,2X,1PG9.2,6(1X,G9.2):/(5X,7(1X,G9.2)))
-
-      END SELECT
-      END DO
+  !> @brief Output column numbers above a matrix printout
+  !!
+  !! nlbl1 is the start column label (number)
+  !! nlbl2 is the stop column label (number)
+  !! nspace is number of blank spaces to leave at start of line
+  !! ncpl is number of column numbers per line
+  !! ndig is number of characters in each column field
+  !! iout is output channel
+  !<
+  subroutine UCOLNO(nlbl1, nlbl2, nspace, ncpl, ndig, iout)
+    ! -- local
+    character(len=1) :: DOT, SPACE, DG, BF
+    dimension :: BF(1000), DG(10)
+    ! -- constants
+    data DG(1), DG(2), DG(3), DG(4), DG(5), DG(6), DG(7), DG(8), DG(9), DG(10)/ &
+       & '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'/
+    data DOT, SPACE/'.', ' '/
+    ! -- formats
+    character(len=*), parameter :: fmtmsgout1 = "(1x)"
+    character(len=*), parameter :: fmtmsgout2 = "(1x, 1000a1)"
+    !
+    ! -- Calculate # of columns to be printed (nlbl), width
+    !    of a line (ntot), number of lines (nwrap).
+    if (iout <= 0) return
+    write (iout, fmtmsgout1)
+    !
+    nlbl = nlbl2 - nlbl1 + 1
+    n = nlbl
+    !
+    if (nlbl < ncpl) n = ncpl
+    ntot = nspace + n * ndig
+    !
+    if (ntot > 1000) go to 50
+    nwrap = (nlbl - 1) / ncpl + 1
+    j1 = nlbl1 - ncpl
+    j2 = nlbl1 - 1
+    !
+    ! -- Build and print each line
+    do n = 1, nwrap
       !
-      ! -- flush file
-      flush(IOUT)
+      ! -- Clear the buffer (BF)
+      do i = 1, 1000
+        BF(i) = SPACE
+      end do
+      nbf = nspace
       !
-      ! -- return
-      RETURN
-      END SUBROUTINE ULAPRW
-
-     SUBROUTINE ULASAV(BUF,TEXT,KSTP,KPER,PERTIM,TOTIM,NCOL, &
-     &                   NROW,ILAY,ICHN)
-!C     ******************************************************************
-!C     SAVE 1 LAYER ARRAY ON DISK
-!C     ******************************************************************
-!C
-!C        SPECIFICATIONS:
-!C     ------------------------------------------------------------------
-      CHARACTER(len=16) TEXT
-      real(DP),dimension(ncol,nrow) :: buf
-      real(DP) :: pertim,totim
-!C     ------------------------------------------------------------------
-!C
-!C1------WRITE AN UNFORMATTED RECORD CONTAINING IDENTIFYING
-!C1------INFORMATION.
-      WRITE(ICHN) KSTP,KPER,PERTIM,TOTIM,TEXT,NCOL,NROW,ILAY
-!C
-!C2------WRITE AN UNFORMATTED RECORD CONTAINING ARRAY VALUES
-!C2------THE ARRAY IS DIMENSIONED (NCOL,NROW)
-      WRITE(ICHN) ((BUF(IC,IR),IC=1,NCOL),IR=1,NROW)
+      ! -- Determine first (j1) and last (j2) column # for this line.
+      j1 = j1 + ncpl
+      j2 = j2 + ncpl
+      if (j2 > nlbl2) j2 = nlbl2
       !
-      ! -- flush file
-      flush(ICHN)
-!C
-!C3------RETURN
-      RETURN
-     END SUBROUTINE ULASAV
+      ! -- Load the column #'s into the buffer.
+      do j = j1, j2
+        nbf = nbf + ndig
+        i2 = j / 10
+        i1 = j - i2 * 10 + 1
+        BF(nbf) = DG(i1)
+        if (i2 == 0) go to 30
+        i3 = i2 / 10
+        i2 = i2 - i3 * 10 + 1
+        BF(nbf - 1) = DG(i2)
+        if (i3 == 0) go to 30
+        i4 = i3 / 10
+        i3 = i3 - i4 * 10 + 1
+        BF(nbf - 2) = DG(i3)
+        if (I4 == 0) go to 30
+        if (I4 > 9) then
+          ! -- If more than 4 digits, use "X" for 4th digit.
+          BF(nbf - 3) = 'X'
+        else
+          BF(nbf - 3) = DG(i4 + 1)
+        end if
+30    end do
+      !
+      ! -- Print the contents of the buffer (i.e. print the line).
+      write (iout, fmtmsgout2) (BF(i), i=1, nbf)
+      !
+    end do
+    !
+    ! -- Print a line of dots (for aesthetic purposes only).
+50  ntot = ntot
+    if (ntot > 1000) ntot = 1000
+    write (iout, fmtmsgout2) (DOT, i=1, ntot)
+    !
+    ! -- Return
+    return
+  end subroutine UCOLNO
 
+  !> @brief Print 1 layer array
+  !<
+  subroutine ULAPRW(buf, text, kstp, kper, ncol, nrow, ilay, iprn, iout)
+    ! -- dummy
+    character(len=16) :: text
+    real(DP), dimension(ncol, nrow) :: buf
+    ! -- formats
+    character(len=*), parameter :: fmtmsgout1 = &
+      & "('1', /2x, a, ' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
+      & ' IN STRESS PERIOD ',I4/2x,75('-'))"
+    character(len=*), parameter :: fmtmsgout2 = &
+      & "('1',/1x,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
+      & ' IN STRESS PERIOD ',I4/1x,79('-'))"
+    character(len=*), parameter :: fmtg10 = &
+      & "(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))"
+    character(len=*), parameter :: fmtg13 = &
+      & "(1x,I3,2x,1PG13.6,8(1x,G13.6):/(5x,9(1x,G13.6)))"
+    character(len=*), parameter :: fmtf7pt1 = &
+      & "(1x,I3,1x,15(1x,F7.1):/(5x,15(1x,F7.1)))"
+    character(len=*), parameter :: fmtf7pt2 = &
+      & "(1x,I3,1x,15(1x,F7.2):/(5x,15(1x,F7.2)))"
+    character(len=*), parameter :: fmtf7pt3 = &
+      & "(1x,I3,1x,15(1x,F7.3):/(5x,15(1x,F7.3)))"
+    character(len=*), parameter :: fmtf7pt4 = &
+      & "(1x,I3,1x,15(1x,F7.4):/(5x,15(1x,F7.4)))"
+    character(len=*), parameter :: fmtf5pt0 = &
+      & "(1x,I3,1x,20(1x,F5.0):/(5x,20(1x,F5.0)))"
+    character(len=*), parameter :: fmtf5pt1 = &
+      & "(1x,I3,1x,20(1x,F5.1):/(5x,20(1x,F5.1)))"
+    character(len=*), parameter :: fmtf5pt2 = &
+      & "(1x,I3,1x,20(1x,F5.2):/(5x,20(1x,F5.2)))"
+    character(len=*), parameter :: fmtf5pt3 = &
+      & "(1x,I3,1x,20(1x,F5.3):/(5x,20(1x,F5.3)))"
+    character(len=*), parameter :: fmtf5pt4 = &
+      & "(1x,I3,1x,20(1x,F5.4):/(5x,20(1x,F5.4)))"
+    character(len=*), parameter :: fmtg11 = &
+      & "(1x,I3,2x,1PG11.4,9(1x,G11.4):/(5x,10(1x,G11.4)))"
+    character(len=*), parameter :: fmtf6pt0 = &
+      & "(1x,I3,1x,10(1x,F6.0):/(5X,10(1x,F6.0)))"
+    character(len=*), parameter :: fmtf6pt1 = &
+      & "(1x,I3,1x,10(1x,F6.1):/(5x,10(1x,F6.1)))"
+    character(len=*), parameter :: fmtf6pt2 = &
+      & "(1x,I3,1x,10(1x,F6.2):/(5x,10(1x,F6.2)))"
+    character(len=*), parameter :: fmtf6pt3 = &
+      & "(1x,I3,1x,10(1x,F6.3):/(5x,10(1x,F6.3)))"
+    character(len=*), parameter :: fmtf6pt4 = &
+      & "(1x,I3,1x,10(1x,F6.4):/(5x,10(1x,F6.4)))"
+    character(len=*), parameter :: fmtf6pt5 = &
+      & "(1x,I3,1x,10(1x,F6.5):/(5x,10(1x,F6.5)))"
+    character(len=*), parameter :: fmtg12 = &
+      & "(1x,I3,2x,1PG12.5,4(1x,G12.5):/(5x,5(1x,G12.5)))"
+    character(len=*), parameter :: fmtg11pt4 = &
+      & "(1x,I3,2x,1PG11.4,5(1x,G11.4):/(5x,6(1x,G11.4)))"
+    character(len=*), parameter :: fmtg9pt2 = &
+      & "(1x,I3,2x,1PG9.2,6(1x,G9.2):/(5x,7(1x,G9.2)))"
+    !
+    if (iout <= 0) return
+    ! -- Print a header depending on ilay
+    if (ilay > 0) then
+      write (iout, fmtmsgout1) text, ilay, kstp, kper
+    else if (ilay < 0) then
+      write (iout, fmtmsgout2) text, kstp, kper
+    end if
+    !
+    ! -- Make sure the format code (ip or iprn) is between 1 and 21
+    ip = iprn
+    if (ip < 1 .or. ip > 21) ip = 12
+    !
+    ! -- Call the utility module ucolno to print column numbers.
+    if (ip == 1) call ucolno(1, ncol, 0, 11, 11, iout)
+    if (ip == 2) call ucolno(1, ncol, 0, 9, 14, iout)
+    if (ip >= 3 .and. ip <= 6) call ucolno(1, ncol, 3, 15, 8, iout)
+    if (ip >= 7 .and. ip <= 11) call ucolno(1, ncol, 3, 20, 6, iout)
+    if (ip == 12) call ucolno(1, ncol, 0, 10, 12, iout)
+    if (ip >= 13 .and. ip <= 18) call ucolno(1, ncol, 3, 10, 7, iout)
+    if (ip == 19) call ucolno(1, ncol, 0, 5, 13, iout)
+    if (ip == 20) call ucolno(1, ncol, 0, 6, 12, iout)
+    if (ip == 21) call ucolno(1, ncol, 0, 7, 10, iout)
+    !
+    ! -- Loop through the rows printing each one in its entirety.
+    do i = 1, nrow
+      select case (ip)
+        !
+      case (1)
+        ! -- format 11G10.3
+        write (iout, fmtg10) i, (buf(j, i), j=1, ncol)
+        !
+      case (2)
+        ! -- format 9G13.6
+        write (iout, fmtg13) i, (buf(j, i), j=1, ncol)
+        !
+      case (3)
+        ! -- format 15F7.1
+        write (iout, fmtf7pt1) i, (buf(j, i), j=1, ncol)
+        !
+      case (4)
+        ! -- format 15F7.2
+        write (iout, fmtf7pt2) i, (buf(j, i), j=1, ncol)
+        !
+      case (5)
+        ! -- format 15F7.3
+        write (iout, fmtf7pt3) i, (buf(j, i), j=1, ncol)
+        !
+      case (6)
+        ! -- format 15F7.4
+        write (iout, fmtf7pt4) i, (buf(j, i), j=1, ncol)
+        !
+      case (7)
+        ! -- format 20F5.0
+        write (iout, fmtf5pt0) i, (buf(j, i), j=1, ncol)
+        !
+      case (8)
+        ! -- format 20F5.1
+        write (iout, fmtf5pt1) i, (buf(j, i), j=1, ncol)
+        !
+      case (9)
+        ! -- format 20F5.2
+        write (iout, fmtf5pt2) i, (buf(j, i), j=1, ncol)
+        !
+      case (10)
+        ! -- format 20F5.3
+        write (iout, fmtf5pt3) i, (buf(j, i), j=1, ncol)
+        !
+      case (11)
+        ! -- format 20F5.4
+        write (iout, fmtf5pt4) i, (buf(j, i), j=1, ncol)
+        !
+      case (12)
+        ! -- format 10G11.4
+        write (iout, fmtg11) i, (buf(j, i), j=1, ncol)
+        !
+      case (13)
+        ! -- format 10F6.0
+        write (iout, fmtf6pt0) i, (buf(j, i), j=1, ncol)
+        !
+      case (14)
+        ! -- format 10F6.1
+        write (iout, fmtf6pt1) i, (buf(j, i), j=1, ncol)
+        !
+      case (15)
+        ! -- format 10F6.2
+        write (iout, fmtf6pt2) i, (buf(j, i), j=1, ncol)
+        !
+      case (16)
+        ! -- format 10F6.3
+        write (iout, fmtf6pt3) i, (buf(j, i), j=1, ncol)
+        !
+      case (17)
+        ! -- format 10F6.4
+        write (iout, fmtf6pt4) i, (buf(j, i), j=1, ncol)
+        !
+      case (18)
+        ! -- format 10F6.5
+        write (iout, fmtf6pt5) i, (buf(j, i), j=1, ncol)
+        !
+      case (19)
+        ! -- format 5G12.5
+        write (iout, fmtg12) i, (buf(j, i), j=1, ncol)
+        !
+      case (20)
+        ! -- format 6G11.4
+        write (iout, fmtg11pt4) i, (buf(j, i), j=1, ncol)
+        !
+      case (21)
+        ! -- format 7G9.2
+        write (iout, fmtg9pt2) i, (buf(j, i), j=1, ncol)
+        !
+      end select
+    end do
+    !
+    ! -- Flush file
+    flush (iout)
+    !
+    ! -- Return
+    return
+  end subroutine ULAPRW
+
+  !> @brief Save 1 layer array on disk
+  !<
+  subroutine ulasav(buf, text, kstp, kper, pertim, totim, ncol, nrow, &
+                    ilay, ichn)
+    ! -- dummy
+    character(len=16) :: text
+    real(DP), dimension(ncol, nrow) :: buf
+    real(DP) :: pertim, totim
+    !
+    ! -- Write an unformatted record containing identifying information
+    write (ichn) kstp, kper, pertim, totim, text, ncol, nrow, ilay
+    !
+    ! -- Write an unformatted record containing array values. The array is
+    !    dimensioned (ncol,nrow)
+    write (ichn) ((buf(ic, ir), ic=1, ncol), ir=1, nrow)
+    !
+    ! -- flush file
+    flush (ICHN)
+    !
+    ! -- Return
+    return
+  end subroutine ulasav
+
+  !> @brief Record cell-by-cell flow terms for one component of flow as a 3-D
+  !! array with extra record to indicate delt, pertim, and totim
+  !<
   subroutine ubdsv1(kstp, kper, text, ibdchn, buff, ncol, nrow, nlay, iout, &
                     delt, pertim, totim)
-! ******************************************************************************
-! Record cell-by-cell flow terms for one component of flow as a 3-D array with
-!   extra record to indicate delt, pertim, and totim
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
+    ! -- dummy
     integer(I4B), intent(in) :: kstp
     integer(I4B), intent(in) :: kper
     character(len=*), intent(in) :: text
@@ -995,35 +980,32 @@ END SUBROUTINE URWORD
     real(DP), intent(in) :: totim
     ! -- format
     character(len=*), parameter :: fmt = &
-      "(1X,'UBDSV1 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
-      "', STRESS PERIOD',I7)"
-! ------------------------------------------------------------------------------
+      & "(1X,'UBDSV1 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
+      & "', STRESS PERIOD',I7)"
     !
     ! -- Write records
-    if(iout > 0) write(iout, fmt) text, ibdchn, kstp, kper
-    write(ibdchn) kstp,kper,text,ncol,nrow,-nlay
-    write(ibdchn) 1,delt,pertim,totim
-    write(ibdchn) buff
+    if (iout > 0) write (iout, fmt) text, ibdchn, kstp, kper
+    write (ibdchn) kstp, kper, text, ncol, nrow, -nlay
+    write (ibdchn) 1, delt, pertim, totim
+    write (ibdchn) buff
     !
     ! -- flush file
-    flush(ibdchn)
+    flush (ibdchn)
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ubdsv1
 
-  subroutine ubdsv06(kstp,kper,text,                                 &
-                     modelnam1,paknam1,modelnam2,paknam2,            &
-                     ibdchn,naux,auxtxt,                             &
-                     ncol,nrow,nlay,nlist,iout,delt,pertim,totim)
-! ******************************************************************
-! write header records for cell-by-cell flow terms for one component
-! of flow.  each item in the list is written by module ubdsvc
-! ******************************************************************
-!
-!     specifications:
-! ------------------------------------------------------------------
+  !> @brief Write header records for cell-by-cell flow terms for one component
+  !! of flow.
+  !!
+  !! Each item in the list is written by module ubdsvc
+  !<
+  subroutine ubdsv06(kstp, kper, text, modelnam1, paknam1, modelnam2, paknam2, &
+                     ibdchn, naux, auxtxt, ncol, nrow, nlay, nlist, iout, &
+                     delt, pertim, totim)
     implicit none
+    ! -- dummy
     integer(I4B), intent(in) :: kstp
     integer(I4B), intent(in) :: kper
     character(len=*), intent(in) :: text
@@ -1042,105 +1024,100 @@ END SUBROUTINE URWORD
     real(DP), intent(in) :: delt
     real(DP), intent(in) :: pertim
     real(DP), intent(in) :: totim
-    ! -- local variables
+    ! -- local
     integer(I4B) :: n
     ! -- format
     character(len=*), parameter :: fmt = &
-      "(1X,'UBDSV06 SAVING ',A16,' IN MODEL ',A16,' PACKAGE ',A16,"//&
-      "'CONNECTED TO MODEL ',A16,' PACKAGE ',A16,"//                 &
-      "' ON UNIT',I7,' AT TIME STEP',I7,', STRESS PERIOD',I7)"
-! ------------------------------------------------------------------
-!
-! write unformatted records identifying data.
-    if (iout > 0) write(iout,fmt) text, modelnam1, paknam1,          &
-                                  modelnam2, paknam2,                &
-                                  ibdchn, kstp, kper
-    write(ibdchn) kstp,kper,text,ncol,nrow,-nlay
-    write(ibdchn) 6,delt,pertim,totim
-    write(ibdchn) modelnam1
-    write(ibdchn) paknam1
-    write(ibdchn) modelnam2
-    write(ibdchn) paknam2
-    write(ibdchn) naux+1
-    if (naux > 0) write(ibdchn) (auxtxt(n),n=1,naux)
-    write(ibdchn) nlist
+      & "(1X,'UBDSV06 SAVING ',A16,' IN MODEL ',A16,' PACKAGE ',A16,"// &
+      & "'CONNECTED TO MODEL ',A16,' PACKAGE ',A16,"// &
+      & "' ON UNIT',I7,' AT TIME STEP',I7,', STRESS PERIOD',I7)"
     !
-    ! -- return
+    ! -- Write unformatted records identifying data.
+    if (iout > 0) write (iout, fmt) text, modelnam1, paknam1, modelnam2, &
+      paknam2, modelnam2, paknam2, ibdchn, kstp, kper
+    write (ibdchn) kstp, kper, text, ncol, nrow, -nlay
+    write (ibdchn) 6, delt, pertim, totim
+    write (ibdchn) modelnam1
+    write (ibdchn) paknam1
+    write (ibdchn) modelnam2
+    write (ibdchn) paknam2
+    write (ibdchn) naux + 1
+    if (naux > 0) write (ibdchn) (auxtxt(n), n=1, naux)
+    write (ibdchn) nlist
+    !
+    ! -- Return
     return
   end subroutine ubdsv06
 
+  !> @brief Write one value of cell-by-cell flow using a list structure.
+  !!
+  !! From node (n) and to node (n2) are written to the file
+  !<
   subroutine ubdsvc(ibdchn, n, q, naux, aux)
-! ******************************************************************************
-! Write one value of cell-by-cell flow using a list structure. From node (n)
-! and to node (n2) are written to the file
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
+    ! -- dummy
     integer(I4B), intent(in) :: ibdchn
     integer(I4B), intent(in) :: n
     real(DP), intent(in) :: q
     integer(I4B), intent(in) :: naux
     real(DP), dimension(naux), intent(in) :: aux
-    ! -- local variables
+    ! -- local
     integer(I4B) :: nn
-! ------------------------------------------------------------------------------
     !
     ! -- Write record
     if (naux > 0) then
-        write(ibdchn) n,q,(aux(nn),nn=1,naux)
+      write (ibdchn) n, q, (aux(nn), nn=1, naux)
     else
-        write(ibdchn) n,q
+      write (ibdchn) n, q
     end if
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ubdsvc
 
+  !> @brief Write one value of cell-by-cell flow using a list structure.
+  !!
+  !! From node (n) and to node (n2) are written to the file
+  !<
   subroutine ubdsvd(ibdchn, n, n2, q, naux, aux)
-! ******************************************************************************
-! Write one value of cell-by-cell flow using a list structure. From node (n)
-! and to node (n2) are written to the file
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
+    ! -- dummy
     integer(I4B), intent(in) :: ibdchn
     integer(I4B), intent(in) :: n
     integer(I4B), intent(in) :: n2
     real(DP), intent(in) :: q
     integer(I4B), intent(in) :: naux
     real(DP), dimension(naux), intent(in) :: aux
-    ! -- local variables
+    ! -- local
     integer(I4B) :: nn
-! ------------------------------------------------------------------------------
     !
     ! -- Write record
     if (naux > 0) then
-        write(ibdchn) n,n2,q,(aux(nn),nn=1,naux)
+      write (ibdchn) n, n2, q, (aux(nn), nn=1, naux)
     else
-        write(ibdchn) n,n2,q
+      write (ibdchn) n, n2, q
     end if
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ubdsvd
 
+  !> @brief Perform a case-insensitive comparison of two words
+  !<
   logical function same_word(word1, word2)
-    ! Perform a case-insensitive comparison of two words
     implicit none
-    ! -- dummy variables variables
+    ! -- dummy
     character(len=*), intent(in) :: word1, word2
-    ! -- local variables
+    ! -- local
     character(len=200) :: upword1, upword2
     !
     upword1 = word1
     call upcase(upword1)
     upword2 = word2
     call upcase(upword2)
-    same_word = (upword1==upword2)
+    same_word = (upword1 == upword2)
+    !
+    ! -- Return
     return
   end function same_word
 
@@ -1161,58 +1138,60 @@ END SUBROUTINE URWORD
   end function
 
   subroutine unitinquire(iu)
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B) :: iu
-    ! -- local variables
+    ! -- local
     character(len=LINELENGTH) :: line
     character(len=100) :: fname, ac, act, fm, frm, seq, unf
     ! -- format
-    character(len=*), parameter :: fmta =                                        &
-       &"('unit:',i4,'  name:',a,'  access:',a,'  action:',a)"                                  
-    character(len=*), parameter :: fmtb =                                        &
-       &"('    formatted:',a,'  sequential:',a,'  unformatted:',a,'  form:',a)"                                  
-    ! -- code
+    character(len=*), parameter :: fmta = &
+       &"('unit:',i4,'  name:',a,'  access:',a,'  action:',a)"
+    character(len=*), parameter :: fmtb = &
+       &"('    formatted:',a,'  sequential:',a,'  unformatted:',a,'  form:',a)"
     !
     ! -- set strings using inquire statement
-    inquire(unit=iu, name=fname, access=ac, action=act, formatted=fm,            &
-            sequential=seq, unformatted=unf, form=frm)
+    inquire (unit=iu, name=fname, access=ac, action=act, formatted=fm, &
+             sequential=seq, unformatted=unf, form=frm)
     !
     ! -- write the results of the inquire statement
-    write(line,fmta) iu, trim(fname), trim(ac), trim(act)
+    write (line, fmta) iu, trim(fname), trim(ac), trim(act)
     call write_message(line)
-    write(line,fmtb) trim(fm), trim(seq), trim(unf), trim(frm)
+    write (line, fmtb) trim(fm), trim(seq), trim(unf), trim(frm)
     call write_message(line)
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine unitinquire
 
+  !> @brief Parse a line into words.
+  !!
+  !! Blanks and commas are recognized as delimiters. Multiple blanks between
+  !! words is OK, but multiple commas between words is treated as an error.
+  !! Quotation marks are not recognized as delimiters.
+  !<
   subroutine ParseLine(line, nwords, words, inunit, filename)
-    ! Parse a line into words. Blanks and commas are recognized as
-    ! delimiters. Multiple blanks between words is OK, but multiple
-    ! commas between words is treated as an error. Quotation marks
-    ! are not recognized as delimiters.
+    ! -- modules
     use ConstantsModule, only: LINELENGTH
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     character(len=*), intent(in) :: line
     integer(I4B), intent(inout) :: nwords
     character(len=*), allocatable, dimension(:), intent(inout) :: words
     integer(I4B), intent(in), optional :: inunit
     character(len=*), intent(in), optional :: filename
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i, idum, istart, istop, linelen, lloc
     real(DP) :: rdum
     !
     nwords = 0
     if (allocated(words)) then
-      deallocate(words)
-    endif
+      deallocate (words)
+    end if
     linelen = len(line)
     !
     ! -- get the number of words in a line and allocate words array
     nwords = get_nwords(line)
-    allocate(words(nwords))
+    allocate (words(nwords))
     !
     ! -- Populate words array and return
     lloc = 1
@@ -1221,133 +1200,137 @@ END SUBROUTINE URWORD
       words(i) = line(istart:istop)
     end do
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ParseLine
 
+  !> @brief Print 1 layer array with user formatting in wrap format
+  !<
   subroutine ulaprufw(ncol, nrow, kstp, kper, ilay, iout, buf, text, userfmt, &
                       nvalues, nwidth, editdesc)
-    ! **************************************************************************
-    ! Print 1 layer array with user formatting in wrap format
-    ! **************************************************************************
-    !
-    !    Specifications:
-    ! --------------------------------------------------------------------------
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(in) :: ncol, nrow, kstp, kper, ilay, iout
-    real(DP),dimension(ncol,nrow), intent(in) :: buf
+    real(DP), dimension(ncol, nrow), intent(in) :: buf
     character(len=*), intent(in) :: text
     character(len=*), intent(in) :: userfmt
     integer(I4B), intent(in) :: nvalues, nwidth
     character(len=1), intent(in) :: editdesc
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i, j, nspaces
-    ! formats
-    1 format('1',/2X,A,' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
-          ' IN STRESS PERIOD ',I4/2X,75('-'))
-    2 format('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
-          ' IN STRESS PERIOD ',I4/1X,79('-'))
-    ! ------------------------------------------------------------------
+    ! -- formats
+    character(len=*), parameter :: fmtmsgout1 = &
+      "('1',/2X,A,' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
+&        ' IN STRESS PERIOD ',I4/2X,75('-'))"
+    character(len=*), parameter :: fmtmsgout2 = &
+      "('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
+&        ' IN STRESS PERIOD ',I4/1X,79('-'))"
     !
-    if (iout<=0) return
+    if (iout <= 0) return
     ! -- Print a header depending on ILAY
     if (ilay > 0) then
-       write(iout,1) trim(text), ilay, kstp, kper
-    else if(ilay < 0) then
-       write(iout,2) trim(text), kstp, kper
+      write (iout, fmtmsgout1) trim(text), ilay, kstp, kper
+    else if (ilay < 0) then
+      write (iout, fmtmsgout2) trim(text), kstp, kper
     end if
     !
     ! -- Print column numbers.
     nspaces = 0
     if (editdesc == 'F') nspaces = 3
-    call ucolno(1, ncol, nspaces, nvalues, nwidth+1, iout)
+    call ucolno(1, ncol, nspaces, nvalues, nwidth + 1, iout)
     !
     ! -- Loop through the rows, printing each one in its entirety.
-    do i=1,nrow
-      write(iout,userfmt) i,(buf(j,i),j=1,ncol)
+    do i = 1, nrow
+      write (iout, userfmt) i, (buf(j, i), j=1, ncol)
     end do
     !
     ! -- flush file
-    flush(IOUT)
+    flush (IOUT)
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine ulaprufw
 
-  function read_line(iu, eof) result (astring)
-    ! This function reads a line of arbitrary length and returns
-    ! it.  The returned string can be stored in a deferred-length
-    ! character variable, for example:
-    !
-    !    integer(I4B) :: iu
-    !    character(len=:), allocatable :: my_string
-    !    logical :: eof
-    !    iu = 8
-    !    open(iu,file='my_file')
-    !    my_string = read_line(iu, eof)
+  !> @breif This function reads a line of arbitrary length and returns it.
+  !!
+  !! The returned string can be stored in a deferred-length character variable,
+  !! for example:
+  !!
+  !!   integer(I4B) :: iu
+  !!   character(len=:), allocatable :: my_string
+  !!   logical :: eof
+  !!   iu = 8
+  !!   open(iu,file='my_file')
+  !!   my_string = read_line(iu, eof)
+  !<
+  function read_line(iu, eof) result(astring)
     !
     implicit none
-    ! -- dummy variables
-    integer(I4B), intent(in)           :: iu
-    logical, intent(out)          :: eof
+    ! -- dummy
+    integer(I4B), intent(in) :: iu
+    logical, intent(out) :: eof
     character(len=:), allocatable :: astring
-    ! -- local variables
-    integer(I4B)        :: isize, istat
-    character(len=256)  :: buffer
+    ! -- local
+    integer(I4B) :: isize, istat
+    character(len=256) :: buffer
     character(len=1000) :: ermsg, fname
-    character(len=7)    :: fmtd
-    logical             :: lop
-    ! -- format
-20  format('Error in read_line: File ',i0,' is not open.')
-30  format('Error in read_line: Attempting to read text ' // &
-              'from unformatted file: "',a,'"')
-40  format('Error reading from file "',a,'" opened on unit ',i0, &
-              ' in read_line.')
+    character(len=7) :: fmtd
+    logical :: lop
+    ! -- formats
+    character(len=*), parameter :: fmterrmsg1 = &
+      & "('Error in read_line: File ',i0,' is not open.')"
+    character(len=*), parameter :: fmterrmsg2 = &
+      & "('Error in read_line: Attempting to read text ' // &
+      & 'from unformatted file: ""',a,'""')"
+    character(len=*), parameter :: fmterrmsg3 = &
+      & "('Error reading from file ""',a,'"" opened on unit ',i0, &
+      & ' in read_line.')"
     !
     astring = ''
     eof = .false.
     do
-      read(iu, '(a)', advance='NO', iostat=istat, size=isize, end=99) buffer
+      read (iu, '(a)', advance='NO', iostat=istat, size=isize, end=99) buffer
       if (istat > 0) then
         ! Determine error if possible, report it, and stop.
         if (iu <= 0) then
-          ermsg = 'Programming error in call to read_line: ' // &
+          ermsg = 'Programming error in call to read_line: '// &
                   'Attempt to read from unit number <= 0'
         else
-          inquire(unit=iu,opened=lop,name=fname,formatted=fmtd)
+          inquire (unit=iu, opened=lop, name=fname, formatted=fmtd)
           if (.not. lop) then
-            write(ermsg,20) iu
+            write (ermsg, fmterrmsg1) iu
           elseif (fmtd == 'NO' .or. fmtd == 'UNKNOWN') then
-            write(ermsg, 30) trim(fname)
+            write (ermsg, fmterrmsg2) trim(fname)
           else
-            write(ermsg,40) trim(fname), iu
-          endif
-        endif
+            write (ermsg, fmterrmsg3) trim(fname), iu
+          end if
+        end if
         call store_error(ermsg)
         call store_error_unit(iu)
-      endif
-      astring = astring // buffer(:isize)
-      ! An end-of-record condition stops the loop.
+      end if
+      astring = astring//buffer(:isize)
+      ! -- An end-of-record condition stops the loop.
       if (istat < 0) then
         return
-      endif
-    enddo
+      end if
+    end do
     !
     return
 99  continue
+    !
     ! An end-of-file condition returns an empty string.
     eof = .true.
-    return
     !
+    ! -- Return
+    return
   end function read_line
 
   subroutine GetFileFromPath(pathname, filename)
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     character(len=*), intent(in) :: pathname
     character(len=*), intent(out) :: filename
-    ! -- local variables
+    ! -- local
     integer(I4B) :: i, istart, istop, lenpath
     character(len=1) :: fs = '/'
     character(len=1) :: bs = '\'
@@ -1356,40 +1339,44 @@ END SUBROUTINE URWORD
     lenpath = len_trim(pathname)
     istart = 1
     istop = lenpath
-    loop: do i=lenpath,1,-1
+    loop: do i = lenpath, 1, -1
       if (pathname(i:i) == fs .or. pathname(i:i) == bs) then
         if (i == istop) then
           istop = istop - 1
         else
           istart = i + 1
           exit loop
-        endif
-      endif
-    enddo loop
+        end if
+      end if
+    end do loop
     if (istop >= istart) then
       filename = pathname(istart:istop)
-    endif
+    end if
     !
+    ! -- Return
     return
   end subroutine GetFileFromPath
 
+  !> @brief Starting at position icol, define string as line(istart:istop).
+  !!
+  !! If string can be interpreted as an integer(I4B), return integer in idnum
+  !! argument. If token is not an integer(I4B), assume it is a boundary name,
+  !! return NAMEDBOUNDFLAG in idnum, convert string to uppercase and return it
+  !! in bndname.
+  !<
   subroutine extract_idnum_or_bndname(line, icol, istart, istop, idnum, bndname)
-    ! Starting at position icol, define string as line(istart:istop).
-    ! If string can be interpreted as an integer(I4B), return integer in idnum argument.
-    ! If token is not an integer(I4B), assume it is a boundary name, return NAMEDBOUNDFLAG
-    ! in idnum, convert string to uppercase and return it in bndname.
     implicit none
-    ! -- dummy variables
-    character(len=*),            intent(inout) :: line
-    integer(I4B),                     intent(inout) :: icol, istart, istop
-    integer(I4B),                     intent(out)   :: idnum
-    character(len=LENBOUNDNAME), intent(out)   :: bndname
-    ! -- local variables
-    integer(I4B) :: istat, ndum, ncode=0
+    ! -- dummy
+    character(len=*), intent(inout) :: line
+    integer(I4B), intent(inout) :: icol, istart, istop
+    integer(I4B), intent(out) :: idnum
+    character(len=LENBOUNDNAME), intent(out) :: bndname
+    ! -- local
+    integer(I4B) :: istat, ndum, ncode = 0
     real(DP) :: rdum
     !
     call urword(line, icol, istart, istop, ncode, ndum, rdum, 0, 0)
-    read(line(istart:istop),*,iostat=istat) ndum
+    read (line(istart:istop), *, iostat=istat) ndum
     if (istat == 0) then
       idnum = ndum
       bndname = ''
@@ -1397,24 +1384,21 @@ END SUBROUTINE URWORD
       idnum = NAMEDBOUNDFLAG
       bndname = line(istart:istop)
       call upcase(bndname)
-    endif
+    end if
     !
+    ! -- Return
     return
   end subroutine extract_idnum_or_bndname
 
+  !> @brief Read auxiliary variables from an input line
+  !<
   subroutine urdaux(naux, inunit, iout, lloc, istart, istop, auxname, line, text)
-! ******************************************************************************
-! Read auxiliary variables from an input line
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use ArrayHandlersModule, only: ExpandArray
-    use ConstantsModule,     only: LENAUXNAME
+    use ConstantsModule, only: LENAUXNAME
     ! -- implicit
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(inout) :: naux
     integer(I4B), intent(in) :: inunit
     integer(I4B), intent(in) :: iout
@@ -1424,18 +1408,19 @@ END SUBROUTINE URWORD
     character(len=LENAUXNAME), allocatable, dimension(:), intent(inout) :: auxname
     character(len=*), intent(inout) :: line
     character(len=*), intent(in) :: text
-    ! -- local variables
+    ! -- local
     integer(I4B) :: n, linelen
     integer(I4B) :: iauxlen
     real(DP) :: rval
-! ------------------------------------------------------------------------------
+    !
     linelen = len(line)
-    if(naux > 0) then
-      write(errmsg,'(a)') 'Auxiliary variables already specified. Auxiliary ' // &
-        'variables must be specified on one line in the options block.'
+    if (naux > 0) then
+      write (errmsg, '(a)') 'Auxiliary variables already specified. '// &
+        & 'Auxiliary variables must be specified on one line in the '// &
+        & 'options block.'
       call store_error(errmsg)
       call store_error_unit(inunit)
-    endif
+    end if
     auxloop: do
       call urword(line, lloc, istart, istop, 1, n, rval, iout, inunit)
       if (istart >= linelen) exit auxloop
@@ -1448,57 +1433,53 @@ END SUBROUTINE URWORD
           & to ', LENAUXNAME, ' characters.'
         call store_error(errmsg)
         call store_error_unit(inunit)
-      end if      
+      end if
       naux = naux + 1
       call ExpandArray(auxname)
       auxname(naux) = line(istart:istop)
-      if(iout > 0) then
-        write(iout, "(4X,'AUXILIARY ',a,' VARIABLE: ',A)")                     &
+      if (iout > 0) then
+        write (iout, "(4X,'AUXILIARY ',a,' VARIABLE: ',A)") &
           trim(adjustl(text)), auxname(naux)
-      endif
-    enddo auxloop
+      end if
+    end do auxloop
     !
+    ! -- Return
     return
   end subroutine urdaux
 
+  !> @brief Define the print or save format
+  !!
+  !! Define cdatafmp as a Fortran output format based on user input. Also define
+  !! nvalues, nwidth, and editdesc.
+  !!
+  !! Syntax for linein:
+  !!   COLUMNS nval WIDTH nwid [DIGITS ndig [options]]
+  !!
+  !! Where:
+  !!   nval = Number of values per line.
+  !!   nwid = Number of character places to be used for each value.
+  !!   ndig = Number of digits to the right of the decimal point (required
+  !!          for real array).
+  !!   options are:
+  !!          editoption: One of [EXPONENTIAL, FIXED, GENERAL, SCIENTIFIC]
+  !! A default value should be passed in for editdesc as G, I, E, F, or S.
+  !! If I is passed in, then the fortran format will be for an integer variable.
+  !<
   subroutine print_format(linein, cdatafmp, editdesc, nvaluesp, nwidthp, inunit)
-! ******************************************************************************
-! print_format -- define the print or save format
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-! Define cdatafmp as a Fortran output format based on user input.  Also define
-! nvalues, nwidth, and editdesc.
-!
-!   Syntax for linein:
-!     COLUMNS nval WIDTH nwid [DIGITS ndig [options]]
-!
-! Where:
-!     nval = Number of values per line.
-!     nwid = Number of character places to be used for each value.
-!     ndig = Number of digits to the right of the decimal point (required
-!            for real array).
-!     options are:
-!            editoption: One of [EXPONENTIAL, FIXED, GENERAL, SCIENTIFIC]
-! A default value should be passed in for editdesc as G, I, E, F, or S.
-! If I is passed in, then the fortran format will be for an integer variable.
-! ------------------------------------------------------------------------------
-    ! -- dummy variables
+    ! -- dummy
     character(len=*), intent(in) :: linein
     character(len=*), intent(inout) :: cdatafmp
     character(len=*), intent(inout) :: editdesc
     integer(I4B), intent(inout) :: nvaluesp
     integer(I4B), intent(inout) :: nwidthp
     integer(I4B), intent(in) :: inunit
-    ! -- local variables
+    ! -- local
     character(len=len(linein)) :: line
     character(len=20), dimension(:), allocatable :: words
     character(len=100) :: ermsg
-    integer(I4B) :: ndigits=0, nwords=0
+    integer(I4B) :: ndigits = 0, nwords = 0
     integer(I4B) :: i, ierr
     logical :: isint
-! ------------------------------------------------------------------------------
     !
     ! -- Parse line and initialize values
     line(:) = linein(:)
@@ -1506,17 +1487,17 @@ END SUBROUTINE URWORD
     ierr = 0
     i = 0
     isint = .false.
-    if(editdesc == 'I') isint = .true.
+    if (editdesc == 'I') isint = .true.
     !
     ! -- Check array name
     if (nwords < 1) then
-      ermsg = 'Could not build PRINT_FORMAT from line' // trim(line)
+      ermsg = 'Could not build PRINT_FORMAT from line'//trim(line)
       call store_error(trim(ermsg))
       ermsg = 'Syntax is: COLUMNS <columns> WIDTH <width> DIGITS &
               &<digits> <format>'
       call store_error(trim(ermsg))
       call store_error_unit(inunit)
-    endif
+    end if
     !
     ermsg = 'Error setting PRINT_FORMAT. Syntax is incorrect in line:'
     if (nwords >= 4) then
@@ -1524,14 +1505,14 @@ END SUBROUTINE URWORD
       if (.not. same_word(words(3), 'WIDTH')) ierr = 1
       ! -- Read nvalues and nwidth
       if (ierr == 0) then
-        read(words(2), *, iostat=ierr) nvaluesp
-      endif
+        read (words(2), *, iostat=ierr) nvaluesp
+      end if
       if (ierr == 0) then
-        read(words(4), *, iostat=ierr) nwidthp
-      endif
+        read (words(4), *, iostat=ierr) nwidthp
+      end if
     else
       ierr = 1
-    endif
+    end if
     if (ierr /= 0) then
       call store_error(ermsg)
       call store_error(line)
@@ -1539,7 +1520,7 @@ END SUBROUTINE URWORD
               &DIGITS <digits> <format>'
       call store_error(trim(ermsg))
       call store_error_unit(inunit)
-    endif
+    end if
     i = 4
     !
     if (.not. isint) then
@@ -1547,12 +1528,12 @@ END SUBROUTINE URWORD
       if (nwords >= 5) then
         if (.not. same_word(words(5), 'DIGITS')) ierr = 1
         ! -- Read ndigits
-        read(words(6), *, iostat=ierr) ndigits
+        read (words(6), *, iostat=ierr) ndigits
       else
         ierr = 1
-      endif
+      end if
       i = i + 2
-    endif
+    end if
     !
     ! -- Check for EXPONENTIAL | FIXED | GENERAL | SCIENTIFIC option.
     ! -- Check for LABEL, WRAP, and STRIP options.
@@ -1574,7 +1555,7 @@ END SUBROUTINE URWORD
           editdesc = 'S'
           if (isint) ierr = 1
         case default
-          ermsg = 'Error in format specification. Unrecognized option: ' // words(i)
+          ermsg = 'Error in format specification. Unrecognized option: '//words(i)
           call store_error(ermsg)
           ermsg = 'Valid values are EXPONENTIAL, FIXED, GENERAL, or SCIENTIFIC.'
           call store_error(ermsg)
@@ -1582,13 +1563,13 @@ END SUBROUTINE URWORD
         end select
       else
         exit
-      endif
-    enddo
+      end if
+    end do
     if (ierr /= 0) then
       call store_error(ermsg)
       call store_error(line)
       call store_error_unit(inunit)
-    endif
+    end if
     !
     ! -- Build the output format.
     select case (editdesc)
@@ -1600,178 +1581,183 @@ END SUBROUTINE URWORD
       call BuildFloatFormat(nvaluesp, nwidthp, ndigits, editdesc, cdatafmp)
     end select
     !
+    ! -- Return
     return
   end subroutine print_format
 
+  !> @brief Build a fixed format for printing or saving a real array
+  !<
   subroutine BuildFixedFormat(nvalsp, nwidp, ndig, outfmt, prowcolnum)
-    ! Build a fixed format for printing or saving a real array
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(in) :: nvalsp, nwidp, ndig
     character(len=*), intent(inout) :: outfmt
-    logical, intent(in), optional :: prowcolnum  ! default true
-    ! -- local variables
-    character(len=8)   :: cvalues, cwidth, cdigits
-    character(len=60)  :: ufmt
+    logical, intent(in), optional :: prowcolnum ! default true
+    ! -- local
+    character(len=8) :: cvalues, cwidth, cdigits
+    character(len=60) :: ufmt
     logical :: prowcolnumlocal
-    ! formats
-    10 format(i8)
+    ! -- formats
+    character(len=*), parameter :: fmtndig = "(i8)"
     !
     if (present(prowcolnum)) then
       prowcolnumlocal = prowcolnum
     else
       prowcolnumlocal = .true.
-    endif
+    end if
     !
     ! -- Convert integers to characters and left-adjust
-    write(cdigits,10) ndig
+    write (cdigits, fmtndig) ndig
     cdigits = adjustl(cdigits)
     !
     ! -- Build format for printing to the list file in wrap format
-    write(cvalues,10) nvalsp
+    write (cvalues, fmtndig) nvalsp
     cvalues = adjustl(cvalues)
-    write(cwidth,10) nwidp
+    write (cwidth, fmtndig) nwidp
     cwidth = adjustl(cwidth)
     if (prowcolnumlocal) then
       ufmt = '(1x,i3,1x,'
     else
       ufmt = '(5x,'
-    endif
-    ufmt = trim(ufmt) // cvalues
-    ufmt = trim(ufmt) // '(1x,f'
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // '.'
-    ufmt = trim(ufmt) // cdigits
-    ufmt = trim(ufmt) // '):/(5x,'
-    ufmt = trim(ufmt) // cvalues
-    ufmt = trim(ufmt) // '(1x,f'
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // '.'
-    ufmt = trim(ufmt) // cdigits
-    ufmt = trim(ufmt) // ')))'
+    end if
+    !
+    ufmt = trim(ufmt)//cvalues
+    ufmt = trim(ufmt)//'(1x,f'
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//'.'
+    ufmt = trim(ufmt)//cdigits
+    ufmt = trim(ufmt)//'):/(5x,'
+    ufmt = trim(ufmt)//cvalues
+    ufmt = trim(ufmt)//'(1x,f'
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//'.'
+    ufmt = trim(ufmt)//cdigits
+    ufmt = trim(ufmt)//')))'
     outfmt = ufmt
     !
+    ! -- Return
     return
   end subroutine BuildFixedFormat
 
+  !> @brief Build a floating-point format for printing or saving a real array
+  !<
   subroutine BuildFloatFormat(nvalsp, nwidp, ndig, editdesc, outfmt, prowcolnum)
-    ! Build a floating-point format for printing or saving a real array
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(in) :: nvalsp, nwidp, ndig
     character(len=*), intent(in) :: editdesc
     character(len=*), intent(inout) :: outfmt
-    logical, intent(in), optional :: prowcolnum  ! default true
-    ! -- local variables
-    character(len=8)   :: cvalues,  cwidth, cdigits
-    character(len=60)  :: ufmt
+    logical, intent(in), optional :: prowcolnum ! default true
+    ! -- local
+    character(len=8) :: cvalues, cwidth, cdigits
+    character(len=60) :: ufmt
     logical :: prowcolnumlocal
-    ! formats
-    10 format(i8)
+    ! -- formats
+    character(len=*), parameter :: fmtndig = "(i8)"
     !
     if (present(prowcolnum)) then
       prowcolnumlocal = prowcolnum
     else
       prowcolnumlocal = .true.
-    endif
+    end if
     !
     ! -- Build the format
-    write(cdigits,10) ndig
+    write (cdigits, fmtndig) ndig
     cdigits = adjustl(cdigits)
     ! -- Convert integers to characters and left-adjust
-    write(cwidth,10) nwidp
+    write (cwidth, fmtndig) nwidp
     cwidth = adjustl(cwidth)
     ! -- Build format for printing to the list file
-    write(cvalues, 10) (nvalsp - 1)
+    write (cvalues, fmtndig) (nvalsp - 1)
     cvalues = adjustl(cvalues)
     if (prowcolnumlocal) then
-      ufmt = '(1x,i3,2x,1p,' // editdesc
+      ufmt = '(1x,i3,2x,1p,'//editdesc
     else
-      ufmt = '(6x,1p,' // editdesc
-    endif
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // '.'
-    ufmt = trim(ufmt) // cdigits
-    if (nvalsp>1) then
-      ufmt = trim(ufmt) // ','
-      ufmt = trim(ufmt) // cvalues
-      ufmt = trim(ufmt) // '(1x,'
-      ufmt = trim(ufmt) // editdesc
-      ufmt = trim(ufmt) // cwidth
-      ufmt = trim(ufmt) // '.'
-      ufmt = trim(ufmt) // cdigits
-      ufmt = trim(ufmt) // ')'
-    endif
-    ufmt = trim(ufmt) // ':/(5x,'
-    write(cvalues, 10) nvalsp
+      ufmt = '(6x,1p,'//editdesc
+    end if
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//'.'
+    ufmt = trim(ufmt)//cdigits
+    if (nvalsp > 1) then
+      ufmt = trim(ufmt)//','
+      ufmt = trim(ufmt)//cvalues
+      ufmt = trim(ufmt)//'(1x,'
+      ufmt = trim(ufmt)//editdesc
+      ufmt = trim(ufmt)//cwidth
+      ufmt = trim(ufmt)//'.'
+      ufmt = trim(ufmt)//cdigits
+      ufmt = trim(ufmt)//')'
+    end if
+    !
+    ufmt = trim(ufmt)//':/(5x,'
+    write (cvalues, fmtndig) nvalsp
     cvalues = adjustl(cvalues)
-    ufmt = trim(ufmt) // cvalues
-    ufmt = trim(ufmt) // '(1x,'
-    ufmt = trim(ufmt) // editdesc
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // '.'
-    ufmt = trim(ufmt) // cdigits
-    ufmt = trim(ufmt) // ')))'
+    ufmt = trim(ufmt)//cvalues
+    ufmt = trim(ufmt)//'(1x,'
+    ufmt = trim(ufmt)//editdesc
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//'.'
+    ufmt = trim(ufmt)//cdigits
+    ufmt = trim(ufmt)//')))'
     outfmt = ufmt
     !
+    ! -- Return
     return
   end subroutine BuildFloatFormat
 
+  !> @brief Build a format for printing or saving an integer array
+  !<
   subroutine BuildIntFormat(nvalsp, nwidp, outfmt, prowcolnum)
-    ! Build a format for printing or saving an integer array
     implicit none
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(in) :: nvalsp, nwidp
     character(len=*), intent(inout) :: outfmt
-    logical, intent(in), optional :: prowcolnum  ! default true
-    ! -- local variables
-    character(len=8)   :: cvalues, cwidth
-    character(len=60)  :: ufmt
+    logical, intent(in), optional :: prowcolnum ! default true
+    ! -- local
+    character(len=8) :: cvalues, cwidth
+    character(len=60) :: ufmt
     logical :: prowcolnumlocal
-    ! formats
-    10 format(i8)
+    ! -- formats
+    character(len=*), parameter :: fmtndig = "(i8)"
     !
     if (present(prowcolnum)) then
       prowcolnumlocal = prowcolnum
     else
       prowcolnumlocal = .true.
-    endif
+    end if
     !
     ! -- Build format for printing to the list file in wrap format
-    write(cvalues,10)nvalsp
+    write (cvalues, fmtndig) nvalsp
     cvalues = adjustl(cvalues)
-    write(cwidth,10)nwidp
+    write (cwidth, fmtndig) nwidp
     cwidth = adjustl(cwidth)
     if (prowcolnumlocal) then
       ufmt = '(1x,i3,1x,'
     else
       ufmt = '(5x,'
-    endif
-    ufmt = trim(ufmt) // cvalues
-    ufmt = trim(ufmt) // '(1x,i'
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // '):/(5x,'
-    ufmt = trim(ufmt) // cvalues
-    ufmt = trim(ufmt) // '(1x,i'
-    ufmt = trim(ufmt) // cwidth
-    ufmt = trim(ufmt) // ')))'
+    end if
+    ufmt = trim(ufmt)//cvalues
+    ufmt = trim(ufmt)//'(1x,i'
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//'):/(5x,'
+    ufmt = trim(ufmt)//cvalues
+    ufmt = trim(ufmt)//'(1x,i'
+    ufmt = trim(ufmt)//cwidth
+    ufmt = trim(ufmt)//')))'
     outfmt = ufmt
     !
+    ! -- Return
     return
   end subroutine BuildIntFormat
 
-
   !> @brief Get the number of words in a string
-  !!
-  !! Function to get the number of words in a string
-  !!
   !<
   function get_nwords(line)
-    ! -- return variable
-    integer(I4B) :: get_nwords            !< number of words in a string
-    ! -- dummy variables
-    character(len=*), intent(in) :: line  !< line
-    ! -- local variables
+    ! -- return
+    integer(I4B) :: get_nwords !< number of words in a string
+    ! -- dummy
+    character(len=*), intent(in) :: line !< line
+    ! -- local
     integer(I4B) :: linelen
     integer(I4B) :: lloc
     integer(I4B) :: istart
@@ -1791,77 +1777,72 @@ END SUBROUTINE URWORD
       get_nwords = get_nwords + 1
     end do
     !
-    ! -- return
+    ! -- Return
     return
   end function get_nwords
 
+  !> @brief Move the file pointer.
+  !!
+  !! Patterned after fseek, which is not supported as part of the fortran
+  !! standard.  For this subroutine to work the file must have been opened with
+  !! access='stream' and action='readwrite'.
+  !<
   subroutine fseek_stream(iu, offset, whence, status)
-! ******************************************************************************
-! Move the file pointer.  Patterned after fseek, which is not 
-! supported as part of the fortran standard.  For this subroutine to work
-! the file must have been opened with access='stream' and action='readwrite'.
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
+    ! -- dummy
     integer(I4B), intent(in) :: iu
     integer(I4B), intent(in) :: offset
     integer(I4B), intent(in) :: whence
     integer(I4B), intent(inout) :: status
+    ! -- local
     integer(I8B) :: ipos
-! ------------------------------------------------------------------------------
     !
-    inquire(unit=iu, size=ipos)
-    
-    select case(whence)
-    case(0)
+    inquire (unit=iu, size=ipos)
+    !
+    select case (whence)
+    case (0)
       !
       ! -- whence = 0, offset is relative to start of file
       ipos = 0 + offset
-    case(1)
+    case (1)
       !
       ! -- whence = 1, offset is relative to current pointer position
-      inquire(unit=iu, pos=ipos)
+      inquire (unit=iu, pos=ipos)
       ipos = ipos + offset
-    case(2)
+    case (2)
       !
       ! -- whence = 2, offset is relative to end of file
-      inquire(unit=iu, size=ipos)
+      inquire (unit=iu, size=ipos)
       ipos = ipos + offset
     end select
     !
     ! -- position the file pointer to ipos
-    write(iu, pos=ipos, iostat=status)
-    inquire(unit=iu, pos=ipos)
+    write (iu, pos=ipos, iostat=status)
+    inquire (unit=iu, pos=ipos)
     !
-    ! -- return
+    ! -- Return
     return
   end subroutine fseek_stream
-  
+
+  !> @brief Read until non-comment line found and then return line.
+  !!
+  !! Different from u8rdcom in that line is a deferred length character string,
+  !! which allows any length lines to be read using the get_line subroutine.
+  !<
   subroutine u9rdcom(iin, iout, line, ierr)
-! ******************************************************************************
-! Read until non-comment line found and then return line.  Different from
-! u8rdcom in that line is a deferred length character string, which allows
-! any length lines to be read using the get_line subroutine.
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
+    ! -- module
     use, intrinsic :: iso_fortran_env, only: IOSTAT_END
     implicit none
-    ! -- dummy variables
-    integer(I4B),         intent(in) :: iin
-    integer(I4B),         intent(in) :: iout
-    character (len=:), allocatable, intent(inout) :: line
-    integer(I4B),        intent(out) :: ierr
-    ! -- local variables
-    character (len=:), allocatable :: linetemp
-    character (len=2), parameter :: comment = '//'
-    character(len=1), parameter  :: tab = CHAR(9)
+    ! -- dummy
+    integer(I4B), intent(in) :: iin
+    integer(I4B), intent(in) :: iout
+    character(len=:), allocatable, intent(inout) :: line
+    integer(I4B), intent(out) :: ierr
+    ! -- local
+    character(len=:), allocatable :: linetemp
+    character(len=2), parameter :: comment = '//'
+    character(len=1), parameter :: tab = CHAR(9)
     logical :: iscomment
     integer(I4B) :: i, j, l, istart, lsize
-! ------------------------------------------------------------------------------
-    !code
     !
     !readerrmsg = ''
     line = comment
@@ -1875,23 +1856,24 @@ END SUBROUTINE URWORD
       elseif (ierr /= 0) then
         ! -- Other error...report it
         call unitinquire(iin)
-        write(errmsg, *) 'u9rdcom: Could not read from unit: ',iin
+        write (errmsg, *) 'u9rdcom: Could not read from unit: ', iin
         call store_error(errmsg, terminate=.TRUE.)
-      endif
-      if (len_trim(line).lt.1) then
+      end if
+      if (len_trim(line) < 1) then
         line = comment
         cycle
       end if
       !
-      ! Ensure that any initial tab characters are treated as spaces
+      ! -- Ensure that any initial tab characters are treated as spaces
       cleartabs: do
         !
         ! -- adjustl manually to avoid stack overflow
         lsize = len(line)
         istart = 1
-        allocate(character(len=lsize) :: linetemp)
+        allocate (character(len=lsize) :: linetemp)
         do j = 1, lsize
-          if (line(j:j) /= ' ' .and. line(j:j) /= ',' .and. line(j:j) /= char(9)) then
+          if (line(j:j) /= ' ' .and. line(j:j) /= ',' .and. &
+              line(j:j) /= char(9)) then
             istart = j
             exit
           end if
@@ -1899,65 +1881,64 @@ END SUBROUTINE URWORD
         linetemp(:) = ' '
         linetemp(:) = line(istart:)
         line(:) = linetemp(:)
-        deallocate(linetemp)
+        deallocate (linetemp)
         !
         ! -- check for comment
         iscomment = .false.
         select case (line(1:1))
-          case ('#')
-            iscomment = .true.
-            exit cleartabs
-          case ('!')
-            iscomment = .true.
-            exit cleartabs
-          case (tab)
-            line(1:1) = ' '
-            cycle cleartabs
-          case default
-            if (line(1:2).eq.comment) iscomment = .true.
-            if (len_trim(line) < 1) iscomment = .true.
-            exit cleartabs
+        case ('#')
+          iscomment = .true.
+          exit cleartabs
+        case ('!')
+          iscomment = .true.
+          exit cleartabs
+        case (tab)
+          line(1:1) = ' '
+          cycle cleartabs
+        case default
+          if (line(1:2) == comment) iscomment = .true.
+          if (len_trim(line) < 1) iscomment = .true.
+          exit cleartabs
         end select
       end do cleartabs
       !
-      if (.not.iscomment) then
+      if (.not. iscomment) then
         exit pcomments
       else
         if (iout > 0) then
           !find the last non-blank character.
-          l=len(line)
+          l = len(line)
           do i = l, 1, -1
-            if(line(i:i).ne.' ') then
+            if (line(i:i) /= ' ') then
               exit
             end if
           end do
-          !print the line up to the last non-blank character.
-          write(iout,'(1x,a)') line(1:i)
+          ! -- print the line up to the last non-blank character.
+          write (iout, '(1x,a)') line(1:i)
         end if
       end if
     end do pcomments
+    !
+    ! -- Return
     return
   end subroutine u9rdcom
 
+  !> @brief Read an unlimited length line from unit number lun into a deferred-
+  !! length character string (line).
+  !!
+  !! Tack on a single space to the end so that routines like URWORD continue to
+  !! function as before.
+  !<
   subroutine get_line(lun, line, iostat)
-! ******************************************************************************
-! Read an unlimited length line from unit number lun into a deferred-length
-! character string (line).  Tack on a single space to the end so that 
-! routines like URWORD continue to function as before.
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
-    ! -- dummy variables
+    ! -- dummy
     integer(I4B), intent(in) :: lun
     character(len=:), intent(out), allocatable :: line
     integer(I4B), intent(out) :: iostat
-    ! -- local variables
+    ! -- local
     integer(I4B), parameter :: buffer_len = MAXCHARLEN
     character(len=buffer_len) :: buffer
     character(len=:), allocatable :: linetemp
     integer(I4B) :: size_read, linesize
-! ------------------------------------------------------------------------------
     !
     ! -- initialize
     line = ''
@@ -1965,36 +1946,33 @@ END SUBROUTINE URWORD
     !
     ! -- process
     do
-      read ( lun, '(A)',  &
-          iostat = iostat,  &
-          advance = 'no',  &
-          size = size_read ) buffer
+      read (lun, '(A)', iostat=iostat, advance='no', size=size_read) buffer
       if (is_iostat_eor(iostat)) then
         linesize = len(line)
-        deallocate(linetemp)
-        allocate(character(len=linesize) :: linetemp)
+        deallocate (linetemp)
+        allocate (character(len=linesize) :: linetemp)
         linetemp(:) = line(:)
-        deallocate(line)
-        allocate(character(len=linesize + size_read + 1) :: line)
+        deallocate (line)
+        allocate (character(len=linesize + size_read + 1) :: line)
         line(:) = linetemp(:)
-        line(linesize+1:) = buffer(:size_read)
+        line(linesize + 1:) = buffer(:size_read)
         linesize = len(line)
         line(linesize:linesize) = ' '
         iostat = 0
         exit
       else if (iostat == 0) then
         linesize = len(line)
-        deallocate(linetemp)
-        allocate(character(len=linesize) :: linetemp)
+        deallocate (linetemp)
+        allocate (character(len=linesize) :: linetemp)
         linetemp(:) = line(:)
-        deallocate(line)
-        allocate(character(len=linesize + size_read) :: line)
+        deallocate (line)
+        allocate (character(len=linesize + size_read) :: line)
         line(:) = linetemp(:)
-        line(linesize+1:) = buffer(:size_read)
+        line(linesize + 1:) = buffer(:size_read)
       else
         exit
       end if
     end do
-  end subroutine get_line  
+  end subroutine get_line
 
-END MODULE InputOutputModule
+end module InputOutputModule

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -19,7 +19,7 @@ module InputOutputModule
             BuildFloatFormat, BuildIntFormat, fseek_stream, get_nwords, &
             u9rdcom, append_processor_id
 
-  contains
+contains
 
   !> @brief Open a file
   !!
@@ -504,7 +504,7 @@ module InputOutputModule
     if(ncode==1) then
       idiff = ichar('a') - ichar('A')
       do 50 k=istart, istop
-        if(line(k:k) > 'a' .and. line(k:k) < 'z') &
+        if(line(k:k) >= 'a' .and. line(k:k) <= 'z') &
            line(k:k) = char(ichar(line(k:k)) - idiff)
 50    continue
       return
@@ -538,7 +538,7 @@ module InputOutputModule
       return
     !
     ! -- If output unit is positive; write a message to output unit.
-    else if(iout==0) then
+    else if(iout > 0) then
       if(in > 0) then
         write(msg_line,201) in, line(istart:istop), string(1:l)
       else

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -19,7 +19,7 @@ module InputOutputModule
             BuildFloatFormat, BuildIntFormat, fseek_stream, get_nwords, &
             u9rdcom, append_processor_id
 
-contains
+  contains
 
   !> @brief Open a file
   !!
@@ -49,11 +49,11 @@ contains
     integer(I4B) :: ivar
     integer(I4B) :: iuop
     ! -- formats
-    character(len=*), parameter :: fmtmsg = &
-      "(1x,/1x,'OPENED ',a,/1x,'FILE TYPE:',a,'   UNIT ',I4,3x,'STATUS:',a,/ &
-&        1x,'FORMAT:',a,3x,'ACCESS:',a/1x,'ACTION:',a/)"
-    character(len=*), parameter :: fmtmsg2 = &
-                                   "(1x,/1x,'DID NOT OPEN ',a,/)"
+50  format(1x,/1x,'OPENED ',a,/ &
+                 1x,'FILE TYPE:',a,'   UNIT ',I4,3x,'STATUS:',a,/ &
+                 1x,'FORMAT:',a,3x,'ACCESS:',a/ &
+                 1x,'ACTION:',a/)
+60  format(1x,/1x,'DID NOT OPEN ',a,/)
     !
     ! -- Process mode_opt
     if (present(mode_opt)) then
@@ -64,8 +64,8 @@ contains
     !
     ! -- Evaluate if the file should be opened
     if (isim_mode < imode) then
-      if (iout > 0) then
-        write (iout, fmtmsg2) trim(fname)
+      if(iout > 0) then
+        write(iout, 60) trim(fname)
       end if
     else
       !
@@ -75,49 +75,49 @@ contains
       filstat = 'OLD'
       !
       ! -- Override defaults
-      if (present(fmtarg_opt)) then
+      if(present(fmtarg_opt)) then
         fmtarg = fmtarg_opt
         call upcase(fmtarg)
-      end if
-      if (present(accarg_opt)) then
+      endif
+      if(present(accarg_opt)) then
         accarg = accarg_opt
         call upcase(accarg)
-      end if
-      if (present(filstat_opt)) then
+      endif
+      if(present(filstat_opt)) then
         filstat = filstat_opt
         call upcase(filstat)
-      end if
-      if (filstat == 'OLD') then
+      endif
+      if(filstat == 'OLD') then
         filact = action(1)
       else
         filact = action(2)
-      end if
+      endif
       !
       ! -- size of fname
       iflen = len_trim(fname)
       !
       ! -- Get a free unit number
-      if (iu <= 0) then
+      if(iu <= 0) then
         call freeunitnumber(iu)
-      end if
+      endif
       !
       ! -- Check to see if file is already open, if not then open the file
-      inquire (file=fname(1:iflen), number=iuop)
-      if (iuop > 0) then
+      inquire(file=fname(1:iflen), number=iuop)
+      if(iuop > 0) then
         ivar = -1
       else
-        open (unit=iu, file=fname(1:iflen), form=fmtarg, access=accarg, &
-              status=filstat, action=filact, iostat=ivar)
-      end if
+        open(unit=iu, file=fname(1:iflen), form=fmtarg, access=accarg,           &
+           status=filstat, action=filact, iostat=ivar)
+      endif
       !
       ! -- Check for an error
-      if (ivar /= 0) then
+      if(ivar /= 0) then
         write (errmsg, '(3a,1x,i0,a)') &
           'Could not open "', fname(1:iflen), '" on unit', iu, '.'
-        if (iuop > 0) then
+        if(iuop > 0) then
           write (errmsg, '(a,1x,a,1x,i0,a)') &
             trim(errmsg), 'File already open on unit', iuop, '.'
-        end if
+        endif
         write (errmsg, '(a,1x,a,1x,a,a)') &
           trim(errmsg), 'Specified file status', trim(filstat), '.'
         write (errmsg, '(a,1x,a,1x,a,a)') &
@@ -131,12 +131,12 @@ contains
         write (errmsg, '(a,1x,a)') &
           trim(errmsg), 'STOP EXECUTION in subroutine openfile().'
         call store_error(errmsg, terminate=.TRUE.)
-      end if
+      endif
       !
       ! -- Write a message
       if (iout > 0) then
-        write (iout, fmtmsg) fname(1:iflen), ftype, iu, filstat, fmtarg, &
-          accarg, filact
+        write(iout, 50) fname(1:iflen), ftype, iu, filstat, fmtarg, accarg, &
+                        filact
       end if
     end if
     !
@@ -152,15 +152,15 @@ contains
     ! -- modules
     implicit none
     ! -- dummy
-    integer(I4B), intent(inout) :: iu !< next free file unit number
+    integer(I4B), intent(inout) :: iu  !< next free file unit number
     ! -- local
     integer(I4B) :: i
     logical :: opened
     !
     do i = iunext, iulast
-      inquire (unit=i, opened=opened)
+      inquire(unit=i, opened=opened)
       if (.not. opened) exit
-    end do
+    enddo
     iu = i
     iunext = iu + 1
     !
@@ -176,7 +176,7 @@ contains
     ! -- modules
     implicit none
     ! -- return
-    integer(I4B) :: getunit !< free unit number
+    integer(I4B) :: getunit  !< free unit number
     ! -- local
     integer(I4B) :: iunit
     !
@@ -187,15 +187,15 @@ contains
     ! -- Return
     return
   end function getunit
-
+  
   !> @brief Convert to upper case
   !!
   !! Subroutine to convert a character string to upper case.
   !<
   subroutine upcase(word)
     implicit none
-    ! -- dummy
-    character(len=*), intent(inout) :: word !< word to convert to upper case
+    ! -- dummy  
+    character (len=*), intent(inout) :: word  !< word to convert to upper case
     ! -- local
     integer(I4B) :: l
     integer(I4B) :: idiff
@@ -232,10 +232,10 @@ contains
     !
     ! -- Loop through the string and convert any uppercase characters.
     do k = 1, l
-      if (word(k:k) >= 'A' .and. word(k:k) <= 'Z') then
-        word(k:k) = char(ichar(word(k:k)) + idiff)
-      end if
-    end do
+      if(word(k:k) >= 'A' .and. word(k:k) <= 'Z') then
+        word(k:k)=char(ichar(word(k:k))+idiff)
+      endif
+    enddo
     !
     ! -- Return
     return
@@ -249,8 +249,8 @@ contains
   !<
   subroutine append_processor_id(name, proc_id)
     ! -- dummy
-    character(len=LINELENGTH), intent(inout) :: name !< file name
-    integer(I4B), intent(in) :: proc_id !< processor id
+    character(len=LINELENGTH), intent(inout) :: name  !< file name
+    integer(I4B), intent(in) :: proc_id  !< processor id
     ! -- local
     character(len=LINELENGTH) :: name_local
     character(len=LINELENGTH) :: name_processor
@@ -263,13 +263,13 @@ contains
     ipos0 = index(name_local, ".", back=.TRUE.)
     ipos1 = len_trim(name)
     if (ipos0 > 0) then
-      write (extension_local, '(a)') name(ipos0:ipos1)
+      write(extension_local, '(a)') name(ipos0:ipos1)
     else
       ipos0 = ipos1
       extension_local = ''
     end if
-    write (name_processor, '(a,a,i0,a)') &
-      name(1:ipos0 - 1), '.p', proc_id, trim(adjustl(extension_local))
+    write(name_processor, '(a,a,i0,a)') &
+      name(1:ipos0-1), '.p', proc_id, trim(adjustl(extension_local))
     name = name_processor
     !
     ! -- Return
@@ -279,26 +279,26 @@ contains
   !> @brief Create a formatted line
   !!
   !! Subroutine to create a formatted line with specified alignment and column
-  !! separators. Like URWORD, UWWORD works with strings, integers, and floats.
+  !! separators. Like URWORD, UWWORD works with strings, integers, and floats. 
   !! Can pass an optional format statement, alignment, and column separator.
   !<
   subroutine UWWORD(line, icol, ilen, ncode, c, n, r, fmt, alignment, sep)
     implicit none
     ! -- dummy
-    character(len=*), intent(inout) :: line !< line
+    character (len=*), intent(inout) :: line !< line
     integer(I4B), intent(inout) :: icol !< column to write to line
     integer(I4B), intent(in) :: ilen !< current length of line
     integer(I4B), intent(in) :: ncode !< code for data type to write
-    character(len=*), intent(in) :: c !< character data type
+    character (len=*), intent(in) :: c !< character data type
     integer(I4B), intent(in) :: n !< integer data type
     real(DP), intent(in) :: r !< float data type
-    character(len=*), optional, intent(in) :: fmt !< format statement
+    character (len=*), optional, intent(in) :: fmt !< format statement
     integer(I4B), optional, intent(in) :: alignment !< alignment specifier
-    character(len=*), optional, intent(in) :: sep !< column separator
-    ! -- local
-    character(len=16) :: cfmt
-    character(len=16) :: cffmt
-    character(len=ILEN) :: cval
+    character (len=*), optional, intent(in) :: sep !< column separator
+    ! -- local 
+    character (len=16) :: cfmt
+    character (len=16) :: cffmt
+    character (len=ILEN) :: cval
     integer(I4B) :: ialign
     integer(I4B) :: i
     integer(I4B) :: ispace
@@ -314,21 +314,21 @@ contains
     if (present(fmt)) then
       cfmt = fmt
     else
-      select case (ncode)
-      case (TABSTRING, TABUCSTRING)
-        write (cfmt, '(a,I0,a)') '(a', ilen, ')'
-      case (TABINTEGER)
-        write (cfmt, '(a,I0,a)') '(I', ilen, ')'
-      case (TABREAL)
-        ireal = 1
-        i = ilen - 7
-        write (cfmt, '(a,I0,a,I0,a)') '(1PG', ilen, '.', i, ')'
-        if (R >= DZERO) then
-          ipad = 1
-        end if
+      select case(ncode)
+        case(TABSTRING, TABUCSTRING)
+          write(cfmt, '(a,I0,a)') '(a', ilen, ')'
+        case(TABINTEGER)
+          write(cfmt, '(a,I0,a)') '(I', ilen, ')'
+        case(TABREAL)
+          ireal = 1
+          i = ilen - 7
+          write(cfmt, '(a,I0,a,I0,a)') '(1PG', ilen, '.', i, ')'
+          if (R >= DZERO) then
+            ipad = 1
+          end if
       end select
     end if
-    write (cffmt, '(a,I0,a)') '(a', ilen, ')'
+    write(cffmt, '(a,I0,a)') '(a', ilen, ')'
     !
     if (present(alignment)) then
       ialign = alignment
@@ -336,16 +336,16 @@ contains
       ialign = TABRIGHT
     end if
     !
-    ! --
+    ! -- 
     if (ncode == TABSTRING .or. ncode == TABUCSTRING) then
       cval = C
       if (ncode == TABUCSTRING) then
         call UPcase(cval)
       end if
     else if (ncode == TABINTEGER) then
-      write (cval, cfmt) n
+      write(cval, cfmt) n
     else if (ncode == TABREAL) then
-      write (cval, cfmt) r
+      write(cval, cfmt) r
     end if
     !
     ! -- Apply alignment to cval
@@ -359,17 +359,17 @@ contains
       ispace = (ilen - i) / 2
       if (ireal > 0) then
         if (ipad > 0) then
-          cval = ' '//trim(adjustl(cval))
+          cval = ' ' //trim(adjustl(cval))
         else
           cval = trim(adjustl(cval))
         end if
       else
-        cval = repeat(' ', ispace)//trim(cval)
+        cval = repeat(' ', ispace) // trim(cval)
       end if
     else if (ialign == TABLEFT) then
       cval = trim(adjustl(cval))
       if (ipad > 0) then
-        cval = ' '//trim(adjustl(cval))
+        cval = ' ' //trim(adjustl(cval))
       end if
     else
       cval = adjustr(cval)
@@ -382,14 +382,14 @@ contains
     istop = icol + ilen - 1
     !
     ! -- Write final string to line
-    write (line(icol:istop), cffmt) cval
+    write(line(icol:istop), cffmt) cval
     !
     icoL = istop + 1
     !
     if (present(sep)) then
       i = len(sep)
       istop = icol + i
-      write (line(icol:istop), '(a)') sep
+      write(line(icol:istop), '(a)') sep
       icol = istop
     end if
     !
@@ -400,9 +400,9 @@ contains
   !> @brief Extract a word from a string
   !!
   !! Subroutine to extract a word from a line of text, and optionally
-  !! convert the word to a number. The last character in the line is
-  !! set to blank so that if any problems occur with finding a word,
-  !! istart and istop will point to this blank character. Thus, a word
+  !! convert the word to a number. The last character in the line is 
+  !! set to blank so that if any problems occur with finding a word, 
+  !! istart and istop will point to this blank character. Thus, a word 
   !! will always be returned unless there is a numeric conversion error.
   !! Be sure that the last character in line is not an important character
   !! because it will always be set to blank.
@@ -413,19 +413,19 @@ contains
   !! commas separated by one or more spaces as a null word.
   !!
   !! For a word that begins with "'" or '"', the word starts with
-  !! the character after the quote and ends with the character preceding
+  !! the character after the quote and ends with the character preceding 
   !! a subsequent quote. Thus, a quoted word can include spaces and commas.
-  !! The quoted word cannot contain a quote character of the same type
-  !! within the word but can contain a different quote character. For
+  !! The quoted word cannot contain a quote character of the same type 
+  !! within the word but can contain a different quote character. For 
   !! example, "WORD'S" or 'WORD"S'.
   !!
-  !! Number conversion error is written to unit iout if iout is positive;
-  !! error is written to default output if iout is 0; no error message is
+  !! Number conversion error is written to unit iout if iout is positive; 
+  !! error is written to default output if iout is 0; no error message is 
   !! written if iout is negative.
   !!
   !<
   subroutine URWORD(line, icol, istart, istop, ncode, n, r, iout, in)
-    ! -- dummy
+    ! -- dummy  
     character(len=*) :: line !< line to parse
     integer(I4B), intent(inout) :: icol !< current column in line
     integer(I4B), intent(inout) :: istart !< starting character position of the word
@@ -436,25 +436,14 @@ contains
     integer(I4B), intent(in) :: iout !< output listing file unit
     integer(I4B), intent(in) :: in !< input file unit number
     ! -- local
-    character(len=20) string
+    character(len=20) string                
     character(len=30) rw
     character(len=1) tab
     character(len=1) charend
     character(len=200) :: msg
     character(len=linelength) :: msg_line
-    ! -- formats
-    character(len=*), parameter :: fmtmsgout1 = &
-      "(1X,'FILE UNIT ',I4,' : ERROR CONVERTING ""',A, &
-      & '"" TO ',A,' IN LINE:')"
-    character(len=*), parameter :: fmtmsgout2 = "(1x, &
-      & 'KEYBOARD INPUT : ERROR CONVERTING ""',a,'"" TO ',a,' IN LINE:')"
-    character(len=*), parameter :: fmtmsgout3 = "('File unit ', &
-      & I0,': Error converting ""',a,'"" to ',A,' in following line:')"
-    character(len=*), parameter :: fmtmsgout4 = &
-      "('Keyboard input: Error converting ""',a, &
-      & '"" to ',A,' in following line:')"
     !
-    tab = char(9)
+    tab=char(9)
     !
     ! -- Set last char in LINE to blank and set ISTART and ISTOP to point
     !    to this blank as a default situation when no word is found.  If
@@ -464,39 +453,39 @@ contains
     istart = linlen
     istop = linlen
     linlen = linlen - 1
-    if (icol < 1 .or. icol > linlen) go to 100
+    if(icol < 1 .or. icol > linlen) go to 100
     !
     ! -- Find start of word, which is indicated by first character that
     !    is not a blank, a comma, or a tab.
-    do i = icol, linlen
-      if (line(i:i) /= ' ' .and. line(i:i) /= ',' .and. &
-          line(i:i) /= tab) go to 20
-    end do
+    do 10 i=icol, linlen
+      if(line(i:i) /= ' ' .and. line(i:i) /= ',' .and. &
+         line(i:i) /= tab) go to 20
+10  continue
     icol = linlen + 1
     go to 100
     !
     ! -- Found start of word.  Look for end.
     !    When word is quoted, only a quote can terminate it.
     !    search for a single (char(39)) or double (char(34)) quote
-20  if (line(i:i) == char(34) .or. line(i:i) == char(39)) then
+20  if(line(i:i)==char(34) .or. line(i:i)==char(39)) then
       if (line(i:i) == char(34)) then
         charend = char(34)
       else
         charend = char(39)
       end if
       i = i + 1
-      if (i <= linlen) then
-        do j = i, linlen
-          if (line(j:j) == charend) go to 40
-        end do
+      if(i <= linlen) then
+        do 25 j=i, linlen
+          if(line(j:j)==charend) go to 40
+25      continue
       end if
-      !
-      ! -- When word is not quoted, space, comma, or tab will terminate.
+    !
+    ! -- When word is not quoted, space, comma, or tab will terminate.
     else
-      do j = i, linlen
-        if (line(j:j) == ' ' .or. line(j:j) == ',' .or. &
-            line(j:j) == tab) go to 40
-      end do
+      do 30 j=i, linlen
+        if(line(j:j)==' ' .or. line(j:j)==',' .or. &
+           line(j:j)==tab) go to 40
+30    continue
     end if
     !
     ! -- End of line without finding end of word; set end of word to
@@ -507,33 +496,33 @@ contains
     !    set ICOL to point to location for scanning for another word.
 40  icol = j + 1
     j = j - 1
-    if (j < i) go to 100
+    if(j < i) go to 100
     istart = i
     istop = j
     !
     ! -- Convert word to upper case and RETURN if NCODE is 1.
-    if (ncode == 1) then
+    if(ncode==1) then
       idiff = ichar('a') - ichar('A')
-      do k = istart, istop
-        if (line(k:k) > 'a' .and. line(k:k) < 'z') &
-          line(k:k) = char(ichar(line(k:k)) - idiff)
-      end do
+      do 50 k=istart, istop
+        if(line(k:k) > 'a' .and. line(k:k) < 'z') &
+           line(k:k) = char(ichar(line(k:k)) - idiff)
+50    continue
       return
     end if
     !
     ! -- Convert word to a number if requested.
-100 if (ncode == 2 .or. ncode == 3) then
+100 if(ncode==2 .or. ncode==3) then
       rw = ' '
-      l = 30 - istop + istart
+      l = 30-istop+istart
       if (l < 1) go to 200
       rw(l:30) = line(istart:istop)
-      if (ncode == 2) read (rw, '(i30)', err=200) n
-      if (ncode == 3) read (rw, '(f30.0)', err=200) r
+      if(ncode == 2) read(rw,'(i30)',err=200) n
+      if(ncode == 3) read(rw,'(f30.0)',err=200) r
     end if
     return
     !
     ! -- Number conversion error.
-200 if (ncode == 3) then
+200 if(ncode == 3) then
       string = 'a real number'
       l = 13
     else
@@ -545,25 +534,29 @@ contains
     if (iout < 0) then
       n = 0
       r = 0.
-      line(linlen + 1:linlen + 1) = 'E'
+      line(linlen+1:linlen+1) = 'E'
       return
-      !
-      ! -- If output unit is positive; write a message to output unit.
-    else if (iout == 0) then
-      if (in > 0) then
-        write (msg_line, fmtmsgout1) in, line(istart:istop), string(1:l)
+    !
+    ! -- If output unit is positive; write a message to output unit.
+    else if(iout==0) then
+      if(in > 0) then
+        write(msg_line,201) in, line(istart:istop), string(1:l)
       else
-        write (msg_line, fmtmsgout2) line(istart:istop), string(1:l)
+        write(msg_line,202) line(istart:istop), string(1:l)
       end if
       call write_message(msg_line, iunit=IOUT, skipbefore=1)
       call write_message(line, iunit=IOUT, fmt='(1x,a)')
-      !
-      ! -- If output unit is 0; write a message to default output.
+201   format(1x,'FILE UNIT ',I4,' : ERROR CONVERTING "',a, &
+             '" TO ',a,' IN LINE:')
+202   format(1x,'KEYBOARD INPUT : ERROR CONVERTING "',a, &
+             '" TO ',a,' IN LINE:')
+    !
+    ! -- If output unit is 0; write a message to default output.
     else
-      if (in > 0) then
-        write (msg_line, fmtmsgout1) in, line(istart:istop), string(1:l)
+      if(in > 0) then
+        write(msg_line,201) in, line(istart:istop), string(1:l)
       else
-        write (msg_line, fmtmsgout2) line(istart:istop), string(1:l)
+        write(msg_line,202) line(istart:istop), string(1:l)
       end if
       call write_message(msg_line, iunit=iout, skipbefore=1)
       call write_message(LINE, iunit=iout, fmt='(1x,a)')
@@ -572,11 +565,14 @@ contains
     ! -- STOP after storing error message.
     call lowcase(string)
     if (in > 0) then
-      write (msg, fmtmsgout3) in, line(istart:istop), trim(string)
+      write(msg,205) in,line(istart:istop), trim(string)
     else
-      write (msg, fmtmsgout4) line(istart:istop), trim(string)
-    end if
-    !
+      write(msg,207) line(istart:istop), trim(string)
+    endif
+205 format('File unit ',I0,': Error converting "',a, &
+           '" to ',A,' in following line:')
+207 format('Keyboard input: Error converting "',a, &
+           '" to ',A,' in following line:')
     call store_error(msg)
     call store_error(trim(line))
     call store_error_unit(in)
@@ -596,28 +592,27 @@ contains
     ! -- constant
     character(len=1) DASH(400)
     data DASH/400*'-'/
-    ! -- formats
-    character(len=*), parameter :: fmtmsgout1 = "(1x, a)"
-    character(len=*), parameter :: fmtmsgout2 = "(1x,400a)"
     !
     ! -- Construct the complete label in BUF.  Start with BUF=LABEL.
-    buf = label
+    buf=label
     !
     ! -- Add auxiliary data names if there are any.
     nbuf = len(label) + 9
-    if (naux > 0) then
-      do i = 1, naux
-        n1 = nbuf + 1
-        nbuf = nbuf + 16
-        buf(n1:nbuf) = caux(i)
-      end do
+    if(naux > 0) then
+       do 10 i=1, naux
+         n1 = nbuf + 1
+         nbuf = nbuf + 16
+         buf(n1:nbuf) = caux(i)
+10     continue
     end if
     !
     ! -- Write the label.
-    write (iout, fmtmsgout1) buf(1:nbuf)
+    write(iout, 103) buf(1:nbuf)
+103 format(1x, a)
     !
     ! -- Add a line of dashes.
-    write (iout, fmtmsgout2) (DASH(j), j=1, nbuf)
+    write(iout, 104) (DASH(j), j=1, nbuf)
+104 format(1x,400a)
     !
     ! -- Return
     return
@@ -630,22 +625,22 @@ contains
   !<
   subroutine UBDSV4(kstp, kper, text, naux, auxtxt, ibdchn, &
      &              ncol, nrow, nlay, nlist, iout, delt, pertim, totim)
-    ! -- dummy
+    ! -- dummy 
     character(len=16) :: text
     character(len=16), dimension(:) :: auxtxt
-    real(DP), intent(in) :: delt, pertim, totim
+    real(DP),intent(in) :: delt, pertim, totim
     ! -- formats
     character(len=*), parameter :: fmt = &
-      & "(1X,'UBDSV4 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
-      & "', STRESS PERIOD',I7)"
+      "(1X,'UBDSV4 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
+      "', STRESS PERIOD',I7)"
     !
     ! -- Write unformatted records identifying data
-    if (iout > 0) write (iout, fmt) text, ibdchn, kstp, kper
-    write (ibdchn) kstp, kper, text, ncol, nrow, -nlay
-    write (ibdchn) 5, delt, pertim, totim
-    write (ibdchn) naux + 1
-    if (naux > 0) write (ibdchn) (auxtxt(n), n=1, naux)
-    write (ibdchn) nlist
+    if(iout > 0) write(iout, fmt) text, ibdchn, kstp, kper
+    write(ibdchn) kstp, kper, text, ncol, nrow, -nlay
+    write(ibdchn) 5, delt, pertim, totim
+    write(ibdchn) naux + 1
+    if(naux > 0) write(ibdchn) (auxtxt(n), n=1, naux)
+    write(ibdchn) nlist
     !
     ! -- Return
     return
@@ -653,18 +648,18 @@ contains
 
   !> @brief Write one value of cell-by-cell flow plus auxiliary data using a
   !! list structure
-  !<
+  !< 
   subroutine UBDSVB(ibdchn, icrl, q, val, nvl, naux, laux)
     ! -- dummy
     real(DP), dimension(nvl) :: val
     real(DP) :: q
     !
     ! -- Write cell number and flow rate
-    IF (naux > 0) then
+    IF(naux > 0) then
       n2 = laux + naux - 1
-      write (ibdchn) icrl, q, (val(n), n=laux, n2)
+      write(ibdchn) icrl, q, (val(n), n=laux, n2)
     else
-      write (ibdchn) icrl, q
+      write(ibdchn) icrl, q
     end if
     !
     ! -- Return
@@ -684,37 +679,34 @@ contains
     ! -- local
     character(len=1) :: DOT, SPACE, DG, BF
     dimension :: BF(1000), DG(10)
-    ! -- constants
-    data DG(1), DG(2), DG(3), DG(4), DG(5), DG(6), DG(7), DG(8), DG(9), DG(10)/ &
-       & '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'/
-    data DOT, SPACE/'.', ' '/
-    ! -- formats
-    character(len=*), parameter :: fmtmsgout1 = "(1x)"
-    character(len=*), parameter :: fmtmsgout2 = "(1x, 1000a1)"
+    !
+    data DG(1),DG(2),DG(3),DG(4),DG(5),DG(6),DG(7),DG(8),DG(9),DG(10)/ &
+       & '0','1','2','3','4','5','6','7','8','9'/
+    data DOT,SPACE/'.',' '/
     !
     ! -- Calculate # of columns to be printed (nlbl), width
     !    of a line (ntot), number of lines (nwrap).
     if (iout <= 0) return
-    write (iout, fmtmsgout1)
-    !
+    write(iout, 1)
+  1 format(1x)
     nlbl = nlbl2 - nlbl1 + 1
     n = nlbl
     !
-    if (nlbl < ncpl) n = ncpl
+    if(nlbl < ncpl) n = ncpl
     ntot = nspace + n * ndig
     !
-    if (ntot > 1000) go to 50
-    nwrap = (nlbl - 1) / ncpl + 1
+    if(ntot > 1000) go to 50
+    nwrap = (nlbl-1) / ncpl + 1
     j1 = nlbl1 - ncpl
     j2 = nlbl1 - 1
     !
     ! -- Build and print each line
-    do n = 1, nwrap
+    do 40 n=1, nwrap
       !
       ! -- Clear the buffer (BF)
-      do i = 1, 1000
+      do 20 i=1, 1000
         BF(i) = SPACE
-      end do
+ 20   continue
       nbf = nspace
       !
       ! -- Determine first (j1) and last (j2) column # for this line.
@@ -722,38 +714,40 @@ contains
       j2 = j2 + ncpl
       if (j2 > nlbl2) j2 = nlbl2
       !
-      ! -- Load the column #'s into the buffer.
-      do j = j1, j2
+      !-- Load the column #'s into the buffer.
+      do 30 j=j1, j2
         nbf = nbf + ndig
         i2 = j / 10
         i1 = j - i2 * 10 + 1
         BF(nbf) = DG(i1)
-        if (i2 == 0) go to 30
+        if(i2 == 0) go to 30
         i3 = i2 / 10
         i2 = i2 - i3 * 10 + 1
-        BF(nbf - 1) = DG(i2)
-        if (i3 == 0) go to 30
+        BF(nbf-1) = DG(i2)
+        if(i3 == 0) go to 30
         i4 = i3 / 10
         i3 = i3 - i4 * 10 + 1
-        BF(nbf - 2) = DG(i3)
+        BF(nbf-2) = DG(i3)
         if (I4 == 0) go to 30
         if (I4 > 9) then
           ! -- If more than 4 digits, use "X" for 4th digit.
-          BF(nbf - 3) = 'X'
+          BF(nbf-3) = 'X'
         else
-          BF(nbf - 3) = DG(i4 + 1)
+          BF(nbf-3) = DG(i4+1)
         end if
-30    end do
+ 30   continue
       !
       ! -- Print the contents of the buffer (i.e. print the line).
-      write (iout, fmtmsgout2) (BF(i), i=1, nbf)
+      write(iout, 31) (BF(i), i=1, nbf)
+ 31   format(1x,1000A1)
       !
-    end do
+ 40 continue
     !
     ! -- Print a line of dots (for aesthetic purposes only).
-50  ntot = ntot
-    if (ntot > 1000) ntot = 1000
-    write (iout, fmtmsgout2) (DOT, i=1, ntot)
+ 50 ntot = ntot
+    if (ntot > 1000) ntot=1000
+    write(iout, 51) (DOT,i=1,ntot)
+ 51 format(1x,1000A1)
     !
     ! -- Return
     return
@@ -761,66 +755,21 @@ contains
 
   !> @brief Print 1 layer array
   !<
-  subroutine ULAPRW(buf, text, kstp, kper, ncol, nrow, ilay, iprn, iout)
+  subroutine ULAPRW(buf,text,kstp,kper,ncol,nrow,ilay,iprn,iout)
     ! -- dummy
     character(len=16) :: text
-    real(DP), dimension(ncol, nrow) :: buf
-    ! -- formats
-    character(len=*), parameter :: fmtmsgout1 = &
-      & "('1', /2x, a, ' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
-      & ' IN STRESS PERIOD ',I4/2x,75('-'))"
-    character(len=*), parameter :: fmtmsgout2 = &
-      & "('1',/1x,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
-      & ' IN STRESS PERIOD ',I4/1x,79('-'))"
-    character(len=*), parameter :: fmtg10 = &
-      & "(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))"
-    character(len=*), parameter :: fmtg13 = &
-      & "(1x,I3,2x,1PG13.6,8(1x,G13.6):/(5x,9(1x,G13.6)))"
-    character(len=*), parameter :: fmtf7pt1 = &
-      & "(1x,I3,1x,15(1x,F7.1):/(5x,15(1x,F7.1)))"
-    character(len=*), parameter :: fmtf7pt2 = &
-      & "(1x,I3,1x,15(1x,F7.2):/(5x,15(1x,F7.2)))"
-    character(len=*), parameter :: fmtf7pt3 = &
-      & "(1x,I3,1x,15(1x,F7.3):/(5x,15(1x,F7.3)))"
-    character(len=*), parameter :: fmtf7pt4 = &
-      & "(1x,I3,1x,15(1x,F7.4):/(5x,15(1x,F7.4)))"
-    character(len=*), parameter :: fmtf5pt0 = &
-      & "(1x,I3,1x,20(1x,F5.0):/(5x,20(1x,F5.0)))"
-    character(len=*), parameter :: fmtf5pt1 = &
-      & "(1x,I3,1x,20(1x,F5.1):/(5x,20(1x,F5.1)))"
-    character(len=*), parameter :: fmtf5pt2 = &
-      & "(1x,I3,1x,20(1x,F5.2):/(5x,20(1x,F5.2)))"
-    character(len=*), parameter :: fmtf5pt3 = &
-      & "(1x,I3,1x,20(1x,F5.3):/(5x,20(1x,F5.3)))"
-    character(len=*), parameter :: fmtf5pt4 = &
-      & "(1x,I3,1x,20(1x,F5.4):/(5x,20(1x,F5.4)))"
-    character(len=*), parameter :: fmtg11 = &
-      & "(1x,I3,2x,1PG11.4,9(1x,G11.4):/(5x,10(1x,G11.4)))"
-    character(len=*), parameter :: fmtf6pt0 = &
-      & "(1x,I3,1x,10(1x,F6.0):/(5X,10(1x,F6.0)))"
-    character(len=*), parameter :: fmtf6pt1 = &
-      & "(1x,I3,1x,10(1x,F6.1):/(5x,10(1x,F6.1)))"
-    character(len=*), parameter :: fmtf6pt2 = &
-      & "(1x,I3,1x,10(1x,F6.2):/(5x,10(1x,F6.2)))"
-    character(len=*), parameter :: fmtf6pt3 = &
-      & "(1x,I3,1x,10(1x,F6.3):/(5x,10(1x,F6.3)))"
-    character(len=*), parameter :: fmtf6pt4 = &
-      & "(1x,I3,1x,10(1x,F6.4):/(5x,10(1x,F6.4)))"
-    character(len=*), parameter :: fmtf6pt5 = &
-      & "(1x,I3,1x,10(1x,F6.5):/(5x,10(1x,F6.5)))"
-    character(len=*), parameter :: fmtg12 = &
-      & "(1x,I3,2x,1PG12.5,4(1x,G12.5):/(5x,5(1x,G12.5)))"
-    character(len=*), parameter :: fmtg11pt4 = &
-      & "(1x,I3,2x,1PG11.4,5(1x,G11.4):/(5x,6(1x,G11.4)))"
-    character(len=*), parameter :: fmtg9pt2 = &
-      & "(1x,I3,2x,1PG9.2,6(1x,G9.2):/(5x,7(1x,G9.2)))"
+    real(DP), dimension(ncol,nrow) :: buf
     !
     if (iout <= 0) return
     ! -- Print a header depending on ilay
     if (ilay > 0) then
-      write (iout, fmtmsgout1) text, ilay, kstp, kper
-    else if (ilay < 0) then
-      write (iout, fmtmsgout2) text, kstp, kper
+      write(iout, 1) text, ilay, kstp, kper
+    1 format('1', /2x, a, ' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
+            & ' IN STRESS PERIOD ',I4/2x,75('-'))
+      else if (ilay < 0) then
+        write(iout,2) text, kstp, kper
+    2    format('1',/1x,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
+            & ' IN STRESS PERIOD ',I4/1x,79('-'))
     end if
     !
     ! -- Make sure the format code (ip or iprn) is between 1 and 21
@@ -837,100 +786,121 @@ contains
     if (ip == 19) call ucolno(1, ncol, 0, 5, 13, iout)
     if (ip == 20) call ucolno(1, ncol, 0, 6, 12, iout)
     if (ip == 21) call ucolno(1, ncol, 0, 7, 10, iout)
-    !
+    ! 
     ! -- Loop through the rows printing each one in its entirety.
-    do i = 1, nrow
-      select case (ip)
-        !
-      case (1)
-        ! -- format 11G10.3
-        write (iout, fmtg10) i, (buf(j, i), j=1, ncol)
-        !
-      case (2)
-        ! -- format 9G13.6
-        write (iout, fmtg13) i, (buf(j, i), j=1, ncol)
-        !
-      case (3)
-        ! -- format 15F7.1
-        write (iout, fmtf7pt1) i, (buf(j, i), j=1, ncol)
-        !
-      case (4)
-        ! -- format 15F7.2
-        write (iout, fmtf7pt2) i, (buf(j, i), j=1, ncol)
-        !
-      case (5)
-        ! -- format 15F7.3
-        write (iout, fmtf7pt3) i, (buf(j, i), j=1, ncol)
-        !
-      case (6)
-        ! -- format 15F7.4
-        write (iout, fmtf7pt4) i, (buf(j, i), j=1, ncol)
-        !
-      case (7)
-        ! -- format 20F5.0
-        write (iout, fmtf5pt0) i, (buf(j, i), j=1, ncol)
-        !
-      case (8)
-        ! -- format 20F5.1
-        write (iout, fmtf5pt1) i, (buf(j, i), j=1, ncol)
-        !
-      case (9)
-        ! -- format 20F5.2
-        write (iout, fmtf5pt2) i, (buf(j, i), j=1, ncol)
-        !
-      case (10)
-        ! -- format 20F5.3
-        write (iout, fmtf5pt3) i, (buf(j, i), j=1, ncol)
-        !
-      case (11)
-        ! -- format 20F5.4
-        write (iout, fmtf5pt4) i, (buf(j, i), j=1, ncol)
-        !
-      case (12)
-        ! -- format 10G11.4
-        write (iout, fmtg11) i, (buf(j, i), j=1, ncol)
-        !
-      case (13)
-        ! -- format 10F6.0
-        write (iout, fmtf6pt0) i, (buf(j, i), j=1, ncol)
-        !
-      case (14)
-        ! -- format 10F6.1
-        write (iout, fmtf6pt1) i, (buf(j, i), j=1, ncol)
-        !
-      case (15)
-        ! -- format 10F6.2
-        write (iout, fmtf6pt2) i, (buf(j, i), j=1, ncol)
-        !
-      case (16)
-        ! -- format 10F6.3
-        write (iout, fmtf6pt3) i, (buf(j, i), j=1, ncol)
-        !
-      case (17)
-        ! -- format 10F6.4
-        write (iout, fmtf6pt4) i, (buf(j, i), j=1, ncol)
-        !
-      case (18)
-        ! -- format 10F6.5
-        write (iout, fmtf6pt5) i, (buf(j, i), j=1, ncol)
-        !
-      case (19)
-        ! -- format 5G12.5
-        write (iout, fmtg12) i, (buf(j, i), j=1, ncol)
-        !
-      case (20)
-        ! -- format 6G11.4
-        write (iout, fmtg11pt4) i, (buf(j, i), j=1, ncol)
-        !
-      case (21)
-        ! -- format 7G9.2
-        write (iout, fmtg9pt2) i, (buf(j, i), j=1, ncol)
-        !
+    do i=1,nrow
+      select case(ip)
+      !
+      case(1)
+      ! -- format 11G10.3
+      write(iout, 11) i,(buf(j, i), j=1, ncol)
+11    format(1X,I3,2X,1PG10.3,10(1X,G10.3):/(5X,11(1X,G10.3)))
+      !
+      case(2)
+      ! -- format 9G13.6
+      write(iout, 21) i, (buf(j, i), j=1, ncol)
+21    format(1x,I3,2x,1PG13.6,8(1x,G13.6):/(5x,9(1x,G13.6)))
+      !
+      case(3)
+      ! -- format 15F7.1
+      write(iout, 31) i, (buf(j, i), j=1, ncol)
+31    format(1x,I3,1x,15(1x,F7.1):/(5x,15(1x,F7.1)))
+      !
+      case(4)
+      ! -- format 15F7.2
+      write(iout,41) i,(buf(j,i),j=1,ncol)
+41    format(1x,I3,1x,15(1x,F7.2):/(5x,15(1x,F7.2)))
+      !
+      case(5)
+      ! -- format 15F7.3
+      write(iout, 51) i, (buf(j, i), j=1, ncol)
+51    format(1x,I3,1x,15(1x,F7.3):/(5x,15(1x,F7.3)))
+      !
+      case(6)
+      ! -- format 15F7.4
+      write(iout, 61) i, (buf(j, i), j=1, ncol)
+61    format(1x,I3,1x,15(1x,F7.4):/(5x,15(1x,F7.4)))
+      !
+      case(7)
+      ! -- format 20F5.0
+      write(iout, 71) i, (buf(j, i), j=1, ncol)
+71    format(1x,I3,1x,20(1x,F5.0):/(5x,20(1x,F5.0)))
+      !
+      case(8)
+      ! -- format 20F5.1
+      write(iout, 81) i, (buf(j, i), j=1, ncol)
+81    format(1x,I3,1x,20(1x,F5.1):/(5x,20(1x,F5.1)))
+      !
+      case(9)
+      ! -- format 20F5.2
+      write(iout, 91) i, (buf(j, i), j=1, ncol)
+91    format(1x,I3,1x,20(1x,F5.2):/(5x,20(1x,F5.2)))
+      !
+      case(10)
+      ! -- format 20F5.3
+      write(iout, 101) i, (buf(j, i), j=1, ncol)
+101   format(1x,I3,1x,20(1x,F5.3):/(5x,20(1x,F5.3)))
+      !
+      case(11)
+      ! -- format 20F5.4
+      write(iout, 111) i, (buf(j, i), j=1, ncol)
+111   format(1x,I3,1x,20(1x,F5.4):/(5x,20(1x,F5.4)))
+      !
+      case(12)
+      ! -- format 10G11.4
+      write(iout,121) i, (buf(j, i), j=1, ncol)
+121   format(1x,I3,2x,1PG11.4,9(1x,G11.4):/(5x,10(1x,G11.4)))
+      !
+      case(13)
+      ! -- format 10F6.0
+      write(iout, 131) i, (buf(j, i), j=1, ncol)
+131   format(1x,I3,1x,10(1x,F6.0):/(5X,10(1x,F6.0)))
+      !
+      case(14)
+      ! -- format 10F6.1
+      write(iout, 141) i, (buf(j, i), j=1, ncol)
+141   format(1x,I3,1x,10(1x,F6.1):/(5x,10(1x,F6.1)))
+      !
+      case(15)
+      ! -- format 10F6.2
+      write(iout, 151) i, (buf(j, i), j=1, ncol)
+151   format(1x,I3,1x,10(1x,F6.2):/(5x,10(1x,F6.2)))
+      !
+      case(16)
+      ! -- format 10F6.3
+      write(iout, 161) i, (buf(j, i), j=1, ncol)
+161   format(1x,I3,1x,10(1x,F6.3):/(5x,10(1x,F6.3)))
+      !
+      case(17)
+      ! -- format 10F6.4
+      write(iout, 171) i, (buf(j, i), j=1, ncol)
+171   format(1x,I3,1x,10(1x,F6.4):/(5x,10(1x,F6.4)))
+      !
+      case(18)
+      ! -- format 10F6.5
+      write(iout, 181) i, (buf(j, i), j=1, ncol)
+181   format(1x,I3,1x,10(1x,F6.5):/(5x,10(1x,F6.5)))
+      !
+      case(19)
+      ! -- format 5G12.5
+      write(iout, 191) i, (buf(j, i), j=1, ncol)
+191   format(1x,I3,2x,1PG12.5,4(1x,G12.5):/(5x,5(1x,G12.5)))
+      !
+      case(20)
+      ! -- format 6G11.4
+      write(iout, 201) i, (buf(j, i), j=1, ncol)
+201   format(1x,I3,2x,1PG11.4,5(1x,G11.4):/(5x,6(1x,G11.4)))
+      !
+      case(21)
+      ! -- format 7G9.2
+      write(iout, 211) i, (buf(j, i), j=1, ncol)
+211   format(1x,I3,2x,1PG9.2,6(1x,G9.2):/(5x,7(1x,G9.2)))
+      !
       end select
     end do
     !
     ! -- Flush file
-    flush (iout)
+    flush(iout)
     !
     ! -- Return
     return
@@ -939,27 +909,27 @@ contains
   !> @brief Save 1 layer array on disk
   !<
   subroutine ulasav(buf, text, kstp, kper, pertim, totim, ncol, nrow, &
-                    ilay, ichn)
+                     ilay, ichn)
     ! -- dummy
     character(len=16) :: text
     real(DP), dimension(ncol, nrow) :: buf
     real(DP) :: pertim, totim
     !
     ! -- Write an unformatted record containing identifying information
-    write (ichn) kstp, kper, pertim, totim, text, ncol, nrow, ilay
+    write(ichn) kstp, kper, pertim, totim, text, ncol, nrow, ilay
     !
     ! -- Write an unformatted record containing array values. The array is
     !    dimensioned (ncol,nrow)
-    write (ichn) ((buf(ic, ir), ic=1, ncol), ir=1, nrow)
+    write(ichn) ((buf(ic, ir), ic=1, ncol), ir=1, nrow)
     !
     ! -- flush file
-    flush (ICHN)
+    flush(ICHN)
     !
     ! -- Return
     return
   end subroutine ulasav
 
-  !> @brief Record cell-by-cell flow terms for one component of flow as a 3-D
+  !> @brief Record cell-by-cell flow terms for one component of flow as a 3-D 
   !! array with extra record to indicate delt, pertim, and totim
   !<
   subroutine ubdsv1(kstp, kper, text, ibdchn, buff, ncol, nrow, nlay, iout, &
@@ -980,24 +950,24 @@ contains
     real(DP), intent(in) :: totim
     ! -- format
     character(len=*), parameter :: fmt = &
-      & "(1X,'UBDSV1 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
-      & "', STRESS PERIOD',I7)"
+      "(1X,'UBDSV1 SAVING ',A16,' ON UNIT',I7,' AT TIME STEP',I7,"// &
+      "', STRESS PERIOD',I7)"
     !
     ! -- Write records
-    if (iout > 0) write (iout, fmt) text, ibdchn, kstp, kper
-    write (ibdchn) kstp, kper, text, ncol, nrow, -nlay
-    write (ibdchn) 1, delt, pertim, totim
-    write (ibdchn) buff
+    if(iout > 0) write(iout, fmt) text, ibdchn, kstp, kper
+    write(ibdchn) kstp,kper,text,ncol,nrow,-nlay
+    write(ibdchn) 1,delt,pertim,totim
+    write(ibdchn) buff
     !
     ! -- flush file
-    flush (ibdchn)
+    flush(ibdchn)
     !
     ! -- Return
     return
   end subroutine ubdsv1
 
   !> @brief Write header records for cell-by-cell flow terms for one component
-  !! of flow.
+  !! of flow.  
   !!
   !! Each item in the list is written by module ubdsvc
   !<
@@ -1028,22 +998,22 @@ contains
     integer(I4B) :: n
     ! -- format
     character(len=*), parameter :: fmt = &
-      & "(1X,'UBDSV06 SAVING ',A16,' IN MODEL ',A16,' PACKAGE ',A16,"// &
-      & "'CONNECTED TO MODEL ',A16,' PACKAGE ',A16,"// &
-      & "' ON UNIT',I7,' AT TIME STEP',I7,', STRESS PERIOD',I7)"
+      "(1X,'UBDSV06 SAVING ',A16,' IN MODEL ',A16,' PACKAGE ',A16,"//&
+      "'CONNECTED TO MODEL ',A16,' PACKAGE ',A16,"//&
+      "' ON UNIT',I7,' AT TIME STEP',I7,', STRESS PERIOD',I7)"
     !
     ! -- Write unformatted records identifying data.
-    if (iout > 0) write (iout, fmt) text, modelnam1, paknam1, modelnam2, &
-      paknam2, modelnam2, paknam2, ibdchn, kstp, kper
-    write (ibdchn) kstp, kper, text, ncol, nrow, -nlay
-    write (ibdchn) 6, delt, pertim, totim
-    write (ibdchn) modelnam1
-    write (ibdchn) paknam1
-    write (ibdchn) modelnam2
-    write (ibdchn) paknam2
-    write (ibdchn) naux + 1
-    if (naux > 0) write (ibdchn) (auxtxt(n), n=1, naux)
-    write (ibdchn) nlist
+    if (iout > 0) write(iout,fmt) text, modelnam1, paknam1, modelnam2, paknam2,&
+                                  modelnam2, paknam2, ibdchn, kstp, kper
+    write(ibdchn) kstp, kper, text, ncol, nrow, -nlay
+    write(ibdchn) 6, delt, pertim, totim
+    write(ibdchn) modelnam1
+    write(ibdchn) paknam1
+    write(ibdchn) modelnam2
+    write(ibdchn) paknam2
+    write(ibdchn) naux+1
+    if (naux > 0) write(ibdchn) (auxtxt(n),n=1,naux)
+    write(ibdchn) nlist
     !
     ! -- Return
     return
@@ -1066,9 +1036,9 @@ contains
     !
     ! -- Write record
     if (naux > 0) then
-      write (ibdchn) n, q, (aux(nn), nn=1, naux)
+        write(ibdchn) n,q,(aux(nn),nn=1,naux)
     else
-      write (ibdchn) n, q
+        write(ibdchn) n,q
     end if
     !
     ! -- Return
@@ -1093,9 +1063,9 @@ contains
     !
     ! -- Write record
     if (naux > 0) then
-      write (ibdchn) n, n2, q, (aux(nn), nn=1, naux)
+        write(ibdchn) n,n2,q,(aux(nn),nn=1,naux)
     else
-      write (ibdchn) n, n2, q
+        write(ibdchn) n,n2,q
     end if
     !
     ! -- Return
@@ -1104,7 +1074,7 @@ contains
 
   !> @brief Perform a case-insensitive comparison of two words
   !<
-  logical function same_word(word1, word2)
+  logical function same_word(word1, word2) 
     implicit none
     ! -- dummy
     character(len=*), intent(in) :: word1, word2
@@ -1115,7 +1085,7 @@ contains
     call upcase(upword1)
     upword2 = word2
     call upcase(upword2)
-    same_word = (upword1 == upword2)
+    same_word = (upword1==upword2)
     !
     ! -- Return
     return
@@ -1150,27 +1120,27 @@ contains
        &"('    formatted:',a,'  sequential:',a,'  unformatted:',a,'  form:',a)"
     !
     ! -- set strings using inquire statement
-    inquire (unit=iu, name=fname, access=ac, action=act, formatted=fm, &
-             sequential=seq, unformatted=unf, form=frm)
+    inquire(unit=iu, name=fname, access=ac, action=act, formatted=fm, &
+            sequential=seq, unformatted=unf, form=frm)
     !
     ! -- write the results of the inquire statement
-    write (line, fmta) iu, trim(fname), trim(ac), trim(act)
+    write(line,fmta) iu, trim(fname), trim(ac), trim(act)
     call write_message(line)
-    write (line, fmtb) trim(fm), trim(seq), trim(unf), trim(frm)
+    write(line,fmtb) trim(fm), trim(seq), trim(unf), trim(frm)
     call write_message(line)
     !
     ! -- Return
     return
   end subroutine unitinquire
 
-  !> @brief Parse a line into words.
+  !> @brief Parse a line into words. 
   !!
-  !! Blanks and commas are recognized as delimiters. Multiple blanks between
-  !! words is OK, but multiple commas between words is treated as an error.
+  !! Blanks and commas are recognized as delimiters. Multiple blanks between 
+  !! words is OK, but multiple commas between words is treated as an error. 
   !! Quotation marks are not recognized as delimiters.
-  !<
+  !< 
   subroutine ParseLine(line, nwords, words, inunit, filename)
-    ! -- modules
+    ! -- modules 
     use ConstantsModule, only: LINELENGTH
     implicit none
     ! -- dummy
@@ -1185,13 +1155,13 @@ contains
     !
     nwords = 0
     if (allocated(words)) then
-      deallocate (words)
-    end if
+      deallocate(words)
+    endif
     linelen = len(line)
     !
     ! -- get the number of words in a line and allocate words array
     nwords = get_nwords(line)
-    allocate (words(nwords))
+    allocate(words(nwords))
     !
     ! -- Populate words array and return
     lloc = 1
@@ -1211,7 +1181,7 @@ contains
     implicit none
     ! -- dummy
     integer(I4B), intent(in) :: ncol, nrow, kstp, kper, ilay, iout
-    real(DP), dimension(ncol, nrow), intent(in) :: buf
+    real(DP),dimension(ncol,nrow), intent(in) :: buf
     character(len=*), intent(in) :: text
     character(len=*), intent(in) :: userfmt
     integer(I4B), intent(in) :: nvalues, nwidth
@@ -1219,33 +1189,31 @@ contains
     ! -- local
     integer(I4B) :: i, j, nspaces
     ! -- formats
-    character(len=*), parameter :: fmtmsgout1 = &
-      "('1',/2X,A,' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
-&        ' IN STRESS PERIOD ',I4/2X,75('-'))"
-    character(len=*), parameter :: fmtmsgout2 = &
-      "('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
-&        ' IN STRESS PERIOD ',I4/1X,79('-'))"
+    1 format('1',/2X,A,' IN LAYER ',I3,' AT END OF TIME STEP ',I3, &
+          ' IN STRESS PERIOD ',I4/2X,75('-'))
+    2 format('1',/1X,A,' FOR CROSS SECTION AT END OF TIME STEP',I3, &
+          ' IN STRESS PERIOD ',I4/1X,79('-'))
     !
-    if (iout <= 0) return
+    if (iout<=0) return
     ! -- Print a header depending on ILAY
     if (ilay > 0) then
-      write (iout, fmtmsgout1) trim(text), ilay, kstp, kper
-    else if (ilay < 0) then
-      write (iout, fmtmsgout2) trim(text), kstp, kper
+       write(iout,1) trim(text), ilay, kstp, kper
+    else if(ilay < 0) then
+       write(iout,2) trim(text), kstp, kper
     end if
     !
     ! -- Print column numbers.
     nspaces = 0
     if (editdesc == 'F') nspaces = 3
-    call ucolno(1, ncol, nspaces, nvalues, nwidth + 1, iout)
+    call ucolno(1, ncol, nspaces, nvalues, nwidth+1, iout)
     !
     ! -- Loop through the rows, printing each one in its entirety.
-    do i = 1, nrow
-      write (iout, userfmt) i, (buf(j, i), j=1, ncol)
+    do i=1,nrow
+      write(iout,userfmt) i,(buf(j,i),j=1,ncol)
     end do
     !
     ! -- flush file
-    flush (IOUT)
+    flush(IOUT)
     !
     ! -- Return
     return
@@ -1253,7 +1221,7 @@ contains
 
   !> @breif This function reads a line of arbitrary length and returns it.
   !!
-  !! The returned string can be stored in a deferred-length character variable,
+  !! The returned string can be stored in a deferred-length character variable, 
   !! for example:
   !!
   !!   integer(I4B) :: iu
@@ -1263,7 +1231,7 @@ contains
   !!   open(iu,file='my_file')
   !!   my_string = read_line(iu, eof)
   !<
-  function read_line(iu, eof) result(astring)
+  function read_line(iu, eof) result (astring)
     !
     implicit none
     ! -- dummy
@@ -1276,44 +1244,41 @@ contains
     character(len=1000) :: ermsg, fname
     character(len=7) :: fmtd
     logical :: lop
-    ! -- formats
-    character(len=*), parameter :: fmterrmsg1 = &
-      & "('Error in read_line: File ',i0,' is not open.')"
-    character(len=*), parameter :: fmterrmsg2 = &
-      & "('Error in read_line: Attempting to read text ' // &
-      & 'from unformatted file: ""',a,'""')"
-    character(len=*), parameter :: fmterrmsg3 = &
-      & "('Error reading from file ""',a,'"" opened on unit ',i0, &
-      & ' in read_line.')"
+    ! -- format
+20  format('Error in read_line: File ',i0,' is not open.')
+30  format('Error in read_line: Attempting to read text ' // &
+              'from unformatted file: "',a,'"')
+40  format('Error reading from file "',a,'" opened on unit ',i0, &
+              ' in read_line.')
     !
     astring = ''
     eof = .false.
     do
-      read (iu, '(a)', advance='NO', iostat=istat, size=isize, end=99) buffer
+      read(iu, '(a)', advance='NO', iostat=istat, size=isize, end=99) buffer
       if (istat > 0) then
         ! Determine error if possible, report it, and stop.
         if (iu <= 0) then
-          ermsg = 'Programming error in call to read_line: '// &
+          ermsg = 'Programming error in call to read_line: ' // &
                   'Attempt to read from unit number <= 0'
         else
-          inquire (unit=iu, opened=lop, name=fname, formatted=fmtd)
+          inquire(unit=iu,opened=lop,name=fname,formatted=fmtd)
           if (.not. lop) then
-            write (ermsg, fmterrmsg1) iu
+            write(ermsg,20) iu
           elseif (fmtd == 'NO' .or. fmtd == 'UNKNOWN') then
-            write (ermsg, fmterrmsg2) trim(fname)
+            write(ermsg, 30) trim(fname)
           else
-            write (ermsg, fmterrmsg3) trim(fname), iu
-          end if
-        end if
+            write(ermsg,40) trim(fname), iu
+          endif
+        endif
         call store_error(ermsg)
         call store_error_unit(iu)
-      end if
-      astring = astring//buffer(:isize)
+      endif
+      astring = astring // buffer(:isize)
       ! -- An end-of-record condition stops the loop.
       if (istat < 0) then
         return
-      end if
-    end do
+      endif
+    enddo
     !
     return
 99  continue
@@ -1339,19 +1304,19 @@ contains
     lenpath = len_trim(pathname)
     istart = 1
     istop = lenpath
-    loop: do i = lenpath, 1, -1
+    loop: do i=lenpath,1,-1
       if (pathname(i:i) == fs .or. pathname(i:i) == bs) then
         if (i == istop) then
           istop = istop - 1
         else
           istart = i + 1
           exit loop
-        end if
-      end if
-    end do loop
+        endif
+      endif
+    enddo loop
     if (istop >= istart) then
       filename = pathname(istart:istop)
-    end if
+    endif
     !
     ! -- Return
     return
@@ -1359,8 +1324,8 @@ contains
 
   !> @brief Starting at position icol, define string as line(istart:istop).
   !!
-  !! If string can be interpreted as an integer(I4B), return integer in idnum
-  !! argument. If token is not an integer(I4B), assume it is a boundary name,
+  !! If string can be interpreted as an integer(I4B), return integer in idnum 
+  !! argument. If token is not an integer(I4B), assume it is a boundary name, 
   !! return NAMEDBOUNDFLAG in idnum, convert string to uppercase and return it
   !! in bndname.
   !<
@@ -1371,12 +1336,12 @@ contains
     integer(I4B), intent(inout) :: icol, istart, istop
     integer(I4B), intent(out) :: idnum
     character(len=LENBOUNDNAME), intent(out) :: bndname
-    ! -- local
-    integer(I4B) :: istat, ndum, ncode = 0
+    ! -- local 
+    integer(I4B) :: istat, ndum, ncode=0
     real(DP) :: rdum
     !
     call urword(line, icol, istart, istop, ncode, ndum, rdum, 0, 0)
-    read (line(istart:istop), *, iostat=istat) ndum
+    read(line(istart:istop),*,iostat=istat) ndum
     if (istat == 0) then
       idnum = ndum
       bndname = ''
@@ -1384,7 +1349,7 @@ contains
       idnum = NAMEDBOUNDFLAG
       bndname = line(istart:istop)
       call upcase(bndname)
-    end if
+    endif
     !
     ! -- Return
     return
@@ -1395,7 +1360,7 @@ contains
   subroutine urdaux(naux, inunit, iout, lloc, istart, istop, auxname, line, text)
     ! -- modules
     use ArrayHandlersModule, only: ExpandArray
-    use ConstantsModule, only: LENAUXNAME
+    use ConstantsModule,     only: LENAUXNAME
     ! -- implicit
     implicit none
     ! -- dummy
@@ -1414,13 +1379,12 @@ contains
     real(DP) :: rval
     !
     linelen = len(line)
-    if (naux > 0) then
-      write (errmsg, '(a)') 'Auxiliary variables already specified. '// &
-        & 'Auxiliary variables must be specified on one line in the '// &
-        & 'options block.'
+    if(naux > 0) then
+      write(errmsg,'(a)') 'Auxiliary variables already specified. Auxiliary ' // &
+        'variables must be specified on one line in the options block.'
       call store_error(errmsg)
       call store_error_unit(inunit)
-    end if
+    endif
     auxloop: do
       call urword(line, lloc, istart, istop, 1, n, rval, iout, inunit)
       if (istart >= linelen) exit auxloop
@@ -1433,15 +1397,15 @@ contains
           & to ', LENAUXNAME, ' characters.'
         call store_error(errmsg)
         call store_error_unit(inunit)
-      end if
+      end if      
       naux = naux + 1
       call ExpandArray(auxname)
       auxname(naux) = line(istart:istop)
-      if (iout > 0) then
-        write (iout, "(4X,'AUXILIARY ',a,' VARIABLE: ',A)") &
+      if(iout > 0) then
+        write(iout, "(4X,'AUXILIARY ',a,' VARIABLE: ',A)")                     &
           trim(adjustl(text)), auxname(naux)
-      end if
-    end do auxloop
+      endif
+    enddo auxloop
     !
     ! -- Return
     return
@@ -1477,7 +1441,7 @@ contains
     character(len=len(linein)) :: line
     character(len=20), dimension(:), allocatable :: words
     character(len=100) :: ermsg
-    integer(I4B) :: ndigits = 0, nwords = 0
+    integer(I4B) :: ndigits=0, nwords=0
     integer(I4B) :: i, ierr
     logical :: isint
     !
@@ -1487,17 +1451,17 @@ contains
     ierr = 0
     i = 0
     isint = .false.
-    if (editdesc == 'I') isint = .true.
+    if(editdesc == 'I') isint = .true.
     !
     ! -- Check array name
     if (nwords < 1) then
-      ermsg = 'Could not build PRINT_FORMAT from line'//trim(line)
+      ermsg = 'Could not build PRINT_FORMAT from line' // trim(line)
       call store_error(trim(ermsg))
       ermsg = 'Syntax is: COLUMNS <columns> WIDTH <width> DIGITS &
               &<digits> <format>'
       call store_error(trim(ermsg))
       call store_error_unit(inunit)
-    end if
+    endif
     !
     ermsg = 'Error setting PRINT_FORMAT. Syntax is incorrect in line:'
     if (nwords >= 4) then
@@ -1505,14 +1469,14 @@ contains
       if (.not. same_word(words(3), 'WIDTH')) ierr = 1
       ! -- Read nvalues and nwidth
       if (ierr == 0) then
-        read (words(2), *, iostat=ierr) nvaluesp
-      end if
+        read(words(2), *, iostat=ierr) nvaluesp
+      endif
       if (ierr == 0) then
-        read (words(4), *, iostat=ierr) nwidthp
-      end if
+        read(words(4), *, iostat=ierr) nwidthp
+      endif
     else
       ierr = 1
-    end if
+    endif
     if (ierr /= 0) then
       call store_error(ermsg)
       call store_error(line)
@@ -1520,7 +1484,7 @@ contains
               &DIGITS <digits> <format>'
       call store_error(trim(ermsg))
       call store_error_unit(inunit)
-    end if
+    endif
     i = 4
     !
     if (.not. isint) then
@@ -1528,12 +1492,12 @@ contains
       if (nwords >= 5) then
         if (.not. same_word(words(5), 'DIGITS')) ierr = 1
         ! -- Read ndigits
-        read (words(6), *, iostat=ierr) ndigits
+        read(words(6), *, iostat=ierr) ndigits
       else
         ierr = 1
-      end if
+      endif
       i = i + 2
-    end if
+    endif
     !
     ! -- Check for EXPONENTIAL | FIXED | GENERAL | SCIENTIFIC option.
     ! -- Check for LABEL, WRAP, and STRIP options.
@@ -1555,7 +1519,7 @@ contains
           editdesc = 'S'
           if (isint) ierr = 1
         case default
-          ermsg = 'Error in format specification. Unrecognized option: '//words(i)
+          ermsg = 'Error in format specification. Unrecognized option: ' // words(i)
           call store_error(ermsg)
           ermsg = 'Valid values are EXPONENTIAL, FIXED, GENERAL, or SCIENTIFIC.'
           call store_error(ermsg)
@@ -1563,13 +1527,13 @@ contains
         end select
       else
         exit
-      end if
-    end do
+      endif
+    enddo
     if (ierr /= 0) then
       call store_error(ermsg)
       call store_error(line)
       call store_error_unit(inunit)
-    end if
+    endif
     !
     ! -- Build the output format.
     select case (editdesc)
@@ -1592,47 +1556,47 @@ contains
     ! -- dummy
     integer(I4B), intent(in) :: nvalsp, nwidp, ndig
     character(len=*), intent(inout) :: outfmt
-    logical, intent(in), optional :: prowcolnum ! default true
+    logical, intent(in), optional :: prowcolnum  ! default true
     ! -- local
-    character(len=8) :: cvalues, cwidth, cdigits
-    character(len=60) :: ufmt
+    character(len=8)   :: cvalues, cwidth, cdigits
+    character(len=60)  :: ufmt
     logical :: prowcolnumlocal
     ! -- formats
-    character(len=*), parameter :: fmtndig = "(i8)"
+    10 format(i8)
     !
     if (present(prowcolnum)) then
       prowcolnumlocal = prowcolnum
     else
       prowcolnumlocal = .true.
-    end if
+    endif
     !
     ! -- Convert integers to characters and left-adjust
-    write (cdigits, fmtndig) ndig
+    write(cdigits,10) ndig
     cdigits = adjustl(cdigits)
     !
     ! -- Build format for printing to the list file in wrap format
-    write (cvalues, fmtndig) nvalsp
+    write(cvalues,10) nvalsp
     cvalues = adjustl(cvalues)
-    write (cwidth, fmtndig) nwidp
+    write(cwidth,10) nwidp
     cwidth = adjustl(cwidth)
     if (prowcolnumlocal) then
       ufmt = '(1x,i3,1x,'
     else
       ufmt = '(5x,'
-    end if
+    endif
     !
-    ufmt = trim(ufmt)//cvalues
-    ufmt = trim(ufmt)//'(1x,f'
-    ufmt = trim(ufmt)//cwidth
-    ufmt = trim(ufmt)//'.'
-    ufmt = trim(ufmt)//cdigits
-    ufmt = trim(ufmt)//'):/(5x,'
-    ufmt = trim(ufmt)//cvalues
-    ufmt = trim(ufmt)//'(1x,f'
-    ufmt = trim(ufmt)//cwidth
-    ufmt = trim(ufmt)//'.'
-    ufmt = trim(ufmt)//cdigits
-    ufmt = trim(ufmt)//')))'
+    ufmt = trim(ufmt) // cvalues
+    ufmt = trim(ufmt) // '(1x,f'
+    ufmt = trim(ufmt) // cwidth
+    ufmt = trim(ufmt) // '.'
+    ufmt = trim(ufmt) // cdigits
+    ufmt = trim(ufmt) // '):/(5x,'
+    ufmt = trim(ufmt) // cvalues
+    ufmt = trim(ufmt) // '(1x,f'
+    ufmt = trim(ufmt) // cwidth
+    ufmt = trim(ufmt) // '.'
+    ufmt = trim(ufmt) // cdigits
+    ufmt = trim(ufmt) // ')))'
     outfmt = ufmt
     !
     ! -- Return
@@ -1647,58 +1611,58 @@ contains
     integer(I4B), intent(in) :: nvalsp, nwidp, ndig
     character(len=*), intent(in) :: editdesc
     character(len=*), intent(inout) :: outfmt
-    logical, intent(in), optional :: prowcolnum ! default true
+    logical, intent(in), optional :: prowcolnum  ! default true
     ! -- local
-    character(len=8) :: cvalues, cwidth, cdigits
-    character(len=60) :: ufmt
+    character(len=8)   :: cvalues,  cwidth, cdigits
+    character(len=60)  :: ufmt
     logical :: prowcolnumlocal
     ! -- formats
-    character(len=*), parameter :: fmtndig = "(i8)"
+    10 format(i8)
     !
     if (present(prowcolnum)) then
       prowcolnumlocal = prowcolnum
     else
       prowcolnumlocal = .true.
-    end if
+    endif
     !
     ! -- Build the format
-    write (cdigits, fmtndig) ndig
+    write(cdigits,10) ndig
     cdigits = adjustl(cdigits)
     ! -- Convert integers to characters and left-adjust
-    write (cwidth, fmtndig) nwidp
+    write(cwidth,10) nwidp
     cwidth = adjustl(cwidth)
     ! -- Build format for printing to the list file
-    write (cvalues, fmtndig) (nvalsp - 1)
+    write(cvalues, 10) (nvalsp - 1)
     cvalues = adjustl(cvalues)
     if (prowcolnumlocal) then
-      ufmt = '(1x,i3,2x,1p,'//editdesc
+      ufmt = '(1x,i3,2x,1p,' // editdesc
     else
-      ufmt = '(6x,1p,'//editdesc
-    end if
-    ufmt = trim(ufmt)//cwidth
-    ufmt = trim(ufmt)//'.'
-    ufmt = trim(ufmt)//cdigits
-    if (nvalsp > 1) then
-      ufmt = trim(ufmt)//','
-      ufmt = trim(ufmt)//cvalues
-      ufmt = trim(ufmt)//'(1x,'
-      ufmt = trim(ufmt)//editdesc
-      ufmt = trim(ufmt)//cwidth
-      ufmt = trim(ufmt)//'.'
-      ufmt = trim(ufmt)//cdigits
-      ufmt = trim(ufmt)//')'
-    end if
+      ufmt = '(6x,1p,' // editdesc
+    endif
+    ufmt = trim(ufmt) // cwidth
+    ufmt = trim(ufmt) // '.'
+    ufmt = trim(ufmt) // cdigits
+    if (nvalsp>1) then
+      ufmt = trim(ufmt) // ','
+      ufmt = trim(ufmt) // cvalues
+      ufmt = trim(ufmt) // '(1x,'
+      ufmt = trim(ufmt) // editdesc
+      ufmt = trim(ufmt) // cwidth
+      ufmt = trim(ufmt) // '.'
+      ufmt = trim(ufmt) // cdigits
+      ufmt = trim(ufmt) // ')'
+    endif
     !
-    ufmt = trim(ufmt)//':/(5x,'
-    write (cvalues, fmtndig) nvalsp
+    ufmt = trim(ufmt) // ':/(5x,'
+    write(cvalues, 10) nvalsp
     cvalues = adjustl(cvalues)
-    ufmt = trim(ufmt)//cvalues
-    ufmt = trim(ufmt)//'(1x,'
-    ufmt = trim(ufmt)//editdesc
-    ufmt = trim(ufmt)//cwidth
-    ufmt = trim(ufmt)//'.'
-    ufmt = trim(ufmt)//cdigits
-    ufmt = trim(ufmt)//')))'
+    ufmt = trim(ufmt) // cvalues
+    ufmt = trim(ufmt) // '(1x,'
+    ufmt = trim(ufmt) // editdesc
+    ufmt = trim(ufmt) // cwidth
+    ufmt = trim(ufmt) // '.'
+    ufmt = trim(ufmt) // cdigits
+    ufmt = trim(ufmt) // ')))'
     outfmt = ufmt
     !
     ! -- Return
@@ -1712,38 +1676,38 @@ contains
     ! -- dummy
     integer(I4B), intent(in) :: nvalsp, nwidp
     character(len=*), intent(inout) :: outfmt
-    logical, intent(in), optional :: prowcolnum ! default true
+    logical, intent(in), optional :: prowcolnum  ! default true
     ! -- local
-    character(len=8) :: cvalues, cwidth
-    character(len=60) :: ufmt
+    character(len=8)   :: cvalues, cwidth
+    character(len=60)  :: ufmt
     logical :: prowcolnumlocal
     ! -- formats
-    character(len=*), parameter :: fmtndig = "(i8)"
+    10 format(i8)
     !
     if (present(prowcolnum)) then
       prowcolnumlocal = prowcolnum
     else
       prowcolnumlocal = .true.
-    end if
+    endif
     !
     ! -- Build format for printing to the list file in wrap format
-    write (cvalues, fmtndig) nvalsp
+    write(cvalues,10)nvalsp
     cvalues = adjustl(cvalues)
-    write (cwidth, fmtndig) nwidp
+    write(cwidth,10)nwidp
     cwidth = adjustl(cwidth)
     if (prowcolnumlocal) then
       ufmt = '(1x,i3,1x,'
     else
       ufmt = '(5x,'
-    end if
-    ufmt = trim(ufmt)//cvalues
-    ufmt = trim(ufmt)//'(1x,i'
-    ufmt = trim(ufmt)//cwidth
-    ufmt = trim(ufmt)//'):/(5x,'
-    ufmt = trim(ufmt)//cvalues
-    ufmt = trim(ufmt)//'(1x,i'
-    ufmt = trim(ufmt)//cwidth
-    ufmt = trim(ufmt)//')))'
+    endif
+    ufmt = trim(ufmt) // cvalues
+    ufmt = trim(ufmt) // '(1x,i'
+    ufmt = trim(ufmt) // cwidth
+    ufmt = trim(ufmt) // '):/(5x,'
+    ufmt = trim(ufmt) // cvalues
+    ufmt = trim(ufmt) // '(1x,i'
+    ufmt = trim(ufmt) // cwidth
+    ufmt = trim(ufmt) // ')))'
     outfmt = ufmt
     !
     ! -- Return
@@ -1756,7 +1720,7 @@ contains
     ! -- return
     integer(I4B) :: get_nwords !< number of words in a string
     ! -- dummy
-    character(len=*), intent(in) :: line !< line
+    character(len=*), intent(in) :: line  !< line
     ! -- local
     integer(I4B) :: linelen
     integer(I4B) :: lloc
@@ -1783,7 +1747,7 @@ contains
 
   !> @brief Move the file pointer.
   !!
-  !! Patterned after fseek, which is not supported as part of the fortran
+  !! Patterned after fseek, which is not supported as part of the fortran 
   !! standard.  For this subroutine to work the file must have been opened with
   !! access='stream' and action='readwrite'.
   !<
@@ -1796,34 +1760,34 @@ contains
     ! -- local
     integer(I8B) :: ipos
     !
-    inquire (unit=iu, size=ipos)
+    inquire(unit=iu, size=ipos)
     !
-    select case (whence)
-    case (0)
+    select case(whence)
+    case(0)
       !
       ! -- whence = 0, offset is relative to start of file
       ipos = 0 + offset
-    case (1)
+    case(1)
       !
       ! -- whence = 1, offset is relative to current pointer position
-      inquire (unit=iu, pos=ipos)
+      inquire(unit=iu, pos=ipos)
       ipos = ipos + offset
-    case (2)
+    case(2)
       !
       ! -- whence = 2, offset is relative to end of file
-      inquire (unit=iu, size=ipos)
+      inquire(unit=iu, size=ipos)
       ipos = ipos + offset
     end select
     !
     ! -- position the file pointer to ipos
-    write (iu, pos=ipos, iostat=status)
-    inquire (unit=iu, pos=ipos)
+    write(iu, pos=ipos, iostat=status)
+    inquire(unit=iu, pos=ipos)
     !
     ! -- Return
     return
   end subroutine fseek_stream
 
-  !> @brief Read until non-comment line found and then return line.
+  !> @brief Read until non-comment line found and then return line. 
   !!
   !! Different from u8rdcom in that line is a deferred length character string,
   !! which allows any length lines to be read using the get_line subroutine.
@@ -1833,14 +1797,14 @@ contains
     use, intrinsic :: iso_fortran_env, only: IOSTAT_END
     implicit none
     ! -- dummy
-    integer(I4B), intent(in) :: iin
-    integer(I4B), intent(in) :: iout
-    character(len=:), allocatable, intent(inout) :: line
-    integer(I4B), intent(out) :: ierr
+    integer(I4B),         intent(in) :: iin
+    integer(I4B),         intent(in) :: iout
+    character (len=:), allocatable, intent(inout) :: line
+    integer(I4B),        intent(out) :: ierr
     ! -- local
-    character(len=:), allocatable :: linetemp
-    character(len=2), parameter :: comment = '//'
-    character(len=1), parameter :: tab = CHAR(9)
+    character (len=:), allocatable :: linetemp
+    character (len=2), parameter :: comment = '//'
+    character(len=1), parameter  :: tab = CHAR(9)
     logical :: iscomment
     integer(I4B) :: i, j, l, istart, lsize
     !
@@ -1856,9 +1820,9 @@ contains
       elseif (ierr /= 0) then
         ! -- Other error...report it
         call unitinquire(iin)
-        write (errmsg, *) 'u9rdcom: Could not read from unit: ', iin
+        write(errmsg, *) 'u9rdcom: Could not read from unit: ',iin
         call store_error(errmsg, terminate=.TRUE.)
-      end if
+      endif
       if (len_trim(line) < 1) then
         line = comment
         cycle
@@ -1870,10 +1834,9 @@ contains
         ! -- adjustl manually to avoid stack overflow
         lsize = len(line)
         istart = 1
-        allocate (character(len=lsize) :: linetemp)
+        allocate(character(len=lsize) :: linetemp)
         do j = 1, lsize
-          if (line(j:j) /= ' ' .and. line(j:j) /= ',' .and. &
-              line(j:j) /= char(9)) then
+          if (line(j:j) /= ' ' .and. line(j:j) /= ',' .and. line(j:j) /= char(9)) then
             istart = j
             exit
           end if
@@ -1881,40 +1844,40 @@ contains
         linetemp(:) = ' '
         linetemp(:) = line(istart:)
         line(:) = linetemp(:)
-        deallocate (linetemp)
+        deallocate(linetemp)
         !
         ! -- check for comment
         iscomment = .false.
         select case (line(1:1))
-        case ('#')
-          iscomment = .true.
-          exit cleartabs
-        case ('!')
-          iscomment = .true.
-          exit cleartabs
-        case (tab)
-          line(1:1) = ' '
-          cycle cleartabs
-        case default
-          if (line(1:2) == comment) iscomment = .true.
-          if (len_trim(line) < 1) iscomment = .true.
-          exit cleartabs
+          case ('#')
+            iscomment = .true.
+            exit cleartabs
+          case ('!')
+            iscomment = .true.
+            exit cleartabs
+          case (tab)
+            line(1:1) = ' '
+            cycle cleartabs
+          case default
+            if (line(1:2) == comment) iscomment = .true.
+            if (len_trim(line) < 1) iscomment = .true.
+            exit cleartabs
         end select
       end do cleartabs
       !
-      if (.not. iscomment) then
+      if (.not.iscomment) then
         exit pcomments
       else
         if (iout > 0) then
           !find the last non-blank character.
           l = len(line)
           do i = l, 1, -1
-            if (line(i:i) /= ' ') then
+            if(line(i:i) /= ' ') then
               exit
             end if
           end do
           ! -- print the line up to the last non-blank character.
-          write (iout, '(1x,a)') line(1:i)
+          write(iout,'(1x,a)') line(1:i)
         end if
       end if
     end do pcomments
@@ -1924,9 +1887,9 @@ contains
   end subroutine u9rdcom
 
   !> @brief Read an unlimited length line from unit number lun into a deferred-
-  !! length character string (line).
+  !! length character string (line).  
   !!
-  !! Tack on a single space to the end so that routines like URWORD continue to
+  !! Tack on a single space to the end so that routines like URWORD continue to 
   !! function as before.
   !<
   subroutine get_line(lun, line, iostat)
@@ -1949,30 +1912,30 @@ contains
       read (lun, '(A)', iostat=iostat, advance='no', size=size_read) buffer
       if (is_iostat_eor(iostat)) then
         linesize = len(line)
-        deallocate (linetemp)
-        allocate (character(len=linesize) :: linetemp)
+        deallocate(linetemp)
+        allocate(character(len=linesize) :: linetemp)
         linetemp(:) = line(:)
-        deallocate (line)
-        allocate (character(len=linesize + size_read + 1) :: line)
+        deallocate(line)
+        allocate(character(len=linesize + size_read + 1) :: line)
         line(:) = linetemp(:)
-        line(linesize + 1:) = buffer(:size_read)
+        line(linesize+1:) = buffer(:size_read)
         linesize = len(line)
         line(linesize:linesize) = ' '
         iostat = 0
         exit
       else if (iostat == 0) then
         linesize = len(line)
-        deallocate (linetemp)
-        allocate (character(len=linesize) :: linetemp)
+        deallocate(linetemp)
+        allocate(character(len=linesize) :: linetemp)
         linetemp(:) = line(:)
-        deallocate (line)
-        allocate (character(len=linesize + size_read) :: line)
+        deallocate(line)
+        allocate(character(len=linesize + size_read) :: line)
         line(:) = linetemp(:)
-        line(linesize + 1:) = buffer(:size_read)
+        line(linesize+1:) = buffer(:size_read)
       else
         exit
       end if
     end do
-  end subroutine get_line
+  end subroutine get_line  
 
 end module InputOutputModule


### PR DESCRIPTION
- Started with docstrings cleanup and expanded from there.  
  - There was some imported mf2k/mf2k5 style code that was massaged into the new code format (lowercase vars, etc.).  
  - There remains a number of `go to` statements that would be nice to remove in the future.  
- Ran fprettify