### PR TITLE
ci(developmode): dev_interface tests need to be marked with developmode

### DIFF
--- a/autotest/test_gwfgwf.py
+++ b/autotest/test_gwfgwf.py
@@ -206,6 +206,7 @@ def check_model(sim, model_number):
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,

--- a/autotest/test_gwt_henry_gwtgwt.py
+++ b/autotest/test_gwt_henry_gwtgwt.py
@@ -427,6 +427,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))
+@pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(
         name=name,


### PR DESCRIPTION
Any tests that use dev_ options need to be marked with developmode.  These two tests now use dev_interfacemodel_on, so they need to be explicitly marked.