### PR TITLE
ci: fix example model init per upstream

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -93,9 +93,9 @@ jobs:
 
       - name: Build example models
         if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6-examples/etc
+        working-directory: modflow6-examples/autotest
         run: |
-          python ci_build_files.py
+          pytest -v -n auto test_scripts.py --init
           ls -lh ../examples/
 
       - name: Run benchmarks

--- a/.github/workflows/large.yml
+++ b/.github/workflows/large.yml
@@ -84,7 +84,7 @@ jobs:
         if: matrix.repo == 'examples' && steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc
         run: |
-          python ci_build_files.py
+          pytest -v -n auto test_scripts.py --init
           ls -lh ../examples/
 
       - name: Add Micromamba Scripts dir to path (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,8 +330,8 @@ jobs:
 
       - name: Build example models
         if: inputs.full == true
-        working-directory: modflow6-examples/etc
-        run: python ci_build_files.py
+        working-directory: modflow6-examples/autotest
+        run: pytest -v -n auto test_scripts.py --init
       
       - name: Create folder structure
         if: inputs.full == true
@@ -494,7 +494,7 @@ jobs:
       - name: Build example models
         if: inputs.full == true
         working-directory: modflow6-examples/etc
-        run: python ci_build_files.py
+        run: pytest -v -n auto test_scripts.py --init
 
       - name: Build distribution
         env:


### PR DESCRIPTION
* https://github.com/MODFLOW-USGS/modflow6-examples/pull/137 changed how pytest is invoked to build models, update usages
* fix broken [nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/runs/7620227867/job/20755460522)