### PR TITLE
feat(input): add optional mfsim.par input file

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/sim-par.dfn
+++ b/doc/mf6io/mf6ivar/dfn/sim-par.dfn
@@ -1,0 +1,29 @@
+# --------------------- sim par options ---------------------
+
+block options
+name log_mpi
+type keyword
+reader urword
+optional true
+longname log mpi traffic
+description keyword to enable logging of mpi traffic to file.
+
+
+# --------------------- sim nam partitions ---------------------
+
+block partitions
+name partitions
+type recarray mrank
+reader urword
+optional
+longname list of partition numbers
+description is the list of zero-based partition numbers.
+
+block partitions
+name mrank
+in_record true
+type integer
+tagged false
+reader urword
+longname model rank
+description is the zero-based partition number (also: MPI rank or processor id) to which the model will be assigned.

--- a/doc/mf6io/mf6ivar/mf6ivar.py
+++ b/doc/mf6io/mf6ivar/mf6ivar.py
@@ -660,6 +660,7 @@ def write_appendix(texdir, allblocks):
 if __name__ == '__main__':
 
     file_order = ['sim-nam',  # dfn completed  tex updated
+                  'sim-par',
                   'sim-tdis',  # dfn completed  tex updated
                   'exg-gwfgwf',  # dfn completed  tex updated
                   'exg-gwfgwt',

--- a/make/makefile
+++ b/make/makefile
@@ -118,6 +118,7 @@ $(OBJDIR)/InputDefinition.o \
 $(OBJDIR)/TimeArray.o \
 $(OBJDIR)/ObsOutput.o \
 $(OBJDIR)/DiscretizationBase.o \
+$(OBJDIR)/simparidm.o \
 $(OBJDIR)/simnamidm.o \
 $(OBJDIR)/gwt1idm.o \
 $(OBJDIR)/gwt1ic1idm.o \
@@ -237,6 +238,7 @@ $(OBJDIR)/SparseMatrix.o \
 $(OBJDIR)/LinearSolverBase.o \
 $(OBJDIR)/ims8reordering.o \
 $(OBJDIR)/ModflowInput.o \
+$(OBJDIR)/IdmLogger.o \
 $(OBJDIR)/Integer2dReader.o \
 $(OBJDIR)/VirtualExchange.o \
 $(OBJDIR)/GridSorting.o \
@@ -268,7 +270,6 @@ $(OBJDIR)/RouterBase.o \
 $(OBJDIR)/ImsLinearSolver.o \
 $(OBJDIR)/ims8base.o \
 $(OBJDIR)/StructVector.o \
-$(OBJDIR)/IdmLogger.o \
 $(OBJDIR)/DefinitionSelect.o \
 $(OBJDIR)/InputLoadType.o \
 $(OBJDIR)/Integer1dReader.o \

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -428,5 +428,6 @@
 			<FileConfiguration Name="Release|Win32">
 				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File>
 		<File RelativePath="..\src\simnamidm.f90"/>
+		<File RelativePath="..\src\simparidm.f90"/>
 		<File RelativePath="..\src\SimulationCreate.f90"/></Filter></Files>
 	<Globals/></VisualStudioProject>

--- a/src/SimulationCreate.f90
+++ b/src/SimulationCreate.f90
@@ -808,7 +808,6 @@ contains
           mask_array(i) = 0
         end if
       end do
-
     else
       call create_load_balance(mask_array)
       do i = 1, size(mask_array)

--- a/src/Utilities/Idm/IdmLoad.f90
+++ b/src/Utilities/Idm/IdmLoad.f90
@@ -21,6 +21,7 @@ module IdmLoadModule
   implicit none
   private
   public :: simnam_load
+  public :: simpar_load
   public :: load_models
   public :: load_exchanges
   public :: idm_df
@@ -425,6 +426,18 @@ contains
     ! --return
     return
   end subroutine simnam_load
+
+  !> @brief MODFLOW 6 mfsim.par input load routine
+  !<
+  subroutine simpar_load()
+    use SourceLoadModule, only: load_simpar
+    !
+    ! -- load sim nam file
+    call load_simpar()
+    !
+    ! --return
+    return
+  end subroutine simpar_load
 
   !> @brief retrieve list of model dynamic loaders
   !<

--- a/src/Utilities/Idm/IdmLoad.f90
+++ b/src/Utilities/Idm/IdmLoad.f90
@@ -432,7 +432,7 @@ contains
   subroutine simpar_load()
     use SourceLoadModule, only: load_simpar
     !
-    ! -- load sim nam file
+    ! -- load simulation parallel file
     call load_simpar()
     !
     ! --return

--- a/src/Utilities/Idm/SourceLoad.F90
+++ b/src/Utilities/Idm/SourceLoad.F90
@@ -175,28 +175,28 @@ contains
   end subroutine load_simnam
 
   subroutine load_simpar()
-    use SimVariablesModule, only: parfile, iout
+    use SimVariablesModule, only: simparfile, iout
     use MessageModule, only: write_message
     use IdmMf6FileModule, only: input_load
     type(ModflowInputType) :: mf6_input
     character(len=LINELENGTH) :: line
     logical :: lexist
     !
-    ! -- load mfsim.nam if it exists
-    inquire (file=trim(adjustl(parfile)), exist=lexist)
+    ! -- load mfsim.par if it exists
+    inquire (file=trim(adjustl(simparfile)), exist=lexist)
     !
     if (lexist) then
       !
-      ! -- write name of namfile to stdout
+      ! -- write name of simparfile to stdout
       write (line, '(2(1x,a))') 'Using simulation parallel file:', &
-        trim(adjustl(parfile))
+        trim(adjustl(simparfile))
       call write_message(line, skipafter=1)
       !
       ! -- create description of input
-      mf6_input = getModflowInput('PAR6', 'SIM', 'PAR', 'SIM', 'PAR', parfile)
+      mf6_input = getModflowInput('PAR6', 'SIM', 'PAR', 'SIM', 'PAR', simparfile)
       !
-      ! -- open namfile and load to input context
-      call input_load(parfile, mf6_input, parfile, iout)
+      ! -- open simulation parallel file and load to input context
+      call input_load(simparfile, mf6_input, simparfile, iout)
     end if
     !
     ! -- return

--- a/src/Utilities/Idm/SourceLoad.F90
+++ b/src/Utilities/Idm/SourceLoad.F90
@@ -18,7 +18,7 @@ module SourceLoadModule
   private
   public :: create_input_loader
   public :: open_source_file
-  public :: load_modelnam, load_simnam
+  public :: load_modelnam, load_simnam, load_simpar
   public :: remote_model_ndim
 
 contains
@@ -173,6 +173,35 @@ contains
     ! -- return
     return
   end subroutine load_simnam
+
+  subroutine load_simpar()
+    use SimVariablesModule, only: parfile, iout
+    use MessageModule, only: write_message
+    use IdmMf6FileModule, only: input_load
+    type(ModflowInputType) :: mf6_input
+    character(len=LINELENGTH) :: line
+    logical :: lexist
+    !
+    ! -- load mfsim.nam if it exists
+    inquire (file=trim(adjustl(parfile)), exist=lexist)
+    !
+    if (lexist) then
+      !
+      ! -- write name of namfile to stdout
+      write (line, '(2(1x,a))') 'Using simulation parallel file:', &
+        trim(adjustl(parfile))
+      call write_message(line, skipafter=1)
+      !
+      ! -- create description of input
+      mf6_input = getModflowInput('PAR6', 'SIM', 'PAR', 'SIM', 'PAR', parfile)
+      !
+      ! -- open namfile and load to input context
+      call input_load(parfile, mf6_input, parfile, iout)
+    end if
+    !
+    ! -- return
+    return
+  end subroutine load_simpar
 
   function remote_model_ndim(mtype, mfname) result(ncelldim)
     use SourceCommonModule, only: package_source_type

--- a/src/Utilities/Idm/selector/IdmSimDfnSelector.f90
+++ b/src/Utilities/Idm/selector/IdmSimDfnSelector.f90
@@ -6,6 +6,7 @@ module IdmSimDfnSelectorModule
   use InputDefinitionModule, only: InputParamDefinitionType, &
                                    InputBlockDefinitionType
   use SimNamInputModule
+  use SimParInputModule
 
   implicit none
   private
@@ -36,6 +37,8 @@ contains
     select case (subcomponent)
     case ('NAM')
       call set_param_pointer(input_definition, sim_nam_param_definitions)
+    case ('PAR')
+      call set_param_pointer(input_definition, sim_par_param_definitions)
     case default
     end select
     return
@@ -48,6 +51,8 @@ contains
     select case (subcomponent)
     case ('NAM')
       call set_param_pointer(input_definition, sim_nam_aggregate_definitions)
+    case ('PAR')
+      call set_param_pointer(input_definition, sim_par_aggregate_definitions)
     case default
     end select
     return
@@ -60,6 +65,8 @@ contains
     select case (subcomponent)
     case ('NAM')
       call set_block_pointer(input_definition, sim_nam_block_definitions)
+    case ('PAR')
+      call set_block_pointer(input_definition, sim_par_block_definitions)
     case default
     end select
     return
@@ -71,6 +78,8 @@ contains
     select case (subcomponent)
     case ('NAM')
       multi_package = sim_nam_multi_package
+    case ('PAR')
+      multi_package = sim_par_multi_package
     case default
       call store_error('Idm selector subcomponent not found; '//&
                        &'component="SIM"'//&
@@ -85,6 +94,8 @@ contains
     integrated = .false.
     select case (subcomponent)
     case ('NAM')
+      integrated = .true.
+    case ('PAR')
       integrated = .true.
     case default
     end select

--- a/src/Utilities/SimVariables.f90
+++ b/src/Utilities/SimVariables.f90
@@ -13,7 +13,7 @@ module SimVariablesModule
                              VALL, MNORMAL, LENMODELNAME
   public
   character(len=LINELENGTH) :: simfile = 'mfsim.nam' !< simulation name file
-  character(len=LINELENGTH) :: parfile = 'mfsim.par' !< simulation parallel file
+  character(len=LINELENGTH) :: simparfile = 'mfsim.par' !< simulation parallel file
   character(len=LINELENGTH) :: simlstfile = 'mfsim.lst' !< simulation listing file name
   character(len=LINELENGTH) :: simstdout = 'mfsim.stdout' !< name of standard out file if screen output is piped to a file
   character(len=LINELENGTH) :: idm_context = '__INPUT__'

--- a/src/Utilities/SimVariables.f90
+++ b/src/Utilities/SimVariables.f90
@@ -13,6 +13,7 @@ module SimVariablesModule
                              VALL, MNORMAL, LENMODELNAME
   public
   character(len=LINELENGTH) :: simfile = 'mfsim.nam' !< simulation name file
+  character(len=LINELENGTH) :: parfile = 'mfsim.par' !< simulation parallel file
   character(len=LINELENGTH) :: simlstfile = 'mfsim.lst' !< simulation listing file name
   character(len=LINELENGTH) :: simstdout = 'mfsim.stdout' !< name of standard out file if screen output is piped to a file
   character(len=LINELENGTH) :: idm_context = '__INPUT__'

--- a/src/meson.build
+++ b/src/meson.build
@@ -260,6 +260,7 @@ modflow_sources = files(
     'mf6core.f90',
     'mf6lists.f90',
     'simnamidm.f90',
+    'simparidm.f90',
     'SimulationCreate.f90',
     'RunControl.f90',
     'RunControlFactory.F90'

--- a/src/mf6core.f90
+++ b/src/mf6core.f90
@@ -283,7 +283,7 @@ contains
     ! -- load simnam input context
     call simnam_load(iparamlog)
     !
-    ! -- load optional mfsimm.par if in parallel mode
+    ! -- load optional mfsim.par if in parallel mode
     if (simulation_mode == 'PARALLEL') then
       call simpar_load()
     end if

--- a/src/mf6core.f90
+++ b/src/mf6core.f90
@@ -267,8 +267,9 @@ contains
   subroutine static_input_load()
     ! -- modules
     use ConstantsModule, only: LENMEMPATH
-    use SimVariablesModule, only: iout
-    use IdmLoadModule, only: simnam_load, load_models, load_exchanges
+    use SimVariablesModule, only: iout, simulation_mode
+    use IdmLoadModule, only: simnam_load, simpar_load, load_models, &
+                             load_exchanges
     use MemoryHelperModule, only: create_mem_path
     use MemoryManagerModule, only: mem_setptr, mem_allocate
     use SimVariablesModule, only: idm_context, iparamlog
@@ -281,6 +282,11 @@ contains
     !
     ! -- load simnam input context
     call simnam_load(iparamlog)
+    !
+    ! -- load optional mfsimm.par if in parallel mode
+    if (simulation_mode == 'PARALLEL') then
+      call simpar_load()
+    end if
     !
     ! -- allocate model load mask
     input_mempath = create_mem_path(component='SIM', context=idm_context)

--- a/src/simparidm.f90
+++ b/src/simparidm.f90
@@ -1,0 +1,101 @@
+! ** Do Not Modify! MODFLOW 6 system generated file. **
+module SimParInputModule
+  use ConstantsModule, only: LENVARNAME
+  use InputDefinitionModule, only: InputParamDefinitionType, &
+                                   InputBlockDefinitionType
+  private
+  public sim_par_param_definitions
+  public sim_par_aggregate_definitions
+  public sim_par_block_definitions
+  public SimParParamFoundType
+  public sim_par_multi_package
+
+  type SimParParamFoundType
+    logical :: log_mpi = .false.
+    logical :: mrank = .false.
+  end type SimParParamFoundType
+
+  logical :: sim_par_multi_package = .false.
+
+  type(InputParamDefinitionType), parameter :: &
+    simpar_log_mpi = InputParamDefinitionType &
+    ( &
+    'SIM', & ! component
+    'PAR', & ! subcomponent
+    'OPTIONS', & ! block
+    'LOG_MPI', & ! tag name
+    'LOG_MPI', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    simpar_mrank = InputParamDefinitionType &
+    ( &
+    'SIM', & ! component
+    'PAR', & ! subcomponent
+    'PARTITIONS', & ! block
+    'MRANK', & ! tag name
+    'MRANK', & ! fortran variable
+    'INTEGER', & ! type
+    '', & ! shape
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    sim_par_param_definitions(*) = &
+    [ &
+    simpar_log_mpi, &
+    simpar_mrank &
+    ]
+
+  type(InputParamDefinitionType), parameter :: &
+    simpar_partitions = InputParamDefinitionType &
+    ( &
+    'SIM', & ! component
+    'PAR', & ! subcomponent
+    'PARTITIONS', & ! block
+    'PARTITIONS', & ! tag name
+    'PARTITIONS', & ! fortran variable
+    'RECARRAY MRANK', & ! type
+    '', & ! shape
+    .true., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    sim_par_aggregate_definitions(*) = &
+    [ &
+    simpar_partitions &
+    ]
+
+  type(InputBlockDefinitionType), parameter :: &
+    sim_par_block_definitions(*) = &
+    [ &
+    InputBlockDefinitionType( &
+    'OPTIONS', & ! blockname
+    .false., & ! required
+    .false., & ! aggregate
+    .false. & ! block_variable
+    ), &
+    InputBlockDefinitionType( &
+    'PARTITIONS', & ! blockname
+    .true., & ! required
+    .true., & ! aggregate
+    .false. & ! block_variable
+    ) &
+    ]
+
+end module SimParInputModule

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -962,6 +962,10 @@ if __name__ == "__main__":
             DFN_PATH / "sim-nam.dfn",
             SRC_PATH / "simnamidm.f90",
         ],
+        [
+            DFN_PATH / "sim-par.dfn",
+            SRC_PATH / "simparidm.f90",
+        ],
     ]
 
     dfn_d = {}


### PR DESCRIPTION
Co-authored with @mjr-deltares 

Assign models to partitions with an optional mfsim.par input file:
- Input file defines a partitions block that assigns models (in mfsim.nam model block order) to provided partitions
- Still needs:
  - update docs 
  - option (log_mpi) support
  - validation of provided partition assignments
  -  FloPy support
  - autotest integration
