### PR TITLE
refactor(meson.build): check for autotest/ before calling subdir()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -225,7 +225,10 @@ subdir('srcbmi')
 subdir('utils')
 
 # add autotest directory
-subdir('autotest')
+fs = import('fs')
+if fs.is_dir('autotest')
+  subdir('autotest')
+endif
 
 # meson tests to evaluate installation success
 testdir = meson.project_source_root() / '.mf6minsim'


### PR DESCRIPTION
* makes the `autotest/` subdirectory of the proj root optional
* motivated by the distribution which doesn't contain autotests