### PR TITLE
perf(mem): add faster lookup into memory list

### DIFF
--- a/src/Model/Connection/GwfInterfaceModel.f90
+++ b/src/Model/Connection/GwfInterfaceModel.f90
@@ -69,8 +69,8 @@ contains
     end if
 
     ! create discretization and packages
-    call disu_cr(this%dis, this%name, '', -1, this%iout)
-    call npf_cr(this%npf, this%name, '', -this%innpf, this%iout)
+    call disu_cr(this%dis, this%name, "__devnull", -1, this%iout)
+    call npf_cr(this%npf, this%name, "__devnull", -this%innpf, this%iout)
     call xt3d_cr(this%xt3d, this%name, -this%innpf, this%iout)
     call buy_cr(this%buy, this%name, this%inbuy, this%iout)
 

--- a/src/Model/Connection/GwtInterfaceModel.f90
+++ b/src/Model/Connection/GwtInterfaceModel.f90
@@ -81,12 +81,12 @@ contains
     end if
 
     ! create dis and packages
-    call disu_cr(this%dis, this%name, '', -1, this%iout)
+    call disu_cr(this%dis, this%name, "__devnull", -1, this%iout)
     call fmi_cr(this%fmi, this%name, 0, this%iout, this%ieqnsclfac, &
                 this%depvartype)
     call adv_cr(this%adv, this%name, adv_unit, this%iout, this%fmi, &
                 this%ieqnsclfac)
-    call dsp_cr(this%dsp, this%name, '', -dsp_unit, this%iout, this%fmi)
+    call dsp_cr(this%dsp, this%name, "__devnull", -dsp_unit, this%iout, this%fmi)
     call tsp_obs_cr(this%obs, inobs)
 
   end subroutine gwtifmod_cr

--- a/src/Utilities/Memory/MemoryList.f90
+++ b/src/Utilities/Memory/MemoryList.f90
@@ -1,18 +1,32 @@
 module MemoryListModule
   use KindModule, only: DP, I4B
+  use ConstantsModule, only: LENCOMPONENTNAME
+  use STLVecIntModule
   use MemoryTypeModule, only: MemoryType
+  use MemoryHelperModule, only: split_mem_path
   use ListModule, only: ListType
   private
   public :: MemoryListType
 
+  ! internal type to manage a faster lookup of memory items
+  type, private :: NamedMemSegmentType
+    character(len=LENCOMPONENTNAME) :: comp_name !< the name of the component for which this memory segment exists
+    type(STLVecInt) :: mem_indexes !< all indexes into the main memory list, for this particular component
+  end type NamedMemSegmentType
+
   type :: MemoryListType
-    type(ListType), private :: list
+    type(ListType), private :: segments !< a list with memory segments grouped by component name
+    type(ListType), private :: list !< the full list of memory entries
   contains
     procedure :: add
-    procedure :: get
+    generic :: get => get_by_idx, get_by_address
     procedure :: count
     procedure :: clear
     procedure :: remove
+    ! private
+    procedure, private :: get_by_idx
+    procedure, private :: get_by_address
+    procedure, private :: get_mem_segment
   end type MemoryListType
 
 contains
@@ -20,12 +34,36 @@ contains
   subroutine add(this, mt)
     class(MemoryListType) :: this
     type(MemoryType), pointer :: mt
+    ! local
     class(*), pointer :: obj => null()
+    character(len=LENCOMPONENTNAME) :: comp_name
+    character(len=LENCOMPONENTNAME) :: subcomp_name
+    type(NamedMemSegmentType), pointer :: mem_segment
+
+    ! add memory item
     obj => mt
     call this%list%add(obj)
+
+    ! add item to lookup structure
+    call split_mem_path(mt%path, comp_name, subcomp_name)
+    mem_segment => this%get_mem_segment(comp_name)
+    if (.not. associated(mem_segment)) then
+      ! create and add
+      allocate (mem_segment)
+      mem_segment%comp_name = comp_name
+      call mem_segment%mem_indexes%init()
+      obj => mem_segment
+      call this%segments%Add(obj)
+    end if
+
+    ! add index (of the last item)
+    call mem_segment%mem_indexes%push_back(this%list%Count())
+
   end subroutine add
 
-  function get(this, ipos) result(res)
+  !> @brief Fast, unsafe access by index into the list.
+  !<
+  function get_by_idx(this, ipos) result(res)
     class(MemoryListType) :: this
     integer(I4B), intent(in) :: ipos
     type(MemoryType), pointer :: res
@@ -36,7 +74,67 @@ contains
       res => obj
     end select
     return
-  end function get
+  end function get_by_idx
+
+  !> @Brief Return the memory data item for the memory
+  !! path and variable name. Returns null when not found.
+  !! This method is faster than getting by list index because
+  !< it will use the lookup data structure for components.
+  function get_by_address(this, mem_path, var_name) result(mt)
+    class(MemoryListType) :: this
+    character(len=*) :: mem_path
+    character(len=*) :: var_name
+    type(MemoryType), pointer :: mt
+    ! local
+    integer(I4B) :: i, m_idx
+    character(len=LENCOMPONENTNAME) :: comp_name
+    character(len=LENCOMPONENTNAME) :: subcomp_name
+    type(NamedMemSegmentType), pointer :: mem_segment
+    type(MemoryType), pointer :: mt_try
+
+    mt => null()
+    mt_try => null()
+
+    call split_mem_path(mem_path, comp_name, subcomp_name)
+    mem_segment => this%get_mem_segment(comp_name)
+    if (.not. associated(mem_segment)) then
+      return
+    end if
+
+    do i = 1, mem_segment%mem_indexes%size
+      m_idx = mem_segment%mem_indexes%at(i)
+      mt_try => this%get(m_idx)
+      if (mt_try%name == var_name .and. mt_try%path == mem_path) then
+        mt => mt_try
+        return
+      end if
+    end do
+
+  end function get_by_address
+
+  !> @Brief get the memory segment for this component.
+  !< Returns null when not found.
+  function get_mem_segment(this, comp_name) result(mem_segment)
+    class(MemoryListType) :: this
+    character(len=*) :: comp_name
+    type(NamedMemSegmentType), pointer :: mem_segment
+    ! local
+    integer(I4B) :: i
+    class(*), pointer :: obj
+
+    mem_segment => null()
+    do i = 1, this%segments%Count()
+      obj => this%segments%GetItem(i)
+      select type (obj)
+      class is (NamedMemSegmentType)
+        if (obj%comp_name == comp_name) then
+          mem_segment => obj
+          return
+        end if
+      end select
+    end do
+
+  end function
 
   function count(this) result(nval)
     class(MemoryListType) :: this

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -313,22 +313,15 @@ contains
     logical(LGP), intent(in), optional :: check !< to suppress aborting the program when not found,
                                                 !! set check = .false.
     ! -- local
-    integer(I4B) :: ipos
     logical(LGP) check_opt
     ! -- code
     !
     ! -- initialize
     mt => null()
     found = .false.
-    !
-    ! -- iterate over the memory list
-    do ipos = 1, memorylist%count()
-      mt => memorylist%Get(ipos)
-      if (mt%name == name .and. mt%path == mem_path) then
-        found = .true.
-        exit
-      end if
-    end do
+    mt => memorylist%Get(mem_path, name)
+    if (associated(mt)) found = .true.
+
     check_opt = .true.
     if (present(check)) then
       check_opt = check

--- a/src/Utilities/Memory/MemoryManagerExt.f90
+++ b/src/Utilities/Memory/MemoryManagerExt.f90
@@ -60,11 +60,13 @@ contains
     logical(LGP) :: checkfail = .false.
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
-      if (mt%intsclr == 0) then
-        p_mem = .false.
-      else
-        p_mem = .true.
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
+        if (mt%intsclr == 0) then
+          p_mem = .false.
+        else
+          p_mem = .true.
+        end if
       end if
     end if
   end subroutine mem_set_value_logical
@@ -80,8 +82,10 @@ contains
     logical(LGP) :: checkfail = .false.
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
-      p_mem = mt%intsclr
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
+        p_mem = mt%intsclr
+      end if
     end if
   end subroutine mem_set_value_int
 
@@ -112,12 +116,14 @@ contains
     integer(I4B) :: i
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
-      do i = 1, size(str_list)
-        if (mt%strsclr == str_list(i)) then
-          p_mem = i
-        end if
-      end do
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
+        do i = 1, size(str_list)
+          if (mt%strsclr == str_list(i)) then
+            p_mem = i
+          end if
+        end do
+      end if
     end if
   end subroutine mem_set_value_str_mapped_int
 
@@ -133,14 +139,16 @@ contains
     integer(I4B) :: n
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
-      if (size(mt%aint1d) /= size(p_mem)) then
-        call store_error('mem_set_value() size mismatch int1d, varname='//&
-                         &trim(varname), terminate=.TRUE.)
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
+        if (size(mt%aint1d) /= size(p_mem)) then
+          call store_error('mem_set_value() size mismatch int1d, varname='//&
+                          &trim(varname), terminate=.TRUE.)
+        end if
+        do n = 1, size(mt%aint1d)
+          p_mem(n) = mt%aint1d(n)
+        end do
       end if
-      do n = 1, size(mt%aint1d)
-        p_mem(n) = mt%aint1d(n)
-      end do
     end if
   end subroutine mem_set_value_int1d
 
@@ -158,19 +166,21 @@ contains
     integer(I4B) :: n
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
-      if (associated(map)) then
-        do n = 1, size(p_mem)
-          p_mem(n) = mt%aint1d(map(n))
-        end do
-      else
-        if (size(mt%aint1d) /= size(p_mem)) then
-          call store_error('mem_set_value() size mismatch int1d, varname='//&
-                           &trim(varname), terminate=.TRUE.)
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
+        if (associated(map)) then
+          do n = 1, size(p_mem)
+            p_mem(n) = mt%aint1d(map(n))
+          end do
+        else
+          if (size(mt%aint1d) /= size(p_mem)) then
+            call store_error('mem_set_value() size mismatch int1d, varname='//&
+                            &trim(varname), terminate=.TRUE.)
+          end if
+          do n = 1, size(mt%aint1d)
+            p_mem(n) = mt%aint1d(n)
+          end do
         end if
-        do n = 1, size(mt%aint1d)
-          p_mem(n) = mt%aint1d(n)
-        end do
       end if
     end if
   end subroutine mem_set_value_int1d_mapped
@@ -187,17 +197,19 @@ contains
     integer(I4B) :: i, j
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
-      if (size(mt%aint2d, dim=1) /= size(p_mem, dim=1) .or. &
-          size(mt%aint2d, dim=2) /= size(p_mem, dim=2)) then
-        call store_error('mem_set_value() size mismatch int2d, varname='//&
-                         &trim(varname), terminate=.TRUE.)
-      end if
-      do j = 1, size(mt%aint2d, dim=2)
-        do i = 1, size(mt%aint2d, dim=1)
-          p_mem(i, j) = mt%aint2d(i, j)
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
+        if (size(mt%aint2d, dim=1) /= size(p_mem, dim=1) .or. &
+            size(mt%aint2d, dim=2) /= size(p_mem, dim=2)) then
+          call store_error('mem_set_value() size mismatch int2d, varname='//&
+                          &trim(varname), terminate=.TRUE.)
+        end if
+        do j = 1, size(mt%aint2d, dim=2)
+          do i = 1, size(mt%aint2d, dim=1)
+            p_mem(i, j) = mt%aint2d(i, j)
+          end do
         end do
-      end do
+      end if
     end if
   end subroutine mem_set_value_int2d
 
@@ -213,20 +225,22 @@ contains
     integer(I4B) :: i, j, k
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
-      if (size(mt%aint3d, dim=1) /= size(p_mem, dim=1) .or. &
-          size(mt%aint3d, dim=2) /= size(p_mem, dim=2) .or. &
-          size(mt%aint3d, dim=3) /= size(p_mem, dim=3)) then
-        call store_error('mem_set_value() size mismatch int3d, varname='//&
-                         &trim(varname), terminate=.TRUE.)
-      end if
-      do k = 1, size(mt%aint3d, dim=3)
-        do j = 1, size(mt%aint3d, dim=2)
-          do i = 1, size(mt%aint3d, dim=1)
-            p_mem(i, j, k) = mt%aint3d(i, j, k)
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
+        if (size(mt%aint3d, dim=1) /= size(p_mem, dim=1) .or. &
+            size(mt%aint3d, dim=2) /= size(p_mem, dim=2) .or. &
+            size(mt%aint3d, dim=3) /= size(p_mem, dim=3)) then
+          call store_error('mem_set_value() size mismatch int3d, varname='//&
+                          &trim(varname), terminate=.TRUE.)
+        end if
+        do k = 1, size(mt%aint3d, dim=3)
+          do j = 1, size(mt%aint3d, dim=2)
+            do i = 1, size(mt%aint3d, dim=1)
+              p_mem(i, j, k) = mt%aint3d(i, j, k)
+            end do
           end do
         end do
-      end do
+      end if
     end if
   end subroutine mem_set_value_int3d
 
@@ -241,8 +255,10 @@ contains
     logical(LGP) :: checkfail = .false.
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
-      p_mem = mt%dblsclr
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
+        p_mem = mt%dblsclr
+      end if
     end if
   end subroutine mem_set_value_dbl
 
@@ -258,14 +274,16 @@ contains
     integer(I4B) :: n
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
-      if (size(mt%adbl1d) /= size(p_mem)) then
-        call store_error('mem_set_value() size mismatch dbl1d, varname='//&
-                         &trim(varname), terminate=.TRUE.)
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
+        if (size(mt%adbl1d) /= size(p_mem)) then
+          call store_error('mem_set_value() size mismatch dbl1d, varname='//&
+                          &trim(varname), terminate=.TRUE.)
+        end if
+        do n = 1, size(mt%adbl1d)
+          p_mem(n) = mt%adbl1d(n)
+        end do
       end if
-      do n = 1, size(mt%adbl1d)
-        p_mem(n) = mt%adbl1d(n)
-      end do
     end if
   end subroutine mem_set_value_dbl1d
 
@@ -283,19 +301,21 @@ contains
     integer(I4B) :: n
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
-      if (associated(map)) then
-        do n = 1, size(p_mem)
-          p_mem(n) = mt%adbl1d(map(n))
-        end do
-      else
-        if (size(mt%adbl1d) /= size(p_mem)) then
-          call store_error('mem_set_value() size mismatch dbl1d, varname='//&
-                           &trim(varname), terminate=.TRUE.)
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
+        if (associated(map)) then
+          do n = 1, size(p_mem)
+            p_mem(n) = mt%adbl1d(map(n))
+          end do
+        else
+          if (size(mt%adbl1d) /= size(p_mem)) then
+            call store_error('mem_set_value() size mismatch dbl1d, varname='//&
+                            &trim(varname), terminate=.TRUE.)
+          end if
+          do n = 1, size(mt%adbl1d)
+            p_mem(n) = mt%adbl1d(n)
+          end do
         end if
-        do n = 1, size(mt%adbl1d)
-          p_mem(n) = mt%adbl1d(n)
-        end do
       end if
     end if
   end subroutine mem_set_value_dbl1d_mapped
@@ -312,17 +332,19 @@ contains
     integer(I4B) :: i, j
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
-      if (size(mt%adbl2d, dim=1) /= size(p_mem, dim=1) .or. &
-          size(mt%adbl2d, dim=2) /= size(p_mem, dim=2)) then
-        call store_error('mem_set_value() size mismatch dbl2d, varname='//&
-                         &trim(varname), terminate=.TRUE.)
-      end if
-      do j = 1, size(mt%adbl2d, dim=2)
-        do i = 1, size(mt%adbl2d, dim=1)
-          p_mem(i, j) = mt%adbl2d(i, j)
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
+        if (size(mt%adbl2d, dim=1) /= size(p_mem, dim=1) .or. &
+            size(mt%adbl2d, dim=2) /= size(p_mem, dim=2)) then
+          call store_error('mem_set_value() size mismatch dbl2d, varname='//&
+                          &trim(varname), terminate=.TRUE.)
+        end if
+        do j = 1, size(mt%adbl2d, dim=2)
+          do i = 1, size(mt%adbl2d, dim=1)
+            p_mem(i, j) = mt%adbl2d(i, j)
+          end do
         end do
-      end do
+      end if
     end if
   end subroutine mem_set_value_dbl2d
 
@@ -338,20 +360,22 @@ contains
     integer(I4B) :: i, j, k
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
-      if (size(mt%adbl3d, dim=1) /= size(p_mem, dim=1) .or. &
-          size(mt%adbl3d, dim=2) /= size(p_mem, dim=2) .or. &
-          size(mt%adbl3d, dim=3) /= size(p_mem, dim=3)) then
-        call store_error('mem_set_value() size mismatch dbl3d, varname='//&
-                         &trim(varname), terminate=.TRUE.)
-      end if
-      do k = 1, size(mt%adbl3d, dim=3)
-        do j = 1, size(mt%adbl3d, dim=2)
-          do i = 1, size(mt%adbl3d, dim=1)
-            p_mem(i, j, k) = mt%adbl3d(i, j, k)
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
+        if (size(mt%adbl3d, dim=1) /= size(p_mem, dim=1) .or. &
+            size(mt%adbl3d, dim=2) /= size(p_mem, dim=2) .or. &
+            size(mt%adbl3d, dim=3) /= size(p_mem, dim=3)) then
+          call store_error('mem_set_value() size mismatch dbl3d, varname='//&
+                          &trim(varname), terminate=.TRUE.)
+        end if
+        do k = 1, size(mt%adbl3d, dim=3)
+          do j = 1, size(mt%adbl3d, dim=2)
+            do i = 1, size(mt%adbl3d, dim=1)
+              p_mem(i, j, k) = mt%adbl3d(i, j, k)
+            end do
           end do
         end do
-      end do
+      end if
     end if
   end subroutine mem_set_value_dbl3d
 
@@ -364,8 +388,10 @@ contains
     logical(LGP) :: checkfail = .false.
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
-      p_mem = mt%strsclr
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
+        p_mem = mt%strsclr
+      end if
     end if
   end subroutine mem_set_value_str
 
@@ -381,10 +407,12 @@ contains
     integer(I4B) :: n
 
     call get_from_memorylist(varname, memory_path, mt, found, checkfail)
-    if (found .and. mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
-      do n = 1, size(mt%acharstr1d)
-        p_mem(n) = mt%acharstr1d(n)
-      end do
+    if (found) then
+      if (mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
+        do n = 1, size(mt%acharstr1d)
+          p_mem(n) = mt%acharstr1d(n)
+        end do
+      end if
     end if
   end subroutine mem_set_value_charstr1d
 


### PR DESCRIPTION
Add faster lookup into memory list to improve performance of get_from_memorylist. We use this everywhere and particularly for large numbers of models and exchanges, the simulation has been reported to slow down.