### PR TITLE
fix(mvr): improve water mover performance

### DIFF
--- a/doc/ReleaseNotes/ReleaseNotes.tex
+++ b/doc/ReleaseNotes/ReleaseNotes.tex
@@ -177,6 +177,7 @@ A list of all MODFLOW 6 releases is shown in table \ref{tab:releases}.  Changes 
 6.4.1 & December 9, 2022 & \url{https://doi.org/10.5066/P9FL1JCC} \\
 6.4.2 & June 28, 2023 & \url{https://doi.org/10.5066/P9FL1JCC} \\
 6.4.3 & February 7, 2024 & \url{https://doi.org/10.5066/P9FL1JCC} \\
+6.x.x & Xxx x, 202x & \url{https://doi.org/10.5066/P9FL1JCC} \\
 \hline
 \label{tab:releases}
 \end{tabular*}

--- a/doc/ReleaseNotes/appendixA.tex
+++ b/doc/ReleaseNotes/appendixA.tex
@@ -1,5 +1,6 @@
 This appendix describes changes introduced into MODFLOW~6 in previous releases. These changes may substantially affect users.
 
+        \input{./previous/v6.4.3.tex}
         \input{./previous/v6.4.2.tex}
         \input{./previous/v6.4.1.tex}
         \input{./previous/v6.4.0.tex}        

--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -2,50 +2,47 @@
 % after a release has just been made.
 	
 	\item \currentmodflowversion
+	
+	%\underline{NEW FUNCTIONALITY}
+	%\begin{itemize}
+	%	\item xxx
+	%	\item xxx
+	%	\item xxx
+	%\end{itemize}
 
-	\underline{NEW FUNCTIONALITY}
-	\begin{itemize}
-		\item The Input Data Processor (IDP), first released in version 6.4.2, is a general utility for reading user-provided input files.  Package-specific routines for reading input files continue to be replaced by the IDP approach.  For packages that use IDP for input, logging information is written to the simulation list file (mfsim.lst).  Additional information on the IDP and the list of supported packages is contained in the MODFLOW 6 Description of Input and Output (mf6io.pdf) under a section titled ``Processing of Program Input.''
-		\item The source code was refactored to support compilation of a parallel version of MODFLOW 6 based on the Message Passing Interface (MPI) and the Portable, Extensible Toolkit for Scientific Computation (PETSc) libraries.  The parallel version of MODFLOW is considered preliminary. Limited testing of the parallel version has been performed on laptops, desktops, and supercomputers, but significant changes are expected in future releases. User support for the parallel version of MODFLOW 6 may be provided in the future.
+	%\underline{EXAMPLES}
+	%\begin{itemize}
 	%	\item xxx
-	\end{itemize}
+	%	\item xxx
+	%	\item xxx
+	%\end{itemize}
 
-	\underline{EXAMPLES}
-	\begin{itemize}
-		\item A new exampled called ex-gwf-rad-disu was added.  This new example uses a DISU grid to represent radial groundwater flow to a pumping well.
-		\item A new exampled called ex-gwf-curv-90 was added.  This new example demonstrates use of a DISV grid to represent a curvilinear spatial discretization.  For this example, the curvilinear grid is applied to one quarter of a radial groundwater flow system.
-		\item A new exampled called ex-gwf-curvilin was added.  This new example uses a curvilinear grid, represented with the DISV Package, to simulate groundwater flow through a multi-region aquifer with bends in the domain boundaries.
-	\end{itemize}
+	%\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
+	%\underline{BASIC FUNCTIONALITY}
+	%\begin{itemize}
+	%	\item xxx
+	%	\item xxx
+	%	\item xxx
+	%\end{itemize}
 
-	\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
-	\underline{BASIC FUNCTIONALITY}
-	\begin{itemize}
-		\item Improve error message if the size of data read from a binary array file is inconsistent with READARRAY control line and variable description keywords.
-		\item The area calculation for cells in the DISV package was inaccurate for some cases with very large cell vertex coordinates.  The area calculation was improved by using transformed cell vertex coordinates prior to making the area calculation.
-		\item Auxiliary variables in RCH and EVT Array-Based input packages are now reset to zero when otherwise not specified in period input data and the auxiliary parameter is not controlled by a time-series.
+	%\underline{INTERNAL FLOW PACKAGES}
+	%\begin{itemize}
 	%	\item xxx
 	%	\item xxx
-	\end{itemize}
+	%	\item xxx
+	%\end{itemize}
 
-	\underline{INTERNAL FLOW PACKAGES}
-	\begin{itemize}
-		\item The data header in the binary output file written by the viscosity (VSC) package was printing `` VISCOSI'' instead of `` VISCOSITY''. The viscosity package now prints the full `` VISCOSITY'' header in the binary output file.
-		\item The CSUB Package did not support output of z-displacement arrays for models using the DISU package.  The CSUB package was updated to support calculation of z-displacement arrays for DISU model grids.
-	%	\item xxx
-	\end{itemize}
-
-	\underline{STRESS PACKAGES}
-	\begin{itemize}
-		\item This release contains a fix for a longstanding issue related to the use of AUXMULTNAME and time series.  Previous release notes included the following description of a known issue: \textit{``The AUXMULTNAME option can be used to scale input values, such as riverbed conductance, using values in an auxiliary column.  When this AUXMULTNAME option is used, the multiplier value in the AUXMULTNAME column should not be represented with a time series unless the value to scale is also represented with a time series.''}  With this release, the Input Data Processor (IDP) is now used to read stress package input files, and the limitation with AUXMULTNAME and time series no longer applies.
+	%\underline{STRESS PACKAGES}
+	%\begin{itemize}
 	%	\item xxx
 	%	\item xxx
-	\end{itemize}
+	%	\item xxx
+	%\end{itemize}
 
 	\underline{ADVANCED STRESS PACKAGES}
 	\begin{itemize}
-		\item Added functionality to support zero values for each grid dimension when specifying the CELLID for SFR reaches that are not connected to an underlying groundwater grid cell. For example, for a DIS grid a CELLID of 0 0 0 should be specified for reaches with no connection to a groundwater cell. Warning messages will be issued if NONE is specified for the CELLID of an unconnected reach. Specifying a CELLID of NONE will eventually be deprecated and will cause MODFLOW 6 to terminate with an error.
-		\item Added functionality to support specification of a DNODATA (3.0E+30) BEDLEAK value for LAK package connections.  This DNODATA value is used to identify lake-GWF connections where conductance is solely a function of aquifer properties in the connected GWF cell.  In this case, the lakebed sediments are assumed to be absent and all resistance to flow is assumed to be within the GWF cell. Warning messages are now issued if NONE is specified for LAK package connections. Specifying a BEDLEAK value equal to NONE will eventually be deprecated and will cause MODFLOW 6 to terminate with an error.
-		\item SFR diversion would not be updated if the outflow of its upstream reach is zero. If diversion was not zero in the previous stress period, it would report mass balance error in the SFR budget. This bug was fixed by always updating the diversion.
+		\item Refactoring of the Water Mover package in version 6.4.3 introduced a reduction in performance for GWF models with a large number of movers.  The program was corrected so that performance is similar to previous versions.
+	%	\item xxx
 	%	\item xxx
 	\end{itemize}
 
@@ -56,9 +53,10 @@
 	%	\item xxx
 	%\end{itemize}
 
-	\underline{EXCHANGES}
-	\begin{itemize}
-		\item A model budget error would occur when a constant-head (CHD) cell in one model had a direct connection to an active cell in another model.  For the model budget to be calculated correctly a new term called ``FLOW-JA-FACE-CHD'' was added to the GWF model budget.  This term is only included in the budget table when the GWF Model is connected to another GWF Model using a GWF-GWF Exchange.  Additionally, the CHD budget calculation for a very specific (and rare) configuration was also incorrect. The incorrect budget calculation occurred when the following conditions were met: (1) a GWF model was connected to another GWF model with a GWF-GWF Exchange; (2) the model as well as the Exchange had the XT3D option enabled, and (3) the model was configured with a CHD cell that is either an Exchange cell, i.e. a cell that is part of the EXCHANGEDATA block, or a cell directly connected to such an Exchange cell.  The size of the error depends on the degree of anisotropy around the particular CHD cell and shows up as a discrepancy in the volume budget table reported in the GWF list file. The program has been updated with the correct budget calculation.
+	%\underline{EXCHANGES}
+	%\begin{itemize}
 	%	\item xxx
 	%	\item xxx
-	\end{itemize}
+	%	\item xxx
+	%\end{itemize}
+

--- a/doc/ReleaseNotes/previous/v6.4.3.tex
+++ b/doc/ReleaseNotes/previous/v6.4.3.tex
@@ -1,0 +1,65 @@
+% Use this template for starting initializing the release notes
+% after a release has just been made.
+	
+	%\item \currentmodflowversion
+	\subsection{Version mf6.4.3--February 7, 2024}
+
+	\underline{NEW FUNCTIONALITY}
+	\begin{itemize}
+		\item The Input Data Processor (IDP), first released in version 6.4.2, is a general utility for reading user-provided input files.  Package-specific routines for reading input files continue to be replaced by the IDP approach.  For packages that use IDP for input, logging information is written to the simulation list file (mfsim.lst).  Additional information on the IDP and the list of supported packages is contained in the MODFLOW 6 Description of Input and Output (mf6io.pdf) under a section titled ``Processing of Program Input.''
+		\item The source code was refactored to support compilation of a parallel version of MODFLOW 6 based on the Message Passing Interface (MPI) and the Portable, Extensible Toolkit for Scientific Computation (PETSc) libraries.  The parallel version of MODFLOW is considered preliminary. Limited testing of the parallel version has been performed on laptops, desktops, and supercomputers, but significant changes are expected in future releases. User support for the parallel version of MODFLOW 6 may be provided in the future.
+	%	\item xxx
+	\end{itemize}
+
+	\underline{EXAMPLES}
+	\begin{itemize}
+		\item A new exampled called ex-gwf-rad-disu was added.  This new example uses a DISU grid to represent radial groundwater flow to a pumping well.
+		\item A new exampled called ex-gwf-curv-90 was added.  This new example demonstrates use of a DISV grid to represent a curvilinear spatial discretization.  For this example, the curvilinear grid is applied to one quarter of a radial groundwater flow system.
+		\item A new exampled called ex-gwf-curvilin was added.  This new example uses a curvilinear grid, represented with the DISV Package, to simulate groundwater flow through a multi-region aquifer with bends in the domain boundaries.
+	\end{itemize}
+
+	\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
+	\underline{BASIC FUNCTIONALITY}
+	\begin{itemize}
+		\item Improve error message if the size of data read from a binary array file is inconsistent with READARRAY control line and variable description keywords.
+		\item The area calculation for cells in the DISV package was inaccurate for some cases with very large cell vertex coordinates.  The area calculation was improved by using transformed cell vertex coordinates prior to making the area calculation.
+		\item Auxiliary variables in RCH and EVT Array-Based input packages are now reset to zero when otherwise not specified in period input data and the auxiliary parameter is not controlled by a time-series.
+	%	\item xxx
+	%	\item xxx
+	\end{itemize}
+
+	\underline{INTERNAL FLOW PACKAGES}
+	\begin{itemize}
+		\item The data header in the binary output file written by the viscosity (VSC) package was printing `` VISCOSI'' instead of `` VISCOSITY''. The viscosity package now prints the full `` VISCOSITY'' header in the binary output file.
+		\item The CSUB Package did not support output of z-displacement arrays for models using the DISU package.  The CSUB package was updated to support calculation of z-displacement arrays for DISU model grids.
+	%	\item xxx
+	\end{itemize}
+
+	\underline{STRESS PACKAGES}
+	\begin{itemize}
+		\item This release contains a fix for a longstanding issue related to the use of AUXMULTNAME and time series.  Previous release notes included the following description of a known issue: \textit{``The AUXMULTNAME option can be used to scale input values, such as riverbed conductance, using values in an auxiliary column.  When this AUXMULTNAME option is used, the multiplier value in the AUXMULTNAME column should not be represented with a time series unless the value to scale is also represented with a time series.''}  With this release, the Input Data Processor (IDP) is now used to read stress package input files, and the limitation with AUXMULTNAME and time series no longer applies.
+	%	\item xxx
+	%	\item xxx
+	\end{itemize}
+
+	\underline{ADVANCED STRESS PACKAGES}
+	\begin{itemize}
+		\item Added functionality to support zero values for each grid dimension when specifying the CELLID for SFR reaches that are not connected to an underlying groundwater grid cell. For example, for a DIS grid a CELLID of 0 0 0 should be specified for reaches with no connection to a groundwater cell. Warning messages will be issued if NONE is specified for the CELLID of an unconnected reach. Specifying a CELLID of NONE will eventually be deprecated and will cause MODFLOW 6 to terminate with an error.
+		\item Added functionality to support specification of a DNODATA (3.0E+30) BEDLEAK value for LAK package connections.  This DNODATA value is used to identify lake-GWF connections where conductance is solely a function of aquifer properties in the connected GWF cell.  In this case, the lakebed sediments are assumed to be absent and all resistance to flow is assumed to be within the GWF cell. Warning messages are now issued if NONE is specified for LAK package connections. Specifying a BEDLEAK value equal to NONE will eventually be deprecated and will cause MODFLOW 6 to terminate with an error.
+		\item SFR diversion would not be updated if the outflow of its upstream reach is zero. If diversion was not zero in the previous stress period, it would report mass balance error in the SFR budget. This bug was fixed by always updating the diversion.
+	%	\item xxx
+	\end{itemize}
+
+	%\underline{SOLUTION}
+	%\begin{itemize}
+	%	\item xxx
+	%	\item xxx
+	%	\item xxx
+	%\end{itemize}
+
+	\underline{EXCHANGES}
+	\begin{itemize}
+		\item A model budget error would occur when a constant-head (CHD) cell in one model had a direct connection to an active cell in another model.  For the model budget to be calculated correctly a new term called ``FLOW-JA-FACE-CHD'' was added to the GWF model budget.  This term is only included in the budget table when the GWF Model is connected to another GWF Model using a GWF-GWF Exchange.  Additionally, the CHD budget calculation for a very specific (and rare) configuration was also incorrect. The incorrect budget calculation occurred when the following conditions were met: (1) a GWF model was connected to another GWF model with a GWF-GWF Exchange; (2) the model as well as the Exchange had the XT3D option enabled, and (3) the model was configured with a CHD cell that is either an Exchange cell, i.e. a cell that is part of the EXCHANGEDATA block, or a cell directly connected to such an Exchange cell.  The size of the error depends on the degree of anisotropy around the particular CHD cell and shows up as a discrepancy in the volume budget table reported in the GWF list file. The program has been updated with the correct budget calculation.
+	%	\item xxx
+	%	\item xxx
+	\end{itemize}

--- a/src/Model/GroundWaterFlow/gwf3mvr8.f90
+++ b/src/Model/GroundWaterFlow/gwf3mvr8.f90
@@ -102,7 +102,7 @@
 !      if(this%inmvr > 0) call this%mvr%mvr_ot()
 !
 module GwfMvrModule
-  use KindModule, only: DP, I4B
+  use KindModule, only: DP, I4B, LGP
   use ConstantsModule, only: LENMEMPATH, LENPACKAGENAME, LENMODELNAME, &
                              LENBUDTXT, LENAUXNAME, LENPAKLOC, &
                              DZERO, DNODATA, MAXCHARLEN, TABCENTER, &
@@ -123,6 +123,7 @@ module GwfMvrModule
   public :: GwfMvrType, mvr_cr
 
   type, extends(NumericalPackageType) :: GwfMvrType
+    logical(LGP), pointer :: reset_mapped_id ! flag to indicate mapped ids must be reset; true when movers change
     integer(I4B), pointer :: ibudgetout => null() !< binary budget output file
     integer(I4B), pointer :: ibudcsv => null() !< unit number for csv budget output file
     integer(I4B), pointer :: maxmvr => null() !< max number of movers to be specified
@@ -172,6 +173,7 @@ module GwfMvrModule
     procedure, private :: mvr_setup_budobj
     procedure, private :: mvr_setup_outputtab
     procedure, private :: mvr_print_outputtab
+    procedure, private :: set_mapped_id
 
   end type GwfMvrType
 
@@ -337,6 +339,7 @@ contains
       write (this%iout, '(/,2x,a,i0)') 'READING WATER MOVERS FOR PERIOD ', kper
       nlist = -1
       i = 1
+      this%reset_mapped_id = .true.
       !
       ! -- set mname to '' if this is an exchange mover, or to the model name
       if (this%iexgmvr == 0) then
@@ -492,19 +495,16 @@ contains
     ! -- dummy
     class(GwfMvrType) :: this
     ! -- locals
-    integer(I4B) :: i, mapped_id
-    class(PackageMoverType), pointer :: pkg_mvr
     ! -- formats
-! ------------------------------------------------------------------------------
     !
-    ! -- set the feature maps
-    allocate (pkg_mvr)
-    do i = 1, this%nmvr
-      call set_packagemover_pointer(pkg_mvr, this%mvr(i)%mem_path_src)
-      mapped_id = pkg_mvr%iprmap(this%mvr(i)%iRchNrSrc)
-      this%mvr(i)%iRchNrSrcMapped = mapped_id
-    end do
-    deallocate (pkg_mvr)
+    ! -- set the feature maps; for performance reasons,
+    !    this should only be called for the first time
+    !    step of a stress period in which a new set of
+    !    movers was provided in a period block.
+    if (this%reset_mapped_id) then
+      call this%set_mapped_id()
+      this%reset_mapped_id = .false.
+    end if
     !
     ! -- fill the budget object
     call this%fill_budobj()
@@ -699,6 +699,7 @@ contains
     end if
     !
     ! -- Scalars
+    call mem_deallocate(this%reset_mapped_id)
     call mem_deallocate(this%ibudgetout)
     call mem_deallocate(this%ibudcsv)
     call mem_deallocate(this%maxmvr)
@@ -1045,6 +1046,7 @@ contains
     call this%NumericalPackageType%allocate_scalars()
     !
     ! -- Allocate
+    call mem_allocate(this%reset_mapped_id, 'RESET_MAPPED_ID', this%memoryPath)
     call mem_allocate(this%ibudgetout, 'IBUDGETOUT', this%memoryPath)
     call mem_allocate(this%ibudcsv, 'IBUDCSV', this%memoryPath)
     call mem_allocate(this%maxmvr, 'MAXMVR', this%memoryPath)
@@ -1055,6 +1057,7 @@ contains
     call mem_allocate(this%imodelnames, 'IMODELNAMES', this%memoryPath)
     !
     ! -- Initialize
+    this%reset_mapped_id = .false.
     this%ibudgetout = 0
     this%ibudcsv = 0
     this%maxmvr = -1
@@ -1344,5 +1347,42 @@ contains
     ! -- Return
     return
   end subroutine mvr_print_outputtab
+
+  !> @brief Set mapped id
+  !!
+  !! For the budget output, we don't write outlet number,
+  !! instead we write the lake number.  Normally the receiver
+  !! number is the same as the feature number provided by the
+  !! user.  For moving water from a lake, the user specifies the
+  !! outlet number, not the lake number, in the mover package.
+  !! The iRchNrSrcMapped variable contains the lake number, not
+  !! the outlet number, and is written to the budget files.  For
+  !! other packages, the iRchNrSrcMapped value is simply the well
+  !! number, the stream reach, or the uzf cell number.
+  !! This routine needs to be called each time a new set of movers
+  !! is read.  It can't be called from within mvr_rp because the
+  !! iprmap isn't updated by lake until lak_rp, which is called
+  !! after mvr_rp.
+  !<
+  subroutine set_mapped_id(this)
+    ! -- dummy
+    class(GwfMvrType) :: this
+    ! -- locals
+    integer(I4B) :: i, mapped_id
+    class(PackageMoverType), pointer :: pkg_mvr
+    ! -- formats
+    !
+    ! -- set the feature maps
+    allocate (pkg_mvr)
+    do i = 1, this%nmvr
+      call set_packagemover_pointer(pkg_mvr, this%mvr(i)%mem_path_src)
+      mapped_id = pkg_mvr%iprmap(this%mvr(i)%iRchNrSrc)
+      this%mvr(i)%iRchNrSrcMapped = mapped_id
+    end do
+    deallocate (pkg_mvr)
+    !
+    ! -- Return
+    return
+  end subroutine set_mapped_id
 
 end module


### PR DESCRIPTION
* A changed introduced in #1427 resulted in a performance decrease for GWF models with a large number of water movers.  This PR reduces the number of lookups by resetting mapped ids only when the set of movers has changed.
* This PR also resets the release notes for the next release.