### PR TITLE
test: make downloaded and rebuilt programs optional

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -66,12 +66,18 @@ def targets() -> Dict[str, Path]:
         # require development binaries
         assert v.is_file(), f"Couldn't find binary '{k}' expected at: {v}"
         d[k] = v
-    for k, v in _binaries["downloaded"] + _binaries["rebuilt"]:
-        # downloaded/rebuilt binaries are optional
+    for k, v in _binaries["downloaded"]:
+        # downloaded binaries are optional
         if v.is_file():
             d[k] = v
         else:
-            warn(f"Couldn't find binary '{k}' expected at: {v}")
+            warn(f"Couldn't find downloaded binary '{k}' expected at: {v}")
+    for k, v in _binaries["rebuilt"]:
+        # rebuilt binaries are optional
+        if v.is_file():
+            d[k] = v
+        else:
+            warn(f"Couldn't find rebuilt binary '{k}' expected at: {v}")
     return d
 
 

--- a/autotest/framework.py
+++ b/autotest/framework.py
@@ -10,6 +10,7 @@ from warnings import warn
 
 import flopy
 import numpy as np
+import pytest
 from common_regression import (
     COMPARE_PROGRAMS,
     adjust_htol,
@@ -777,17 +778,20 @@ class TestFramework:
 
                 # run comparison simulation if libmf6 or mf6 regression
                 if self.compare in ["mf6_regression", "libmf6"]:
-                    # todo: don't hardcode workspace or assume agreement with test case
-                    # simulation workspace, set & access simulation workspaces directly
-                    workspace = self.workspace / self.compare
-                    success, _ = self.run_sim_or_model(
-                        workspace,
-                        self.targets.get(self.compare, self.targets["mf6"]),
-                    )
-                    assert success, f"Comparison model failed: {workspace}"
+                    if self.compare not in self.targets:
+                        warn(f"Couldn't find comparison program '{self.compare}', skipping comparison")
+                    else:
+                        # todo: don't hardcode workspace or assume agreement with test case
+                        # simulation workspace, set & access simulation workspaces directly
+                        workspace = self.workspace / self.compare
+                        success, _ = self.run_sim_or_model(
+                            workspace,
+                            self.targets.get(self.compare, self.targets["mf6"]),
+                        )
+                        assert success, f"Comparison model failed: {workspace}"
 
                 # compare model results, if enabled
-                if self.verbose:
+                if self.verbose and self.compare in self.targets:
                     print("Comparing outputs")
                 self.compare_output(self.compare)
 

--- a/autotest/test_gwf_csub_zdisp01.py
+++ b/autotest/test_gwf_csub_zdisp01.py
@@ -6,6 +6,7 @@ import pytest
 from flopy.utils.compare import compare_heads
 
 from framework import TestFramework
+from conftest import try_get_target
 
 cases = ["csub_zdisp01"]
 cmppth = "mfnwt"
@@ -330,7 +331,10 @@ def build_models(idx, test):
     cpth = cmppth
     ws = os.path.join(test.workspace, cpth)
     mc = flopy.modflow.Modflow(
-        name, model_ws=ws, version=cpth, exe_name=test.targets["mfnwt"]
+        name,
+        model_ws=ws,
+        version=cpth,
+        exe_name=try_get_target(test.targets, "mfnwt"),
     )
     dis = flopy.modflow.ModflowDis(
         mc,

--- a/autotest/test_gwf_npf01_75x75.py
+++ b/autotest/test_gwf_npf01_75x75.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from framework import TestFramework
+from conftest import try_get_target
 
 cases = ["npf01a_75x75", "npf01b_75x75"]
 top = [100.0, 0.0]
@@ -149,7 +150,9 @@ def build_models(idx, test):
 
     # build MODFLOW-2005 files
     ws = os.path.join(test.workspace, "mf2005")
-    mc = flopy.modflow.Modflow(name, model_ws=ws, exe_name=test.targets["mf2005"])
+    mc = flopy.modflow.Modflow(
+        name, model_ws=ws, exe_name=try_get_target(test.targets, "mf2005")
+    )
     dis = flopy.modflow.ModflowDis(
         mc,
         nlay=nlay,

--- a/autotest/test_gwf_sto01.py
+++ b/autotest/test_gwf_sto01.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from framework import TestFramework
+from conftest import try_get_target
 
 cases = ["gwf_sto01"]
 cmppth = "mfnwt"
@@ -203,7 +204,10 @@ def build_models(idx, test):
     cpth = cmppth
     ws = os.path.join(test.workspace, cpth)
     mc = flopy.modflow.Modflow(
-        name, model_ws=ws, version=cpth, exe_name=test.targets["mfnwt"]
+        name,
+        model_ws=ws,
+        version=cpth,
+        exe_name=try_get_target(test.targets, "mfnwt"),
     )
     dis = flopy.modflow.ModflowDis(
         mc,


### PR DESCRIPTION
* skip, don't crash/fail tests if downloaded programs or rebuilt regression mf6 programs not found
* only require local development binaries to gracefully run autotests