### PR TITLE
ci(release): add distribution for apple silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,13 +63,9 @@ jobs:
       matrix:
         include:
           - os: ${{ inputs.linux_version }}
-            ostag: linux
           - os: macos-12
-            ostag: mac
           - os: macos-14
-            ostag: macm1
           - os: windows-2022
-            ostag: win64
     defaults:
       run:
         shell: bash -l {0}
@@ -143,10 +139,16 @@ jobs:
           meson install -C builddir
           meson test --verbose --no-rebuild -C builddir
 
+      - name: Get OS tag
+        id: ostag
+        run: |
+          ostag=$(python -c "from modflow_devtools.ostags import get_ostag; print(get_ostag())")
+          echo "ostag=$ostag" >> $GITHUB_OUTPUT
+
       - name: Upload binaries
         uses: actions/upload-artifact@v3
         with:
-          name: bin-${{ runner.os }}
+          name: bin-${{ steps.ostag.outputs.ostag }}
           path: modflow6/bin
 
       # only run steps below if inputs.run_tests is true
@@ -311,10 +313,16 @@ jobs:
         working-directory: modflow6/autotest
         run: python update_flopy.py
 
+      - name: Get OS tag
+        id: ostag
+        run: |
+          ostag=$(python -c "from modflow_devtools.ostags import get_ostag; print(get_ostag())")
+          echo "ostag=$ostag" >> $GITHUB_OUTPUT
+
       - name: Download pre-built binaries
         uses: actions/download-artifact@v3
         with:
-          name: bin-${{ runner.os }}
+          name: bin-${{ steps.ostag.outputs.ostag }}
           path: bin
 
       # execute permissions may not have survived artifact upload/download
@@ -404,13 +412,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            ostag: linux
           - os: macos-12
-            ostag: mac
           - os: macos-14
-            ostag: macm1
           - os: windows-2022
-            ostag: win64
     defaults:
       run:
         shell: bash -l {0}
@@ -457,22 +461,28 @@ jobs:
             cmd="$cmd --releasemode"
           fi
           eval "$cmd"
+ 
+      - name: Get OS tag
+        id: ostag
+        run: |
+          ostag=$(python -c "from modflow_devtools.ostags import get_ostag; print(get_ostag())")
+          echo "ostag=$ostag" >> $GITHUB_OUTPUT
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          path: ${{ needs.build.outputs.distname }}_${{ matrix.ostag }}
+          path: ${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}
       
       - name: Select artifacts
-        working-directory: ${{ needs.build.outputs.distname }}_${{ matrix.ostag }}
+        working-directory: ${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}
         run: |
-          echo "selecting ${{ matrix.ostag }} artifacts"
+          echo "selecting ${{ steps.ostag.outputs.ostag }} artifacts"
           # remove dists for other systems
           rm -rf ${{ needs.build.outputs.distname }}_*
           # remove release notes
           rm -rf release_notes
           # rename dist bin directory
-          mv bin-${{ runner.os }} bin
+          mv bin-${{ steps.ostag.outputs.ostag }} bin
           # remove binaries for other systems
           rm -rf bin-*
 
@@ -484,7 +494,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           pip install -r modflow6-examples/etc/requirements.pip.txt
-          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
           echo "$distname/bin" >> $GITHUB_PATH
           # execute permissions may not have survived artifact upload/download
           chmod +x "$distname/bin/mf6"
@@ -511,7 +521,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           # build distribution
-          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
           cmd="python modflow6/distribution/build_dist.py -o $distname -e modflow6-examples"
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
@@ -526,7 +536,7 @@ jobs:
       - name: Zip distribution
         if: runner.os != 'Windows'
         run: |
-          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
           if [[ "${{ inputs.full }}" == "true" ]]; then
             zip -r $distname.zip \
               $distname/bin \
@@ -561,7 +571,7 @@ jobs:
       - name: Zip distribution (Windows)
         if: runner.os == 'Windows'
         run: |
-          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
           if [[ "${{ inputs.full }}" == "true" ]]; then
             7z a -tzip $distname.zip \
               $distname/bin \
@@ -594,20 +604,20 @@ jobs:
       - name: Upload distribution
         uses: actions/upload-artifact@v3
         with:
-          name: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
-          path: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}.zip"
+          name: "${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
+          path: "${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}.zip"
 
       - name: Upload release notes
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v3
         with:
           name: release_notes
-          path: "${{ needs.build.outputs.distname }}_${{ matrix.ostag }}/doc/release.pdf"
+          path: "${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}/doc/release.pdf"
 
       - name: Check distribution
         run: |
           # unzip and validate the archive
-          distname="${{ needs.build.outputs.distname }}_${{ matrix.ostag }}"
+          distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
           distfile="$distname.zip"
           checkdir="check"
           mkdir $checkdir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
             ostag: linux
           - os: macos-12
             ostag: mac
+          - os: macos-14
+            ostag: macm1
           - os: windows-2022
             ostag: win64
     defaults:
@@ -405,6 +407,8 @@ jobs:
             ostag: linux
           - os: macos-12
             ostag: mac
+          - os: macos-14
+            ostag: macm1
           - os: windows-2022
             ostag: win64
     defaults:

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -34,16 +34,6 @@ on:
         required: false
         type: string
         default: '2021.7'
-      commit_version:
-        description: 'Commit version numbers back to the develop branch. Not considered if reset is false.'
-        required: false
-        type: boolean
-        default: false
-      reset:
-        description: 'Reset the develop branch from the master branch. Not considered if approve is false.'
-        required: false
-        type: boolean
-        default: false
       run_tests:
         description: 'Run tests after building binaries.'
         required: false

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -129,8 +129,8 @@ jobs:
           echo "version=$ver" >> $GITHUB_OUTPUT
   make_dist:
     name: Make distribution
-    needs: set_options
     uses: MODFLOW-USGS/modflow6/.github/workflows/release.yml@develop
+    needs: set_options
     with:
       # If the workflow is manually triggered, the maintainer must manually set approve=true to approve a release.
       # If triggered by pushing a release branch, the release is approved if the branch name doesn't contain "rc".


### PR DESCRIPTION
* following up on https://github.com/MODFLOW-USGS/modflow6/discussions/1286
* add `macos-14` (M1 runner) to the matrix in `release.yml`
* use devtools `ostags` module instead of hard-coding OS tags
  * enabled by https://github.com/MODFLOW-USGS/modflow-devtools/pull/139
* test run: https://github.com/wpbonelli/modflow6/actions/runs/7950956265
* when this merges, a `macarm.zip` asset will become available on the nightly build &mdash; since `release.yml` is reused by the full release procedure, we shouldn't need further modification here to include an ARM build in the next official release, however the exes distribution will
* miscellaneous: remove unused inputs to `release_dispatch.yml`