### PR TITLE
test: remove executables v14 workaround from 7bc29b7

### DIFF
--- a/autotest/get_exes.py
+++ b/autotest/get_exes.py
@@ -97,9 +97,7 @@ def test_rebuild_release(rebuilt_bin_path: Path):
 def test_get_executables(downloaded_bin_path: Path):
     print(f"Installing MODFLOW-related executables to: {downloaded_bin_path}")
     downloaded_bin_path.mkdir(exist_ok=True, parents=True)
-    # todo: remove release_id workaround when double-precision comparison issues fixed
-    # https://github.com/MODFLOW-USGS/modflow6/pull/1612
-    flopy.utils.get_modflow(str(downloaded_bin_path), release_id="14.0")
+    flopy.utils.get_modflow(str(downloaded_bin_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* double precision mf2005, mfnwt, mflgr and mfusg are back in [exes dist v16](https://github.com/MODFLOW-USGS/executables/releases/tag/16.0)