### PR TITLE
ci(release): add gfortran build for ARM macs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,17 @@ jobs:
       matrix:
         include:
           - os: ${{ inputs.linux_version }}
-          - os: macos-12
+            compiler: ${{ inputs.compiler_toolchain }}
+            version: ${{ inputs.compiler_version }}
+          - os: macos-13
+            compiler: ${{ inputs.compiler_toolchain }}
+            version: ${{ inputs.compiler_version }}
           - os: macos-14
+            compiler: gcc
+            version: 13
           - os: windows-2022
+            compiler: ${{ inputs.compiler_toolchain }}
+            version: ${{ inputs.compiler_version }}
     defaults:
       run:
         shell: bash -l {0}
@@ -90,12 +98,13 @@ jobs:
             bash
             powershell
 
-      - name: Setup ${{ inputs.compiler_toolchain }} ${{ inputs.compiler_version }}
+      - name: Setup ${{ matrix.compiler }} ${{ matrix.version }}
+        id: setup-fortran
         uses: fortran-lang/setup-fortran@v1
         with:
-          compiler: ${{ inputs.compiler_toolchain }}
-          version: ${{ inputs.compiler_version }}
-
+          compiler: ${{ matrix.compiler }}
+          version: ${{ matrix.version }}
+      
       - name: Set version number
         id: set_version
         run: |
@@ -122,6 +131,22 @@ jobs:
           fi
           eval "$cmd"
 
+      # for statically linked gfortran ARM mac build
+      - name: Hide dylibs (macOS)
+        if: matrix.os == 'macos-14'
+        run: |
+          mv /opt/homebrew/opt/gcc/lib/gcc/current/libgfortran.5.dylib /opt/homebrew/opt/gcc/lib/gcc/current/libgfortran.5.dylib.bak
+          mv /opt/homebrew/opt/gcc/lib/gcc/current/libquadmath.0.dylib /opt/homebrew/opt/gcc/lib/gcc/current/libquadmath.0.dylib.bak
+
+      - name: Set LDFLAGS (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          os_ver=$(sw_vers -productVersion | cut -d'.' -f1)
+          if (( "$os_ver" > 12 )); then
+            ldflags="$LDFLAGS -Wl,-ld_classic"
+            echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
+          fi
+
       - name: Build binaries
         if: runner.os != 'Windows'
         working-directory: modflow6
@@ -144,6 +169,13 @@ jobs:
         run: |
           ostag=$(python -c "from modflow_devtools.ostags import get_ostag; print(get_ostag())")
           echo "ostag=$ostag" >> $GITHUB_OUTPUT
+
+      - name: Check architecture (macOS)
+        working-directory: modflow6/bin
+        if: runner.os == 'macOS'
+        run: |
+          otool -L mf6
+          lipo -info mf6
 
       - name: Upload binaries
         uses: actions/upload-artifact@v3
@@ -412,7 +444,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-          - os: macos-12
+          - os: macos-13
           - os: macos-14
           - os: windows-2022
     defaults:

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -130,7 +130,7 @@ jobs:
       branch: ${{ needs.set_options.outputs.branch }}
       developmode: false
       full: true
-      run_tests: ${{ inputs.run_tests == '' || inputs.run_tests == 'true' }}
+      run_tests: ${{ inputs.run_tests }}
       version: ${{ needs.set_options.outputs.version }}
   pr:
     name: Draft release PR


### PR DESCRIPTION
* followup to #1625 which was misguided because intel compilers can't create ARM binaries
* statically linked build with gfortran
  * link static `libgfortran` and `libquadmath` by hiding dylibs
  * `-static*` flags don't seem to work on macOS
  * luckily homebrew gcc includes static libs
* set `LDFLAGS` for macos >= 13 &mdash; https://github.com/MODFLOW-USGS/modflow6/blob/develop/DEVELOPER.md#macos