### PR TITLE
refactor(ts): skip search for repeated boundary time series file

### DIFF
--- a/src/Utilities/TimeSeries/TimeSeriesManager.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesManager.f90
@@ -580,22 +580,25 @@ contains
         r = timeseries%GetValue(totimsav, totim, &
                                 tsManager%extendTsToEndOfSimulation)
         bndElem = r
-        ! Look to see if this array element already has a time series
-        ! linked to it.  If not, make a link to it.
-        nlinks = tsManager%CountLinks(auxOrBnd)
         found = .false.
-        searchlinks: do i = 1, nlinks
-          tslTemp => tsManager%GetLink(auxOrBnd, i)
-          if (tslTemp%PackageName == pkgName) then
-            ! -- Check ii, jj against iRow, jCol stored in link
-            if (tslTemp%IRow == ii .and. tslTemp%JCol == jj) then
-              ! -- This array element is already linked to a time series.
-              tsLink => tslTemp
-              found = .true.
-              exit searchlinks
+        if (auxOrBnd /= 'BND') then
+          ! Look to see if this array element already has a time series
+          ! linked to it.  If not, make a link to it.
+          ! Assuming check is not necessary for 'BND' type time series
+          nlinks = tsManager%CountLinks(auxOrBnd)
+          searchlinks: do i = 1, nlinks
+            tslTemp => tsManager%GetLink(auxOrBnd, i)
+            if (tslTemp%PackageName == pkgName) then
+              ! -- Check ii, jj against iRow, jCol stored in link
+              if (tslTemp%IRow == ii .and. tslTemp%JCol == jj) then
+                ! -- This array element is already linked to a time series.
+                tsLink => tslTemp
+                found = .true.
+                exit searchlinks
+              end if
             end if
-          end if
-        end do searchlinks
+          end do searchlinks
+        end if
         if (.not. found) then
           ! -- Link was not found. Make one and add it to the list.
           call tsManager%make_link(timeseries, pkgName, auxOrBnd, bndElem, &

--- a/src/Utilities/TimeSeries/TimeSeriesManager.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesManager.f90
@@ -550,7 +550,7 @@ contains
   !<
   subroutine read_value_or_time_series(textInput, ii, jj, bndElem, pkgName, &
                                        auxOrBnd, tsManager, iprpak, tsLink)
-    ! -- dummy
+    ! dummy
     character(len=*), intent(in) :: textInput
     integer(I4B), intent(in) :: ii
     integer(I4B), intent(in) :: jj
@@ -560,31 +560,34 @@ contains
     type(TimeSeriesManagerType), intent(inout) :: tsManager
     integer(I4B), intent(in) :: iprpak
     type(TimeSeriesLinkType), pointer, intent(inout) :: tsLink
-    ! -- local
+    ! local
     type(TimeSeriesType), pointer :: timeseries => null()
     integer(I4B) :: istat
     real(DP) :: r
     character(len=LINELENGTH) :: errmsg
     character(len=LENTIMESERIESNAME) :: tsNameTemp
-    !
+
     read (textInput, *, iostat=istat) r
     if (istat == 0) then
       bndElem = r
     else
+
+      ! Check to see if this is a time series name
       tsNameTemp = textInput
       call UPCASE(tsNameTemp)
-      ! -- If text is a time-series name, get value
-      !    from time series.
       timeseries => tsManager%get_time_series(tsNameTemp)
-      ! -- Create a time series link and add it to the package
-      !    list of time series links used by the array.
+
+      ! If this is a time series, then create a link between
+      ! the time series and the row and column position of
+      ! bndElem
       if (associated(timeseries)) then
         ! -- Assign value from time series to current
         !    array element
         r = timeseries%GetValue(totimsav, totim, &
                                 tsManager%extendTsToEndOfSimulation)
         bndElem = r
-        ! Make a new linke and add it to the list.
+        ! Make a new link between the time series and the row and
+        ! column position in the array
         call tsManager%make_link(timeseries, pkgName, auxOrBnd, bndElem, &
                                  ii, jj, iprpak, tsLink, '', '')
       else
@@ -593,9 +596,7 @@ contains
         call store_error(errmsg)
       end if
     end if
-    !
-    ! -- Return
-    return
+
   end subroutine read_value_or_time_series
 
   !> @brief Call this subroutine from advanced packages to define timeseries

--- a/src/Utilities/TimeSeries/TimeSeriesManager.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesManager.f90
@@ -543,7 +543,7 @@ contains
   !> @brief Call this subroutine if the time-series link is available or needed
   !!
   !! This routine assumes that there is not an existing link for the
-  !! specified package and array row and column.  For the standard 
+  !! specified package and array row and column.  For the standard
   !! boundary package, all links are removed by calling the tsmanager%reset()
   !! method.  For advanced packages, there is a separate routine called
   !! read_value_or_time_series_adv, which should be used instead of this one.
@@ -586,7 +586,7 @@ contains
         bndElem = r
         ! Make a new linke and add it to the list.
         call tsManager%make_link(timeseries, pkgName, auxOrBnd, bndElem, &
-                                  ii, jj, iprpak, tsLink, '', '')
+                                 ii, jj, iprpak, tsLink, '', '')
       else
         errmsg = 'Error in list input. Expected numeric value or '// &
                  "time-series name, but found '"//trim(textInput)//"'."

--- a/src/Utilities/TimeSeries/TimeSeriesManager.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesManager.f90
@@ -541,6 +541,12 @@ contains
   ! -- Non-type-bound procedures
 
   !> @brief Call this subroutine if the time-series link is available or needed
+  !!
+  !! This routine assumes that there is not an existing link for the
+  !! specified package and array row and column.  For the standard 
+  !! boundary package, all links are removed by calling the tsmanager%reset()
+  !! method.  For advanced packages, there is a separate routine called
+  !! read_value_or_time_series_adv, which should be used instead of this one.
   !<
   subroutine read_value_or_time_series(textInput, ii, jj, bndElem, pkgName, &
                                        auxOrBnd, tsManager, iprpak, tsLink)
@@ -556,12 +562,10 @@ contains
     type(TimeSeriesLinkType), pointer, intent(inout) :: tsLink
     ! -- local
     type(TimeSeriesType), pointer :: timeseries => null()
-    type(TimeSeriesLinkType), pointer :: tslTemp => null()
-    integer(I4B) :: i, istat, nlinks
+    integer(I4B) :: istat
     real(DP) :: r
     character(len=LINELENGTH) :: errmsg
     character(len=LENTIMESERIESNAME) :: tsNameTemp
-    logical :: found
     !
     read (textInput, *, iostat=istat) r
     if (istat == 0) then
@@ -580,30 +584,9 @@ contains
         r = timeseries%GetValue(totimsav, totim, &
                                 tsManager%extendTsToEndOfSimulation)
         bndElem = r
-        found = .false.
-        if (auxOrBnd /= 'BND') then
-          ! Look to see if this array element already has a time series
-          ! linked to it.  If not, make a link to it.
-          ! Assuming check is not necessary for 'BND' type time series
-          nlinks = tsManager%CountLinks(auxOrBnd)
-          searchlinks: do i = 1, nlinks
-            tslTemp => tsManager%GetLink(auxOrBnd, i)
-            if (tslTemp%PackageName == pkgName) then
-              ! -- Check ii, jj against iRow, jCol stored in link
-              if (tslTemp%IRow == ii .and. tslTemp%JCol == jj) then
-                ! -- This array element is already linked to a time series.
-                tsLink => tslTemp
-                found = .true.
-                exit searchlinks
-              end if
-            end if
-          end do searchlinks
-        end if
-        if (.not. found) then
-          ! -- Link was not found. Make one and add it to the list.
-          call tsManager%make_link(timeseries, pkgName, auxOrBnd, bndElem, &
-                                   ii, jj, iprpak, tsLink, '', '')
-        end if
+        ! Make a new linke and add it to the list.
+        call tsManager%make_link(timeseries, pkgName, auxOrBnd, bndElem, &
+                                  ii, jj, iprpak, tsLink, '', '')
       else
         errmsg = 'Error in list input. Expected numeric value or '// &
                  "time-series name, but found '"//trim(textInput)//"'."


### PR DESCRIPTION
This should be done now. I ended up keeping the search loop and instead skip it when the time series file is for a boundary condition. My reasoning is that I spent all my time evaluating its application in the CHD and GHB packages and not their auxiliary variables. Just to be safe, I will let it do that for the aux time series files but skip for the boundary time series files.

I ran through each of Richard Winston's examples and get the same answer with a substantial speedup. In particular, the million time series file example reduced the runtime from 19 hours to 3 minutes!

commit message:

The subroutine read_value_or_time_series checks to see if a time series file (TS) has been previously included in the time series manager (tsManager) before adding it.

The check compares against the package name and the input parser row and column (ii, jj) location in the input file. If the package name and location match, then the TS is not added to the tsManager.

This check is never true for boundary (BND) type TS, so a conditional is added to only perform the search for for non-BND TS types.

This results in a substantial performance increase when there are a large number of time series files.