### PR TITLE
refactor: move hyeff function to separate module

### DIFF
--- a/make/makefile
+++ b/make/makefile
@@ -261,6 +261,7 @@ $(OBJDIR)/TspAdvOptions.o \
 $(OBJDIR)/UzfCellGroup.o \
 $(OBJDIR)/Xt3dInterface.o \
 $(OBJDIR)/gwf-tvk.o \
+$(OBJDIR)/HGeoUtil.o \
 $(OBJDIR)/gwf-vsc.o \
 $(OBJDIR)/GwfNpfOptions.o \
 $(OBJDIR)/InterfaceMap.o \
@@ -284,12 +285,12 @@ $(OBJDIR)/gwf-uzf.o \
 $(OBJDIR)/tsp-apt.o \
 $(OBJDIR)/gwt-mst.o \
 $(OBJDIR)/GwtDspOptions.o \
-$(OBJDIR)/gwf-npf.o \
 $(OBJDIR)/gwf-tvs.o \
 $(OBJDIR)/GwfStorageUtils.o \
 $(OBJDIR)/Mover.o \
 $(OBJDIR)/GwfMvrPeriodData.o \
 $(OBJDIR)/ImsLinearMisc.o \
+$(OBJDIR)/gwf-npf.o \
 $(OBJDIR)/GwfBuyInputData.o \
 $(OBJDIR)/GweCndOptions.o \
 $(OBJDIR)/VirtualSolution.o \

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -505,6 +505,7 @@
 		<File RelativePath="..\src\Utilities\GeomUtil.f90"/>
 		<File RelativePath="..\src\Utilities\HashTable.f90"/>
 		<File RelativePath="..\src\Utilities\HeadFileReader.f90"/>
+		<File RelativePath="..\src\Utilities\HGeoUtil.f90"/>
 		<File RelativePath="..\src\Utilities\InputOutput.f90"/>
 		<File RelativePath="..\src\Utilities\Iunit.f90"/>
 		<File RelativePath="..\src\Utilities\kind.f90"/>

--- a/src/Model/GroundWaterEnergy/gwe-cnd.f90
+++ b/src/Model/GroundWaterEnergy/gwe-cnd.f90
@@ -809,7 +809,7 @@ contains
   !<
   subroutine calcdispcoef(this)
     ! -- modules
-    use GwfNpfModule, only: hyeff_calc
+    use HGeoUtilModule, only: hyeff
     ! -- dummy
     class(GweCndType) :: this
     ! -- local
@@ -859,12 +859,12 @@ contains
         !    normal to the shared n-m face and for cell m in the direction
         !    normal to the shared n-m face.
         call this%dis%connection_normal(n, m, ihc, vg1, vg2, vg3, ipos)
-        dn = hyeff_calc(this%d11(n), this%d22(n), this%d33(n), &
-                        this%angle1(n), this%angle2(n), this%angle3(n), &
-                        vg1, vg2, vg3, iavgmeth)
-        dm = hyeff_calc(this%d11(m), this%d22(m), this%d33(m), &
-                        this%angle1(m), this%angle2(m), this%angle3(m), &
-                        vg1, vg2, vg3, iavgmeth)
+        dn = hyeff(this%d11(n), this%d22(n), this%d33(n), &
+                   this%angle1(n), this%angle2(n), this%angle3(n), &
+                   vg1, vg2, vg3, iavgmeth)
+        dm = hyeff(this%d11(m), this%d22(m), this%d33(m), &
+                   this%angle1(m), this%angle2(m), this%angle3(m), &
+                   vg1, vg2, vg3, iavgmeth)
         !
         ! -- Calculate dispersion conductance based on NPF subroutines and the
         !    effective dispersion coefficients dn and dm.

--- a/src/Model/GroundWaterFlow/gwf-npf.f90
+++ b/src/Model/GroundWaterFlow/gwf-npf.f90
@@ -20,6 +20,7 @@ module GwfNpfModule
                                  mem_deallocate, mem_setptr, &
                                  mem_reassignptr
   use MatrixBaseModule
+  use HGeoUtilModule, only: hyeff
 
   implicit none
 
@@ -30,7 +31,6 @@ module GwfNpfModule
   public :: vcond
   public :: condmean
   public :: thksatnm
-  public :: hyeff_calc
 
   type, extends(NumericalPackageType) :: GwfNpfType
 
@@ -2472,8 +2472,8 @@ contains
         ang2 = this%angle2(n)
         ang3 = DZERO
         if (this%iangle3 > 0) ang3 = this%angle3(n)
-        hy = hyeff_calc(hy11, hy22, hy33, ang1, ang2, ang3, vg1, vg2, vg3, &
-                        this%iavgkeff)
+        hy = hyeff(hy11, hy22, hy33, ang1, ang2, ang3, vg1, vg2, vg3, &
+                   this%iavgkeff)
       end if
       !
     else
@@ -2498,8 +2498,8 @@ contains
             if (this%iangle3 > 0) ang3 = this%angle3(n)
           end if
         end if
-        hy = hyeff_calc(hy11, hy22, hy33, ang1, ang2, ang3, vg1, vg2, vg3, &
-                        this%iavgkeff)
+        hy = hyeff(hy11, hy22, hy33, ang1, ang2, ang3, vg1, vg2, vg3, &
+                   this%iavgkeff)
       end if
       !
     end if
@@ -2861,108 +2861,6 @@ contains
     ! -- Return
     return
   end function logmean
-
-  !> @brief Calculate the effective horizontal hydraulic conductivity from an
-  !! ellipse using a specified direction (unit vector vg1, vg2, vg3)
-  !!
-  !! k11 is the hydraulic conductivity of the major ellipse axis
-  !! k22 is the hydraulic conductivity of first minor axis
-  !! k33 is the hydraulic conductivity of the second minor axis
-  !! ang1 is the counter-clockwise rotation (radians) of the ellipse in
-  !!   the (x, y) plane
-  !! ang2 is the rotation of the conductivity ellipsoid upward or
-  !!   downward from the (x, y) plane
-  !! ang3 is the rotation of the conductivity ellipsoid about the major
-  !!   axis
-  !! vg1, vg2, and vg3 are the components of a unit vector in model coordinates
-  !!   in the direction of the connection between cell n and m
-  !!iavgmeth is the averaging method.  If zero, then use harmonic averaging.
-  !!   if one, then use arithmetic averaging.
-  !<
-  function hyeff_calc(k11, k22, k33, ang1, ang2, ang3, vg1, vg2, vg3, &
-                      iavgmeth) result(hyeff)
-    ! -- modules
-    use ConstantsModule, only: DONE
-    ! -- return
-    real(DP) :: hyeff
-    ! -- dummy
-    real(DP), intent(in) :: k11
-    real(DP), intent(in) :: k22
-    real(DP), intent(in) :: k33
-    real(DP), intent(in) :: ang1
-    real(DP), intent(in) :: ang2
-    real(DP), intent(in) :: ang3
-    real(DP), intent(in) :: vg1
-    real(DP), intent(in) :: vg2
-    real(DP), intent(in) :: vg3
-    integer(I4B), intent(in) :: iavgmeth
-    ! -- local
-    real(DP) :: s1, s2, s3, c1, c2, c3
-    real(DP), dimension(3, 3) :: r
-    real(DP) :: ve1, ve2, ve3
-    real(DP) :: denom, dnum, d1, d2, d3
-    !
-    ! -- Sin and cos of angles
-    s1 = sin(ang1)
-    c1 = cos(ang1)
-    s2 = sin(ang2)
-    c2 = cos(ang2)
-    s3 = sin(ang3)
-    c3 = cos(ang3)
-    !
-    ! -- Rotation matrix
-    r(1, 1) = c1 * c2
-    r(1, 2) = c1 * s2 * s3 - s1 * c3
-    r(1, 3) = -c1 * s2 * c3 - s1 * s3
-    r(2, 1) = s1 * c2
-    r(2, 2) = s1 * s2 * s3 + c1 * c3
-    r(2, 3) = -s1 * s2 * c3 + c1 * s3
-    r(3, 1) = s2
-    r(3, 2) = -c2 * s3
-    r(3, 3) = c2 * c3
-    !
-    ! -- Unit vector in direction of n-m connection in a local coordinate
-    !    system aligned with the ellipse axes
-    ve1 = r(1, 1) * vg1 + r(2, 1) * vg2 + r(3, 1) * vg3
-    ve2 = r(1, 2) * vg1 + r(2, 2) * vg2 + r(3, 2) * vg3
-    ve3 = r(1, 3) * vg1 + r(2, 3) * vg2 + r(3, 3) * vg3
-    !
-    ! -- Effective hydraulic conductivity calculated using harmonic (1)
-    !    or arithmetic (2) weighting
-    hyeff = DZERO
-    if (iavgmeth == 0) then
-      !
-      ! -- Arithmetic weighting.  If principal direction corresponds exactly with
-      !    unit vector then set to principal direction.  Otherwise weight it.
-      dnum = DONE
-      d1 = ve1**2
-      d2 = ve2**2
-      d3 = ve3**2
-      if (ve1 /= DZERO) then
-        dnum = dnum * k11
-        d2 = d2 * k11
-        d3 = d3 * k11
-      end if
-      if (ve2 /= DZERO) then
-        dnum = dnum * k22
-        d1 = d1 * k22
-        d3 = d3 * k22
-      end if
-      if (ve3 /= DZERO) then
-        dnum = dnum * k33
-        d1 = d1 * k33
-        d2 = d2 * k33
-      end if
-      denom = d1 + d2 + d3
-      if (denom > DZERO) hyeff = dnum / denom
-    else if (iavgmeth == 1) then
-      ! -- arithmetic
-      hyeff = ve1**2 * k11 + ve2**2 * k22 + ve3**2 * k33
-    end if
-    !
-    ! -- Return
-    return
-  end function hyeff_calc
 
   !> @brief Calculate the 3 conmponents of specific discharge at the cell center
   !<

--- a/src/Model/GroundWaterTransport/gwt-dsp.f90
+++ b/src/Model/GroundWaterTransport/gwt-dsp.f90
@@ -790,7 +790,7 @@ contains
   !<
   subroutine calcdispcoef(this)
     ! -- modules
-    use GwfNpfModule, only: hyeff_calc
+    use HGeoUtilModule, only: hyeff
     ! -- dummy
     class(GwtDspType) :: this
     ! -- local
@@ -840,12 +840,12 @@ contains
         !    normal to the shared n-m face and for cell m in the direction
         !    normal to the shared n-m face.
         call this%dis%connection_normal(n, m, ihc, vg1, vg2, vg3, ipos)
-        dn = hyeff_calc(this%d11(n), this%d22(n), this%d33(n), &
-                        this%angle1(n), this%angle2(n), this%angle3(n), &
-                        vg1, vg2, vg3, iavgmeth)
-        dm = hyeff_calc(this%d11(m), this%d22(m), this%d33(m), &
-                        this%angle1(m), this%angle2(m), this%angle3(m), &
-                        vg1, vg2, vg3, iavgmeth)
+        dn = hyeff(this%d11(n), this%d22(n), this%d33(n), &
+                   this%angle1(n), this%angle2(n), this%angle3(n), &
+                   vg1, vg2, vg3, iavgmeth)
+        dm = hyeff(this%d11(m), this%d22(m), this%d33(m), &
+                   this%angle1(m), this%angle2(m), this%angle3(m), &
+                   vg1, vg2, vg3, iavgmeth)
         !
         ! -- Calculate dispersion conductance based on NPF subroutines and the
         !    effective dispersion coefficients dn and dm.

--- a/src/Utilities/HGeoUtil.f90
+++ b/src/Utilities/HGeoUtil.f90
@@ -1,0 +1,110 @@
+!> @brief General-purpose hydrogeologic functions.
+module HGeoUtilModule
+  use KindModule, only: DP, I4B
+  use ConstantsModule, only: DZERO, DONE
+
+  implicit none
+  private
+  public :: hyeff
+
+contains
+
+  !> @brief Calculate the effective horizontal hydraulic conductivity from an
+  !! ellipse using a specified direction (unit vector vg1, vg2, vg3)
+  !!
+  !! k11 is the hydraulic conductivity of the major ellipse axis
+  !! k22 is the hydraulic conductivity of first minor axis
+  !! k33 is the hydraulic conductivity of the second minor axis
+  !! ang1 is the counter-clockwise rotation (radians) of the ellipse in
+  !!   the (x, y) plane
+  !! ang2 is the rotation of the conductivity ellipsoid upward or
+  !!   downward from the (x, y) plane
+  !! ang3 is the rotation of the conductivity ellipsoid about the major
+  !!   axis
+  !! vg1, vg2, and vg3 are the components of a unit vector in model coordinates
+  !!   in the direction of the connection between cell n and m
+  !!iavgmeth is the averaging method.  If zero, then use harmonic averaging.
+  !!   if one, then use arithmetic averaging.
+  !<
+  function hyeff(k11, k22, k33, ang1, ang2, ang3, vg1, vg2, vg3, &
+                 iavgmeth) result(K)
+    ! -- return
+    real(DP) :: K
+    ! -- dummy
+    real(DP), intent(in) :: k11
+    real(DP), intent(in) :: k22
+    real(DP), intent(in) :: k33
+    real(DP), intent(in) :: ang1
+    real(DP), intent(in) :: ang2
+    real(DP), intent(in) :: ang3
+    real(DP), intent(in) :: vg1
+    real(DP), intent(in) :: vg2
+    real(DP), intent(in) :: vg3
+    integer(I4B), intent(in) :: iavgmeth
+    ! -- local
+    real(DP) :: s1, s2, s3, c1, c2, c3
+    real(DP), dimension(3, 3) :: r
+    real(DP) :: ve1, ve2, ve3
+    real(DP) :: denom, dnum, d1, d2, d3
+    !
+    ! -- Sin and cos of angles
+    s1 = sin(ang1)
+    c1 = cos(ang1)
+    s2 = sin(ang2)
+    c2 = cos(ang2)
+    s3 = sin(ang3)
+    c3 = cos(ang3)
+    !
+    ! -- Rotation matrix
+    r(1, 1) = c1 * c2
+    r(1, 2) = c1 * s2 * s3 - s1 * c3
+    r(1, 3) = -c1 * s2 * c3 - s1 * s3
+    r(2, 1) = s1 * c2
+    r(2, 2) = s1 * s2 * s3 + c1 * c3
+    r(2, 3) = -s1 * s2 * c3 + c1 * s3
+    r(3, 1) = s2
+    r(3, 2) = -c2 * s3
+    r(3, 3) = c2 * c3
+    !
+    ! -- Unit vector in direction of n-m connection in a local coordinate
+    !    system aligned with the ellipse axes
+    ve1 = r(1, 1) * vg1 + r(2, 1) * vg2 + r(3, 1) * vg3
+    ve2 = r(1, 2) * vg1 + r(2, 2) * vg2 + r(3, 2) * vg3
+    ve3 = r(1, 3) * vg1 + r(2, 3) * vg2 + r(3, 3) * vg3
+    !
+    ! -- Effective hydraulic conductivity calculated using harmonic (1)
+    !    or arithmetic (2) weighting
+    K = DZERO
+    if (iavgmeth == 0) then
+      !
+      ! -- Arithmetic weighting.  If principal direction corresponds exactly with
+      !    unit vector then set to principal direction.  Otherwise weight it.
+      dnum = DONE
+      d1 = ve1**2
+      d2 = ve2**2
+      d3 = ve3**2
+      if (ve1 /= DZERO) then
+        dnum = dnum * k11
+        d2 = d2 * k11
+        d3 = d3 * k11
+      end if
+      if (ve2 /= DZERO) then
+        dnum = dnum * k22
+        d1 = d1 * k22
+        d3 = d3 * k22
+      end if
+      if (ve3 /= DZERO) then
+        dnum = dnum * k33
+        d1 = d1 * k33
+        d2 = d2 * k33
+      end if
+      denom = d1 + d2 + d3
+      if (denom > DZERO) K = dnum / denom
+    else if (iavgmeth == 1) then
+      ! -- arithmetic
+      K = ve1**2 * k11 + ve2**2 * k22 + ve3**2 * k33
+    end if
+
+  end function hyeff
+
+end module HGeoUtilModule

--- a/src/meson.build
+++ b/src/meson.build
@@ -326,6 +326,7 @@ modflow_sources = files(
     'Utilities' / 'GeomUtil.f90',
     'Utilities' / 'HashTable.f90',
     'Utilities' / 'HeadFileReader.f90',
+    'Utilities' / 'HGeoUtil.f90',
     'Utilities' / 'InputOutput.f90',
     'Utilities' / 'Iunit.f90',
     'Utilities' / 'kind.f90',


### PR DESCRIPTION
* move function for effective horizontal hydraulic conductivity out of `gwf-npf.f90` so gwt-dsp and gwe-cnd don't depend on gwf-npf &mdash; toward eliminating dependencies between models
* introduce `HGeoUtilModule` for standalone hydrogeologic functions
* split out from #1532
* part of #1491