### PR TITLE
test(gwe/uze): relax sln comparison failing on ARM macs

### DIFF
--- a/autotest/test_gwe_uze00.py
+++ b/autotest/test_gwe_uze00.py
@@ -552,7 +552,7 @@ def check_output(idx, test):
         "Simulated fits to analytical solution are "
         "falling outside established bounds on day 100"
     )
-    assert np.max(analytical_sln[100] - temps[100]) <= 0.10680304268, msg4
+    assert np.max(analytical_sln[100] - temps[100]) <= 0.107, msg4
     assert np.min(analytical_sln[100] - temps[100]) >= -0.20763221276, msg4
 
     # If a plot is needed for visual inspection, change following if statement to "True"


### PR DESCRIPTION
To catch this sort of thing we might eventually consider adding CI tests for gfortran build on ARM mac