### PR TITLE
ci: don't test large models with ifx

### DIFF
--- a/.github/workflows/large.yml
+++ b/.github/workflows/large.yml
@@ -38,8 +38,6 @@ jobs:
         include:
           - {compiler: gcc, version: 13, repo: examples}
           - {compiler: gcc, version: 13, repo: largetestmodels}
-          - {compiler: intel, version: 2022.2.1, repo: examples}
-          - {compiler: intel, version: 2022.2.1, repo: largetestmodels}
           - {compiler: intel-classic, version: 2021.6, repo: examples}
           - {compiler: intel-classic, version: 2021.6, repo: largetestmodels}
     defaults:


### PR DESCRIPTION
* revert part of [2f52a23](https://github.com/MODFLOW-USGS/modflow6/commit/2f52a232a845a694ba00080f0e08445bd5cd47bd)
* fixes large model test CI
* I don't know why I did this, we should wait until ifx can pass the full test suite before we CI test with it