### PR TITLE
test: avoid warnings from 3rd party libs, misc cleanup

### DIFF
--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -16,3 +16,8 @@ markers =
     lak: tests for lake package
     maw: tests for multi-aquifer well package
     parallel: test relying on a parallel (MPI+PETSc) build
+filterwarnings =
+    # from python-dateutil, used by arrow, jupyter_client, matplotlib, pandas
+    ignore:datetime.datetime.utcfromtimestamp  
+    # from pandas, see https://github.com/pandas-dev/pandas/issues/54466
+    ignore:\n.*Pyarrow  

--- a/autotest/test_gwe_esl_analyt_sln.py
+++ b/autotest/test_gwe_esl_analyt_sln.py
@@ -1,51 +1,51 @@
-"""
- An analytical solution provided by Carslaw & Jaeger (1947) and discussed in 
- accompanying Techniques & Methods report.
- 
- Energy is added to the right hand side boundary using the energy source loading
- (ESL) package.  Basic model set up is below, with a slab of unit thickness 
- (1.0 m) that is 100 m "deep" with energy being loaded on right side.  
- Temperature will begin to rise on the right and propagate to the left. There are
- no sinks in this first example.  The titles that follow, for example
- "Section 43, case x" refer to specific analytical solutions found in Carslaw &
- Jaeger (1947)
- 
- Section 43, case i:
- -------------------
+r"""
+An analytical solution provided by Carslaw & Jaeger (1947) and discussed in 
+accompanying Techniques & Methods report.
 
-        | <--------------------------   10 m   --------------------------> |
-      
-        +------------------------------------------------------------------+
-        |                      Initial temperature = T_0                   | <-- *ESL
-        +------------------------------------------------------------------+
-        ^                                      * ESL: Energy Source Loading Boundary
-        |
-        No heat-flow boundary
+Energy is added to the right hand side boundary using the energy source loading
+(ESL) package.  Basic model set up is below, with a slab of unit thickness 
+(1.0 m) that is 100 m "deep" with energy being loaded on right side.  
+Temperature will begin to rise on the right and propagate to the left. There are
+no sinks in this first example.  The titles that follow, for example
+"Section 43, case x" refer to specific analytical solutions found in Carslaw &
+Jaeger (1947)
 
- 
- Section 43, case ii:
- --------------------
- 
-        +------------------------------------------------------------------+
-        |                     Initial temperature = 0.0                    | <-- *ESL
-        +------------------------------------------------------------------+
-        ^                                     
-        |
-        Specified temperature boundary, T_0
+Section 43, case i:
+-------------------
+
+       | <--------------------------   10 m   --------------------------> |
+     
+       +------------------------------------------------------------------+
+       |                      Initial temperature = T_0                   | <-- *ESL
+       +------------------------------------------------------------------+
+       ^                                      * ESL: Energy Source Loading Boundary
+       |
+       No heat-flow boundary
 
 
- Section 43, case iii:
- ---------------------
-         
+Section 43, case ii:
+--------------------
+
+       +------------------------------------------------------------------+
+       |                     Initial temperature = 0.0                    | <-- *ESL
+       +------------------------------------------------------------------+
+       ^                                     
+       |
+       Specified temperature boundary, T_0
+
+
+Section 43, case iii:
+---------------------
+        
         +------------------------------------------------------------------+
 CTP ->  |                                                                  | <- CTP = T_0
   = T_0 +------------------------------------------------------------------+
-          \-------------------------------------------------------------/
-                                    |
-               Uniform, constant heat production throughout the slab
-      
-      
-   Specified temperature boundary, T_0
+         \-------------------------------------------------------------/
+                                   |
+              Uniform, constant heat production throughout the slab
+     
+     
+  Specified temperature boundary, T_0
 
 """
 

--- a/autotest/test_gwe_lke_conduction.py
+++ b/autotest/test_gwe_lke_conduction.py
@@ -71,7 +71,7 @@ def get_bud(fname, srchStr):
 def trenddetector(list_of_index, array_of_data, order=1):
     result = np.polyfit(list_of_index, list(array_of_data), order)
     slope = result[-2]
-    return float(slope)
+    return float(slope.item())
 
 
 cases = ["lke-conductn", "lke-conductm", "lke-conductr"]

--- a/autotest/test_gwe_split_analyt.py
+++ b/autotest/test_gwe_split_analyt.py
@@ -1,4 +1,4 @@
-"""
+r"""
  An analytical solution provided by Carslaw & Jaeger (1947) and discussed in 
  accompanying Techniques & Methods report.
  

--- a/autotest/test_gwf_sfr_npoint01.py
+++ b/autotest/test_gwf_sfr_npoint01.py
@@ -33,7 +33,7 @@ xsect_types = (
     "w",
     "v_invalid",
     "|/",
-    "\|",
+    r"\|",
 )
 
 # spatial discretization data

--- a/autotest/test_gwf_sto03.py
+++ b/autotest/test_gwf_sto03.py
@@ -194,7 +194,7 @@ def eval_hmax(fpth):
     bv[:] = b.get_data(totim=1.0)[obsname]
     sv = np.zeros(ctimes.shape, dtype=float)
     for i, t in enumerate(ctimes):
-        sv[i] = b.get_data(totim=t)[obsname]
+        sv[i] = b.get_data(totim=t)[obsname].item()
 
     msg = (
         "maximum heads in {} exceed tolerance ".format(fpth)
@@ -229,7 +229,7 @@ def check_output(idx, test):
     base_cmp[:] = base_obs.get_data(totim=1.0)[obsname]
     offset_cmp = np.zeros(cmp_times.shape, dtype=float)
     for i, t in enumerate(cmp_times):
-        offset_cmp[i] = base_obs.get_data(totim=t)[obsname]
+        offset_cmp[i] = base_obs.get_data(totim=t)[obsname].item()
 
     msg = (
         "maximum heads exceed tolerance when offset removed "

--- a/autotest/test_prt_voronoi1.py
+++ b/autotest/test_prt_voronoi1.py
@@ -402,6 +402,7 @@ def check_output(idx, test):
         p.show()
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     if (

--- a/autotest/test_prt_voronoi2.py
+++ b/autotest/test_prt_voronoi2.py
@@ -421,6 +421,7 @@ def check_output(idx, test):
         p.show()
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(


### PR DESCRIPTION
* ignore well-known `python-dateutil` and `pandas` warnings
* use `.item()` to extract single items from numpy arrays
* mark PRT voronoi tests slow (todo: refactor, speed up)
* use raw docstrings if they contain backslashes

There are a few more warnings to clean up, either directly from flopy or indirectly via numpy or matplotlib
```
matplotlib/quiver.py:649: RuntimeWarning: divide by zero encountered in scalar divide
    length = a * (widthu_per_lenu / (self.scale * self.width))
```
```
flopy/mf6/data/mfdataplist.py:1092: ParserWarning: Length of header or names does not match length of data. This leads to a loss of data with index_col=False.
    data_frame = pandas.read_csv(
```
```
flopy/utils/geometry.py:871: RuntimeWarning: invalid value encountered in divide
    tmp = polygon[i][0] + (polygon[j][0] - polygon[i][0]) * (
```