### PR TITLE
test(PRT): refactor/cleanup voronoi DISV grid tests

### DIFF
--- a/autotest/test_prt_budget.py
+++ b/autotest/test_prt_budget.py
@@ -14,9 +14,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from flopy.mf6.utils.postprocessing import get_structured_faceflows
 from flopy.utils import PathlineFile
 from flopy.utils.binaryfile import HeadFile
-from flopy.mf6.utils.postprocessing import get_structured_faceflows
+
+from framework import TestFramework
 from prt_test_utils import (
     HorizontalCase,
     all_equal,
@@ -26,8 +28,6 @@ from prt_test_utils import (
     get_partdata,
     has_default_boundnames,
 )
-
-from framework import TestFramework
 
 simname = "prtbud"
 cases = [simname]

--- a/autotest/test_prt_disv1.py
+++ b/autotest/test_prt_disv1.py
@@ -20,6 +20,8 @@ import pytest
 from flopy.utils import PathlineFile
 from flopy.utils.binaryfile import HeadFile
 from flopy.utils.gridutil import get_disv_kwargs
+
+from framework import TestFramework
 from prt_test_utils import (
     all_equal,
     check_budget_data,
@@ -28,8 +30,6 @@ from prt_test_utils import (
     has_default_boundnames,
     plot_nodes_and_vertices,
 )
-
-from framework import TestFramework
 
 simname = "prtdisv1"
 cases = [f"{simname}", f"{simname}bprp", f"{simname}trts", f"{simname}trtf"]

--- a/autotest/test_prt_drape.py
+++ b/autotest/test_prt_drape.py
@@ -22,7 +22,7 @@ from prt_test_utils import all_equal, check_track_data, get_model_name
 
 from framework import TestFramework
 
-simname = "prtfmi09"
+simname = "prtdrape"
 cases = [simname, f"{simname}_drp"]
 nlay, nrow, ncol = 2, 1, 5
 chdheads = [25.0]

--- a/autotest/test_prt_drape.py
+++ b/autotest/test_prt_drape.py
@@ -18,9 +18,9 @@ import numpy as np
 import pandas as pd
 import pytest
 from flopy.utils.binaryfile import HeadFile
-from prt_test_utils import all_equal, check_track_data, get_model_name
 
 from framework import TestFramework
+from prt_test_utils import all_equal, check_track_data, get_model_name
 
 simname = "prtdrape"
 cases = [simname, f"{simname}_drp"]

--- a/autotest/test_prt_exg.py
+++ b/autotest/test_prt_exg.py
@@ -23,9 +23,9 @@ import pandas as pd
 import pytest
 from flopy.utils import PathlineFile
 from flopy.utils.binaryfile import HeadFile
-from prt_test_utils import FlopyReadmeCase, check_budget_data, check_track_data
 
 from framework import TestFramework
+from prt_test_utils import FlopyReadmeCase, check_budget_data, check_track_data
 
 simname = "prtexg01"
 cases = [simname, f"{simname}bnms"]

--- a/autotest/test_prt_fmi.py
+++ b/autotest/test_prt_fmi.py
@@ -36,6 +36,8 @@ import pandas as pd
 import pytest
 from flopy.utils import PathlineFile
 from flopy.utils.binaryfile import HeadFile
+
+from framework import TestFramework
 from prt_test_utils import (
     FlopyReadmeCase,
     all_equal,
@@ -45,8 +47,6 @@ from prt_test_utils import (
     get_partdata,
     has_default_boundnames,
 )
-
-from framework import TestFramework
 
 simname = "prtfmi01"
 cases = [simname, f"{simname}saws", f"{simname}bprp"]

--- a/autotest/test_prt_release_timing.py
+++ b/autotest/test_prt_release_timing.py
@@ -36,6 +36,8 @@ import pandas as pd
 import pytest
 from flopy.utils import PathlineFile
 from flopy.utils.binaryfile import HeadFile
+
+from framework import TestFramework
 from prt_test_utils import (
     FlopyReadmeCase,
     all_equal,
@@ -44,8 +46,6 @@ from prt_test_utils import (
     get_model_name,
     get_partdata,
 )
-
-from framework import TestFramework
 
 simname = "prtrelt"
 cases = [

--- a/autotest/test_prt_stop_zones.py
+++ b/autotest/test_prt_stop_zones.py
@@ -33,14 +33,14 @@ import pytest
 from flopy.utils import PathlineFile
 from flopy.utils.binaryfile import HeadFile
 from matplotlib.collections import LineCollection
+
+from framework import TestFramework
 from prt_test_utils import (
     FlopyReadmeCase,
     check_budget_data,
     check_track_data,
     get_model_name,
 )
-
-from framework import TestFramework
 
 simname = "prtfmi03"
 cases = [f"{simname}_l1", f"{simname}_l2"]

--- a/autotest/test_prt_ternary_methods.py
+++ b/autotest/test_prt_ternary_methods.py
@@ -24,18 +24,18 @@ import pytest
 from flopy.discretization import VertexGrid
 from flopy.utils import GridIntersect
 from flopy.utils.triangle import Triangle
-from prt_test_utils import get_model_name
 from shapely.geometry import LineString
 
 from framework import TestFramework
+from prt_test_utils import get_model_name
 from test_prt_triangle import (
     active_domain,
-    nlay,
-    top,
     botm,
-    porosity,
-    get_tri,
     build_gwf_sim,
+    get_tri,
+    nlay,
+    porosity,
+    top,
 )
 
 simname = "prtter"

--- a/autotest/test_prt_ternary_methods.py
+++ b/autotest/test_prt_ternary_methods.py
@@ -14,7 +14,6 @@ The ZERO_METHOD option is used to select root-
 finding methods for total runtime comparison.
 """
 
-from math import isclose
 from pathlib import Path
 
 import flopy

--- a/autotest/test_prt_track_events.py
+++ b/autotest/test_prt_track_events.py
@@ -33,14 +33,14 @@ import pandas as pd
 import pytest
 from flopy.utils import PathlineFile
 from flopy.utils.binaryfile import HeadFile
+
+from framework import TestFramework
 from prt_test_utils import (
     FlopyReadmeCase,
     check_budget_data,
     check_track_data,
     get_model_name,
 )
-
-from framework import TestFramework
 
 simname = "prtevnt"
 cases = [

--- a/autotest/test_prt_triangle.py
+++ b/autotest/test_prt_triangle.py
@@ -21,10 +21,10 @@ import pytest
 from flopy.discretization import VertexGrid
 from flopy.utils import GridIntersect
 from flopy.utils.triangle import Triangle
-from prt_test_utils import get_model_name
 from shapely.geometry import LineString
 
 from framework import TestFramework
+from prt_test_utils import get_model_name
 
 simname = "prttri"
 cases = [f"{simname}r2l", f"{simname}diag"]

--- a/autotest/test_prt_voronoi1.py
+++ b/autotest/test_prt_voronoi1.py
@@ -29,11 +29,11 @@ from flopy.discretization import VertexGrid
 from flopy.utils import GridIntersect
 from flopy.utils.triangle import Triangle
 from flopy.utils.voronoi import VoronoiGrid
-from prt_test_utils import get_model_name
-from shapely.geometry import LineString, Point
 from modflow_devtools.misc import is_in_ci
+from shapely.geometry import LineString, Point
 
 from framework import TestFramework
+from prt_test_utils import get_model_name
 
 simname = "prtvor1"
 cases = [f"{simname}l2r", f"{simname}welp", f"{simname}weli"]
@@ -78,7 +78,7 @@ def build_gwf_sim(name, ws, targets):
     grid = get_grid(ws / "grid", targets)
     vgrid = VertexGrid(**grid.get_gridprops_vertexgrid(), nlay=1)
     ibd = np.zeros(vgrid.ncpl, dtype=int)
-    
+
     # Intersecting points with the grid is slow, so below we
     # hardcode the known cell IDs; if this test changes they
     # will need to be recomputed.
@@ -87,30 +87,148 @@ def build_gwf_sim(name, ws, targets):
     # identify cells on left edge
     # line = LineString([(xmin, ymin), (xmin, ymax)])
     # cells_left = gi.intersect(line)["cellids"]
-    left_cells = [   0,    3, 1197, 1268, 1442, 1443, 1459, 1461, 1474, 1499, 1515,
-       1520, 1529, 1545, 1552, 1563, 1581, 1584, 1586, 1590, 1596, 1608,
-       1609, 1614, 1616, 1625, 1643, 1649, 1652, 1655, 1659, 1662]
+    left_cells = [
+        0,
+        3,
+        1197,
+        1268,
+        1442,
+        1443,
+        1459,
+        1461,
+        1474,
+        1499,
+        1515,
+        1520,
+        1529,
+        1545,
+        1552,
+        1563,
+        1581,
+        1584,
+        1586,
+        1590,
+        1596,
+        1608,
+        1609,
+        1614,
+        1616,
+        1625,
+        1643,
+        1649,
+        1652,
+        1655,
+        1659,
+        1662,
+    ]
     left_cells = np.array(list(left_cells))
     ibd[left_cells] = 1
 
     # identify cells on right edge
     # line = LineString([(xmax, ymin), (xmax, ymax)])
     # cells_right = gi.intersect(line)["cellids"]
-    right_cells = [  1,   2,   6,  12, 210, 399, 400, 406, 412, 421, 519, 559, 601,
-       605, 617, 623, 624, 674, 770, 783, 785, 786, 792, 793, 801, 809,
-       812, 813, 814, 920]
+    right_cells = [
+        1,
+        2,
+        6,
+        12,
+        210,
+        399,
+        400,
+        406,
+        412,
+        421,
+        519,
+        559,
+        601,
+        605,
+        617,
+        623,
+        624,
+        674,
+        770,
+        783,
+        785,
+        786,
+        792,
+        793,
+        801,
+        809,
+        812,
+        813,
+        814,
+        920,
+    ]
     right_cells = np.array(list(right_cells))
     ibd[right_cells] = 2
 
     # identify cells on bottom edge
     # line = LineString([(xmin, ymin), (xmax, ymin)])
     # cells_bottom = gi.intersect(line)["cellids"]
-    bottom_cells = [   0,    1,    4,    8,  258,  274,  308,  328,  332,  333,  334,
-        342,  343,  345,  347,  353,  354,  355,  439,  445,  456,  460,
-        465,  475,  479,  485,  516,  527,  533,  541,  631,  752,  810,
-        819,  824,  830,  832,  834,  835,  927,  929,  932, 1091, 1096,
-       1207, 1212, 1215, 1217, 1242, 1247, 1249, 1257, 1262, 1269, 1276,
-       1389, 1393, 1447, 1455, 1462, 1677, 1685]
+    bottom_cells = [
+        0,
+        1,
+        4,
+        8,
+        258,
+        274,
+        308,
+        328,
+        332,
+        333,
+        334,
+        342,
+        343,
+        345,
+        347,
+        353,
+        354,
+        355,
+        439,
+        445,
+        456,
+        460,
+        465,
+        475,
+        479,
+        485,
+        516,
+        527,
+        533,
+        541,
+        631,
+        752,
+        810,
+        819,
+        824,
+        830,
+        832,
+        834,
+        835,
+        927,
+        929,
+        932,
+        1091,
+        1096,
+        1207,
+        1212,
+        1215,
+        1217,
+        1242,
+        1247,
+        1249,
+        1257,
+        1262,
+        1269,
+        1276,
+        1389,
+        1393,
+        1447,
+        1455,
+        1462,
+        1677,
+        1685,
+    ]
     bottom_cells = np.array(list(bottom_cells))
     ibd[bottom_cells] = 3
 
@@ -118,8 +236,6 @@ def build_gwf_sim(name, ws, targets):
     # points = [Point((1200, 500)), Point((700, 200)), Point((1600, 700))]
     # well_cells = [vgrid.intersect(p.x, p.y) for p in points]
     well_cells = [163, 1178, 67]
-
-    # import pdb; pdb.set_trace()
 
     # create simulation
     sim = flopy.mf6.MFSimulation(
@@ -184,7 +300,7 @@ def build_gwf_sim(name, ws, targets):
         "left": left_cells,
         "right": right_cells,
         "bottom": bottom_cells,
-        "well": well_cells
+        "well": well_cells,
     }
 
 
@@ -273,7 +389,12 @@ def build_prt_sim(idx, name, gwf_ws, prt_ws, targets, cell_ids):
 def build_models(idx, test):
     gwf_sim, cell_ids = build_gwf_sim(test.name, test.workspace, test.targets)
     prt_sim = build_prt_sim(
-        idx, test.name, test.workspace, test.workspace / "prt", test.targets, cell_ids
+        idx,
+        test.name,
+        test.workspace,
+        test.workspace / "prt",
+        test.targets,
+        cell_ids,
     )
     return gwf_sim, prt_sim
 

--- a/autotest/test_prt_weak_sinks.py
+++ b/autotest/test_prt_weak_sinks.py
@@ -33,6 +33,8 @@ import pandas as pd
 import pytest
 from flopy.utils import PathlineFile
 from flopy.utils.binaryfile import HeadFile
+
+from framework import TestFramework
 from prt_test_utils import (
     FlopyReadmeCase,
     check_budget_data,
@@ -40,8 +42,6 @@ from prt_test_utils import (
     get_ireason_code,
     get_model_name,
 )
-
-from framework import TestFramework
 
 simname = "prtfmi04"
 cases = [simname, f"{simname}saws"]


### PR DESCRIPTION
* followup to #1670
* fix test name in `test_prt_drape.py`
* reuse functions from `test_prt_voronoi1.py` in `..._voronoi2.py`
* hardcode cell IDs in voronoi tests instead of re-intersecting every run
* remove slow markers, tests now run in a few seconds