### PR TITLE
ci(win/par): add test workflow for parallel mf6 on Windows

### DIFF
--- a/.github/actions/test-par-win/action.yml
+++ b/.github/actions/test-par-win/action.yml
@@ -71,6 +71,15 @@ runs:
         path: petsc
         key: petsc-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
+    - name: Configure environment
+      shell: bash
+      run: |
+        PETSC_DIR=$GITHUB_WORKSPACE/petsc
+        PETSC_ARCH=arch-mswin-c-opt
+        echo "PETSC_DIR=$PETSC_DIR" >> $GITHUB_ENV
+        echo "PETSC_ARCH=$PETSC_ARCH" >> $GITHUB_ENV
+        echo "$PETSC_DIR/$PETSC_ARCH/lib" >> $GITHUB_PATH
+
     - name: Download PETSc
       if: steps.petsc-cache.outputs.cache-hit != 'true'
       shell: bash
@@ -91,15 +100,6 @@ runs:
       run: |
         mv /usr/bin/link.exe /usr/bin/link-cygwin.exe
         which link
-
-    - name: Configure environment
-      shell: bash
-      run: |
-        PETSC_DIR=$GITHUB_WORKSPACE/petsc
-        PETSC_ARCH=arch-mswin-c-opt
-        echo "PETSC_DIR=$PETSC_DIR" >> $GITHUB_ENV
-        echo "PETSC_ARCH=$PETSC_ARCH" >> $GITHUB_ENV
-        echo "$PETSC_DIR/$PETSC_ARCH/lib" >> $GITHUB_PATH
 
     - name: Configure PETSc
       if: steps.petsc-cache.outputs.cache-hit != 'true'

--- a/.github/actions/test-par-win/action.yml
+++ b/.github/actions/test-par-win/action.yml
@@ -1,0 +1,152 @@
+name: Test parallel MF6 (Windows)
+description: Build and test parallel MODFLOW 6 on Windows
+runs:
+  using: "composite"
+  steps:
+
+    - name: Convert line endings
+      shell: cmd
+      run: |
+        unix2dos -n "modflow6\.github\common\configure_petsc.sh" "%TEMP%\configure_petsc.sh"
+        unix2dos -n "modflow6\.github\common\compile_petsc.sh" "%TEMP%\compile_petsc.sh"
+        unix2dos -n "modflow6\.github\common\compile_modflow6.bat" "%TEMP%\compile_modflow6.bat"
+        unix2dos -n "modflow6\.github\common\test_modflow6.bat" "%TEMP%\test_modflow6.bat"
+
+    - name: Hide Strawberry programs
+      shell: bash
+      run: |
+        mkdir "$RUNNER_TEMP/strawberry"
+        mv /c/Strawberry/c/bin/gmake "$RUNNER_TEMP/strawberry/gmake"
+        mv /c/Strawberry/perl/bin/pkg-config "$RUNNER_TEMP/strawberry/pkg-config"
+        mv /c/Strawberry/perl/bin/pkg-config.bat "$RUNNER_TEMP/strawberry/pkg-config.bat"
+
+    - name: Get date
+      id: get-date
+      shell: bash
+      run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
+
+    - name: Set oneAPI install dir
+      id: oneapi-root
+      shell: bash
+      run: echo "ONEAPI_ROOT=C:\Program Files (x86)\Intel\oneAPI" >> "$GITHUB_ENV"
+
+    - name: Restore oneAPI cache
+      id: oneapi-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: ${{ env.ONEAPI_ROOT }}
+        key: oneapi-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+
+    - name: Install oneAPI BaseKit
+      shell: bash
+      if: steps.oneapi-cache.outputs.cache-hit != 'true'
+      run: |
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5cb30fb9-21e9-47e8-82da-a91e00191670/w_BaseKit_p_2024.0.1.45_offline.exe"
+        cmp="intel.oneapi.win.mkl.devel"
+        "modflow6/.github/common/install_intel_windows.bat" $url $cmp
+        rm -rf $TEMP/webimage.exe
+        rm -rf $TEMP/webimage_extracted
+
+    - name: Install oneAPI HPCKit
+      shell: bash
+      if: steps.oneapi-cache.outputs.cache-hit != 'true'
+      run: |
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7a6db8a1-a8b9-4043-8e8e-ca54b56c34e4/w_HPCKit_p_2024.0.1.35_offline.exe"
+        cmp="intel.oneapi.win.cpp-dpcpp-common:intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel"
+        "modflow6/.github/common/install_intel_windows.bat" $url $cmp
+        rm -rf $TEMP/webimage.exe
+        rm -rf $TEMP/webimage_extracted
+
+    - name: Save oneAPI cache
+      if: steps.oneapi-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ env.ONEAPI_ROOT }}
+        key: oneapi-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+
+    - name: Restore PETSc cache
+      id: petsc-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: petsc
+        key: petsc-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+
+    - name: Download PETSc
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.20.5.tar.gz -O -J
+        mkdir petsc
+        tar -xzf petsc-3.20.5.tar.gz -C petsc --strip-components=1
+
+    - name: Setup Cygwin
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      uses: egor-tensin/setup-cygwin@v4
+      with:
+        packages: python3 make gcc-core gcc-g++ pkg-config
+
+    - name: Hide Cygwin linker
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+      run: |
+        mv /usr/bin/link.exe /usr/bin/link-cygwin.exe
+        which link
+
+    - name: Configure environment
+      shell: bash
+      run: |
+        PETSC_DIR=$GITHUB_WORKSPACE/petsc
+        PETSC_ARCH=arch-mswin-c-opt
+        echo "PETSC_DIR=$PETSC_DIR" >> $GITHUB_ENV
+        echo "PETSC_ARCH=$PETSC_ARCH" >> $GITHUB_ENV
+        echo "$PETSC_DIR/$PETSC_ARCH/lib" >> $GITHUB_PATH
+
+    - name: Configure PETSc
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        "${{ env.ONEAPI_ROOT }}\setvars.bat" intel64 vs2022 && "C:\tools\cygwin\bin\bash.exe" --login --norc -eo pipefail -o igncr "%TEMP%\configure_petsc.sh"
+
+    - name: Build PETSc
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        "${{ env.ONEAPI_ROOT }}\setvars.bat" intel64 vs2022 && "C:\tools\cygwin\bin\bash.exe" --login --norc -eo pipefail -o igncr "%TEMP%\compile_petsc.sh"
+
+    - name: Save PETSc cache
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: petsc
+        key: petsc-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+
+    - name: Build modflow6
+      shell: cmd
+      run: |
+        "${{ env.ONEAPI_ROOT }}\setvars.bat" intel64 vs2022 && "%TEMP%\compile_modflow6.bat"
+
+    - name: Show Meson logs
+      if: failure()
+      shell: bash
+      working-directory: modflow6
+      run: cat builddir/meson-logs/meson-log.txt
+
+    - name: Update flopy
+      working-directory: modflow6/autotest
+      shell: cmd
+      run: micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 python update_flopy.py
+
+    - name: Get executables
+      working-directory: modflow6/autotest
+      shell: cmd
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 pytest -v --durations 0 get_exes.py
+
+    - name: Test programs
+      working-directory: modflow6/autotest
+      shell: cmd 
+      env:
+        REPOS_PATH: ${{ github.workspace }}
+      run: |
+        "${{ env.ONEAPI_ROOT }}\setvars.bat" intel64 vs2022 && "%TEMP%\test_modflow6.bat"

--- a/.github/actions/test-par/action.yml
+++ b/.github/actions/test-par/action.yml
@@ -1,0 +1,81 @@
+name: Test parallel MF6
+description: Build and test parallel MODFLOW 6
+runs:
+  using: "composite"
+  steps:
+
+    - name: Setup GNU Fortran
+      uses: fortran-lang/setup-fortran@v1
+      with:
+        compiler: gcc
+        version: 13
+
+    - name: Checkout PETSc
+      uses: actions/checkout@v4
+      with:
+        repository: petsc/petsc
+        path: petsc
+        ref: release
+
+    - name: Configure environment
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/petsc/linux-gnu/lib/pkgconfig" >> $GITHUB_ENV
+        echo "$GITHUB_WORKSPACE/petsc/linux-gnu/bin" >> $GITHUB_PATH
+
+    - name: Configure environment
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/petsc/arch-darwin-gcc-debug/lib/pkgconfig" >> $GITHUB_ENV
+        echo "$GITHUB_WORKSPACE/petsc/arch-darwin-gcc-debug/bin" >> $GITHUB_PATH
+
+    - name: Configure PETSc
+      if: runner.os == 'Linux'
+      shell: bash
+      working-directory: petsc
+      run: |
+        sudo ./configure PETSC_ARCH=linux-gnu --download-fblaslapack --download-openmpi
+        sudo make all
+
+    - name: Configure PETSc
+      if: runner.os == 'macOS'
+      shell: bash
+      working-directory: petsc
+      run: |
+        sudo ./configure PETSC_DIR="$GITHUB_WORKSPACE/petsc" PETSC_ARCH=arch-darwin-gcc-debug --download-fblaslapack --download-openmpi
+        sudo make all
+
+    - name: Build modflow6
+      shell: bash -l {0}
+      working-directory: modflow6
+      run: |
+        meson setup builddir -Ddebug=false -Dparallel=true --prefix=$(pwd) --libdir=bin
+        meson install -C builddir
+        meson test --verbose --no-rebuild -C builddir
+
+    - name: Show Meson logs
+      if: failure()
+      shell: bash
+      working-directory: modflow6
+      run: cat builddir/meson-logs/meson-log.txt
+
+    - name: Update flopy
+      shell: bash -l {0}
+      working-directory: modflow6/autotest
+      run: python update_flopy.py
+
+    - name: Get executables
+      shell: bash -l {0}
+      working-directory: modflow6/autotest
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: pytest -v --durations 0 get_exes.py
+
+    - name: Test programs
+      shell: bash -l {0}
+      working-directory: modflow6/autotest
+      env:
+        REPOS_PATH: ${{ github.workspace }}
+      run: pytest -v -n auto --parallel --durations 0 -k "test_par" --keep-failed .failed

--- a/.github/common/compile_modflow6.bat
+++ b/.github/common/compile_modflow6.bat
@@ -1,0 +1,6 @@
+set FC=ifort
+cd "%GITHUB_WORKSPACE%\modflow6"
+micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 meson setup builddir -Ddebug=false -Dparallel=true --prefix=%CD% --libdir=bin
+micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 meson install -C builddir
+:: commented until flakiness is resolved
+:: micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 meson test --verbose --no-rebuild -C builddir

--- a/.github/common/compile_modflow6.bat
+++ b/.github/common/compile_modflow6.bat
@@ -2,5 +2,4 @@ set FC=ifort
 cd "%GITHUB_WORKSPACE%\modflow6"
 micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 meson setup builddir -Ddebug=false -Dparallel=true --prefix=%CD% --libdir=bin
 micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 meson install -C builddir
-:: commented until flakiness is resolved
-:: micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 meson test --verbose --no-rebuild -C builddir
+micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 meson test --verbose --no-rebuild -C builddir

--- a/.github/common/compile_petsc.sh
+++ b/.github/common/compile_petsc.sh
@@ -1,0 +1,3 @@
+cd "$GITHUB_WORKSPACE/petsc"
+make all
+make check

--- a/.github/common/configure_petsc.sh
+++ b/.github/common/configure_petsc.sh
@@ -1,0 +1,12 @@
+cd "$GITHUB_WORKSPACE/petsc"
+./configure \
+    --with-debugging=0 \
+    --with-shared-libraries=1 \
+    --with-cc='cl' \
+    --with-fc='ifort' \
+    --with-cxx='cl' \
+    --with-blaslapack-lib='-L/cygdrive/c/PROGRA~2/Intel/oneAPI/mkl/latest/lib mkl_intel_lp64_dll.lib mkl_sequential_dll.lib mkl_core_dll.lib' \
+    --with-mpi-include='/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/include' \
+    --with-mpi-lib='/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/lib/impi.lib' \
+    --with-mpiexec='/cygdrive/c/PROGRA~2/Intel/oneAPI/mpi/latest/bin/mpiexec -localonly' \
+    --with-python-exec='/usr/bin/PYTHON~1.EXE'

--- a/.github/common/install_intel_windows.bat
+++ b/.github/common/install_intel_windows.bat
@@ -1,0 +1,8 @@
+@echo off
+
+:: download and unpack installer
+curl.exe --output %TEMP%\webimage.exe --url %1 --retry 5 --retry-delay 5
+start /b /wait %TEMP%\webimage.exe -s -x -f %TEMP%\webimage_extracted --log %TEMP%\extract.log
+
+:: run installer
+%TEMP%\webimage_extracted\bootstrapper.exe -s --action install --components=%2 --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=1 --log-dir=%TEMP%

--- a/.github/common/test_modflow6.bat
+++ b/.github/common/test_modflow6.bat
@@ -1,0 +1,3 @@
+cd "%GITHUB_WORKSPACE%\modflow6\autotest"
+ldd ..\bin\mf6
+micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 pytest -v -n auto --parallel -k "test_par" --durations 0 --keep-failed .failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,101 +422,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-12 ] #, windows-2022 ]
+        os: [ ubuntu-22.04, macos-12, windows-2022 ]
     defaults:
       run:
         shell: bash -l {0}
-    env:
-      FC: gfortran
-      FC_V: 12
+    
     steps:
 
       - name: Checkout modflow6
         uses: actions/checkout@v4
         with:
           path: modflow6
-
-      - name: Setup MSYS2
-        if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
-        with:
-          update: true
-          install: |
-            git
-            make
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-python
-            mingw-w64-x86_64-python-pip
-            mingw-w64-x86_64-python-pytest
-
-      - name: Setup MPI
-        if: runner.os == 'Windows'
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: msmpi
-
-      - name: Setup ${{ env.FC }} ${{ env.FC_V }}
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: ${{ env.FC_V }}
-
-      - name: Cache PETSc
-        id: cache-petsc
-        uses: actions/cache@v4
-        with:
-          path: petsc
-          key: ${{ runner.os }}-petsc
-
-      - name: Clone PETSc
-        if: runner.os != 'Windows' && steps.cache-petsc.outputs.cache-hit != 'true'
-        run: git clone -b release https://gitlab.com/petsc/petsc.git petsc
-
-      - name: Download PETSc
-        if: runner.os == 'Windows'
-        run: |
-          curl https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.18.4.tar.gz -O -J
-          mkdir petsc
-          tar -xzf petsc-3.18.4.tar.gz -C petsc --strip-components=1
-
-      - name: Configure environment
-        if: runner.os == 'Linux'
-        run: |
-          echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/petsc/linux-gnu/lib/pkgconfig" >> $GITHUB_ENV
-          echo "$GITHUB_WORKSPACE/petsc/linux-gnu/bin" >> $GITHUB_PATH
-
-      - name: Configure environment
-        if: runner.os == 'macOS'
-        run: |
-          echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/petsc/arch-darwin-gcc-debug/lib/pkgconfig" >> $GITHUB_ENV
-          echo "$GITHUB_WORKSPACE/petsc/arch-darwin-gcc-debug/bin" >> $GITHUB_PATH
-
-      - name: Configure PETSc
-        if: runner.os == 'Linux'
-        working-directory: petsc
-        run: |
-          sudo ./configure PETSC_ARCH=linux-gnu --download-fblaslapack --download-openmpi
-          sudo make all
-
-      - name: Configure PETSc
-        if: runner.os == 'macOS'
-        working-directory: petsc
-        run: |
-          sudo ./configure PETSC_DIR="$GITHUB_WORKSPACE/petsc" PETSC_ARCH=arch-darwin-gcc-debug --download-fblaslapack --download-openmpi
-          sudo make all
-
-      - name: Configure PETSc
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
-        working-directory: petsc
-        run: |
-          pacman -Syu
-          pacman -Sy --noconfirm autoconf automake-wrapper bison bsdcpio make git \
-            mingw-w64-x86_64-toolchain patch python flex \
-            pkg-config pkgfile tar unzip mingw-w64-x86_64-cmake \
-            mingw-w64-x86_64-msmpi mingw-w64-x86_64-openblas mingw-w64-x86_64-jq
-          /usr/bin/python ./configure --with-mpiexec='/C/Program\ Files/Microsoft\ MPI/Bin/mpiexec' --with-shared-libraries=0
-          make all
 
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1
@@ -528,42 +444,17 @@ jobs:
           cache-environment: true
           cache-downloads: true
 
-      - name: Build modflow6
-        working-directory: modflow6
-        run: |
-          meson setup builddir -Ddebug=false -Dparallel=true --prefix=$(pwd) --libdir=bin
-          meson install -C builddir
-          meson test --verbose --no-rebuild -C builddir
+      - name: Test parallel MF6
+        if: runner.os != 'Windows'
+        uses: ./modflow6/.github/actions/test-par
 
-      - name: Show Meson logs
-        if: failure()
-        working-directory: modflow6
-        run: cat builddir/meson-logs/meson-log.txt
-
-      - name: Update flopy
-        working-directory: modflow6/autotest
-        run: python update_flopy.py
-
-      - name: Get executables
-        working-directory: modflow6/autotest
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: pytest -v --durations 0 get_exes.py
-
-      - name: Test programs (parallel)
-        working-directory: modflow6/autotest
-        env:
-          REPOS_PATH: ${{ github.workspace }}
-        run: |
-          branch="${{ github.ref_name }}"
-          marker="not large"
-          markers=$([ "$branch" == "master" ] && echo "$marker and not developmode" || echo "$marker")
-          pytest -v -n auto --parallel --durations 0 -m "$markers" --keep-failed .failed
+      - name: Test parallel MF6 (Windows)
+        if: runner.os == 'Windows'
+        uses: ./modflow6/.github/actions/test-par-win
 
       - name: Upload failed test output
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: failed-${{ matrix.os }}-${{ env.FC }}-${{ env.FC_V }}
+          name: failed-${{ matrix.os }}
           path: modflow6/autotest/.failed
-          

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths-ignore:
       - '.github/workflows/release.yml'
+      - '.github/workflows/ci.yml'
       - '.hpc/**'
   pull_request:
     branches:

--- a/autotest/framework.py
+++ b/autotest/framework.py
@@ -92,9 +92,14 @@ def run_parallel(workspace, target, ncpus) -> Tuple[bool, List[str]]:
     buff = []
 
     # parallel commands
-    mpiexec_cmd = (
-        ["mpiexec"] + oversubscribed + ["-np", str(ncpus), target, "-p"]
-    )
+    if get_ostag() in ["win64"]:
+        mpiexec_cmd = (
+        ["mpiexec", "-np", str(ncpus), target, "-p"]
+        )
+    else:
+        mpiexec_cmd = (
+            ["mpiexec"] + oversubscribed + ["-np", str(ncpus), target, "-p"]
+        )
 
     proc = Popen(mpiexec_cmd, stdout=PIPE, stderr=STDOUT, cwd=workspace)
 

--- a/meson.build
+++ b/meson.build
@@ -72,6 +72,7 @@ if fc_id == 'intel-cl'
                    '/Qdiag-disable:7416', # f2008 warning
                    '/Qdiag-disable:7025', # f2008 warning
                    '/Qdiag-disable:5268', # Line too long
+                   '/Qdiag-disable:10448',# ifort deprecation warning
                   ]
   link_args += ['/ignore:4217', # access through ddlimport might be inefficient
                 '/ignore:4286'  # same as 4217, but more general
@@ -128,8 +129,11 @@ endif
 message('Extended build:', is_extended_build)
 
 # windows options for petsc
-petsc_dir = meson.project_source_root() / '..' /'petsc-3.18.5'
-petsc_arch = 'arch-ci-mswin-intel-modflow6'
+petsc_dir_rel = '..' /'petsc'
+petsc_dir_abs = meson.project_source_root() / '..' /'petsc'
+petsc_arch = 'arch-mswin-c-opt'
+petsc_compiled_rel = petsc_dir_rel / petsc_arch
+petsc_compiled_abs = petsc_dir_abs / petsc_arch
 
 # on windows only with intel
 if build_machine.system() == 'windows' and is_extended_build
@@ -149,8 +153,7 @@ if is_extended_build
     petsc = dependency('PETSc', required : true)
   else
     # directly look for petsc
-    petsc_compiled = petsc_dir / petsc_arch
-    petsc = fc.find_library('libpetsc', dirs: petsc_compiled / 'lib', required : true)
+    petsc = fc.find_library('libpetsc', dirs: petsc_compiled_abs / 'lib', required : true)
   endif
   extra_cmp_args += [ '-D__WITH_PETSC__' ]
   dependencies += petsc
@@ -194,8 +197,8 @@ add_project_link_arguments(fc.get_supported_arguments(link_args), language: 'for
 
 if is_extended_build and build_machine.system() == 'windows'
   message('Compiling PETSc Fortran modules')
-  petsc_incdir = include_directories([petsc_dir / 'include', petsc_compiled / 'include'])
-  petsc_src = petsc_dir / 'src'
+  petsc_incdir = include_directories([petsc_dir_rel / 'include', petsc_compiled_rel / 'include'])
+  petsc_src = petsc_dir_abs / 'src'
   sources_petsc = [petsc_src / 'dm/f90-mod/petscdmdamod.F90',
                   petsc_src / 'dm/f90-mod/petscdmmod.F90',
                   petsc_src / 'dm/f90-mod/petscdmplexmod.F90',

--- a/meson.build
+++ b/meson.build
@@ -238,11 +238,11 @@ testdir = meson.project_source_root() / '.mf6minsim'
 if with_mpi
   mpiexec = find_program('mpiexec', required : false)
   if mpiexec.found()
-    test('Parallel version command line test', mpiexec, args : ['-n', '2', mf6exe, '-v', '-p'])
-    test('Parallel compiler command line test', mpiexec, args : ['-n', '2', mf6exe, '-c', '-p'])
-    test('Serial simulation test', mf6exe, workdir : testdir)
-    test('Parallel simulation test - 1 core', mpiexec, workdir : testdir, args : ['-n', '1', mf6exe, '-p'])
-    test('Parallel simulation test - 2 cores', mpiexec, workdir : testdir, args : ['-n', '2', mf6exe, '-p'])
+    test('Parallel version command line test', mpiexec, args : ['-n', '2', mf6exe, '-v', '-p'], is_parallel : false)
+    test('Parallel compiler command line test', mpiexec, args : ['-n', '2', mf6exe, '-c', '-p'], is_parallel : false)
+    test('Serial simulation test', mf6exe, workdir : testdir, is_parallel : false)
+    test('Parallel simulation test - 1 core', mpiexec, workdir : testdir, args : ['-n', '1', mf6exe, '-p'], is_parallel : false)
+    test('Parallel simulation test - 2 cores', mpiexec, workdir : testdir, args : ['-n', '2', mf6exe, '-p'], is_parallel : false)
   endif
 else
   test('Version command line test', mf6exe, args : ['-v',])


### PR DESCRIPTION
CI test mf6 parallel on Windows. Step toward a Windows parallel distribution.

* use [cygwin approach](https://petsc.org/main/install/windows/#cygwin-gnu-compilers-on-microsoft-windows) to build petsc with `ifort` and `cl`
* factor out actions for parallel testing on windows/non-windows
* factor out scripts for windows steps needing special treatment
* cache oneAPI and PETSc, installing/building is slow

Parallel autotests pass, but there are a couple remaining (but non-blocking) issues

* PETSc `make check` reports some errors, but they don't seem to invalidate the build
* `meson test` fails intermittently on "Parallel simulation test - 2 cores" on Windows, for now it's skipped

@mjr-deltares should these be solved before merging or should we come back to them?