### PR TITLE
ci: test oldest supported python (currently 3.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,8 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: modflow6/environment.yml
+          create-args: >-
+            python=3.9
           init-shell: >-
             bash
             powershell
@@ -438,6 +440,8 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: modflow6/environment.yml
+          create-args: >-
+            python=3.9
           init-shell: >-
             bash
             powershell

--- a/autotest/test_swf_dfw_bowl.py
+++ b/autotest/test_swf_dfw_bowl.py
@@ -253,7 +253,7 @@ def check_output(idx, test):
     # print out the answer in a form that can be 
     # dropped into this script, if necessary, as the answer
     for v in stage_all[-1].flatten():
-        print(f"{2*"    "}{v:.8f},")
+        print(f"{v:18.8f},")
 
     msg = (
         "Simulated stage does not match with the answer "


### PR DESCRIPTION
* probably want to maintain compatibility until version EOL
* catch syntax usages only supported on newer versions
* raised in https://github.com/MODFLOW-USGS/modflow6/pull/1673#discussion_r1527624056
* update print format syntax in `test_swf_dfw_bowl.py`