### PR TITLE
ci(parallel): don't use -n auto on windows to avoid oversubscription

### DIFF
--- a/.github/common/test_modflow6.bat
+++ b/.github/common/test_modflow6.bat
@@ -1,4 +1,4 @@
 cd "%GITHUB_WORKSPACE%\modflow6\autotest"
 where libpetsc.dll
 ldd ..\bin\mf6
-micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 pytest -v -n 2 --parallel -k "test_par" --durations 0 --keep-failed .failed
+micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 pytest -v --parallel -k "test_par" --durations 0 --keep-failed .failed

--- a/.github/common/test_modflow6.bat
+++ b/.github/common/test_modflow6.bat
@@ -1,4 +1,4 @@
 cd "%GITHUB_WORKSPACE%\modflow6\autotest"
 where libpetsc.dll
 ldd ..\bin\mf6
-micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 pytest -v -n auto --parallel -k "test_par" --durations 0 --keep-failed .failed
+micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 pytest -v -n 2 --parallel -k "test_par" --durations 0 --keep-failed .failed


### PR DESCRIPTION
* runner VM [has 4 cores](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), most parallel tests are 2-way split, so use `-n 2`
* hoping to reduce parallel CI runtime