### PR TITLE
refactor(swf-dfw): remove slope as input variable

### DIFF
--- a/autotest/test_swf_dfw.py
+++ b/autotest/test_swf_dfw.py
@@ -82,7 +82,6 @@ def build_models(idx, test):
         print_flows=True,
         save_flows=True,
         manningsn=0.035,
-        slope=0.001,
         idcxs=0,
     )
 

--- a/autotest/test_swf_dfw_beg2022.py
+++ b/autotest/test_swf_dfw_beg2022.py
@@ -100,7 +100,6 @@ def build_models(idx, test):
         print_flows=True,
         save_flows=True,
         manningsn=1.0 / 80.0,
-        slope=slope,
         idcxs=0,
     )
 

--- a/autotest/test_swf_dfw_bowl.py
+++ b/autotest/test_swf_dfw_bowl.py
@@ -117,7 +117,6 @@ def build_models(idx, test):
         print_flows=True,
         save_flows=True,
         manningsn=0.035,
-        slope=1 / dx,
         idcxs=0,
     )
 

--- a/autotest/test_swf_dfw_gwf.py
+++ b/autotest/test_swf_dfw_gwf.py
@@ -114,7 +114,6 @@ def add_swf_model(sim):
         length_conversion=1.0,
         time_conversion=86400.0,
         manningsn=0.035,
-        slope=0.001,
         idcxs=0,
     )
 

--- a/autotest/test_swf_dfw_loop.py
+++ b/autotest/test_swf_dfw_loop.py
@@ -249,7 +249,6 @@ def build_models(idx, test):
         print_flows=True,
         save_flows=True,
         manningsn=0.03,
-        slope=0.001,
         idcxs=idcxs,
     )
 

--- a/autotest/test_swf_dfw_swrt2.py
+++ b/autotest/test_swf_dfw_swrt2.py
@@ -104,7 +104,6 @@ def build_models(idx, test):
         print_flows=True,
         save_flows=True,
         manningsn=0.30,
-        slope=0.05 / 500.0,
         idcxs=None,
     )
 

--- a/autotest/test_swf_dfw_swrt2b.py
+++ b/autotest/test_swf_dfw_swrt2b.py
@@ -114,7 +114,6 @@ def build_models(idx, test):
         print_flows=True,
         save_flows=True,
         manningsn=0.30,
-        slope=0.05 / 500.0,
         idcxs=None,
     )
 

--- a/autotest/test_swf_dfw_swrt2dis.py
+++ b/autotest/test_swf_dfw_swrt2dis.py
@@ -117,7 +117,6 @@ def build_models(idx, test):
         print_flows=True,
         save_flows=True,
         manningsn=0.30,
-        slope=0.05 / 500.0,
         idcxs=None,
     )
 

--- a/autotest/test_swf_vcatch.py
+++ b/autotest/test_swf_vcatch.py
@@ -141,7 +141,6 @@ def build_models(idx, test):
         print_flows=False,
         save_flows=True,
         manningsn=rough,
-        slope=-3e30,  # todo: this is reason to get rid of slope as input
         idcxs=None,
     )
 

--- a/doc/mf6io/mf6ivar/dfn/swf-dfw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-dfw.dfn
@@ -102,17 +102,6 @@ longname mannings roughness coefficient
 description mannings roughness coefficient
 
 block griddata
-name slope
-type double precision
-shape (nodes)
-valid
-reader readarray
-layered false
-optional
-longname bottom slope
-description bottom slope of the river bed
-
-block griddata
 name idcxs
 type integer
 shape (nodes)

--- a/doc/mf6io/mf6ivar/md/mf6ivar.md
+++ b/doc/mf6io/mf6ivar/md/mf6ivar.md
@@ -1578,7 +1578,6 @@
 | SWF | DFW | OPTIONS | FILEIN | KEYWORD | keyword to specify that an input filename is expected next. |
 | SWF | DFW | OPTIONS | OBS6_FILENAME | STRING | name of input file to define observations for the DFW package. See the ``Observation utility'' section for instructions for preparing observation input files. Tables \ref{table:gwf-obstypetable} and \ref{table:gwt-obstypetable} lists observation type(s) supported by the DFW package. |
 | SWF | DFW | GRIDDATA | MANNINGSN | DOUBLE PRECISION (NODES) | mannings roughness coefficient |
-| SWF | DFW | GRIDDATA | SLOPE | DOUBLE PRECISION (NODES) | bottom slope of the river bed |
 | SWF | DFW | GRIDDATA | IDCXS | INTEGER (NODES) | integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide. |
 | SWF | CXS | OPTIONS | PRINT_INPUT | KEYWORD | keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read. |
 | SWF | CXS | DIMENSIONS | NSECTIONS | INTEGER | integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block. |

--- a/doc/mf6io/mf6ivar/tex/swf-dfw-desc.tex
+++ b/doc/mf6io/mf6ivar/tex/swf-dfw-desc.tex
@@ -25,8 +25,6 @@
 \begin{description}
 \item \texttt{manningsn}---mannings roughness coefficient
 
-\item \texttt{slope}---bottom slope of the river bed
-
 \item \texttt{idcxs}---integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide.
 
 \end{description}

--- a/doc/mf6io/mf6ivar/tex/swf-dfw-griddata.dat
+++ b/doc/mf6io/mf6ivar/tex/swf-dfw-griddata.dat
@@ -1,8 +1,6 @@
 BEGIN GRIDDATA
   MANNINGSN
     <manningsn(nodes)> -- READARRAY
-  SLOPE
-    <slope(nodes)> -- READARRAY
   [IDCXS
     <idcxs(nodes)> -- READARRAY]
 END GRIDDATA

--- a/src/Idm/swf-dfwidm.f90
+++ b/src/Idm/swf-dfwidm.f90
@@ -21,7 +21,6 @@ module SwfDfwInputModule
     logical :: filein = .false.
     logical :: obs6_filename = .false.
     logical :: manningsn = .false.
-    logical :: slope = .false.
     logical :: idcxs = .false.
   end type SwfDfwParamFoundType
 
@@ -198,23 +197,6 @@ module SwfDfwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    swfdfw_slope = InputParamDefinitionType &
-    ( &
-    'SWF', & ! component
-    'DFW', & ! subcomponent
-    'GRIDDATA', & ! block
-    'SLOPE', & ! tag name
-    'SLOPE', & ! fortran variable
-    'DOUBLE1D', & ! type
-    'NODES', & ! shape
-    .true., & ! required
-    .false., & ! multi-record
-    .false., & ! preserve case
-    .false., & ! layered
-    .false. & ! timeseries
-    )
-
-  type(InputParamDefinitionType), parameter :: &
     swfdfw_idcxs = InputParamDefinitionType &
     ( &
     'SWF', & ! component
@@ -244,7 +226,6 @@ module SwfDfwInputModule
     swfdfw_filein, &
     swfdfw_obs6_filename, &
     swfdfw_manningsn, &
-    swfdfw_slope, &
     swfdfw_idcxs &
     ]
 

--- a/src/Model/SurfaceWaterFlow/swf-dfw.f90
+++ b/src/Model/SurfaceWaterFlow/swf-dfw.f90
@@ -8,7 +8,6 @@
 ! todo:
 !   Move Newton to FN routines
 !   Implement a proper perturbation epsilon
-!   Is slope input parameter needed?
 !   Parameterize the smoothing depth?
 !
 module SwfDfwModule
@@ -41,9 +40,8 @@ module SwfDfwModule
     integer(I4B), pointer :: icentral => null() !< flag to use central in space weighting (default is upstream weighting)
     real(DP), pointer :: unitconv !< conversion factor used in mannings equation; calculated from timeconv and lengthconv
     real(DP), pointer :: timeconv !< conversion factor from model length units to meters (1.0 if model uses meters for length)
-    real(DP), pointer :: lengthconv !< conversion factor frommodel time units to seconds (1.0 if model uses seconds for time)
+    real(DP), pointer :: lengthconv !< conversion factor from model time units to seconds (1.0 if model uses seconds for time)
     real(DP), dimension(:), pointer, contiguous :: manningsn => null() !< mannings roughness for each reach
-    real(DP), dimension(:), pointer, contiguous :: slope => null() !< slope for each reach
     integer(I4B), dimension(:), pointer, contiguous :: idcxs => null() !< cross section id for each reach
     integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !< pointer to model ibound
     integer(I4B), dimension(:), pointer, contiguous :: icelltype => null() !< set to 1 and is accessed by chd for checking
@@ -213,8 +211,6 @@ contains
     ! -- user-provided input
     call mem_allocate(this%manningsn, this%dis%nodes, &
                       'MANNINGSN', this%memoryPath)
-    call mem_allocate(this%slope, this%dis%nodes, &
-                      'SLOPE', this%memoryPath)
     call mem_allocate(this%idcxs, this%dis%nodes, &
                       'IDCXS', this%memoryPath)
     call mem_allocate(this%icelltype, this%dis%nodes, &
@@ -222,7 +218,6 @@ contains
 
     do n = 1, this%dis%nodes
       this%manningsn(n) = DZERO
-      this%slope(n) = DZERO
       this%idcxs(n) = 0
       this%icelltype(n) = 1
     end do
@@ -386,18 +381,11 @@ contains
     ! -- update defaults with idm sourced values
     call mem_set_value(this%manningsn, 'MANNINGSN', &
                        idmMemoryPath, map, found%manningsn)
-    call mem_set_value(this%slope, 'SLOPE', idmMemoryPath, map, found%slope)
     call mem_set_value(this%idcxs, 'IDCXS', idmMemoryPath, map, found%idcxs)
     !
     ! -- ensure MANNINGSN was found
     if (.not. found%manningsn) then
       write (errmsg, '(a)') 'Error in GRIDDATA block: MANNINGSN not found.'
-      call store_error(errmsg)
-    end if
-    !
-    ! -- ensure SLOPE was found
-    if (.not. found%slope) then
-      write (errmsg, '(a)') 'Error in GRIDDATA block: SLOPE not found.'
       call store_error(errmsg)
     end if
 
@@ -425,10 +413,6 @@ contains
 
     if (found%manningsn) then
       write (this%iout, '(4x,a)') 'MANNINGSN set from input file'
-    end if
-
-    if (found%slope) then
-      write (this%iout, '(4x,a)') 'SLOPE set from input file'
     end if
 
     if (found%idcxs) then
@@ -1028,7 +1012,6 @@ contains
     !
     ! -- Deallocate arrays
     call mem_deallocate(this%manningsn)
-    call mem_deallocate(this%slope)
     call mem_deallocate(this%idcxs)
     call mem_deallocate(this%icelltype)
 


### PR DESCRIPTION
Slope does not need to be an input parameter in DFW.  It can be calculated from the elevations in the DIS packages.