### PR TITLE
ci(parallel): nightly cache warming for mf6 parallel oneapi components

### DIFF
--- a/.github/actions/build-par-win/action.yml
+++ b/.github/actions/build-par-win/action.yml
@@ -29,39 +29,8 @@ runs:
       shell: bash
       run: echo "ONEAPI_ROOT=C:\Program Files (x86)\Intel\oneAPI" >> "$GITHUB_ENV"
 
-    - name: Restore oneAPI cache
-      id: oneapi-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: ${{ env.ONEAPI_ROOT }}
-        key: oneapi-${{ runner.os }}-${{ steps.get-date.outputs.date }}
-
-    - name: Install oneAPI BaseKit
-      shell: bash
-      if: steps.oneapi-cache.outputs.cache-hit != 'true'
-      run: |
-        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5cb30fb9-21e9-47e8-82da-a91e00191670/w_BaseKit_p_2024.0.1.45_offline.exe"
-        cmp="intel.oneapi.win.mkl.devel"
-        "modflow6/.github/common/install_intel_windows.bat" $url $cmp
-        rm -rf $TEMP/webimage.exe
-        rm -rf $TEMP/webimage_extracted
-
-    - name: Install oneAPI HPCKit
-      shell: bash
-      if: steps.oneapi-cache.outputs.cache-hit != 'true'
-      run: |
-        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7a6db8a1-a8b9-4043-8e8e-ca54b56c34e4/w_HPCKit_p_2024.0.1.35_offline.exe"
-        cmp="intel.oneapi.win.cpp-dpcpp-common:intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel"
-        "modflow6/.github/common/install_intel_windows.bat" $url $cmp
-        rm -rf $TEMP/webimage.exe
-        rm -rf $TEMP/webimage_extracted
-
-    - name: Save oneAPI cache
-      if: steps.oneapi-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
-      with:
-        path: ${{ env.ONEAPI_ROOT }}
-        key: oneapi-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+    - name: Setup oneAPI
+      uses: ./modflow6/.github/actions/setup-par-oneapi
 
     - name: Restore PETSc cache
       id: petsc-cache

--- a/.github/actions/setup-par-oneapi/action.yml
+++ b/.github/actions/setup-par-oneapi/action.yml
@@ -1,0 +1,48 @@
+name: Setup oneAPI for parallel MF6
+description: Setup oneAPI components for parallel MODFLOW 6
+runs:
+  using: "composite"
+  steps:
+
+    - name: Get date
+      id: get-date
+      shell: bash
+      run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
+
+    - name: Set oneAPI install dir
+      shell: bash
+      run: echo "ONEAPI_ROOT=C:\Program Files (x86)\Intel\oneAPI" >> "$GITHUB_ENV"
+
+    - name: Restore oneAPI cache
+      id: oneapi-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: ${{ env.ONEAPI_ROOT }}
+        key: oneapi-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+
+    - name: Install oneAPI BaseKit
+      shell: bash
+      if: steps.oneapi-cache.outputs.cache-hit != 'true'
+      run: |
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5cb30fb9-21e9-47e8-82da-a91e00191670/w_BaseKit_p_2024.0.1.45_offline.exe"
+        cmp="intel.oneapi.win.mkl.devel"
+        "modflow6/.github/common/install_intel_windows.bat" $url $cmp
+        rm -rf $TEMP/webimage.exe
+        rm -rf $TEMP/webimage_extracted
+
+    - name: Install oneAPI HPCKit
+      shell: bash
+      if: steps.oneapi-cache.outputs.cache-hit != 'true'
+      run: |
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7a6db8a1-a8b9-4043-8e8e-ca54b56c34e4/w_HPCKit_p_2024.0.1.35_offline.exe"
+        cmp="intel.oneapi.win.cpp-dpcpp-common:intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel"
+        "modflow6/.github/common/install_intel_windows.bat" $url $cmp
+        rm -rf $TEMP/webimage.exe
+        rm -rf $TEMP/webimage_extracted
+
+    - name: Save oneAPI cache
+      if: steps.oneapi-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ env.ONEAPI_ROOT }}
+        key: oneapi-${{ runner.os }}-${{ steps.get-date.outputs.date }}

--- a/.github/workflows/large.yml
+++ b/.github/workflows/large.yml
@@ -17,6 +17,8 @@ jobs:
         include:
           # ifx
           - {os: windows-2022, compiler: intel, version: 2022.2}
+          # use this combo to install and cache oneapi components for mf6 parallel (compilers + mkl/mpi)
+          - {os: windows-2022, compiler: intel, version: 2024.0}
           # ifort
           - {os: windows-2022, compiler: intel-classic, version: "2021.10"}
           - {os: windows-2022, compiler: intel-classic, version: 2021.9}
@@ -25,10 +27,21 @@ jobs:
           - {os: windows-2022, compiler: intel-classic, version: 2021.6}
     steps:
       - name: Setup ${{ matrix.compiler }} ${{ matrix.version }}
+        if: (!(matrix.compiler == 'intel' && matrix.version == '2024.0'))
         uses: fortran-lang/setup-fortran@v1
         with:
           compiler: ${{ matrix.compiler }}
           version: ${{ matrix.version }}
+
+      - name: Checkout modflow6
+        if: matrix.compiler == 'intel' && matrix.version == '2024.0'
+        uses: actions/checkout@v4
+        with:
+          path: modflow6
+
+      - name: Setup oneAPI
+        if: matrix.compiler == 'intel' && matrix.version == '2024.0'
+        uses: ./modflow6/.github/actions/setup-par-oneapi
   test:
     name: Test
     runs-on: ubuntu-22.04


### PR DESCRIPTION
* followup to #1685
* installs can take 30+ min and not handled by setup-fortran, so need to cache manually
* factor out an action for mf6 parallel oneapi install