### PR TITLE
perf(PRT): allocate cell defn arrays lazily

### DIFF
--- a/autotest/test_prt_voronoi1.py
+++ b/autotest/test_prt_voronoi1.py
@@ -535,7 +535,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, benchmark):
     if (
         "weli" in name
         and system() == "Darwin"
@@ -552,4 +552,4 @@ def test_mf6model(idx, name, function_tmpdir, targets):
         targets=targets,
         compare=None,
     )
-    test.run()
+    benchmark(test.run)

--- a/src/Model/ParticleTracking/prt-oc.f90
+++ b/src/Model/ParticleTracking/prt-oc.f90
@@ -8,7 +8,6 @@ module PrtOcModule
   use SimVariablesModule, only: errmsg, warnmsg
   use MemoryManagerModule, only: mem_allocate, mem_deallocate, mem_reallocate
   use MemoryHelperModule, only: create_mem_path
-  use ArrayHandlersModule, only: ExpandArray
   use BlockParserModule, only: BlockParserType
   use InputOutputModule, only: urword, openfile
   use TimeSelectModule, only: TimeSelectType

--- a/src/Solution/ParticleTracker/CellDefn.f90
+++ b/src/Solution/ParticleTracker/CellDefn.f90
@@ -41,6 +41,11 @@ contains
   subroutine create_defn(cellDefn)
     type(CellDefnType), pointer :: cellDefn
     allocate (cellDefn)
+    ! Initially, allocate arrays to size for structured grid tracking method.
+    ! They can be (lazily) expanded as necessary for the unstructured method.
+    allocate (cellDefn%ispv180(5))
+    allocate (cellDefn%facenbr(7))
+    allocate (cellDefn%faceflow(7))
   end subroutine create_defn
 
   !> @brief Return the number of polygon vertices

--- a/src/Solution/ParticleTracker/CellPoly.f90
+++ b/src/Solution/ParticleTracker/CellPoly.f90
@@ -1,7 +1,7 @@
 module CellPolyModule
 
   use CellModule, only: CellType
-  use CellDefnModule, only: CellDefnType
+  use CellDefnModule, only: CellDefnType, create_defn
   implicit none
 
   private
@@ -19,7 +19,7 @@ contains
   subroutine create_cell_poly(cell)
     type(CellPolyType), pointer :: cell
     allocate (cell)
-    allocate (cell%defn)
+    call create_defn(cell%defn)
     allocate (cell%type)
     cell%type = 'poly'
   end subroutine create_cell_poly

--- a/src/Solution/ParticleTracker/CellRect.f90
+++ b/src/Solution/ParticleTracker/CellRect.f90
@@ -1,7 +1,7 @@
 module CellRectModule
 
   use CellModule, only: CellType
-  use CellDefnModule, only: CellDefnType
+  use CellDefnModule, only: CellDefnType, create_defn
   implicit none
 
   private
@@ -39,7 +39,7 @@ contains
   subroutine create_cell_rect(cell)
     type(CellRectType), pointer :: cell
     allocate (cell)
-    allocate (cell%defn)
+    call create_defn(cell%defn)
     allocate (cell%type)
     cell%type = 'rect'
   end subroutine create_cell_rect

--- a/src/Solution/ParticleTracker/CellRectQuad.f90
+++ b/src/Solution/ParticleTracker/CellRectQuad.f90
@@ -1,7 +1,7 @@
 module CellRectQuadModule
 
   use CellModule, only: CellType
-  use CellDefnModule, only: CellDefnType
+  use CellDefnModule, only: CellDefnType, create_defn
   implicit none
 
   private
@@ -43,7 +43,7 @@ contains
   subroutine create_cell_rect_quad(cell)
     type(CellRectQuadType), pointer :: cell
     allocate (cell)
-    allocate (cell%defn)
+    call create_defn(cell%defn)
     allocate (cell%irectvert(5))
     allocate (cell%ipv4irv(2, 4))
     allocate (cell%rectflow(2, 4))

--- a/src/Solution/ParticleTracker/MethodCellTernary.f90
+++ b/src/Solution/ParticleTracker/MethodCellTernary.f90
@@ -9,7 +9,6 @@ module MethodCellTernaryModule
   use SubcellTriModule, only: SubcellTriType, create_subcell_tri
   use ParticleModule
   use TrackModule, only: TrackFileControlType
-  use ArrayHandlersModule, only: ExpandArray
   implicit none
 
   private

--- a/src/Solution/ParticleTracker/MethodDis.f90
+++ b/src/Solution/ParticleTracker/MethodDis.f90
@@ -11,7 +11,6 @@ module MethodDisModule
   use DisModule, only: DisType
   use TrackModule, only: TrackFileControlType
   use GeomUtilModule, only: get_ijk, get_jk
-  use ArrayHandlersModule, only: ExpandArray
   implicit none
 
   private
@@ -285,7 +284,6 @@ contains
       call this%load_nbrs_to_defn(defn)
 
       ! -- Load 180 degree face indicators
-      call ExpandArray(defn%ispv180, defn%npolyverts + 1)
       defn%ispv180(1:defn%npolyverts + 1) = .false.
 
       ! -- Load flows (assumes face neighbors already loaded)
@@ -314,9 +312,6 @@ contains
     integer(I4B) :: klay1
     integer(I4B) :: klay2
     integer(I4B) :: iedgeface
-
-    ! -- Allocate facenbr array
-    call ExpandArray(defn%facenbr, defn%npolyverts + 3)
 
     select type (dis => this%fmi%dis)
     type is (DisType)
@@ -379,9 +374,6 @@ contains
 
     ic = defn%icell
     npolyverts = defn%npolyverts
-
-    ! -- allocate faceflow array
-    call ExpandArray(defn%faceflow, npolyverts + 3)
 
     ! -- Load face flows.
     defn%faceflow = 0d0 ! kluge note: eventually use DZERO for 0d0 throughout

--- a/src/Solution/ParticleTracker/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/MethodDisv.f90
@@ -378,8 +378,9 @@ contains
     ic = defn%icell
     npolyverts = defn%npolyverts
 
-    ! -- allocate facenbr array
-    call ExpandArray(defn%facenbr, npolyverts + 3)
+    ! -- expand facenbr array if needed
+    if (size(defn%facenbr) < npolyverts + 3) &
+      call ExpandArray(defn%facenbr, npolyverts + 3)
 
     select type (dis => this%fmi%dis)
     type is (DisvType)
@@ -403,6 +404,7 @@ contains
                              dis%javert(istart2:istop2), &
                              iedgeface)
         if (iedgeface /= 0) then
+
           ! -- Edge (polygon) face neighbor
           defn%facenbr(iedgeface) = int(iloc, 1)
         else
@@ -476,8 +478,9 @@ contains
     ic = defn%icell
     npolyverts = defn%npolyverts
 
-    ! -- allocate faceflow array
-    call ExpandArray(defn%faceflow, npolyverts + 3)
+    ! -- expand faceflow array if needed
+    if (size(defn%faceflow) < npolyverts + 3) &
+      call ExpandArray(defn%faceflow, npolyverts + 3)
 
     ! -- Load face flows. Note that the faceflow array
     ! -- does not get reallocated if it is already allocated
@@ -687,8 +690,9 @@ contains
     ic = defn%icell
     npolyverts = defn%npolyverts
 
-    ! -- allocate ispv180 array
-    call ExpandArray(defn%ispv180, npolyverts + 1)
+    ! -- expand ispv180 array if needed
+    if (size(defn%ispv180) < npolyverts + 3) &
+      call ExpandArray(defn%ispv180, npolyverts + 1)
 
     ! -- Load 180-degree indicator.
     ! -- Also, set flags that indicate how cell can be represented.


### PR DESCRIPTION
Performance issue discovered while working on https://github.com/MODFLOW-USGS/modflow6-examples/pull/161. Previously cell definition arrays (face flows, face neighbors, etc) were reallocated for each subcell regardless of tracking method. This introduced overhead for each subcell solve, scaling with the total particle count.
Probably unnoticed until now because a) autotests have fairly low particle counts and b) the initial draft of MP7 example P01 used a smaller number of particles for debugging.

Reallocation can be skipped for structured grids since subcells are guaranteed to be 4-sided, and can happen lazily for unstructured grids.

Removing the unnecessary allocations speeds up the PRT model in the example from a minute or more to subsecond runtime on my machine