### PR TITLE
ci(parallel): factor out petsc action, save petsc cache nightly

### DIFF
--- a/.github/actions/build-par-win/action.yml
+++ b/.github/actions/build-par-win/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
 
     - name: Setup PETSc
-      uses: ${{ github.workspace }}/modflow6/.github/actions/build-petsc-win
+      uses: ./modflow6/.github/actions/build-petsc-win
 
     - name: Build modflow6
       shell: cmd

--- a/.github/actions/build-par-win/action.yml
+++ b/.github/actions/build-par-win/action.yml
@@ -4,91 +4,13 @@ runs:
   using: "composite"
   steps:
 
-    - name: Convert line endings
-      shell: cmd
-      run: |
-        unix2dos -n "modflow6\.github\common\configure_petsc.sh" "%TEMP%\configure_petsc.sh"
-        unix2dos -n "modflow6\.github\common\compile_petsc.sh" "%TEMP%\compile_petsc.sh"
-        unix2dos -n "modflow6\.github\common\compile_modflow6.bat" "%TEMP%\compile_modflow6.bat"
-        unix2dos -n "modflow6\.github\common\test_modflow6.bat" "%TEMP%\test_modflow6.bat"
-
-    - name: Hide Strawberry programs
-      shell: bash
-      run: |
-        mkdir "$RUNNER_TEMP/strawberry"
-        mv /c/Strawberry/c/bin/gmake "$RUNNER_TEMP/strawberry/gmake"
-        mv /c/Strawberry/perl/bin/pkg-config "$RUNNER_TEMP/strawberry/pkg-config"
-        mv /c/Strawberry/perl/bin/pkg-config.bat "$RUNNER_TEMP/strawberry/pkg-config.bat"
-
-    - name: Get date
-      id: get-date
-      shell: bash
-      run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
-
-    - name: Set oneAPI install dir
-      shell: bash
-      run: echo "ONEAPI_ROOT=C:\Program Files (x86)\Intel\oneAPI" >> "$GITHUB_ENV"
-
-    - name: Setup oneAPI
-      uses: ./modflow6/.github/actions/setup-par-oneapi
-
-    - name: Restore PETSc cache
-      id: petsc-cache
-      uses: actions/cache/restore@v3
-      with:
-        path: petsc
-        key: petsc-${{ runner.os }}-${{ steps.get-date.outputs.date }}
-
-    - name: Download PETSc
-      if: steps.petsc-cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        curl https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.20.5.tar.gz -O -J
-        mkdir petsc
-        tar -xzf petsc-3.20.5.tar.gz -C petsc --strip-components=1
-
-    - name: Setup Cygwin
-      if: steps.petsc-cache.outputs.cache-hit != 'true'
-      uses: egor-tensin/setup-cygwin@v4
-      with:
-        packages: python3 make gcc-core gcc-g++ pkg-config
-
-    - name: Hide Cygwin linker
-      if: steps.petsc-cache.outputs.cache-hit != 'true'
-      shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
-      run: mv /usr/bin/link.exe /usr/bin/link-cygwin.exe
-
-    - name: Configure PETSc
-      if: steps.petsc-cache.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "C:\tools\cygwin\bin\bash.exe" --login --norc -eo pipefail -o igncr "%TEMP%\configure_petsc.sh"
-
-    - name: Build PETSc
-      if: steps.petsc-cache.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "C:\tools\cygwin\bin\bash.exe" --login --norc -eo pipefail -o igncr "%TEMP%\compile_petsc.sh"
-
-    - name: Save PETSc cache
-      if: steps.petsc-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
-      with:
-        path: petsc
-        key: petsc-${{ runner.os }}-${{ steps.get-date.outputs.date }}
-
-    - name: Setup PETSC environment
-      shell: cmd
-      run: |
-        set PETSC_DIR=%GITHUB_WORKSPACE%\petsc
-        set PETSC_ARCH=arch-mswin-c-opt
-        echo PETSC_DIR=%PETSC_DIR%>>%GITHUB_ENV%
-        echo PETSC_ARCH=%PETSC_ARCH%>>%GITHUB_ENV%
-        echo %PETSC_DIR%\%PETSC_ARCH%\lib>>%GITHUB_PATH%
+    - name: Setup PETSc
+      uses: ./modflow6/.github/actions/build-petsc-win
 
     - name: Build modflow6
       shell: cmd
       run: |
+        unix2dos -n "modflow6\.github\common\compile_modflow6.bat" "%TEMP%\compile_modflow6.bat"
         "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "%TEMP%\compile_modflow6.bat"
 
     - name: Show Meson logs

--- a/.github/actions/build-par-win/action.yml
+++ b/.github/actions/build-par-win/action.yml
@@ -5,12 +5,12 @@ runs:
   steps:
 
     - name: Setup PETSc
-      uses: ./modflow6/.github/actions/build-petsc-win
+      uses: ${{ github.workspace }}/modflow6/.github/actions/build-petsc-win
 
     - name: Build modflow6
       shell: cmd
       run: |
-        unix2dos -n "modflow6\.github\common\compile_modflow6.bat" "%TEMP%\compile_modflow6.bat"
+        unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\compile_modflow6.bat" "%TEMP%\compile_modflow6.bat"
         "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "%TEMP%\compile_modflow6.bat"
 
     - name: Show Meson logs

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -1,0 +1,81 @@
+name: Build PETSc (Windows)
+description: Build PETSc on Windows with Cygwin
+runs:
+  using: "composite"
+  steps:
+
+    - name: Convert line endings
+      shell: cmd
+      run: |
+        unix2dos -n "modflow6\.github\common\configure_petsc.sh" "%TEMP%\configure_petsc.sh"
+        unix2dos -n "modflow6\.github\common\compile_petsc.sh" "%TEMP%\compile_petsc.sh"
+
+    - name: Hide Strawberry programs
+      shell: bash
+      run: |
+        mkdir "$RUNNER_TEMP/strawberry"
+        mv /c/Strawberry/c/bin/gmake "$RUNNER_TEMP/strawberry/gmake"
+        mv /c/Strawberry/perl/bin/pkg-config "$RUNNER_TEMP/strawberry/pkg-config"
+        mv /c/Strawberry/perl/bin/pkg-config.bat "$RUNNER_TEMP/strawberry/pkg-config.bat"
+
+    - name: Get date
+      id: get-date
+      shell: bash
+      run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
+
+    - name: Setup oneAPI
+      uses: ./modflow6/.github/actions/setup-par-oneapi
+
+    - name: Restore PETSc cache
+      id: petsc-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: petsc
+        key: petsc-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+
+    - name: Download PETSc
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.20.5.tar.gz -O -J
+        mkdir petsc
+        tar -xzf petsc-3.20.5.tar.gz -C petsc --strip-components=1
+
+    - name: Setup Cygwin
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      uses: egor-tensin/setup-cygwin@v4
+      with:
+        packages: python3 make gcc-core gcc-g++ pkg-config
+
+    - name: Hide Cygwin linker
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+      run: mv /usr/bin/link.exe /usr/bin/link-cygwin.exe
+
+    - name: Configure PETSc
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "C:\tools\cygwin\bin\bash.exe" --login --norc -eo pipefail -o igncr "%TEMP%\configure_petsc.sh"
+
+    - name: Build PETSc
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "C:\tools\cygwin\bin\bash.exe" --login --norc -eo pipefail -o igncr "%TEMP%\compile_petsc.sh"
+
+    - name: Save PETSc cache
+      if: steps.petsc-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: petsc
+        key: petsc-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+
+    - name: Setup PETSC environment
+      shell: cmd
+      run: |
+        set PETSC_DIR=%GITHUB_WORKSPACE%\petsc
+        set PETSC_ARCH=arch-mswin-c-opt
+        echo PETSC_DIR=%PETSC_DIR%>>%GITHUB_ENV%
+        echo PETSC_ARCH=%PETSC_ARCH%>>%GITHUB_ENV%
+        echo %PETSC_DIR%\%PETSC_ARCH%\lib>>%GITHUB_PATH%

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -24,7 +24,7 @@ runs:
       run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
 
     - name: Setup oneAPI
-      uses: ${{ github.workspace }}/modflow6/.github/actions/setup-par-oneapi
+      uses: ./modflow6/.github/actions/setup-par-oneapi
 
     - name: Restore PETSc cache
       id: petsc-cache

--- a/.github/actions/build-petsc-win/action.yml
+++ b/.github/actions/build-petsc-win/action.yml
@@ -7,8 +7,8 @@ runs:
     - name: Convert line endings
       shell: cmd
       run: |
-        unix2dos -n "modflow6\.github\common\configure_petsc.sh" "%TEMP%\configure_petsc.sh"
-        unix2dos -n "modflow6\.github\common\compile_petsc.sh" "%TEMP%\compile_petsc.sh"
+        unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\configure_petsc.sh" "%TEMP%\configure_petsc.sh"
+        unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\compile_petsc.sh" "%TEMP%\compile_petsc.sh"
 
     - name: Hide Strawberry programs
       shell: bash
@@ -24,7 +24,7 @@ runs:
       run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
 
     - name: Setup oneAPI
-      uses: ./modflow6/.github/actions/setup-par-oneapi
+      uses: ${{ github.workspace }}/modflow6/.github/actions/setup-par-oneapi
 
     - name: Restore PETSc cache
       id: petsc-cache

--- a/.github/actions/setup-par-oneapi/action.yml
+++ b/.github/actions/setup-par-oneapi/action.yml
@@ -26,7 +26,7 @@ runs:
       run: |
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5cb30fb9-21e9-47e8-82da-a91e00191670/w_BaseKit_p_2024.0.1.45_offline.exe"
         cmp="intel.oneapi.win.mkl.devel"
-        "modflow6/.github/common/install_intel_windows.bat" $url $cmp
+        "$GITHUB_WORKSPACE/modflow6/.github/common/install_intel_windows.bat" $url $cmp
         rm -rf $TEMP/webimage.exe
         rm -rf $TEMP/webimage_extracted
 
@@ -36,7 +36,7 @@ runs:
       run: |
         url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7a6db8a1-a8b9-4043-8e8e-ca54b56c34e4/w_HPCKit_p_2024.0.1.35_offline.exe"
         cmp="intel.oneapi.win.cpp-dpcpp-common:intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel"
-        "modflow6/.github/common/install_intel_windows.bat" $url $cmp
+        "$GITHUB_WORKSPACE/modflow6/.github/common/install_intel_windows.bat" $url $cmp
         rm -rf $TEMP/webimage.exe
         rm -rf $TEMP/webimage_extracted
 

--- a/.github/actions/test-par-win/action.yml
+++ b/.github/actions/test-par-win/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
 
     - name: Build MF6 parallel
-      uses: ${{ github.workspace }}/modflow6/.github/actions/build-par-win
+      uses: ./modflow6/.github/actions/build-par-win
 
     - name: Update flopy
       working-directory: modflow6/autotest

--- a/.github/actions/test-par-win/action.yml
+++ b/.github/actions/test-par-win/action.yml
@@ -25,4 +25,5 @@ runs:
       env:
         REPOS_PATH: ${{ github.workspace }}
       run: |
+        unix2dos -n "modflow6\.github\common\test_modflow6.bat" "%TEMP%\test_modflow6.bat"
         "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "%TEMP%\test_modflow6.bat"

--- a/.github/actions/test-par-win/action.yml
+++ b/.github/actions/test-par-win/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
 
     - name: Build MF6 parallel
-      uses: ./modflow6/.github/actions/build-par-win
+      uses: ${{ github.workspace }}/modflow6/.github/actions/build-par-win
 
     - name: Update flopy
       working-directory: modflow6/autotest
@@ -20,10 +20,9 @@ runs:
       run: micromamba run -r "C:\Users\runneradmin\micromamba" -n modflow6 pytest -v --durations 0 get_exes.py
 
     - name: Test programs
-      working-directory: modflow6/autotest
       shell: cmd 
       env:
         REPOS_PATH: ${{ github.workspace }}
       run: |
-        unix2dos -n "modflow6\.github\common\test_modflow6.bat" "%TEMP%\test_modflow6.bat"
+        unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\test_modflow6.bat" "%TEMP%\test_modflow6.bat"
         "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "%TEMP%\test_modflow6.bat"

--- a/.github/workflows/large.yml
+++ b/.github/workflows/large.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           # ifx
           - {os: windows-2022, compiler: intel, version: 2022.2}
-          # use this combo to install and cache oneapi components for mf6 parallel (compilers + mkl/mpi)
+          # use this combo to install and cache oneapi components (compilers + mkl/mpi) and petsc for mf6 parallel 
           - {os: windows-2022, compiler: intel, version: 2024.0}
           # ifort
           - {os: windows-2022, compiler: intel-classic, version: "2021.10"}
@@ -33,15 +33,15 @@ jobs:
           compiler: ${{ matrix.compiler }}
           version: ${{ matrix.version }}
 
+      # cache oneapi and petsc for mf6 parallel
       - name: Checkout modflow6
         if: matrix.compiler == 'intel' && matrix.version == '2024.0'
         uses: actions/checkout@v4
         with:
           path: modflow6
-
-      - name: Setup oneAPI
+      - name: Cache oneAPI and PETSc
         if: matrix.compiler == 'intel' && matrix.version == '2024.0'
-        uses: ./modflow6/.github/actions/setup-par-oneapi
+        uses: ./modflow6/.github/actions/build-petsc-win
   test:
     name: Test
     runs-on: ubuntu-22.04


### PR DESCRIPTION
* factor out an action `build-petsc-win` to build/cache PETSc
* warm the PETSc cache nightly like we do for oneAPI
* cut ~15min off parallel windows CI time, [example](https://github.com/MODFLOW-USGS/modflow6/actions/runs/8524618515/job/23349879474#step:5:125)