### PR TITLE
ci: trim cached oneapi versions

### DIFF
--- a/.github/workflows/large.yml
+++ b/.github/workflows/large.yml
@@ -15,16 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ifx
-          - {os: windows-2022, compiler: intel, version: 2022.2}
-          # use this combo to install and cache oneapi components (compilers + mkl/mpi) and petsc for mf6 parallel 
+          # this combo is for windows parallel oneapi components (compilers + mkl/mpi) and petsc
           - {os: windows-2022, compiler: intel, version: 2024.0}
-          # ifort
-          - {os: windows-2022, compiler: intel-classic, version: "2021.10"}
-          - {os: windows-2022, compiler: intel-classic, version: 2021.9}
-          - {os: windows-2022, compiler: intel-classic, version: 2021.8}
+          # ifort 2021.7 currently used for all other CI testing
           - {os: windows-2022, compiler: intel-classic, version: 2021.7}
-          - {os: windows-2022, compiler: intel-classic, version: 2021.6}
     steps:
       - name: Setup ${{ matrix.compiler }} ${{ matrix.version }}
         if: (!(matrix.compiler == 'intel' && matrix.version == '2024.0'))


### PR DESCRIPTION
* only need to cache intel-classic 2021.7 and intel 2024.0