### PR TITLE
ci(compilers): add intel 2024, trim intel versions, drop gcc 7-10

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -15,31 +15,19 @@ jobs:
         # combinations from https://github.com/fortran-lang/setup-fortran#runner-compatibility
         include:
           # gfortran
-          - {os: ubuntu-20.04, compiler: gcc, version: 9}
-          - {os: ubuntu-20.04, compiler: gcc, version: 10}
           - {os: ubuntu-20.04, compiler: gcc, version: 11}
-          - {os: ubuntu-22.04, compiler: gcc, version: 9}
-          - {os: ubuntu-22.04, compiler: gcc, version: 10}
           - {os: ubuntu-22.04, compiler: gcc, version: 11}
           - {os: ubuntu-22.04, compiler: gcc, version: 12}
           - {os: ubuntu-22.04, compiler: gcc, version: 13}
-          - {os: macos-11, compiler: gcc, version: 9}
-          - {os: macos-11, compiler: gcc, version: 10}
           - {os: macos-11, compiler: gcc, version: 11}
           - {os: macos-11, compiler: gcc, version: 12}
           - {os: macos-11, compiler: gcc, version: 13}
-          - {os: macos-12, compiler: gcc, version: 9}
-          - {os: macos-12, compiler: gcc, version: 10}
           - {os: macos-12, compiler: gcc, version: 11}
           - {os: macos-12, compiler: gcc, version: 12}
           - {os: macos-12, compiler: gcc, version: 13}
-          - {os: windows-2019, compiler: gcc, version: 9}
-          - {os: windows-2019, compiler: gcc, version: 10}
           - {os: windows-2019, compiler: gcc, version: 11}
           - {os: windows-2019, compiler: gcc, version: 12}
           - {os: windows-2019, compiler: gcc, version: 13}
-          - {os: windows-2022, compiler: gcc, version: 9}
-          - {os: windows-2022, compiler: gcc, version: 10}
           - {os: windows-2022, compiler: gcc, version: 11}
           - {os: windows-2022, compiler: gcc, version: 12}
           - {os: windows-2022, compiler: gcc, version: 13}
@@ -51,11 +39,6 @@ jobs:
           - {os: ubuntu-20.04, compiler: intel, version: "2023.0"}
           - {os: ubuntu-20.04, compiler: intel, version: 2022.2.1}
           - {os: ubuntu-20.04, compiler: intel, version: 2022.2}
-          - {os: ubuntu-20.04, compiler: intel, version: 2022.1}
-          - {os: ubuntu-20.04, compiler: intel, version: "2022.0"}
-          - {os: ubuntu-20.04, compiler: intel, version: 2021.4}
-          - {os: ubuntu-20.04, compiler: intel, version: 2021.2}
-          - {os: ubuntu-20.04, compiler: intel, version: 2021.1}
           - {os: ubuntu-22.04, compiler: intel, version: 2024.1}
           - {os: ubuntu-22.04, compiler: intel, version: "2024.0"}
           - {os: ubuntu-22.04, compiler: intel, version: 2023.2}
@@ -63,11 +46,6 @@ jobs:
           - {os: ubuntu-22.04, compiler: intel, version: "2023.0"}
           - {os: ubuntu-22.04, compiler: intel, version: 2022.2.1}
           - {os: ubuntu-22.04, compiler: intel, version: 2022.2}
-          - {os: ubuntu-22.04, compiler: intel, version: 2022.1}
-          - {os: ubuntu-22.04, compiler: intel, version: "2022.0"}
-          - {os: ubuntu-22.04, compiler: intel, version: 2021.4}
-          - {os: ubuntu-22.04, compiler: intel, version: 2021.2}
-          - {os: ubuntu-22.04, compiler: intel, version: 2021.1}
           # no ifx on mac
           - {os: windows-2019, compiler: intel, version: 2024.1}
           - {os: windows-2019, compiler: intel, version: "2024.0"}
@@ -75,14 +53,12 @@ jobs:
           - {os: windows-2019, compiler: intel, version: 2023.1}
           - {os: windows-2019, compiler: intel, version: "2023.0"}
           - {os: windows-2019, compiler: intel, version: 2022.2}
-          - {os: windows-2019, compiler: intel, version: 2022.1}
           - {os: windows-2022, compiler: intel, version: 2024.1}
           - {os: windows-2022, compiler: intel, version: "2024.0"}
           - {os: windows-2022, compiler: intel, version: 2023.2}
           - {os: windows-2022, compiler: intel, version: 2023.1}
           - {os: windows-2022, compiler: intel, version: "2023.0"}
           - {os: windows-2022, compiler: intel, version: 2022.2}
-          - {os: windows-2022, compiler: intel, version: 2022.1}
           # ifort
           - {os: ubuntu-20.04, compiler: intel-classic, version: "2021.10"}
           - {os: ubuntu-20.04, compiler: intel-classic, version: 2021.9}

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -15,8 +15,6 @@ jobs:
         # combinations from https://github.com/fortran-lang/setup-fortran#runner-compatibility
         include:
           # gfortran
-          - {os: ubuntu-20.04, compiler: gcc, version: 7}
-          - {os: ubuntu-20.04, compiler: gcc, version: 8}
           - {os: ubuntu-20.04, compiler: gcc, version: 9}
           - {os: ubuntu-20.04, compiler: gcc, version: 10}
           - {os: ubuntu-20.04, compiler: gcc, version: 11}
@@ -25,15 +23,11 @@ jobs:
           - {os: ubuntu-22.04, compiler: gcc, version: 11}
           - {os: ubuntu-22.04, compiler: gcc, version: 12}
           - {os: ubuntu-22.04, compiler: gcc, version: 13}
-          - {os: macos-11, compiler: gcc, version: 7}
-          - {os: macos-11, compiler: gcc, version: 8}
           - {os: macos-11, compiler: gcc, version: 9}
           - {os: macos-11, compiler: gcc, version: 10}
           - {os: macos-11, compiler: gcc, version: 11}
           - {os: macos-11, compiler: gcc, version: 12}
           - {os: macos-11, compiler: gcc, version: 13}
-          - {os: macos-12, compiler: gcc, version: 7}
-          - {os: macos-12, compiler: gcc, version: 8}
           - {os: macos-12, compiler: gcc, version: 9}
           - {os: macos-12, compiler: gcc, version: 10}
           - {os: macos-12, compiler: gcc, version: 11}
@@ -50,6 +44,8 @@ jobs:
           - {os: windows-2022, compiler: gcc, version: 12}
           - {os: windows-2022, compiler: gcc, version: 13}
           # ifx
+          - {os: ubuntu-20.04, compiler: intel, version: 2024.1}
+          - {os: ubuntu-20.04, compiler: intel, version: "2024.0"}
           - {os: ubuntu-20.04, compiler: intel, version: 2023.2}
           - {os: ubuntu-20.04, compiler: intel, version: 2023.1}
           - {os: ubuntu-20.04, compiler: intel, version: "2023.0"}
@@ -60,6 +56,8 @@ jobs:
           - {os: ubuntu-20.04, compiler: intel, version: 2021.4}
           - {os: ubuntu-20.04, compiler: intel, version: 2021.2}
           - {os: ubuntu-20.04, compiler: intel, version: 2021.1}
+          - {os: ubuntu-22.04, compiler: intel, version: 2024.1}
+          - {os: ubuntu-22.04, compiler: intel, version: "2024.0"}
           - {os: ubuntu-22.04, compiler: intel, version: 2023.2}
           - {os: ubuntu-22.04, compiler: intel, version: 2023.1}
           - {os: ubuntu-22.04, compiler: intel, version: "2023.0"}
@@ -71,11 +69,15 @@ jobs:
           - {os: ubuntu-22.04, compiler: intel, version: 2021.2}
           - {os: ubuntu-22.04, compiler: intel, version: 2021.1}
           # no ifx on mac
+          - {os: windows-2019, compiler: intel, version: 2024.1}
+          - {os: windows-2019, compiler: intel, version: "2024.0"}
           - {os: windows-2019, compiler: intel, version: 2023.2}
           - {os: windows-2019, compiler: intel, version: 2023.1}
           - {os: windows-2019, compiler: intel, version: "2023.0"}
           - {os: windows-2019, compiler: intel, version: 2022.2}
           - {os: windows-2019, compiler: intel, version: 2022.1}
+          - {os: windows-2022, compiler: intel, version: 2024.1}
+          - {os: windows-2022, compiler: intel, version: "2024.0"}
           - {os: windows-2022, compiler: intel, version: 2023.2}
           - {os: windows-2022, compiler: intel, version: 2023.1}
           - {os: windows-2022, compiler: intel, version: "2023.0"}


### PR DESCRIPTION
* add intel 2024.0 and 2024.1 to compiler test matrix
* remove incompatible intel versions 2021.1 - 2022.1
* remove gcc 7 - 10