### PR TITLE
fix(prt): set tmax properly before particle solve

### DIFF
--- a/autotest/test_prt_disv1.py
+++ b/autotest/test_prt_disv1.py
@@ -15,13 +15,11 @@ tracking to termination or particle stop times
 during the simulation's final time step.
 
 Several cases are provided:
-    - default: no user-specified tracking times, MP7 in pathline mode
-    - bprp: mismatching cell IDs in PRP input, expect PRT to catch and reject these
-    - trts: user-specified tracking times, some falling exactly on boundaries between
-            time steps. TODO: make sure PRT and MP7 agree on which time step a point
-            on a boundary belongs to, currently PRT assigns to subsequent time step
-            while MP7 assigns to previous.
-    - trtf: same as trts, except tracking times are provided to PRT in a separate file,
+    - default: No user-specified tracking times, MP7 in pathline mode.
+    - bprp: Mismatching cell IDs in PRP input, expect PRT to catch and reject these.
+    - trts: User-specified tracking times, some falling exactly on boundaries between
+            time steps. PRT and MP7 should both assign the datum to the prior time step.
+    - trtf: Same as trts, except tracking times are provided to PRT in a separate file,
             rather than inline in the OC input file.
 """
 
@@ -478,18 +476,12 @@ def check_output(idx, test):
     del mf6_pls["yloc"]
     del mf6_pls["zloc"]
     del mf6_pls["node"]  # node numbers reversed in y direction in mp7
-    # del mf6_pls[
-    #     "timestep"
-    # ]  # todo: reinstate if PRT and MP7 agree on times falling on temporal boundaries
     del mp7_pls["sequencenumber"]
     del mp7_pls["particleidloc"]
     del mp7_pls["xloc"]
     del mp7_pls["yloc"]
     del mp7_pls["zloc"]
     del mp7_pls["node"]
-    # del mp7_pls[
-    #     "timestep"
-    # ]  # todo: reinstate if PRT and MP7 agree on times falling on temporal boundaries
 
     # compare mf6 / mp7 pathline data
     if "bprp" in name:

--- a/autotest/test_prt_disv1.py
+++ b/autotest/test_prt_disv1.py
@@ -478,18 +478,18 @@ def check_output(idx, test):
     del mf6_pls["yloc"]
     del mf6_pls["zloc"]
     del mf6_pls["node"]  # node numbers reversed in y direction in mp7
-    del mf6_pls[
-        "timestep"
-    ]  # todo: reinstate if PRT and MP7 agree on times falling on temporal boundaries
+    # del mf6_pls[
+    #     "timestep"
+    # ]  # todo: reinstate if PRT and MP7 agree on times falling on temporal boundaries
     del mp7_pls["sequencenumber"]
     del mp7_pls["particleidloc"]
     del mp7_pls["xloc"]
     del mp7_pls["yloc"]
     del mp7_pls["zloc"]
     del mp7_pls["node"]
-    del mp7_pls[
-        "timestep"
-    ]  # todo: reinstate if PRT and MP7 agree on times falling on temporal boundaries
+    # del mp7_pls[
+    #     "timestep"
+    # ]  # todo: reinstate if PRT and MP7 agree on times falling on temporal boundaries
 
     # compare mf6 / mp7 pathline data
     if "bprp" in name:

--- a/autotest/test_prt_disv1.py
+++ b/autotest/test_prt_disv1.py
@@ -1,11 +1,28 @@
 """
 Tests particle tracking on a vertex (DISV) grid
-that reduces to a regular grid.
+that reduces to a regular grid. This exercises
+PRT's ability to detect when a vertex grid can
+be solved via Pollock's method applied to quad-
+refined cells, instead of the new ternary method
+which applies more generally to polygonal cells.
 
-Two cases are provided, one with valid release
-position and cell correspondences, and another
-with mismatching cell IDs; expect PRT to catch
-these and reject them.
+The simulation includes a single stress period
+with multiple time steps. This serves to test
+whether PRT properly solves trajectories over
+"internal" time steps, i.e. within the step's
+slice of simulation time, as well as extending
+tracking to termination or particle stop times
+during the simulation's final time step.
+
+Several cases are provided:
+    - default: no user-specified tracking times, MP7 in pathline mode
+    - bprp: mismatching cell IDs in PRP input, expect PRT to catch and reject these
+    - trts: user-specified tracking times, some falling exactly on boundaries between
+            time steps. TODO: make sure PRT and MP7 agree on which time step a point
+            on a boundary belongs to, currently PRT assigns to subsequent time step
+            while MP7 assigns to previous.
+    - trtf: same as trts, except tracking times are provided to PRT in a separate file,
+            rather than inline in the OC input file.
 """
 
 from pathlib import Path
@@ -52,7 +69,7 @@ strt = 20
 nouter, ninner = 100, 300
 hclose, rclose, relax = 1e-9, 1e-3, 0.97
 porosity = 0.1
-tracktimes = list(np.linspace(0, 11, 10))
+tracktimes = list(np.linspace(0, 19, 20))
 
 
 def tracktimes_file(path) -> Path:
@@ -225,6 +242,7 @@ def build_prt_sim(idx, gwf_ws, prt_ws, mf6):
             trackcsv_filerecord=[prt_track_csv_file],
             track_release=True,
             track_terminate=True,
+            track_transit=True,
             track_usertime=True,
             track_timesrecord=tracktimes if "trts" in name else None,
             track_timesfilerecord=(
@@ -266,6 +284,7 @@ def build_prt_sim(idx, gwf_ws, prt_ws, mf6):
 
 
 def build_mp7_sim(idx, ws, mp7, gwf):
+    name = cases[idx]
     partdata = get_partdata(gwf.modelgrid, releasepts_mp7)
     mp7_name = f"{cases[idx]}_mp7"
     pg = flopy.modpath.ParticleGroup(
@@ -287,10 +306,13 @@ def build_mp7_sim(idx, ws, mp7, gwf):
     )
     mpsim = flopy.modpath.Modpath7Sim(
         mp,
-        simulationtype="pathline",
+        simulationtype="combined"
+        if ("trts" in name or "trtf" in name)
+        else "pathline",
         trackingdirection="forward",
         budgetoutputoption="summary",
-        stoptimeoption="total",
+        stoptimeoption="extend",
+        timepointdata=[20, tracktimes],
         particlegroups=[pg],
     )
 
@@ -360,8 +382,6 @@ def check_output(idx, test):
 
     # load mf6 pathline results
     mf6_pls = pd.read_csv(prt_ws / prt_track_csv_file, na_filter=False)
-    if "trts" in name or "trtf" in name:
-        assert len(mf6_pls) == 100
 
     # make sure pathline df has "name" (boundname) column and default values
     assert "name" in mf6_pls
@@ -458,15 +478,21 @@ def check_output(idx, test):
     del mf6_pls["yloc"]
     del mf6_pls["zloc"]
     del mf6_pls["node"]  # node numbers reversed in y direction in mp7
+    del mf6_pls[
+        "timestep"
+    ]  # todo: reinstate if PRT and MP7 agree on times falling on temporal boundaries
     del mp7_pls["sequencenumber"]
     del mp7_pls["particleidloc"]
     del mp7_pls["xloc"]
     del mp7_pls["yloc"]
     del mp7_pls["zloc"]
     del mp7_pls["node"]
+    del mp7_pls[
+        "timestep"
+    ]  # todo: reinstate if PRT and MP7 agree on times falling on temporal boundaries
 
     # compare mf6 / mp7 pathline data
-    if "trts" in name or "trtf" in name:
+    if "bprp" in name:
         pass
     else:
         assert mf6_pls.shape == mp7_pls.shape

--- a/src/Model/ModelUtilities/TrackData.f90
+++ b/src/Model/ModelUtilities/TrackData.f90
@@ -23,10 +23,8 @@ module TrackModule
 
   !> @brief Manages particle track (i.e. pathline) files.
   !!
-  !! Optionally filters events ("ireason" codes), e.g. release
-  !! or cell-to-cell transitions. Events ("ireason" codes) are:
+  !! Optionally filters events ("ireason" codes, selectable in the PRT-OC pkg):
   !!
-  !!   -1: ALL
   !!    0: RELEASE: particle is released
   !!    1: TRANSIT: particle moves from cell to cell
   !!    2: TIMESTEP: timestep ends
@@ -34,7 +32,7 @@ module TrackModule
   !!    4: WEAKSINK: particle exits a weak sink
   !!    5: USERTIME: user-specified tracking time
   !!
-  !! An arbitrary number of files can be managed. internal arrays
+  !! An arbitrary number of files can be managed. Internal arrays
   !! are resized as needed.
   !<
   type :: TrackFileControlType

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -2,7 +2,7 @@ module PrtModule
   use KindModule, only: DP, I4B, LGP
   use ErrorUtilModule, only: pstop
   use InputOutputModule, only: ParseLine, upcase, lowcase
-  use ConstantsModule, only: LENFTYPE, LENMEMPATH, DZERO, DONE, DSAME, &
+  use ConstantsModule, only: LENFTYPE, LENMEMPATH, DZERO, DONE, &
                              LENPAKLOC, LENPACKAGETYPE, LENBUDTXT, MNORMAL, &
                              LINELENGTH
   use VersionModule, only: write_listfile_header

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -2,7 +2,7 @@ module PrtModule
   use KindModule, only: DP, I4B, LGP
   use ErrorUtilModule, only: pstop
   use InputOutputModule, only: ParseLine, upcase, lowcase
-  use ConstantsModule, only: LENFTYPE, LENMEMPATH, DZERO, DONE, &
+  use ConstantsModule, only: LENFTYPE, LENMEMPATH, DZERO, DONE, DSAME, &
                              LENPAKLOC, LENPACKAGETYPE, LENBUDTXT, MNORMAL, &
                              LINELENGTH
   use VersionModule, only: write_listfile_header
@@ -972,8 +972,7 @@ contains
 
           ! -- If particle is permanently unreleased, record its initial/terminal state
           if (particle%istatus == 8) &
-            call this%trackfilectl%save(particle, kper=kper, &
-                                        kstp=kstp, reason=3) ! reason=3: termination
+            call this%method%save(particle, reason=3) ! reason=3: termination
 
           ! -- If particle is inactive or not yet to be released, cycle
           if (particle%istatus > 1) cycle
@@ -981,8 +980,7 @@ contains
           ! -- If particle released this time step, record its initial state
           particle%istatus = 1
           if (particle%trelease >= totimc) &
-            call this%trackfilectl%save(particle, kper=kper, &
-                                        kstp=kstp, reason=0) ! reason=0: release
+            call this%method%save(particle, reason=0) ! reason=0: release
 
           ! -- Maximum time is end of time step unless this is the last
           !    time step in the simulation, which case it's the particle

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -928,7 +928,7 @@ contains
   !> @brief Solve the model
   subroutine prt_solve(this)
     ! -- modules
-    use TdisModule, only: kper, kstp, totimc, totim, nper, nstp
+    use TdisModule, only: kper, kstp, totimc, nper, nstp, delt
     use PrtPrpModule, only: PrtPrpType
     ! -- dummy variables
     class(PrtModelType) :: this
@@ -984,11 +984,12 @@ contains
             call this%trackfilectl%save(particle, kper=kper, &
                                         kstp=kstp, reason=0) ! reason=0: release
 
-          ! -- Unless in last stress period and it has only one time step,
-          ! -- limit max time to no later than end of time step
-          tmax = particle%tstop
-          if (kper == nper .and. nstp(kper) /= 1 .and. totim < particle%tstop) &
-            tmax = totim
+          ! -- Maximum time is end of time step unless this is the last
+          !    time step in the simulation, which case it's the particle
+          !    stop time.
+          tmax = totimc + delt
+          if (nper == kper .and. nstp(kper) == kstp) &
+            tmax = particle%tstop
 
           ! -- Get and apply the tracking method
           call this%method%apply(particle, tmax)

--- a/src/Solution/ParticleTracker/Method.f90
+++ b/src/Solution/ParticleTracker/Method.f90
@@ -154,7 +154,7 @@ contains
 
   !> @brief Save a particle's current state.
   subroutine save(this, particle, reason)
-    use TdisModule, only: kper, kstp, nper, nstp, totimc, delt
+    use TdisModule, only: kper, kstp, totimc
     ! dummy
     class(MethodType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle

--- a/src/Solution/ParticleTracker/MethodCellPassToBot.f90
+++ b/src/Solution/ParticleTracker/MethodCellPassToBot.f90
@@ -5,7 +5,7 @@ module MethodCellPassToBotModule
   use CellDefnModule, only: CellDefnType, create_defn
   use PrtFmiModule, only: PrtFmiType
   use BaseDisModule, only: DisBaseType
-  use ParticleModule
+  use ParticleModule, only: ParticleType
   use CellModule, only: CellType
   use SubcellModule, only: SubcellType
   use TrackModule, only: TrackFileControlType
@@ -43,8 +43,6 @@ contains
 
   !> @brief Pass particle vertically and instantaneously to the cell bottom
   subroutine apply_ptb(this, particle, tmax)
-    ! -- modules
-    use TdisModule, only: kper, kstp
     ! -- dummy
     class(MethodCellPassToBotType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -54,8 +52,7 @@ contains
     if (.not. particle%advancing) return
     particle%z = this%defn%bot
     particle%iboundary(2) = this%defn%npolyverts + 2
-    call this%trackfilectl%save(particle, kper=kper, &
-                                kstp=kstp, reason=1) ! reason=1: cell transition
+    call this%save(particle, reason=1) ! reason=1: cell transition
   end subroutine apply_ptb
 
 end module MethodCellPassToBotModule

--- a/src/Solution/ParticleTracker/MethodCellPollock.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollock.f90
@@ -117,7 +117,6 @@ contains
 
   !> @brief Apply Pollock's method to a rectangular cell
   subroutine apply_mcp(this, particle, tmax)
-    use TdisModule, only: kper, kstp
     ! -- dummy
     class(MethodCellPollockType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -144,8 +143,7 @@ contains
       ! -- the particle state to output file(s).
       if (particle%z > cell%defn%top) then
         particle%z = cell%defn%top
-        call this%trackfilectl%save(particle, kper=kper, &
-                                    kstp=kstp, reason=1) ! reason=1: cell transition
+        call this%save(particle, reason=1) ! reason=1: cell transition
       end if
 
       !  Transform particle location into local cell coordinates

--- a/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
@@ -197,7 +197,6 @@ contains
 
   !> @brief Solve the quad-rectangular cell via Pollock's method
   subroutine apply_mcpq(this, particle, tmax)
-    use TdisModule, only: kper, kstp
     ! -- dummy
     class(MethodCellPollockQuadType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -217,8 +216,7 @@ contains
       ! -- the particle state to output file(s).
       if (particle%z > cell%defn%top) then
         particle%z = cell%defn%top
-        call this%trackfilectl%save(particle, kper=kper, &
-                                    kstp=kstp, reason=1) ! reason=1: cell transition
+        call this%save(particle, reason=1) ! reason=1: cell transition
       end if
 
       ! -- Transform particle location into local cell coordinates,

--- a/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
@@ -42,7 +42,6 @@ contains
     method%delegates = .true.
     call create_subcell_rect(subcell)
     method%subcell => subcell
-    print *, "-=-==-=--=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
   end subroutine create_method_cell_quad
 
   !> @brief Destroy the tracking method

--- a/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
@@ -42,6 +42,7 @@ contains
     method%delegates = .true.
     call create_subcell_rect(subcell)
     method%subcell => subcell
+    print *, "-=-==-=--=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
   end subroutine create_method_cell_quad
 
   !> @brief Destroy the tracking method

--- a/src/Solution/ParticleTracker/MethodCellTernary.f90
+++ b/src/Solution/ParticleTracker/MethodCellTernary.f90
@@ -146,7 +146,6 @@ contains
   !> @brief Apply the ternary method to a polygonal cell
   subroutine apply_mct(this, particle, tmax)
     use ConstantsModule, only: DZERO, DONE, DHALF
-    use TdisModule, only: kper, kstp
     ! dummy
     class(MethodCellTernaryType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -193,8 +192,7 @@ contains
       ! -- particle state to file
       if (particle%z > cell%defn%top) then
         particle%z = cell%defn%top
-        call this%trackfilectl%save(particle, kper=kper, &
-                                    kstp=kstp, reason=1) ! reason=1: cell transition
+        call this%save(particle, reason=1) ! reason=1: cell transition
       end if
 
       npolyverts = cell%defn%npolyverts

--- a/src/Solution/ParticleTracker/MethodDis.f90
+++ b/src/Solution/ParticleTracker/MethodDis.f90
@@ -135,8 +135,6 @@ contains
 
   !> @brief Pass a particle to the next cell, if there is one
   subroutine pass_dis(this, particle)
-    ! -- modules
-    use TdisModule, only: kper, kstp
     ! -- dummy
     class(MethodDisType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -174,8 +172,7 @@ contains
           ! particle%idomain(2) = -abs(particle%idomain(2))   ! kluge???
           particle%istatus = 2 ! kluge note: use -2 to allow check for transfer to another model???
           particle%advancing = .false.
-          call this%trackfilectl%save(particle, kper=kper, &
-                                      kstp=kstp, reason=3) ! reason=3: termination
+          call this%save(particle, reason=3) ! reason=3: termination
           ! particle%iboundary(2) = -1
         else
           idiag = dis%con%ia(cell%defn%icell)

--- a/src/Solution/ParticleTracker/MethodDisv.f90
+++ b/src/Solution/ParticleTracker/MethodDisv.f90
@@ -127,7 +127,6 @@ contains
   subroutine pass_disv(this, particle)
     ! -- modules
     use DisvModule, only: DisvType
-    use TdisModule, only: kper, kstp
     ! -- dummy
     class(MethodDisvType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -158,8 +157,7 @@ contains
           ! particle%idomain(2) = -abs(particle%idomain(2))   ! kluge???
           particle%istatus = 2 ! kluge note, todo: use -2 to check for transfer to another model???
           particle%advancing = .false.
-          call this%trackfilectl%save(particle, kper=kper, &
-                                      kstp=kstp, reason=3) ! reason=3: termination
+          call this%save(particle, reason=3) ! reason=3: termination
           ! particle%iboundary(2) = -1
         else
           idiag = dis%con%ia(cell%defn%icell)

--- a/src/Solution/ParticleTracker/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/MethodSubcellPollock.f90
@@ -186,6 +186,7 @@ contains
     !    within the current period and time step only.
     call this%tracktimes%try_advance()
     tslice = this%tracktimes%selection
+
     if (all(tslice > 0)) then
       do i = tslice(1), tslice(2)
         t = this%tracktimes%times(i)

--- a/src/Solution/ParticleTracker/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/MethodSubcellPollock.f90
@@ -186,7 +186,6 @@ contains
     !    within the current period and time step only.
     call this%tracktimes%try_advance()
     tslice = this%tracktimes%selection
-
     if (all(tslice > 0)) then
       do i = tslice(1), tslice(2)
         t = this%tracktimes%times(i)

--- a/src/Solution/ParticleTracker/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/MethodSubcellPollock.f90
@@ -86,7 +86,6 @@ contains
   subroutine track_subcell(this, subcell, particle, tmax)
     ! modules
     use ParticleModule, only: get_particle_id
-    use TdisModule, only: kper, kstp
     ! dummy
     class(MethodSubcellPollockType), intent(inout) :: this
     class(SubcellRectType), intent(in) :: subcell
@@ -186,6 +185,7 @@ contains
     !    within the current period and time step only.
     call this%tracktimes%try_advance()
     tslice = this%tracktimes%selection
+
     if (all(tslice > 0)) then
       do i = tslice(1), tslice(2)
         t = this%tracktimes%times(i)
@@ -202,8 +202,7 @@ contains
         particle%z = z * subcell%dz
         particle%ttrack = t
         particle%istatus = 1
-        call this%trackfilectl%save(particle, kper=kper, &
-                                    kstp=kstp, reason=5)
+        call this%save(particle, reason=5)
       end do
     end if
 
@@ -266,9 +265,7 @@ contains
     particle%iboundary(3) = exitFace
 
     ! -- Save particle track record
-    if (reason > -1) &
-      call this%trackfilectl%save(particle, kper=kper, &
-                                  kstp=kstp, reason=reason)
+    if (reason >= 0) call this%save(particle, reason=reason)
 
   end subroutine track_subcell
 

--- a/src/Solution/ParticleTracker/MethodSubcellTernary.f90
+++ b/src/Solution/ParticleTracker/MethodSubcellTernary.f90
@@ -64,8 +64,6 @@ contains
 
   !> @brief Track a particle across a triangular subcell using the ternary method
   subroutine track_subcell(this, subcell, particle, tmax)
-    ! modules
-    use TdisModule, only: kper, kstp
     ! dummy
     class(MethodSubcellTernaryType), intent(inout) :: this
     class(SubcellTriType), intent(in) :: subcell
@@ -283,8 +281,7 @@ contains
         particle%z = z
         particle%ttrack = t
         particle%istatus = 1
-        call this%trackfilectl%save(particle, kper=kper, &
-                                    kstp=kstp, reason=5)
+        call this%save(particle, reason=5)
       end do
     end if
 
@@ -349,8 +346,7 @@ contains
 
     ! -- Save particle track record
     if (reason > -1) &
-      call this%trackfilectl%save(particle, kper=kper, &
-                                  kstp=kstp, reason=reason) ! reason=2: timestep
+      call this%save(particle, reason=reason) ! reason=2: timestep
   end subroutine track_subcell
 
   !> @brief Do calculations related to analytical z solution


### PR DESCRIPTION
Fix two issues:
* maximum tracking time was set incorrectly, particles were solved beyond the end of the time step for multi-step simulations &mdash; max time within the tracking loop should be end of time step unless it's the last time step in the simulation, in which case it should be particle stop time
* if, on recording a particle datum, the tracking time fell exactly on the boundary between time steps, the datum was assigned to the subsequent time step and stress period, while MODPATH 7 assigns it the previous &mdash; factor out a routine in the base `MethodType` to save particle data, with some extra logic for an inclusive upper bound on the time step like MP7