### PR TITLE
patch(swf): coordinate invariant flow calculations

### DIFF
--- a/autotest/test_swf_dfw_loop.py
+++ b/autotest/test_swf_dfw_loop.py
@@ -44,11 +44,11 @@ def build_models(idx, test):
     )
     ims = flopy.mf6.ModflowIms(
         sim,
-        outer_maximum=100,
+        outer_maximum=200,
         inner_maximum=50,
         print_option="all",
-        outer_dvclose=1.0e-6,
-        inner_dvclose=1.0e-6,
+        outer_dvclose=1.0e-8,
+        inner_dvclose=1.0e-8,
         linear_acceleration="BICGSTAB",
         backtracking_number=5,
         backtracking_tolerance=1.0,
@@ -243,6 +243,7 @@ def build_models(idx, test):
     dfw = flopy.mf6.ModflowSwfdfw(
         swf,
         central_in_space=True,
+        #dev_swr_conductance=True,
         print_flows=True,
         save_flows=True,
         manningsn=0.03,

--- a/autotest/test_swf_dfw_loop.py
+++ b/autotest/test_swf_dfw_loop.py
@@ -47,8 +47,8 @@ def build_models(idx, test):
         outer_maximum=200,
         inner_maximum=50,
         print_option="all",
-        outer_dvclose=1.0e-8,
-        inner_dvclose=1.0e-8,
+        outer_dvclose=1.0e-6,
+        inner_dvclose=1.0e-6,
         linear_acceleration="BICGSTAB",
         backtracking_number=5,
         backtracking_tolerance=1.0,
@@ -464,7 +464,7 @@ def check_output(idx, test):
 
         fja = flowja[itime].flatten()
         qresidual = fja[ia[:-1]]
-        atol = 0.03
+        atol = 0.1
         for n in range(grb.nodes):
             passfail = "FAIL" if abs(qresidual[n]) > atol else ""
             print(

--- a/doc/mf6io/mf6ivar/dfn/swf-dfw.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-dfw.dfn
@@ -46,6 +46,15 @@ description keyword to indicate that calculated flows between cells will be prin
 mf6internal iprflow
 
 block options
+name save_velocity
+type keyword
+reader urword
+optional true
+longname keyword to save velocity
+description keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.
+mf6internal isavvelocity
+
+block options
 name obs_filerecord
 type record obs6 filein obs6_filename
 shape
@@ -87,6 +96,18 @@ reader urword
 optional false
 longname obs6 input filename
 description REPLACE obs6_filename {'{#1}': 'DFW'}
+
+# dev options
+
+block options
+name dev_swr_conductance
+type keyword
+reader urword
+optional true
+longname use SWR conductance formulation
+description use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005.
+mf6internal iswrcond
+
 
 # --------------------- swf dfw griddata ---------------------
 

--- a/make/makefile
+++ b/make/makefile
@@ -359,6 +359,7 @@ $(OBJDIR)/InputLoadType.o \
 $(OBJDIR)/swf-cxs.o \
 $(OBJDIR)/Disv1d.o \
 $(OBJDIR)/swf-ic.o \
+$(OBJDIR)/VectorInterpolation.o \
 $(OBJDIR)/MethodDisv.o \
 $(OBJDIR)/MethodDis.o \
 $(OBJDIR)/GridConnection.o \

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -288,6 +288,7 @@
 		<File RelativePath="..\src\Model\ModelUtilities\TrackData.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\TspAdvOptions.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\UzfCellGroup.f90"/>
+		<File RelativePath="..\src\Model\ModelUtilities\VectorInterpolation.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\Xt3dAlgorithm.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\Xt3dInterface.f90"/></Filter>
 		<Filter Name="ParticleTracking">

--- a/src/Idm/swf-dfwidm.f90
+++ b/src/Idm/swf-dfwidm.f90
@@ -16,10 +16,12 @@ module SwfDfwInputModule
     logical :: timeconv = .false.
     logical :: ipakcb = .false.
     logical :: iprflow = .false.
+    logical :: isavvelocity = .false.
     logical :: obs_filerecord = .false.
     logical :: obs6 = .false.
     logical :: filein = .false.
     logical :: obs6_filename = .false.
+    logical :: iswrcond = .false.
     logical :: manningsn = .false.
     logical :: idcxs = .false.
   end type SwfDfwParamFoundType
@@ -112,6 +114,23 @@ module SwfDfwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
+    swfdfw_isavvelocity = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DFW', & ! subcomponent
+    'OPTIONS', & ! block
+    'SAVE_VELOCITY', & ! tag name
+    'ISAVVELOCITY', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
     swfdfw_obs_filerecord = InputParamDefinitionType &
     ( &
     'SWF', & ! component
@@ -180,6 +199,23 @@ module SwfDfwInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
+    swfdfw_iswrcond = InputParamDefinitionType &
+    ( &
+    'SWF', & ! component
+    'DFW', & ! subcomponent
+    'OPTIONS', & ! block
+    'DEV_SWR_CONDUCTANCE', & ! tag name
+    'ISWRCOND', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
     swfdfw_manningsn = InputParamDefinitionType &
     ( &
     'SWF', & ! component
@@ -221,10 +257,12 @@ module SwfDfwInputModule
     swfdfw_timeconv, &
     swfdfw_ipakcb, &
     swfdfw_iprflow, &
+    swfdfw_isavvelocity, &
     swfdfw_obs_filerecord, &
     swfdfw_obs6, &
     swfdfw_filein, &
     swfdfw_obs6_filename, &
+    swfdfw_iswrcond, &
     swfdfw_manningsn, &
     swfdfw_idcxs &
     ]

--- a/src/Model/Discretization/Dis2d.f90
+++ b/src/Model/Discretization/Dis2d.f90
@@ -1000,78 +1000,54 @@ contains
 
   !> @brief Get unit vector components between the cell and a given neighbor
   !!
-  !! Saturation must be provided to compute cell center vertical coordinates.
-  !! Also return the straight-line connection length.
-  !<
+  !< For dis2d there is no z component
   subroutine connection_vector(this, noden, nodem, nozee, satn, satm, ihc, &
                                xcomp, ycomp, zcomp, conlen)
-    ! -- modules
+    ! modules
     use DisvGeom, only: line_unit_vector
-    ! -- dummy
+    ! dummy
     class(Dis2dType) :: this
     integer(I4B), intent(in) :: noden !< cell (reduced nn)
     integer(I4B), intent(in) :: nodem !< neighbor (reduced nn)
-    logical, intent(in) :: nozee
-    real(DP), intent(in) :: satn
-    real(DP), intent(in) :: satm
-    integer(I4B), intent(in) :: ihc !< horizontal connection flag
-    real(DP), intent(inout) :: xcomp
-    real(DP), intent(inout) :: ycomp
-    real(DP), intent(inout) :: zcomp
-    real(DP), intent(inout) :: conlen
-    ! -- local
+    logical, intent(in) :: nozee !< not used for dis2d
+    real(DP), intent(in) :: satn !< not used for dis2d
+    real(DP), intent(in) :: satm !< not used for dis2d
+    integer(I4B), intent(in) :: ihc !< not used for dis2d (always horizontal)
+    real(DP), intent(inout) :: xcomp !< x component of the connection vector
+    real(DP), intent(inout) :: ycomp !< y componenet of the connection vector
+    real(DP), intent(inout) :: zcomp !< z component, which is always zero
+    real(DP), intent(inout) :: conlen !< calculated connection length
+    ! local
     real(DP) :: z1, z2
     real(DP) :: x1, y1, x2, y2
     real(DP) :: ds
     integer(I4B) :: i1, i2, j1, j2, k1, k2
     integer(I4B) :: nodeu1, nodeu2, ipos
-    !
-    ! -- Set vector components based on ihc
-    if (ihc == 0) then
-      !
-      ! -- vertical connection; set zcomp positive upward
-      xcomp = DZERO
-      ycomp = DZERO
-      if (nodem < noden) then
-        zcomp = DONE
-      else
-        zcomp = -DONE
-      end if
-      z1 = this%bot(noden) + DHALF * (this%top(noden) - this%bot(noden))
-      z2 = this%bot(nodem) + DHALF * (this%top(nodem) - this%bot(nodem))
-      conlen = abs(z2 - z1)
-    else
-      !
-      if (nozee) then
-        z1 = DZERO
-        z2 = DZERO
-      else
-        z1 = this%bot(noden) + DHALF * satn * (this%top(noden) - this%bot(noden))
-        z2 = this%bot(nodem) + DHALF * satm * (this%top(nodem) - this%bot(nodem))
-      end if
-      ipos = this%con%getjaindex(noden, nodem)
-      ds = this%con%cl1(this%con%jas(ipos)) + this%con%cl2(this%con%jas(ipos))
-      nodeu1 = this%get_nodeuser(noden)
-      nodeu2 = this%get_nodeuser(nodem)
-      call get_ijk(nodeu1, this%nrow, this%ncol, 1, i1, j1, k1)
-      call get_ijk(nodeu2, this%nrow, this%ncol, 1, i2, j2, k2)
-      x1 = DZERO
-      x2 = DZERO
-      y1 = DZERO
-      y2 = DZERO
-      if (i2 < i1) then ! back
-        y2 = ds
-      elseif (j2 < j1) then ! left
-        x2 = -ds
-      elseif (j2 > j1) then ! right
-        x2 = ds
-      else ! front
-        y2 = -ds
-      end if
-      call line_unit_vector(x1, y1, z1, x2, y2, z2, xcomp, ycomp, zcomp, conlen)
+
+    ! Calculate vector components
+    z1 = DZERO
+    z2 = DZERO
+    ipos = this%con%getjaindex(noden, nodem)
+    ds = this%con%cl1(this%con%jas(ipos)) + this%con%cl2(this%con%jas(ipos))
+    nodeu1 = this%get_nodeuser(noden)
+    nodeu2 = this%get_nodeuser(nodem)
+    call get_ijk(nodeu1, this%nrow, this%ncol, 1, i1, j1, k1)
+    call get_ijk(nodeu2, this%nrow, this%ncol, 1, i2, j2, k2)
+    x1 = DZERO
+    x2 = DZERO
+    y1 = DZERO
+    y2 = DZERO
+    if (i2 < i1) then ! back
+      y2 = ds
+    elseif (j2 < j1) then ! left
+      x2 = -ds
+    elseif (j2 > j1) then ! right
+      x2 = ds
+    else ! front
+      y2 = -ds
     end if
-    !
-  end subroutine
+    call line_unit_vector(x1, y1, z1, x2, y2, z2, xcomp, ycomp, zcomp, conlen)
+  end subroutine connection_vector
 
   !> @brief Get the discretization type
   !<

--- a/src/Model/GroundWaterFlow/gwf-npf.f90
+++ b/src/Model/GroundWaterFlow/gwf-npf.f90
@@ -1055,9 +1055,10 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
+
+    ! pointers
+    this%hnew => null()
+
   end subroutine npf_da
 
   !> @ brief Allocate scalars
@@ -2425,7 +2426,7 @@ contains
     return
   end function hy_eff
 
-  !> @brief Calculate the 3 conmponents of specific discharge at the cell center
+  !> @brief Calculate the 3 components of specific discharge at the cell center
   !<
   subroutine calc_spdis(this, flowja)
     ! -- modules

--- a/src/Model/ModelUtilities/VectorInterpolation.f90
+++ b/src/Model/ModelUtilities/VectorInterpolation.f90
@@ -1,0 +1,289 @@
+module VectorInterpolationModule
+
+  use KindModule, only: I4B, DP
+  use ConstantsModule, only: DZERO, DONE, DEM10
+  use BaseDisModule, only: DisBaseType
+
+  implicit none
+
+  public :: vector_interpolation_2d
+
+  contains
+
+  !> @brief Interpolate 2D vector components at cell center
+  !!
+  !! Given a component of a vector on the edges of all cells, assumed to be
+  !! normal to the edge, interpolate a 2d vector using an XT3D-like
+  !! interpolation.  Can be used to calculate a cell-center velocity given
+  !! face flows.  Routine can optionally divide the edge flow by area,
+  !! if provided, to interpolate velocity, for example.  Sign on flowja is
+  !! assumed to be positive into the cell.
+  !!
+  !! Routine requires that dis%connection_vector() and dis%connection_normal()
+  !! are available.
+  !<
+  subroutine vector_interpolation_2d(dis, flowja, nedges, nodedge, &
+                                     propsedge, vcomp, vmag, flowareaja)
+    ! modules
+    ! dummy
+    class(DisBaseType), intent(in) :: dis !< discretization package object
+    real(DP), intent(in), dimension(:) :: flowja !< flow across each face in model grid
+    integer(I4B), intent(in), optional :: nedges !< number of external edges for which a flow is provided
+    integer(I4B), dimension(:), intent(in), optional :: nodedge !< array of node numbers that have edges
+    real(DP), dimension(:, :), intent(in), optional :: propsedge !< edge properties (Q, area, nx, ny, distance)
+    real(DP), dimension(:, :), intent(inout), optional :: vcomp !< vector components: vx, vy, vz (nodes, 3)
+    real(DP), dimension(:), intent(inout), optional :: vmag !< vector magnitude (nodes)
+    real(DP), intent(in), dimension(:), optional :: flowareaja !< flow area across each face in model grid
+    ! local
+    integer(I4B) :: n
+    integer(I4B) :: m
+    integer(I4B) :: ipos
+    integer(I4B) :: isympos
+    integer(I4B) :: ihc
+    integer(I4B) :: ic
+    integer(I4B) :: iz
+    integer(I4B) :: nc
+    real(DP) :: vx
+    real(DP) :: vy
+    real(DP) :: vz
+    real(DP) :: xn
+    real(DP) :: yn
+    real(DP) :: zn
+    real(DP) :: xc
+    real(DP) :: yc
+    real(DP) :: zc
+    real(DP) :: cl1
+    real(DP) :: cl2
+    real(DP) :: dltot
+    real(DP) :: ooclsum
+    real(DP) :: dsumx
+    real(DP) :: dsumy
+    real(DP) :: dsumz
+    real(DP) :: denom
+    real(DP) :: area
+    real(DP) :: axy
+    real(DP) :: ayx
+    real(DP), allocatable, dimension(:) :: vi
+    real(DP), allocatable, dimension(:) :: di
+    real(DP), allocatable, dimension(:) :: viz
+    real(DP), allocatable, dimension(:) :: diz
+    real(DP), allocatable, dimension(:) :: nix
+    real(DP), allocatable, dimension(:) :: niy
+    real(DP), allocatable, dimension(:) :: wix
+    real(DP), allocatable, dimension(:) :: wiy
+    real(DP), allocatable, dimension(:) :: wiz
+    real(DP), allocatable, dimension(:) :: bix
+    real(DP), allocatable, dimension(:) :: biy
+    logical :: nozee = .true.
+    !
+    ! -- Ensure dis has necessary information
+    ! todo: do we need this?  this needs to be done outside of this routine
+    ! if (this%icalcvelocity /= 0 .and. this%dis%con%ianglex == 0) then
+    !   call store_error('Error.  ANGLDEGX not provided in '// &
+    !                    'discretization file.  ANGLDEGX required for '// &
+    !                    'calculation of velocity.', terminate=.TRUE.)
+    ! end if
+    !
+    ! -- Find max number of connections and allocate weight arrays
+    nc = 0
+    do n = 1, dis%nodes
+      !
+      ! -- Count internal model connections
+      ic = dis%con%ia(n + 1) - dis%con%ia(n) - 1
+      !
+      ! -- Count edge connections
+      if (present(nedges)) then
+        do m = 1, nedges
+          if (nodedge(m) == n) then
+            ic = ic + 1
+          end if
+        end do
+      end if
+      !
+      ! -- Set max number of connections for any cell
+      if (ic > nc) nc = ic
+    end do
+    !
+    ! -- Allocate storage arrays needed for cell-centered calculation
+    allocate (vi(nc))
+    allocate (di(nc))
+    allocate (viz(nc))
+    allocate (diz(nc))
+    allocate (nix(nc))
+    allocate (niy(nc))
+    allocate (wix(nc))
+    allocate (wiy(nc))
+    allocate (wiz(nc))
+    allocate (bix(nc))
+    allocate (biy(nc))
+    !
+    ! -- Go through each cell and calculate specific discharge
+    do n = 1, dis%nodes
+      !
+      ! -- first calculate geometric properties for x and y directions and
+      !    the specific discharge at a face (vi)
+      ic = 0
+      iz = 0
+      vi(:) = DZERO
+      di(:) = DZERO
+      viz(:) = DZERO
+      diz(:) = DZERO
+      nix(:) = DZERO
+      niy(:) = DZERO
+      do ipos = dis%con%ia(n) + 1, dis%con%ia(n + 1) - 1
+        m = dis%con%ja(ipos)
+        isympos = dis%con%jas(ipos)
+        ihc = 1
+        ic = ic + 1
+
+        ! Find the normal components (xn, yn, zn) for this connection
+        call dis%connection_normal(n, m, ihc, xn, yn, zn, ipos)
+
+        ! Find the straight-line distance between n and m and put
+        ! in dltot
+        call dis%connection_vector(n, m, nozee, DONE, DONE, &
+                                   ihc, xc, yc, zc, dltot)
+
+        ! Find the connection lengths, cl1 and cl2, adjusting for the
+        ! n, m symmetry
+        cl1 = dis%con%cl1(isympos)
+        cl2 = dis%con%cl2(isympos)
+        if (m < n) then
+          cl1 = dis%con%cl2(isympos)
+          cl2 = dis%con%cl1(isympos)
+        end if
+
+        ! Set the normal components and distance for this connection
+        ooclsum = DONE / (cl1 + cl2)
+        nix(ic) = -xn
+        niy(ic) = -yn
+        di(ic) = dltot * cl1 * ooclsum
+
+        ! Set vi to flow area and divide by area if present
+        vi(ic) = flowja(ipos)
+        if (present(flowareaja)) then
+          area = flowareaja(isympos)
+          if (area > DZERO) then
+            vi(ic) = vi(ic) / area
+          else
+            vi(ic) = DZERO
+          end if
+        end if
+
+      end do
+      !
+      ! -- Look through edge flows that may have been provided by an exchange
+      !    and incorporate them into the averaging arrays
+      if (present(nedges)) then
+        do m = 1, nedges        
+          if (nodedge(m) == n) then
+            ic = ic + 1
+            nix(ic) = -propsedge(3, m)
+            niy(ic) = -propsedge(4, m)
+            di(ic) = propsedge(5, m)
+            vi(ic) = propsedge(1, m)
+            if (present(flowareaja)) then
+              area = propsedge(2, m)
+              if (area > DZERO) then
+                vi(ic) = vi(ic) / area
+              else
+                vi(ic) = DZERO
+              end if
+            end if
+          end if
+        end do
+      end if
+
+      ! Set vz to zero
+      vz = DZERO
+
+      ! -- distance-based weighting
+      nc = ic
+      dsumx = DZERO
+      dsumy = DZERO
+      dsumz = DZERO
+      do ic = 1, nc
+        wix(ic) = di(ic) * abs(nix(ic))
+        wiy(ic) = di(ic) * abs(niy(ic))
+        dsumx = dsumx + wix(ic)
+        dsumy = dsumy + wiy(ic)
+      end do
+      !
+      ! -- Finish computing omega weights.  Add a tiny bit
+      !    to dsum so that the normalized omega weight later
+      !    evaluates to (essentially) 1 in the case of a single
+      !    relevant connection, avoiding 0/0.
+      dsumx = dsumx + DEM10 * dsumx
+      dsumy = dsumy + DEM10 * dsumy
+      do ic = 1, nc
+        wix(ic) = (dsumx - wix(ic)) * abs(nix(ic))
+        wiy(ic) = (dsumy - wiy(ic)) * abs(niy(ic))
+      end do
+      !
+      ! -- compute B weights
+      dsumx = DZERO
+      dsumy = DZERO
+      do ic = 1, nc
+        bix(ic) = wix(ic) * sign(DONE, nix(ic))
+        biy(ic) = wiy(ic) * sign(DONE, niy(ic))
+        dsumx = dsumx + wix(ic) * abs(nix(ic))
+        dsumy = dsumy + wiy(ic) * abs(niy(ic))
+      end do
+      if (dsumx > DZERO) dsumx = DONE / dsumx
+      if (dsumy > DZERO) dsumy = DONE / dsumy
+      axy = DZERO
+      ayx = DZERO
+      do ic = 1, nc
+        bix(ic) = bix(ic) * dsumx
+        biy(ic) = biy(ic) * dsumy
+        axy = axy + bix(ic) * niy(ic)
+        ayx = ayx + biy(ic) * nix(ic)
+      end do
+      !
+      ! -- Calculate vector components at cell center. The divide by zero checking
+      !    below is problematic for cells with only one flow, such as can happen
+      !    with triangular cells in corners.  In this case, the resulting
+      !    cell velocity will be calculated as zero.  The method should be
+      !    improved so that edge flows of zero are included in these
+      !    calculations.  But this needs to be done with consideration for LGR
+      !    cases in which flows are submitted from an exchange.
+      vx = DZERO
+      vy = DZERO
+      do ic = 1, nc
+        vx = vx + (bix(ic) - axy * biy(ic)) * vi(ic)
+        vy = vy + (biy(ic) - ayx * bix(ic)) * vi(ic)
+      end do
+      denom = DONE - axy * ayx
+      if (denom /= DZERO) then
+        vx = vx / denom
+        vy = vy / denom
+      end if
+
+      ! Store velocity components
+      if (present(vcomp)) then
+        vcomp(1, n) = vx
+        vcomp(2, n) = vy
+        vcomp(3, n) = vz
+      end if
+
+      ! Store velocity magnitude
+      if (present(vmag)) then
+        vmag(n) = sqrt(vx ** 2 + vy ** 2 + vz ** 2)
+      end if
+
+    end do
+
+    ! cleanup
+    deallocate (vi)
+    deallocate (di)
+    deallocate (nix)
+    deallocate (niy)
+    deallocate (wix)
+    deallocate (wiy)
+    deallocate (wiz)
+    deallocate (bix)
+    deallocate (biy)
+
+  end subroutine vector_interpolation_2d
+
+end module VectorInterpolationModule

--- a/src/Model/ModelUtilities/VectorInterpolation.f90
+++ b/src/Model/ModelUtilities/VectorInterpolation.f90
@@ -8,7 +8,7 @@ module VectorInterpolationModule
 
   public :: vector_interpolation_2d
 
-  contains
+contains
 
   !> @brief Interpolate 2D vector components at cell center
   !!
@@ -181,7 +181,7 @@ module VectorInterpolationModule
       ! -- Look through edge flows that may have been provided by an exchange
       !    and incorporate them into the averaging arrays
       if (present(nedges)) then
-        do m = 1, nedges        
+        do m = 1, nedges
           if (nodedge(m) == n) then
             ic = ic + 1
             nix(ic) = -propsedge(3, m)
@@ -274,7 +274,7 @@ module VectorInterpolationModule
 
       ! Store velocity magnitude
       if (present(vmag)) then
-        vmag(n) = sqrt(vx ** 2 + vy ** 2 + vz ** 2)
+        vmag(n) = sqrt(vx**2 + vy**2 + vz**2)
       end if
 
     end do

--- a/src/Model/ModelUtilities/VectorInterpolation.f90
+++ b/src/Model/ModelUtilities/VectorInterpolation.f90
@@ -27,7 +27,7 @@ module VectorInterpolationModule
     ! modules
     ! dummy
     class(DisBaseType), intent(in) :: dis !< discretization package object
-    real(DP), intent(in), dimension(:) :: flowja !< flow across each face in model grid
+    real(DP), intent(in), dimension(:) :: flowja !< flow across each face in model grid (size njas)
     integer(I4B), intent(in), optional :: nedges !< number of external edges for which a flow is provided
     integer(I4B), dimension(:), intent(in), optional :: nodedge !< array of node numbers that have edges
     real(DP), dimension(:, :), intent(in), optional :: propsedge !< edge properties (Q, area, nx, ny, distance)
@@ -56,6 +56,7 @@ module VectorInterpolationModule
     real(DP) :: cl2
     real(DP) :: dltot
     real(DP) :: ooclsum
+    real(DP) :: q
     real(DP) :: dsumx
     real(DP) :: dsumy
     real(DP) :: dsumz
@@ -160,7 +161,12 @@ module VectorInterpolationModule
         di(ic) = dltot * cl1 * ooclsum
 
         ! Set vi to flow area and divide by area if present
-        vi(ic) = flowja(ipos)
+        q = flowja(isympos)
+        if (n < m) then
+          vi(ic) = q
+        else
+          vi(ic) = -q
+        end if
         if (present(flowareaja)) then
           area = flowareaja(isympos)
           if (area > DZERO) then

--- a/src/Model/SurfaceWaterFlow/swf-dfw.f90
+++ b/src/Model/SurfaceWaterFlow/swf-dfw.f90
@@ -261,11 +261,11 @@ contains
     call mem_allocate(this%nodedge, 0, 'NODEDGE', this%memoryPath)
     call mem_allocate(this%ihcedge, 0, 'IHCEDGE', this%memoryPath)
     call mem_allocate(this%propsedge, 0, 0, 'PROPSEDGE', this%memoryPath)
-                                        
+
     ! Specific discharge is (re-)allocated when nedges is known
     call mem_allocate(this%vcomp, 3, 0, 'VCOMP', this%memoryPath)
     call mem_allocate(this%vmag, 0, 'VMAG', this%memoryPath)
-    
+
     do n = 1, this%dis%nodes
       this%manningsn(n) = DZERO
       this%idcxs(n) = 0
@@ -285,7 +285,7 @@ contains
         this%dhdsja(n) = DZERO
       end do
     end if
-  
+
     ! -- Return
     return
   end subroutine allocate_arrays
@@ -337,11 +337,11 @@ contains
                        this%input_mempath, found%ipakcb)
     call mem_set_value(this%isavvelocity, 'ISAVVELOCITY', &
                        this%input_mempath, found%isavvelocity)
-    
+
     ! save flows option active
     if (found%icentral) this%icentral = 1
     if (found%ipakcb) this%ipakcb = -1
-     
+
     ! calculate unit conversion
     this%unitconv = this%lengthconv**DONETHIRD
     this%unitconv = this%unitconv * this%timeconv
@@ -427,7 +427,7 @@ contains
 
     if (found%iswrcond) then
       write (this%iout, '(4x,a, G0)') 'Conductance will be calculated using &
-                                       &the SWR development option.' 
+                                       &the SWR development option.'
     end if
 
     write (this%iout, '(1x,a,/)') 'End Setting DFW Options'
@@ -768,7 +768,7 @@ contains
     length_nm = cln + clm
     cond = DZERO
     if (length_nm > DPREC) then
-      
+
       ! -- Calculate depth in each reach
       depth_n = stage_n - this%dis%bot(n)
       depth_m = stage_m - this%dis%bot(m)
@@ -843,7 +843,7 @@ contains
     ! Calculate conveyance, which is a * r**DTWOTHIRDS / roughc
     rough = this%manningsn(n)
     conveyance = this%cxs%get_conveyance(this%idcxs(n), width, depth, rough)
-    dhds_sqr = dhds ** DHALF
+    dhds_sqr = dhds**DHALF
     if (dhds_sqr < DEM10) then
       dhds_sqr = DEM10
     end if
@@ -940,7 +940,7 @@ contains
                                             depth_m, area_m)
         rhavg = weight_n * rhn + weight_m * rhm
       else
-        rhavg =  area_avg / width_n
+        rhavg = area_avg / width_n
       end if
       rhavg = rhavg**DTWOTHIRDS
 
@@ -952,7 +952,7 @@ contains
         dhds_m = this%grad_dhds_mag(m)
         dhds_nm = weight_n * dhds_n + weight_m * dhds_m
       end if
-      dhds_sqr = dhds_nm ** DHALF
+      dhds_sqr = dhds_nm**DHALF
       if (dhds_sqr < DEM10) then
         dhds_sqr = DEM10
       end if
@@ -1345,7 +1345,6 @@ contains
         ihc = this%dis%con%ihc(isympos)
         area = this%dis%con%hwva(isympos)
 
-
         ! -- horizontal connection
         ic = ic + 1
         if (this%hnew(n) > this%hnew(m)) then
@@ -1372,7 +1371,6 @@ contains
         else
           vi(ic) = DZERO
         end if
-
 
       end do
       !
@@ -1492,7 +1490,7 @@ contains
       this%vcomp(1, n) = vx
       this%vcomp(2, n) = vy
       this%vcomp(3, n) = vz
-      this%vmag(n) = sqrt(vx ** 2 + vy ** 2 + vz ** 2)
+      this%vmag(n) = sqrt(vx**2 + vy**2 + vz**2)
       !
     end do
     !

--- a/src/Model/SurfaceWaterFlow/swf.f90
+++ b/src/Model/SurfaceWaterFlow/swf.f90
@@ -391,7 +391,7 @@ contains
     !
     ! -- Call dis_ar to write binary grid file
     call this%dis%dis_ar(itemp)
-    if (this%indfw > 0) call this%dfw%dfw_ar(this%ibound)
+    if (this%indfw > 0) call this%dfw%dfw_ar(this%ibound, this%x)
     if (this%insto > 0) call this%sto%sto_ar(this%dis, this%ibound)
     if (this%inobs > 0) call this%obs%swf_obs_ar(this%ic, this%x, this%flowja)
     deallocate (itemp)
@@ -703,6 +703,14 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_bd(this%budget)
     end do
+    !
+    ! -- dfw velocities have to be calculated here, after swf-swf exchanges
+    !    have passed in their contributions from exg_cq()
+    if (this%indfw > 0) then
+      if (this%dfw%icalcvelocity /= 0) then
+        call this%dfw%calc_velocity(this%flowja)
+      end if
+    end if
     !
     ! -- Return
     return

--- a/src/meson.build
+++ b/src/meson.build
@@ -209,6 +209,7 @@ modflow_sources = files(
     'Model' / 'ModelUtilities' / 'TimeSelect.f90',
     'Model' / 'ModelUtilities' / 'TrackData.f90',
     'Model' / 'ModelUtilities' / 'UzfCellGroup.f90',
+    'Model' / 'ModelUtilities' / 'VectorInterpolation.f90',
     'Model' / 'ModelUtilities' / 'Xt3dAlgorithm.f90',
     'Model' / 'ModelUtilities' / 'Xt3dInterface.f90',
     'Model' / 'TransportModel' / 'tsp.f90',


### PR DESCRIPTION
* Added coordinate invariant flow calculations by using xt3d-style interpolation of gradient on cell faces to cell center.  This gradient is then averaged to cell faces and used in the denominator of the mannings flow expression.
* Added capability to save overland flow velocities to SWF budget file.  Flows are saved when SAVE_VELOCITY keyword is added to the SWF-DFW options block.
* added DEV_SWF_CONDUCTANCE option to SWF-DFW package to allow testing of the SWF model using the flow expression implemented in the SWR Process for MODFLOW-2005.