### PR TITLE
ci(pixi): pin pixi version to 0.19.1 for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
       - name: Checkout modflow6
         uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.5.1
+      - uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
 
       - name: Check Fortran source formatting
         run: pixi run fortran-format-check
@@ -79,9 +79,9 @@ jobs:
           compiler: gcc
           version: ${{ env.FC_V }}
 
-      - uses: prefix-dev/setup-pixi@v0.5.1
+      - uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
 
       - name: Meson setup
         run: pixi run setup -Dwerror=true builddir
@@ -124,9 +124,9 @@ jobs:
           version: ${{ env.FC_V }}
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.5.1
+        uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
           manifest-path: "modflow6/pixi.toml"
 
       - name: Build test-drive
@@ -219,9 +219,9 @@ jobs:
           version: ${{ env.FC_V }}
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.5.1
+        uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
           manifest-path: "modflow6/pixi.toml"
 
       - name: Build modflow6
@@ -332,9 +332,9 @@ jobs:
           path: modflow6-examples
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.5.1
+        uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
           manifest-path: "modflow6/pixi.toml"
 
       - name: Setup ${{ env.FC }} ${{ env.FC_V }}
@@ -419,9 +419,9 @@ jobs:
           path: modflow6
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.5.1
+        uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
           manifest-path: "modflow6/pixi.toml"
 
       - name: Test parallel MF6

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -138,9 +138,9 @@ jobs:
           version: ${{ matrix.version }}
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.5.1
+        uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
           manifest-path: "modflow6/pixi.toml"
 
       - name: Build modflow6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,9 +43,9 @@ jobs:
           path: usgslatex
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.5.1
+        uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
           manifest-path: "modflow6/pixi.toml"
   
       - name: Install additional packages for Sphinx using pip
@@ -194,9 +194,9 @@ jobs:
           sudo apt-get install doxygen graphviz
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.5.1
+        uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
 
       - name: Print python package versions
         run: pixi run pip list

--- a/.github/workflows/large.yml
+++ b/.github/workflows/large.yml
@@ -67,9 +67,9 @@ jobs:
           path: modflow6-largetestmodels
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.5.1
+        uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
           manifest-path: "modflow6/pixi.toml"
 
       - name: Setup ${{ matrix.compiler }} ${{ matrix.version }}

--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.5.1
+      - uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
           cache: false
 
       - name: Update pixi lock file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,9 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.5.1
+        uses: prefix-dev/setup-pixi@v0.5.2
         with:
-          pixi-version: "latest"
+          pixi-version: v0.19.1
           manifest-path: "modflow6/pixi.toml"
 
       - name: Setup Micromamba


### PR DESCRIPTION
* pin pixi version to [0.19.1](https://github.com/prefix-dev/pixi/releases/tag/v0.19.1)
* bump setup-pixi to [0.5.2](https://github.com/prefix-dev/setup-pixi/releases/tag/v0.5.2)
* avoid breaking changes while pixi matures &mdash; pinning the action alone leaves us exposed to regressions in pixi itself
* discussed offline with @langevin-usgs @jdhughes-usgs @mjr-deltares 