### PR TITLE
ci: add test job for arm mac with gfortran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-12, windows-2022 ]
+        os: [ ubuntu-22.04, macos-12, macos-14, windows-2022 ]
     defaults:
       run:
         shell: bash
@@ -223,6 +223,15 @@ jobs:
         with:
           pixi-version: v0.19.1
           manifest-path: "modflow6/pixi.toml"
+
+      - name: Set LDFLAGS (macOS)
+        if: matrix.os == 'macos-14'
+        run: |
+          os_ver=$(sw_vers -productVersion | cut -d'.' -f1)
+          if (( "$os_ver" > 12 )); then
+            ldflags="$LDFLAGS -Wl,-ld_classic"
+            echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
+          fi
 
       - name: Build modflow6
         working-directory: modflow6


### PR DESCRIPTION
Up to now we only test ARM mac as part of the release workflow. We should probably test in standard CI.