### PR TITLE
test(framework): remove verbose warnings on simulation failure

### DIFF
--- a/autotest/framework.py
+++ b/autotest/framework.py
@@ -660,16 +660,6 @@ class TestFramework:
                 else:
                     success = True
 
-            lst_file_path = Path(workspace) / "mfsim.lst"
-            if (
-                "mf6" in target.name
-                and not success
-                and lst_file_path.is_file()
-            ):
-                warn(
-                    "MODFLOW 6 listing file ended with: \n"
-                    + get_mfsim_lst_tail(lst_file_path)
-                )
         except Exception:
             success = False
             warn(


### PR DESCRIPTION
Showing the end of the list file in case of simulation failure makes CI logs extremely verbose, making it difficult to scroll/read. We upload failed test outputs as artifacts, so the list file can be inspected that way if needed.