### PR TITLE
fix(uzf): rename uzf package variables to avoid name clashes

### DIFF
--- a/src/Model/GroundWaterFlow/gwf-uzf.f90
+++ b/src/Model/GroundWaterFlow/gwf-uzf.f90
@@ -2035,7 +2035,8 @@ contains
           n = this%igwfnode(i)
           call this%uzfobj%setdata(i, this%gwfarea(n), this%gwftop(n), &
                                    this%gwfbot(n), surfdep, vks, thtr, thts, &
-                                   thti, eps, this%ntrail_pvar, landflag, ivertcon)
+                                   thti, eps, this%ntrail_pvar, landflag, &
+                                   ivertcon)
           if (ivertcon > 0) then
             this%iuzf2uzf = 1
           end if

--- a/src/Model/GroundWaterFlow/gwf-uzf.f90
+++ b/src/Model/GroundWaterFlow/gwf-uzf.f90
@@ -95,7 +95,7 @@ module UzfModule
     real(DP), dimension(:), pointer, contiguous :: wcnew => null() !< water content for this time step
     real(DP), dimension(:), pointer, contiguous :: wcold => null() !< water content for previous time step
     !
-    ! -- timeseries aware package variables; these variables with 
+    ! -- timeseries aware package variables; these variables with
     !    _pvar have uzfobj counterparts
     real(DP), dimension(:), pointer, contiguous :: sinf_pvar => null()
     real(DP), dimension(:), pointer, contiguous :: pet_pvar => null()


### PR DESCRIPTION
* 9 uzf variables had counterparts in uzf%uzfobj with the same memory path
* renamed the uzf package variables by adding _pvar to them
* close #1741 

This does not fix underlying memory problems with UZF.  Instead it is a simple way to avoid multiple uzf variables with the same memory path.  A proper fix will require additional work as the variable contents in uzf and uzf%uzfobj are not the same.