### PR TITLE
ci(release): support model selection for docs/dfns/examples

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,10 @@ on:
         description: 'Version number to use for release.'
         required: true
         type: string
+      models:
+        description: 'Models to include in the release documentation'
+        required: false
+        type: string
     outputs:
       version:
         description: 'Version number used for release'
@@ -419,7 +423,9 @@ jobs:
       - name: Build example models
         if: inputs.full == true
         working-directory: modflow6-examples/autotest
-        run: pytest -v -n auto test_scripts.py --init
+        run: |
+          models="${{ inputs.models }}""
+          pytest -v -n auto test_scripts.py --init -k "${$models/,/ or }"
       
       - name: Create folder structure
         if: inputs.full == true
@@ -461,7 +467,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "${{ needs.build.outputs.distname }}/doc"
-          cmd="python modflow6/distribution/build_docs.py -b bin -o doc"
+          models="${{ inputs.models }}""
+          cmd="python modflow6/distribution/build_docs.py -b bin -o doc -m ${models/,/ -m }"
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -575,40 +575,14 @@ jobs:
           echo "dist directory contains:"
           ls
       
-      - name: Install dependencies for example models
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          pip install -r modflow6-examples/etc/requirements.pip.txt
-          distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
-          echo "$distname/bin" >> $GITHUB_PATH
-          # execute permissions may not have survived artifact upload/download
-          chmod +x "$distname/bin/mf6"
-          chmod +x "$distname/bin/mf5to6"
-          chmod +x "$distname/bin/zbud6"
-
-      # the example models also need mf2005, triangle and gridgen
-      - name: Install extra executables
-        uses: modflowpy/install-modflow-action@v1
-        with:
-          subset: mf2005,triangle,gridgen
-
-      - name: Update Flopy
-        working-directory: modflow6/autotest
-        run: python update_flopy.py
-  
-      - name: Build example models
-        if: inputs.full == true
-        working-directory: modflow6-examples/autotest
-        run: pytest -v -n auto test_scripts.py --init
-
       - name: Build distribution
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           # build distribution
           distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
-          cmd="python modflow6/distribution/build_dist.py -o $distname -e modflow6-examples"
+          models="${{ inputs.models }}"
+          cmd="python modflow6/distribution/build_dist.py -o $distname -m ${models//,/ -m }"
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,8 +424,8 @@ jobs:
         if: inputs.full == true
         working-directory: modflow6-examples/autotest
         run: |
-          models="${{ inputs.models }}""
-          pytest -v -n auto test_scripts.py --init -k "${$models/,/ or }"
+          models="${{ inputs.models }}"
+          pytest -v -n auto test_scripts.py --init -k "${models//,/ or }"
       
       - name: Create folder structure
         if: inputs.full == true
@@ -467,8 +467,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "${{ needs.build.outputs.distname }}/doc"
-          models="${{ inputs.models }}""
-          cmd="python modflow6/distribution/build_docs.py -b bin -o doc -m ${models/,/ -m }"
+          models="${{ inputs.models }}"
+          cmd="python modflow6/distribution/build_docs.py -b bin -o doc -m ${models//,/ -m }"
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
           fi

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -48,6 +48,10 @@ on:
         description: 'Version number to use for release.'
         required: true
         type: string
+      models:
+        description: 'Models to include in the release documentation'
+        required: false
+        type: string
 jobs:
   set_options:
     name: Set release options
@@ -137,6 +141,7 @@ jobs:
       full: true
       run_tests: ${{ inputs.run_tests }}
       version: ${{ needs.set_options.outputs.version }}
+      models: ${{ inputs.models }}
   pr:
     name: Draft release PR
     if: ${{ github.ref_name != 'master' && ((github.event_name == 'workflow_dispatch' && inputs.approve == 'true') || (github.event_name != 'workflow_dispatch' && !contains(github.ref_name, 'rc'))) }}

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -124,7 +124,7 @@ def setup_examples(
     download_and_unzip(asset["browser_download_url"], examples_path, verbose=True)
 
     # filter examples for models selected for release
-    for p in os.listdir(examples_path):
+    for p in examples_path.glob("*"):
         if not any(m in p.stem for m in models):
             p.unlink()
 
@@ -418,5 +418,5 @@ if __name__ == "__main__":
         output_path=out_path,
         full=args.full,
         overwrite=args.force,
-        model=models,
+        models=models,
     )

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -618,7 +618,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-m",
-        "--models",
+        "--model",
         required=False,
         action="append",
         help="Filter model types to include",

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -487,11 +487,15 @@ def build_documentation(
     bin_path = Path(bin_path).expanduser().absolute()
     output_path = Path(output_path).expanduser().absolute()
 
+    if (output_path / "mf6io.pdf").is_file() and not overwrite:
+        print(f"{output_path / 'mf6io.pdf'} already exists")
+        return
+
     # make sure output directory exists
     output_path.mkdir(parents=True, exist_ok=True)
 
     # build LaTex input/output docs from DFN files
-    build_mf6io_tex_from_dfn(overwrite=True, models=models)
+    build_mf6io_tex_from_dfn(overwrite=overwrite, models=models)
 
     # build LaTeX input/output example model docs
     with TemporaryDirectory() as temp:


### PR DESCRIPTION
* allow model selection for docs/dfns/examples in release workflow and dist scripts
* carved out from #1540 
* step toward #1491
* [test run](https://github.com/wpbonelli/modflow6/actions/runs/8754006064)