### PR TITLE
ci(release): fix model selection options for dist scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,8 +467,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "${{ needs.build.outputs.distname }}/doc"
+          cmd="python modflow6/distribution/build_docs.py -b bin -o doc"
           models="${{ inputs.models }}"
-          cmd="python modflow6/distribution/build_docs.py -b bin -o doc -m ${models//,/ -m }"
+          if [ -n "$models" ]; then
+            cmd="$cmd -m ${models//,/ -m }"
+          fi
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
           fi
@@ -581,8 +584,11 @@ jobs:
         run: |
           # build distribution
           distname="${{ needs.build.outputs.distname }}_${{ steps.ostag.outputs.ostag }}"
+          cmd="python modflow6/distribution/build_dist.py -o $distname"
           models="${{ inputs.models }}"
-          cmd="python modflow6/distribution/build_dist.py -o $distname -m ${models//,/ -m }"
+          if [ -n "$models" ]; then
+            cmd="$cmd -m ${models//,/ -m }"
+          fi
           if [[ "${{ inputs.full }}" == "true" ]]; then
             cmd="$cmd --full"
           fi

--- a/autotest/get_exes.py
+++ b/autotest/get_exes.py
@@ -53,6 +53,7 @@ def test_rebuild_release(rebuilt_bin_path: Path):
         )
 
     with TemporaryDirectory() as td:
+        # download the release
         download_path = Path(td)
         download_and_unzip(
             asset["browser_download_url"],
@@ -76,21 +77,11 @@ def test_rebuild_release(rebuilt_bin_path: Path):
                 f.write(f"{line}\n")
 
         # rebuild with Meson
-        def rebuild():
-            meson_build(
-                project_path=source_files_path.parent,
-                build_path=download_path / "builddir",
-                bin_path=rebuilt_bin_path,
-            )
-
-        # temp workaround until next release,
-        # ifx fails to build 6.4.2 on Windows
-        # most likely due to backspace issues
-        if system() == "Windows" and environ.get("FC") == "ifx":
-            with set_env(FC="ifort", CC="icl"):
-                rebuild()
-        else:
-            rebuild()
+        meson_build(
+            project_path=source_files_path.parent,
+            build_path=download_path / "builddir",
+            bin_path=rebuilt_bin_path,
+        )
 
 
 @flaky(max_runs=3)

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -6,7 +6,7 @@ import textwrap
 from os import PathLike, environ
 from pathlib import Path
 from pprint import pprint
-from shutil import copy, copyfile, copytree, ignore_patterns
+from shutil import copy, copyfile, copytree, ignore_patterns, rmtree
 from typing import List, Optional
 
 import pytest
@@ -114,19 +114,18 @@ def setup_examples(
     models: Optional[List[str]] = None,
 ):
     examples_path = Path(examples_path).expanduser().absolute()
-
-    # download example models zip asset
     latest = get_release("MODFLOW-USGS/modflow6-examples", "latest")
     assets = latest["assets"]
     asset = next(
         iter([a for a in assets if a["name"] == "modflow6-examples.zip"]), None
     )
+    # download example models zip asset
     download_and_unzip(asset["browser_download_url"], examples_path, verbose=True)
 
     # filter examples for models selected for release
     for p in examples_path.glob("*"):
         if not any(m in p.stem for m in models):
-            p.unlink()
+            rmtree(p)
 
     # list folders with mfsim.nam (recursively)
     # and add run.sh/bat script to each folder


### PR DESCRIPTION
* fix [nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/runs/8761942029/job/24049761871#step:19:35) broken by #1746
*  can't assume models will be explicitly provided, would otherwise need to set default value for `models` workflow input
* fix example filtering in `build_dist.py`, use `rmtree` not `unlink`
* [test run](https://github.com/wpbonelli/modflow6/actions/runs/8767647217) with gwf only &mdash; also, we still need to support model selection for mf6-examples repo, if we want to avoid rebuilding the examples document in `release.yml`
* unrelated: remove old workaround from `autotest/get_exes.py`