### PR TITLE
fix(par): improve CSV report for convergence in parallel mode

### DIFF
--- a/src/Solution/PETSc/PetscConvergence.F90
+++ b/src/Solution/PETSc/PetscConvergence.F90
@@ -2,7 +2,7 @@ module PetscConvergenceModule
 #include <petsc/finclude/petscksp.h>
   use petscksp
   use KindModule, only: I4B, DP
-  use ConstantsModule, only: DPREC
+  use ConstantsModule, only: DPREC, DZERO
   use ListModule
   use ConvergenceSummaryModule
   use ImsLinearSettingsModule
@@ -156,10 +156,10 @@ contains
     if (summary%nitermax > 1) then
       summary%itinner(iter_cnt) = n
       do i = 1, summary%convnmod
-        summary%convdvmax(i, iter_cnt) = -huge(dvmax_model)
-        summary%convlocdv(i, iter_cnt) = -1
-        summary%convrmax(i, iter_cnt) = -huge(rmax_model)
-        summary%convlocr(i, iter_cnt) = -1
+        summary%convdvmax(i, iter_cnt) = DZERO
+        summary%convlocdv(i, iter_cnt) = 0
+        summary%convrmax(i, iter_cnt) = DZERO
+        summary%convlocr(i, iter_cnt) = 0
       end do
     end if
 
@@ -185,10 +185,10 @@ contains
     CHKERRQ(ierr)
     do i = 1, summary%convnmod
       ! reset
-      dvmax_model = 0.0
-      idx_dv = -1
-      rmax_model = 0.0
-      idx_r = -1
+      dvmax_model = DZERO
+      idx_dv = 0
+      rmax_model = DZERO
+      idx_r = 0
       ! get first and last model index
       istart = summary%model_bounds(i)
       iend = summary%model_bounds(i + 1) - 1

--- a/src/Solution/PETSc/PetscSolver.F90
+++ b/src/Solution/PETSc/PetscSolver.F90
@@ -2,7 +2,7 @@ module PetscSolverModule
 #include <petsc/finclude/petscksp.h>
   use petscksp
   use KindModule, only: I4B, DP, LGP
-  use ConstantsModule, only: LINELENGTH, LENSOLUTIONNAME
+  use ConstantsModule, only: LINELENGTH, LENSOLUTIONNAME, DZERO
   use LinearSolverBaseModule
   use MatrixBaseModule
   use VectorBaseModule
@@ -338,10 +338,6 @@ contains
     this%is_converged = 0
     if (kiter == 1) then
       this%petsc_ctx%cnvg_summary%iter_cnt = 0
-      this%petsc_ctx%cnvg_summary%convlocdv = 0
-      this%petsc_ctx%cnvg_summary%convdvmax = 0.0
-      this%petsc_ctx%cnvg_summary%convlocr = 0
-      this%petsc_ctx%cnvg_summary%convrmax = 0.0
     end if
 
     ! update matrix coefficients


### PR DESCRIPTION
- streamline convergence csv report between IMS and PETSc solver
- fix typo in csv header (inner report now contains model data for PETSc solver, similar to IMS)

this should close #1753 