### PR TITLE
fix(idm): allow filein tags in mfsim.nam options block

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -39,6 +39,7 @@ To build and test a parallel version of the program, first read the instructions
     - [Configuring integration tests](#configuring-integration-tests)
       - [Rebuilding release binaries](#rebuilding-release-binaries)
       - [Updating FloPy packages](#updating-flopy-packages)
+      - [Updating Fortran definitions](#updating-fortran-definitions)
       - [Installing external models](#installing-external-models)
   - [Running tests](#running-tests)
     - [Running unit tests](#running-unit-tests)
@@ -363,6 +364,15 @@ There is a single optional argument, the path to the folder containing definitio
 ```shell
 pixi run update-flopy
 pixi run update-flopy doc/mf6io/mf6ivar/dfn
+```
+
+##### Updating Fortran definitions
+
+Any time a MODFLOW 6 input definition file (dfn) has been changed internal MODFLOW 6 Fortran definitions should be updated as well. The can be accomplished locally by running utils/idmloader/scripts/dfn2f90.py and then recompiling. This script will update the appropriate input package Fortran definition files if the dfn change is relevant to input processing.
+
+```shell
+cd utils/idmloader/scripts
+python dfn2f90.py
 ```
 
 ##### Installing external models

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -368,7 +368,7 @@ pixi run update-flopy doc/mf6io/mf6ivar/dfn
 
 ##### Updating Fortran definitions
 
-Any time a MODFLOW 6 input definition file (dfn) has been changed internal MODFLOW 6 Fortran definitions should be updated as well. The can be accomplished locally by running utils/idmloader/scripts/dfn2f90.py and then recompiling. This script will update the appropriate input package Fortran definition files if the dfn change is relevant to input processing.
+Any time a MODFLOW 6 input definition file (dfn) has been changed internal MODFLOW 6 Fortran definitions should be updated as well. This can be accomplished locally by running utils/idmloader/scripts/dfn2f90.py and then recompiling. This script will update the appropriate input package Fortran definition files if the dfn change is relevant to input processing. Updated definition files should accompany related dfn file changes when creating a pull request.
 
 ```shell
 cd utils/idmloader/scripts

--- a/src/Idm/sim-namidm.f90
+++ b/src/Idm/sim-namidm.f90
@@ -16,6 +16,10 @@ module SimNamInputModule
     logical :: prmem = .false.
     logical :: maxerrors = .false.
     logical :: print_input = .false.
+    logical :: hpc_filerecord = .false.
+    logical :: hpc6 = .false.
+    logical :: filein = .false.
+    logical :: hpc6_filename = .false.
     logical :: tdis6 = .false.
     logical :: mtype = .false.
     logical :: mfname = .false.
@@ -113,6 +117,74 @@ module SimNamInputModule
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    simnam_hpc_filerecord = InputParamDefinitionType &
+    ( &
+    'SIM', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'HPC_FILERECORD', & ! tag name
+    'HPC_FILERECORD', & ! fortran variable
+    'RECORD HPC6 FILEIN HPC6_FILENAME', & ! type
+    '', & ! shape
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    simnam_hpc6 = InputParamDefinitionType &
+    ( &
+    'SIM', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'HPC6', & ! tag name
+    'HPC6', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    simnam_filein = InputParamDefinitionType &
+    ( &
+    'SIM', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEIN', & ! tag name
+    'FILEIN', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    simnam_hpc6_filename = InputParamDefinitionType &
+    ( &
+    'SIM', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'HPC6_FILENAME', & ! tag name
+    'HPC6_FILENAME', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -329,6 +401,10 @@ module SimNamInputModule
     simnam_prmem, &
     simnam_maxerrors, &
     simnam_print_input, &
+    simnam_hpc_filerecord, &
+    simnam_hpc6, &
+    simnam_filein, &
+    simnam_hpc6_filename, &
     simnam_tdis6, &
     simnam_mtype, &
     simnam_mfname, &

--- a/src/Utilities/Idm/DefinitionSelect.f90
+++ b/src/Utilities/Idm/DefinitionSelect.f90
@@ -19,6 +19,7 @@ module DefinitionSelectModule
   public :: get_aggregate_definition_type
   public :: split_record_definition
   public :: idt_parse_rectype
+  public :: idt_datatype
 
 contains
 

--- a/src/Utilities/Idm/IdmLoad.f90
+++ b/src/Utilities/Idm/IdmLoad.f90
@@ -619,6 +619,7 @@ contains
     use SimVariablesModule, only: simfile
     use MemoryManagerModule, only: mem_allocate
     use CharacterStringModule, only: CharacterStringType
+    use DefinitionSelectModule, only: idt_datatype
     character(len=LENMEMPATH), intent(in) :: input_mempath
     type(InputParamDefinitionType), pointer, intent(in) :: idt
     character(len=LINELENGTH), pointer :: cstr
@@ -627,11 +628,15 @@ contains
     !
     ! -- initialize
     !
-    select case (idt%datatype)
+    select case (idt_datatype(idt))
     case ('KEYWORD', 'INTEGER')
       !
-      ! -- allocate and set default
-      call allocate_simnam_int(input_mempath, idt)
+      if (idt%in_record) then
+        ! -- no-op
+      else
+        ! -- allocate and set default
+        call allocate_simnam_int(input_mempath, idt)
+      end if
       !
     case ('STRING')
       !
@@ -647,6 +652,8 @@ contains
         call mem_allocate(cstr, LINELENGTH, idt%mf6varname, input_mempath)
         cstr = ''
       end if
+    case ('RECORD')
+      ! -- no-op
     case default
       write (errmsg, '(a,a)') &
         'IdmLoad allocate simnam param unhandled datatype: ', &


### PR DESCRIPTION
This PR addresses the error below.  This issue can be seen following #1763 which adds a FILEIN style tag to the mfsim.nam options block in support of parallel.
```
ERROR REPORT:

  1. IdmLoad allocate simnam param unhandled datatype: RECORD HPC6 FILEIN
     HPC6_FILENAME

UNIT ERROR REPORT:

  1. ERROR OCCURRED WHILE READING FILE 'mfsim.nam'
```