### PR TITLE
refactor(idm): verify and store error based on length of user input names

### DIFF
--- a/src/Utilities/Idm/ModelPackageInputs.f90
+++ b/src/Utilities/Idm/ModelPackageInputs.f90
@@ -413,14 +413,14 @@ contains
       fname = fnames(n)
       call inlen_check(pnames(n), pname, LENPACKAGENAME, 'PACKAGENAME')
       !
-      ! -- terminate if errors were detected
-      if (count_errors() > 0) then
-        call store_error_filename(this%modelfname)
-      end if
-      !
       ! -- add this instance to package list
       call this%add(ftype, fname, pname)
     end do
+    !
+    ! -- terminate if errors were detected
+    if (count_errors() > 0) then
+      call store_error_filename(this%modelfname)
+    end if
     !
     ! --
     return

--- a/src/Utilities/Idm/ModelPackageInputs.f90
+++ b/src/Utilities/Idm/ModelPackageInputs.f90
@@ -10,7 +10,7 @@ module ModelPackageInputsModule
   use SimVariablesModule, only: errmsg
   use ConstantsModule, only: LINELENGTH, LENMEMPATH, LENMODELNAME, LENFTYPE, &
                              LENPACKAGETYPE, LENPACKAGENAME, LENCOMPONENTNAME
-  use SimModule, only: store_error, store_error_filename
+  use SimModule, only: store_error, count_errors, store_error_filename
   use SimVariablesModule, only: iout
   use ArrayHandlersModule, only: expandarray
   use CharacterStringModule, only: CharacterStringType
@@ -384,6 +384,7 @@ contains
   subroutine modelpkgs_addpkgs(this)
     ! -- modules
     use MemoryManagerModule, only: mem_setptr
+    use SourceCommonModule, only: inlen_check
     ! -- dummy
     class(ModelPackageInputsType) :: this
     ! -- local
@@ -410,7 +411,12 @@ contains
       ! -- attributes for this package
       ftype = ftypes(n)
       fname = fnames(n)
-      pname = pnames(n)
+      call inlen_check(pnames(n), pname, LENPACKAGENAME, 'PACKAGENAME')
+      !
+      ! -- terminate if errors were detected
+      if (count_errors() > 0) then
+        call store_error_filename(this%modelfname)
+      end if
       !
       ! -- add this instance to package list
       call this%add(ftype, fname, pname)

--- a/src/Utilities/Idm/SourceCommon.f90
+++ b/src/Utilities/Idm/SourceCommon.f90
@@ -21,6 +21,7 @@ module SourceCommonModule
   public :: file_ext
   public :: ifind_charstr
   public :: filein_fname
+  public :: inlen_check
 
 contains
 
@@ -445,7 +446,6 @@ contains
   !<
   function filein_fname(filename, tagname, input_mempath, input_fname) &
     result(found)
-    use SimModule, only: store_error, store_error_filename
     use MemoryManagerModule, only: mem_setptr, get_isize
     use CharacterStringModule, only: CharacterStringType
     character(len=*), intent(inout) :: filename
@@ -482,5 +482,34 @@ contains
     ! -- return
     return
   end function filein_fname
+
+  !> @brief store an error for input exceeding internal name length
+  !<
+  subroutine inlen_check(input_name, mf6_name, maxlen, name_type)
+    use CharacterStringModule, only: CharacterStringType
+    type(CharacterStringType), intent(in) :: input_name
+    character(len=*), intent(inout) :: mf6_name
+    integer(I4B), intent(in) :: maxlen
+    character(len=*), intent(in) :: name_type
+    character(len=LINELENGTH) :: input_str
+    integer(I4B) :: ilen
+    !
+    ! -- initialize
+    mf6_name = ''
+    input_str = input_name
+    ilen = len_trim(input_str)
+    if (ilen > maxlen) then
+      write (errmsg, '(a,i0,a)') &
+        'Input name "'//trim(input_str)//'" exceeds maximum allowed length (', &
+        maxlen, ') for '//trim(name_type)//'.'
+      call store_error(errmsg)
+    end if
+    !
+    ! -- set truncated name
+    mf6_name = trim(input_str)
+    !
+    ! -- return
+    return
+  end subroutine inlen_check
 
 end module SourceCommonModule


### PR DESCRIPTION
Improve error message for input name length violation as reported in #1774.

Updated error report:
```
ERROR REPORT:

  1. Input name "LONGLONGLONG_GWF1" exceeds maximum allowed length (16) for
     MODELNAME.
  2. Input name "LONGLONGLONG_GWF2" exceeds maximum allowed length (16) for
     MODELNAME.
  3. Exchange has invalid (unrecognized) model name(s): LONGLONGLONG_GWF
     LONGLONGLONG_GWF

UNIT ERROR REPORT:

  1. ERROR OCCURRED WHILE READING FILE 'mfsim.nam'
```