### PR TITLE
feat(idm): support binary for regular, numeric list input blocks

### DIFF
--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -8,6 +8,7 @@
 		\item A new Groundwater Energy (GWE) transport model is introduced to the code base for simulating heat transport in the subsurface.  Additional information for activating the GWE model type within a MODFLOW 6 simulation is available within the mf6io.pdf document.  New example problems have been developed for testing and demonstrating GWE capabilities (in addition to other internal tests that help verify the accuracy of GWE); however, additional changes to the code and input may be necessary in response to user needs and further testing.
 	    \item A new capability has been introduced to create parameter layer export files of user input data for packages including DIS, DISV, IC, NPF, DSP(GWT), MIP(PRT), and CND(GWE).  The number of supported packages is expected to increase in the future.  The capability can be turned on with the package EXPORT\_ARRAY\_ASCII option.  The package parameter export set is pre-defined and currently focuses on griddata.  The number of parameters per package may also increase in the future.
     	\item Add capability to vary the hydraulic conductivity of the reach streambed (RHK) by stress period in the Streamflow Routing (SFR) package. RHK can be modified by stress period using the BEDK SFRSETTING. RHK can also be defined using a timeseries string in the PACKAGEDATA or PERIOD blocks.
+        \item Extend binary input support to all list style input blocks that have a regular shape and don't contain string fields (e.g. BOUNDNAME).
 	\end{itemize}
 
 	%\underline{EXAMPLES}

--- a/doc/mf6io/mf6ivar/dfn/exg-gwegwe.dfn
+++ b/doc/mf6io/mf6ivar/dfn/exg-gwegwe.dfn
@@ -267,6 +267,7 @@ reader urword
 optional true
 longname auxiliary variables
 description represents the values of the auxiliary variables for each GWEGWE Exchange. The values of auxiliary variables must be present for each exchange. The values must be specified in the order of the auxiliary variables specified in the OPTIONS block.
+mf6internal auxvar
 
 block exchangedata
 name boundname

--- a/doc/mf6io/mf6ivar/dfn/exg-gwfgwf.dfn
+++ b/doc/mf6io/mf6ivar/dfn/exg-gwfgwf.dfn
@@ -307,6 +307,7 @@ reader urword
 optional true
 longname auxiliary variables
 description represents the values of the auxiliary variables for each GWFGWF Exchange. The values of auxiliary variables must be present for each exchange. The values must be specified in the order of the auxiliary variables specified in the OPTIONS block.
+mf6internal auxvar
 
 block exchangedata
 name boundname

--- a/doc/mf6io/mf6ivar/dfn/exg-gwtgwt.dfn
+++ b/doc/mf6io/mf6ivar/dfn/exg-gwtgwt.dfn
@@ -267,6 +267,7 @@ reader urword
 optional true
 longname auxiliary variables
 description represents the values of the auxiliary variables for each GWTGWT Exchange. The values of auxiliary variables must be present for each exchange. The values must be specified in the order of the auxiliary variables specified in the OPTIONS block.
+mf6internal auxvar
 
 block exchangedata
 name boundname

--- a/src/Exchange/DisConnExchange.f90
+++ b/src/Exchange/DisConnExchange.f90
@@ -291,7 +291,7 @@ contains
     call mem_setptr(cl1, 'CL1', this%input_mempath)
     call mem_setptr(cl2, 'CL2', this%input_mempath)
     call mem_setptr(hwva, 'HWVA', this%input_mempath)
-    call mem_setptr(auxvar, 'AUX', this%input_mempath)
+    call mem_setptr(auxvar, 'AUXVAR', this%input_mempath)
     call mem_setptr(boundname, 'BOUNDNAME', this%input_mempath)
     ndim1 = size(cellidm1, dim=1)
     ndim2 = size(cellidm2, dim=1)

--- a/src/Idm/exg-gwegweidm.f90
+++ b/src/Idm/exg-gwegweidm.f90
@@ -36,7 +36,7 @@ module ExgGwegweInputModule
     logical :: cl1 = .false.
     logical :: cl2 = .false.
     logical :: hwva = .false.
-    logical :: aux = .false.
+    logical :: auxvar = .false.
     logical :: boundname = .false.
   end type ExgGwegweParamFoundType
 
@@ -468,13 +468,13 @@ module ExgGwegweInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    exggwegwe_aux = InputParamDefinitionType &
+    exggwegwe_auxvar = InputParamDefinitionType &
     ( &
     'EXG', & ! component
     'GWEGWE', & ! subcomponent
     'EXCHANGEDATA', & ! block
     'AUX', & ! tag name
-    'AUX', & ! fortran variable
+    'AUXVAR', & ! fortran variable
     'DOUBLE1D', & ! type
     'NAUX', & ! shape
     .false., & ! required
@@ -529,7 +529,7 @@ module ExgGwegweInputModule
     exggwegwe_cl1, &
     exggwegwe_cl2, &
     exggwegwe_hwva, &
-    exggwegwe_aux, &
+    exggwegwe_auxvar, &
     exggwegwe_boundname &
     ]
 

--- a/src/Idm/exg-gwfgwfidm.f90
+++ b/src/Idm/exg-gwfgwfidm.f90
@@ -40,7 +40,7 @@ module ExgGwfgwfInputModule
     logical :: cl1 = .false.
     logical :: cl2 = .false.
     logical :: hwva = .false.
-    logical :: aux = .false.
+    logical :: auxvar = .false.
     logical :: boundname = .false.
   end type ExgGwfgwfParamFoundType
 
@@ -540,13 +540,13 @@ module ExgGwfgwfInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    exggwfgwf_aux = InputParamDefinitionType &
+    exggwfgwf_auxvar = InputParamDefinitionType &
     ( &
     'EXG', & ! component
     'GWFGWF', & ! subcomponent
     'EXCHANGEDATA', & ! block
     'AUX', & ! tag name
-    'AUX', & ! fortran variable
+    'AUXVAR', & ! fortran variable
     'DOUBLE1D', & ! type
     'NAUX', & ! shape
     .false., & ! required
@@ -605,7 +605,7 @@ module ExgGwfgwfInputModule
     exggwfgwf_cl1, &
     exggwfgwf_cl2, &
     exggwfgwf_hwva, &
-    exggwfgwf_aux, &
+    exggwfgwf_auxvar, &
     exggwfgwf_boundname &
     ]
 

--- a/src/Idm/exg-gwtgwtidm.f90
+++ b/src/Idm/exg-gwtgwtidm.f90
@@ -36,7 +36,7 @@ module ExgGwtgwtInputModule
     logical :: cl1 = .false.
     logical :: cl2 = .false.
     logical :: hwva = .false.
-    logical :: aux = .false.
+    logical :: auxvar = .false.
     logical :: boundname = .false.
   end type ExgGwtgwtParamFoundType
 
@@ -468,13 +468,13 @@ module ExgGwtgwtInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    exggwtgwt_aux = InputParamDefinitionType &
+    exggwtgwt_auxvar = InputParamDefinitionType &
     ( &
     'EXG', & ! component
     'GWTGWT', & ! subcomponent
     'EXCHANGEDATA', & ! block
     'AUX', & ! tag name
-    'AUX', & ! fortran variable
+    'AUXVAR', & ! fortran variable
     'DOUBLE1D', & ! type
     'NAUX', & ! shape
     .false., & ! required
@@ -529,7 +529,7 @@ module ExgGwtgwtInputModule
     exggwtgwt_cl1, &
     exggwtgwt_cl2, &
     exggwtgwt_hwva, &
-    exggwtgwt_aux, &
+    exggwtgwt_auxvar, &
     exggwtgwt_boundname &
     ]
 

--- a/src/Utilities/Idm/BoundInputContext.f90
+++ b/src/Utilities/Idm/BoundInputContext.f90
@@ -133,7 +133,7 @@ contains
     end if
     !
     ! -- initialize package params object
-    call this%package_params%init(this%mf6_input, this%readasarrays, &
+    call this%package_params%init(this%mf6_input, 'PERIOD', this%readasarrays, &
                                   this%naux, this%inamedbound)
     !
     ! -- return

--- a/src/Utilities/Idm/BoundInputContext.f90
+++ b/src/Utilities/Idm/BoundInputContext.f90
@@ -167,22 +167,11 @@ contains
       call mem_allocate(cellid, 0, 0, 'CELLID', this%mf6_input%mempath)
     end if
     !
-    ! -- allocate or set pointer to BOUNDNAME
-    if (this%inamedbound == 0) then
-      call mem_allocate(this%boundname_cst, LENBOUNDNAME, 0, &
-                        'BOUNDNAME', this%mf6_input%mempath)
-      !
-    else
-      call mem_setptr(this%boundname_cst, 'BOUNDNAME', this%mf6_input%mempath)
-    end if
+    ! -- set pointer to BOUNDNAME
+    call mem_setptr(this%boundname_cst, 'BOUNDNAME', this%mf6_input%mempath)
     !
-    ! -- allocate or set pointer to AUXVAR
-    if (this%naux == 0) then
-      call mem_allocate(this%auxvar, 0, 0, 'AUXVAR', this%mf6_input%mempath)
-      !
-    else
-      call mem_setptr(this%auxvar, 'AUXVAR', this%mf6_input%mempath)
-    end if
+    ! -- set pointer to AUXVAR
+    call mem_setptr(this%auxvar, 'AUXVAR', this%mf6_input%mempath)
     !
     ! -- return
     return

--- a/src/Utilities/Idm/DynamicPackageParams.f90
+++ b/src/Utilities/Idm/DynamicPackageParams.f90
@@ -5,7 +5,7 @@
 module DynamicPackageParamsModule
 
   use KindModule, only: DP, I4B, LGP
-  use ConstantsModule, only: LINELENGTH, DZERO, IZERO
+  use ConstantsModule, only: LINELENGTH, LENBOUNDNAME, DZERO, IZERO
   use SimVariablesModule, only: errmsg
   use SimModule, only: store_error, store_error_filename
   use MemoryManagerModule, only: mem_allocate
@@ -103,6 +103,8 @@ contains
     ! -- local
     type(InputParamDefinitionType), pointer :: idt
     integer(I4B), dimension(:), allocatable :: idt_idxs
+    type(CharacterStringType), dimension(:), pointer, contiguous :: boundname
+    real(DP), dimension(:, :), pointer, contiguous :: auxvar
     integer(I4B) :: keepcnt, iparam
     logical(LGP) :: keep
     !
@@ -124,6 +126,11 @@ contains
       if (idt%tagname == 'AUX') then
         if (this%iauxiliary == 0) then
           keep = .false.
+          call mem_allocate(auxvar, 0, 0, 'AUXVAR', this%mf6_input%mempath)
+        end if
+        if (this%inamedbound == 0) then
+          call mem_allocate(boundname, LENBOUNDNAME, 0, 'BOUNDNAME', &
+                            this%mf6_input%mempath)
         end if
       end if
       !
@@ -165,6 +172,8 @@ contains
     ! -- local
     type(InputParamDefinitionType), pointer :: ra_idt, idt
     character(len=LINELENGTH), dimension(:), allocatable :: ra_cols
+    type(CharacterStringType), dimension(:), pointer, contiguous :: boundname
+    real(DP), dimension(:, :), pointer, contiguous :: auxvar
     integer(I4B) :: ra_ncol, icol, keepcnt
     logical(LGP) :: keep
     !
@@ -197,10 +206,15 @@ contains
       else if (ra_cols(icol) == 'AUX') then
         if (this%iauxiliary > 0) then
           keep = .true.
+        else
+          call mem_allocate(auxvar, 0, 0, 'AUXVAR', this%mf6_input%mempath)
         end if
       else if (ra_cols(icol) == 'BOUNDNAME') then
         if (this%inamedbound /= 0) then
           keep = .true.
+        else
+          call mem_allocate(boundname, LENBOUNDNAME, 0, 'BOUNDNAME', &
+                            this%mf6_input%mempath)
         end if
       else
         ! -- determine if the param is scope

--- a/src/Utilities/Idm/SourceCommon.f90
+++ b/src/Utilities/Idm/SourceCommon.f90
@@ -18,7 +18,6 @@ module SourceCommonModule
   public :: idm_component_type, idm_subcomponent_type, idm_subcomponent_name
   public :: set_model_shape
   public :: get_shape_from_string
-  public :: mem_allocate_naux
   public :: file_ext
   public :: ifind_charstr
   public :: filein_fname
@@ -404,26 +403,6 @@ contains
     ! -- return
     return
   end subroutine set_model_shape
-
-  subroutine mem_allocate_naux(mempath)
-    use MemoryManagerModule, only: mem_allocate, mem_setptr, get_isize
-    character(len=*), intent(in) :: mempath
-    integer(I4B), pointer :: naux
-    integer(I4B) :: isize
-    !
-    ! -- initialize
-    nullify (naux)
-    !
-    ! -- allocate optional input scalars locally
-    call get_isize('NAUX', mempath, isize)
-    if (isize < 0) then
-      call mem_allocate(naux, 'NAUX', mempath)
-      naux = 0
-    end if
-    !
-    ! -- return
-    return
-  end subroutine mem_allocate_naux
 
   function ifind_charstr(array, str)
     use CharacterStringModule, only: CharacterStringType

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -93,7 +93,6 @@ contains
     !
     ! -- initialize static load
     call this%init(parser, mf6_input, filename, iout)
-    write (iout, '(a)') 'IDM LOAD mempath='//trim(mf6_input%mempath)
     !
     ! -- process blocks
     do iblk = 1, size(this%mf6_input%block_dfns)
@@ -223,7 +222,7 @@ contains
     ! -- modules
     use ConstantsModule, only: LENBOUNDNAME
     use CharacterStringModule, only: CharacterStringType
-    use SourceCommonModule, only: set_model_shape, mem_allocate_naux
+    use SourceCommonModule, only: set_model_shape
     ! -- dummy
     class(LoadMf6FileType) :: this
     integer(I4B), intent(in) :: iblk
@@ -282,10 +281,12 @@ contains
       do iparam = 1, size(this%mf6_input%param_dfns)
         idt => this%mf6_input%param_dfns(iparam)
         if (idt%blockname == 'EXCHANGEDATA') then
-          if (idt%tagname == 'BOUNDNAME') then
+          if (idt%tagname == 'AUX') then
             if (this%iauxiliary == 0) then
               call mem_allocate(auxvar, 0, 0, 'AUX', this%mf6_input%mempath)
             end if
+          end if
+          if (idt%tagname == 'BOUNDNAME') then
             if (this%inamedbound == 0) then
               call mem_allocate(boundnames, LENBOUNDNAME, 0, &
                                 'BOUNDNAME', this%mf6_input%mempath)
@@ -689,10 +690,12 @@ contains
       call this%structarray%mem_create_vector(icol, idt)
     end do
     !
+    ! -- read the block control record
     ibinary = read_control_record(this%parser, oc_inunit, this%iout)
     !
     if (ibinary == 1) then
       !
+      ! -- read from binary
       nrowsread = this%structarray%read_from_binary(oc_inunit, this%iout)
       !
       call this%parser%terminateblock()
@@ -701,6 +704,7 @@ contains
       !
     else
       !
+      ! -- read from ascii
       nrowsread = this%structarray%read_from_parser(this%parser, this%ts_active, &
                                                     this%iout)
     end if

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -230,10 +230,6 @@ contains
     type(InputParamDefinitionType), pointer :: idt
     integer(I4B) :: iparam
     integer(I4B), pointer :: intptr
-    real(DP), dimension(:, :), pointer, &
-      contiguous :: auxvar
-    type(CharacterStringType), dimension(:), contiguous, &
-      pointer :: boundnames !< array of bound names
     !
     ! -- update state based on read tags
     do iparam = 1, size(this%block_tags)
@@ -277,24 +273,6 @@ contains
                              this%mf6_input%component_mempath, &
                              this%mf6_input%mempath, this%mshape)
       end if
-    case ('EXCHANGEDATA')
-      do iparam = 1, size(this%mf6_input%param_dfns)
-        idt => this%mf6_input%param_dfns(iparam)
-        if (idt%blockname == 'EXCHANGEDATA') then
-          if (idt%tagname == 'AUX') then
-            if (this%iauxiliary == 0) then
-              call mem_allocate(auxvar, 0, 0, 'AUX', this%mf6_input%mempath)
-            end if
-          end if
-          if (idt%tagname == 'BOUNDNAME') then
-            if (this%inamedbound == 0) then
-              call mem_allocate(boundnames, LENBOUNDNAME, 0, &
-                                'BOUNDNAME', this%mf6_input%mempath)
-            end if
-            exit
-          end if
-        end if
-      end do
     case default
     end select
     !

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
@@ -36,8 +36,6 @@ module Mf6FileListInputModule
   !<
   type, abstract, extends(AsciiDynamicPkgLoadBaseType) :: ListInputBaseType
     integer(I4B) :: ts_active
-    !integer(I4B) :: ibinary
-    !integer(I4B) :: oc_inunit
     type(TimeSeriesManagerType), pointer :: tsmanager => null()
     type(StructArrayType), pointer :: structarray => null()
   contains
@@ -413,8 +411,6 @@ contains
     !
     ! -- initialize
     this%ts_active = 0
-    !this%ibinary = 0
-    !this%oc_inunit = 0
     !
     ! -- initialize static loader
     call loader%init(parser, mf6_input, this%input_name, iout)

--- a/src/Utilities/Idm/mf6blockfile/StructArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/StructArray.f90
@@ -995,8 +995,9 @@ contains
           read (inunit, iostat=ierr) this%struct_vectors(j)%dbl1d(irow)
         case (3) ! -- memtype charstring
           !
-          errmsg = 'IDM unimplemented. StructArray::read_from_binary string &
-                   &types not supported for binary inputs.'
+          errmsg = 'List style binary inputs not supported &
+                   &for text columns, tag='// &
+                   trim(this%struct_vectors(j)%idt%tagname)//'.'
           call store_error(errmsg, terminate=.TRUE.)
           !
         case (4) ! -- memtype intvector


### PR DESCRIPTION
Support binary for any recarray style input block which is regular and contains no text columns
  - Includes, for example, DISV cell2d if ncvert is constant
  - Includes exchange exchagedata block if BOUNDNAMES is not optioned (#128)
  - Not currently supported by FloPy- how to test in ci for now?