### PR TITLE
fix(mf6io): apply suggested change to DSP write-up for consistency with CND write-up

### DIFF
--- a/doc/mf6io/gwt/dsp.tex
+++ b/doc/mf6io/gwt/dsp.tex
@@ -1,4 +1,4 @@
-Dispersion (DSP) Package information is read from the file that is specified by ``DSP6'' as the file type.  Only one DSP Package can be specified for a GWT model.  The DSP Package is based on the mathematical formulation presented for the XT3D option of the NPF Package available to represent full three-dimensional anisotropy in groundwater flow.  XT3D can be computationally expensive and can be turned off to use a simplified and approximate form of the dispersion equations.  For most problems, however, XT3D will be required to accurately represent dispersion.
+Dispersion (DSP) Package information is read from the file that is specified by ``DSP6'' as the file type.  Only one DSP Package can be specified for a GWT model.  By default, the DSP Package uses the mathematical formulation presented for the XT3D option of the NPF Package to represent full three-dimensional anisotropy in groundwater flow.  XT3D can be computationally expensive and can be turned off to use a simplified and approximate form of the dispersion equations.  For most problems, however, XT3D will be required to accurately represent dispersion.
 
 \vspace{5mm}
 \subsubsection{Structure of Blocks}


### PR DESCRIPTION
A relatively minor alteration to clarify the role of XT3D within the DSP package.  This change parallels a change made in #1781.