### PR TITLE
refactor(prt): misc cleanup/refactoring, benchmark shared face routines

### DIFF
--- a/autotest/TestGeomUtil.f90
+++ b/autotest/TestGeomUtil.f90
@@ -370,8 +370,58 @@ contains
 
     call shared_face(iverts1, iverts2, iface)
     call check(error, iface == 2)
-
     if (allocated(error)) return
+
+  end subroutine
+
+  function rand_int(a, b) result(i)
+    integer(I4B) :: a, b, i
+    real(DP) :: u
+
+    call random_number(u)
+    i = a + floor((b + 1 - a) * u)
+
+  end function
+
+  subroutine test_shared_face_large(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer(I4B) :: iverts1(33), iverts2(33)
+    integer(I4B) :: exp_iface, iface, i, iv1, iv2
+    real(DP) :: tstart, tstop
+
+    iface = 0
+    iverts1 = (/1, 2, 3, 4, 10, 14, 18, &
+                22, 33, 36, 40, 44, 48, &
+                52, 58, 57, 56, 55, 51, &
+                47, 43, 39, 35, 32, 30, &
+                28, 26, 24, 21, 17, 13, &
+                9, 1/)
+    iverts2 = (/5, 6, 7, 8, 12, 16, 20, &
+                23, 25, 27, 29, 31, 34, &
+                38, 42, 46, 50, 54, 62, &
+                61, 60, 59, 53, 49, 45, &
+                41, 37, 33, 22, 19, 15, &
+                11, 5/)
+
+    call shared_face(iverts1, iverts2, iface)
+    call check(error, iface == 8, to_string(iface))
+    if (allocated(error)) return
+
+    call cpu_time(tstart)
+    do i = 1, 1000
+      iverts1 = cshift(iverts1, shift=rand_int(0, 32))
+      call shared_face(iverts1, iverts2, iface)
+    end do
+    call cpu_time(tstop)
+    print *, 'shared_face took: ', tstop - tstart
+
+    call cpu_time(tstart)
+    do i = 1, 1000
+      iverts1 = cshift(iverts1, shift=rand_int(0, 32))
+      call shared_edge(iverts1, iverts2, iv1, iv2)
+    end do
+    call cpu_time(tstop)
+    print *, 'shared_edge took: ', tstop - tstart
 
   end subroutine
 

--- a/autotest/TestGeomUtil.f90
+++ b/autotest/TestGeomUtil.f90
@@ -5,6 +5,7 @@ module TestGeomUtil
   use GeomUtilModule, only: get_node, get_ijk, get_jk, point_in_polygon, &
                             skew, area, shared_face
   use ConstantsModule, only: LINELENGTH
+  use DisvGeom, only: shared_edge
   implicit none
   private
   public :: collect_geomutil
@@ -24,7 +25,9 @@ contains
                              test_point_in_polygon_irr), &
                 new_unittest("skew", test_skew), &
                 new_unittest("area", test_area), &
-                new_unittest("shared_face", test_shared_face) &
+                new_unittest("shared_face", test_shared_face), &
+                new_unittest("shared_face_large", &
+                             test_shared_face_large) &
                 ]
   end subroutine collect_geomutil
 
@@ -386,7 +389,7 @@ contains
   subroutine test_shared_face_large(error)
     type(error_type), allocatable, intent(out) :: error
     integer(I4B) :: iverts1(33), iverts2(33)
-    integer(I4B) :: exp_iface, iface, i, iv1, iv2
+    integer(I4B) :: iface, i, iv1, iv2
     real(DP) :: tstart, tstop
 
     iface = 0

--- a/src/Model/ModelUtilities/DisvGeom.f90
+++ b/src/Model/ModelUtilities/DisvGeom.f90
@@ -5,7 +5,7 @@ module DisvGeom
   implicit none
   private
   public :: DisvGeomType
-  public :: line_unit_vector
+  public :: line_unit_vector, shared_edge
 
   type DisvGeomType
 

--- a/src/Solution/ParticleTracker/CellDefn.f90
+++ b/src/Solution/ParticleTracker/CellDefn.f90
@@ -27,7 +27,6 @@ module CellDefnModule
     real(DP), allocatable, public :: faceflow(:) !< flows that correspond to faces(/vertices)
     real(DP), public :: distflow !< net distributed flow into cell
   contains
-    procedure, public :: get_npolyverts !< returns the number of polygon vertices
     procedure, public :: get_ispv180 !< returns 180-degree indicator for a vertex
     procedure, public :: get_botflow !< returns bottom flow
     procedure, public :: get_topflow !< returns top flow
@@ -60,13 +59,6 @@ contains
       iatop = 1
     end if
   end function get_iatop
-
-  !> @brief Return the number of polygon vertices
-  function get_npolyverts(this) result(npolyverts)
-    class(CellDefnType), intent(inout) :: this
-    integer(I4B) :: npolyverts
-    npolyverts = this%npolyverts
-  end function get_npolyverts
 
   !> @brief Return 180-degree indicator for a vertex
   function get_ispv180(this, m) result(ispv180)

--- a/src/Solution/ParticleTracker/CellRectQuad.f90
+++ b/src/Solution/ParticleTracker/CellRectQuad.f90
@@ -78,12 +78,10 @@ contains
     ! -- dummy
     class(CellRectQuadType), intent(inout) :: this
     ! -- local
-    integer(I4B) :: npolyverts, n, m
-
-    npolyverts = this%defn%get_npolyverts()
+    integer(I4B) :: n, m
 
     n = 0
-    do m = 1, npolyverts
+    do m = 1, this%defn%npolyverts
       if (.not. this%defn%get_ispv180(m)) then
         n = n + 1
         this%irectvert(n) = m

--- a/src/Solution/ParticleTracker/CellRectQuad.f90
+++ b/src/Solution/ParticleTracker/CellRectQuad.f90
@@ -31,10 +31,10 @@ module CellRectQuadModule
     procedure :: destroy => destroy_cell_rect_quad !< destructor for the cell
     procedure :: init_from !< initializes the cell from an existing cell
 
-    procedure :: load_irectvert_rectflow ! loads list of indices of the rectangle vertices and face flows
-    procedure :: get_irectvertSW ! gets index of southwest rectangle vertex
-    procedure :: get_rectDimensionsRotation ! gets rectangular dimensions and rotation
-    procedure :: get_rectflow !< returns a rectangle face flow
+    procedure :: load_rect_verts_flows ! loads list of indices of the rectangle vertices and face flows
+    procedure :: get_rect_ivert_sw ! gets index of southwest rectangle vertex
+    procedure :: get_rect_dim_rot ! gets rectangular dimensions and rotation
+    procedure :: get_rect_flow !< returns a rectangle face flow
     procedure :: face_is_refined !< returns whether a rectangle face is refined
   end type CellRectQuadType
 
@@ -65,7 +65,7 @@ contains
     class(CellRectQuadType), intent(inout) :: this
     type(CellDefnType), pointer :: defn
     this%defn => defn
-    call this%load_irectvert_rectflow()
+    call this%load_rect_verts_flows()
   end subroutine init_from
 
   !> @brief Load local polygon vertex indices and rectangular
@@ -74,7 +74,7 @@ contains
   !! Loads local polygon vertex indices of the four rectangle
   !! vertices and face flows of a rectangular-quad cell.
   !<
-  subroutine load_irectvert_rectflow(this)
+  subroutine load_rect_verts_flows(this)
     ! -- dummy
     class(CellRectQuadType), intent(inout) :: this
     ! -- local
@@ -101,14 +101,14 @@ contains
 
     ! Wrap around for convenience
     this%irectvert(5) = this%irectvert(1)
-  end subroutine load_irectvert_rectflow
+  end subroutine load_rect_verts_flows
 
   !> @brief Get index of SW rectangle vertex
   !!
   !! Return the index (1, 2, 3, or 4) of the southwest
   !! rectangle vertex of a rectangular-quad cell
   !<
-  function get_irectvertSW(this) result(irv1)
+  function get_rect_ivert_sw(this) result(irv1)
     ! -- dummy
     class(CellRectQuadType), intent(inout) :: this
     integer(I4B) :: irv1
@@ -145,7 +145,7 @@ contains
         if (y2 .gt. y1) return
       end if
     end do
-  end function get_irectvertSW
+  end function get_rect_ivert_sw
 
   !> @brief Get rectangular cell dimensions and rotation
   !!
@@ -153,23 +153,20 @@ contains
   !! the cell using the specified rectangle vertex
   !! as the origin
   !<
-  subroutine get_rectDimensionsRotation(this, irv1, xOrigin, yOrigin, zOrigin, &
-                                        dx, dy, dz, sinrot, cosrot)
+  subroutine get_rect_dim_rot(this)
     ! -- dummy
     class(CellRectQuadType), intent(inout) :: this
-    integer(I4B) :: irv1
-    real(DP) :: xOrigin, yOrigin, zOrigin, dx, dy, dz, sinrot, cosrot
     ! -- local
     integer(I4B) :: irv2, irv4, ipv1, ipv2, ipv4
     integer(I4B), dimension(4) :: irvnxt = (/2, 3, 4, 1/)
     real(DP) :: x1, y1, x2, y2, x4, y4, dx2, dy2, dx4, dy4
 
     ! -- Get rectangle vertex neighbors irv2 and irv4
-    irv2 = irvnxt(irv1)
+    irv2 = irvnxt(this%irvOrigin)
     irv4 = irvnxt(irvnxt(irv2))
 
     ! -- Get model coordinates at irv1, irv2, and irv4
-    ipv1 = this%irectvert(irv1)
+    ipv1 = this%irectvert(this%irvOrigin)
     x1 = this%defn%polyvert(1, ipv1)
     y1 = this%defn%polyvert(2, ipv1)
     ipv2 = this%irectvert(irv2)
@@ -180,30 +177,30 @@ contains
     y4 = this%defn%polyvert(2, ipv4)
 
     ! -- Compute rectangle dimensions
-    xOrigin = x1
-    yOrigin = y1
-    zOrigin = this%defn%bot
-    dx2 = x2 - xOrigin
-    dy2 = y2 - yOrigin
-    dx4 = x4 - xOrigin
-    dy4 = y4 - yOrigin
-    dx = dsqrt(dx4 * dx4 + dy4 * dy4)
-    dy = dsqrt(dx2 * dx2 + dy2 * dy2)
-    dz = this%defn%top - zOrigin
+    this%xOrigin = x1
+    this%yOrigin = y1
+    this%zOrigin = this%defn%bot
+    dx2 = x2 - this%xOrigin
+    dy2 = y2 - this%yOrigin
+    dx4 = x4 - this%xOrigin
+    dy4 = y4 - this%yOrigin
+    this%dx = dsqrt(dx4 * dx4 + dy4 * dy4)
+    this%dy = dsqrt(dx2 * dx2 + dy2 * dy2)
+    this%dz = this%defn%top - this%zOrigin
 
     ! -- Compute sine and cosine of rotation angle (angle between "southern"
     ! -- rectangle side irv1-irv4 and the model x axis)
-    sinrot = dy4 / dx
-    cosrot = dx4 / dx
-  end subroutine get_rectDimensionsRotation
+    this%sinrot = dy4 / this%dx
+    this%cosrot = dx4 / this%dx
+  end subroutine get_rect_dim_rot
 
   !> @brief Return a rectangle face flow
-  function get_rectflow(this, iq, irv) result(rectflow)
+  function get_rect_flow(this, iq, irv) result(rectflow)
     class(CellRectQuadType), intent(inout) :: this
     integer(I4B) :: iq, irv
     real(DP) :: rectflow
     rectflow = this%rectflow(iq, irv)
-  end function get_rectflow
+  end function get_rect_flow
 
   !> @brief Return whether a rectangle face is refined
   function face_is_refined(this, i) result(is_refined)

--- a/src/Solution/ParticleTracker/CellUtil.f90
+++ b/src/Solution/ParticleTracker/CellUtil.f90
@@ -129,28 +129,22 @@ contains
     ! -- west" rectangle vertex to be the local origin so that the rotation
     ! -- angle is zero if the cell already aligns with the model x and y
     ! -- coordinates.
-    quad%irvOrigin = quad%get_irectvertSW()
-    ! todo, before/after initial release: refactor without unnecessary args
-    call quad%get_rectDimensionsRotation( &
-      quad%irvOrigin, quad%xOrigin, &
-      quad%yOrigin, quad%zOrigin, &
-      quad%dx, quad%dy, &
-      quad%dz, quad%sinrot, &
-      quad%cosrot)
+    quad%irvOrigin = quad%get_rect_ivert_sw()
+    call quad%get_rect_dim_rot()
 
     ! -- Set the external and internal face flows used for subcells
     do i = 0, 3
       irv = mod_offset(i + quad%irvOrigin, 4, 1)
       isc = mod_offset(i + 3, 4, 1)
       if (.not. quad%face_is_refined(irv)) then
-        qhalf = 5d-1 * quad%get_rectflow(1, irv)
+        qhalf = 5d-1 * quad%get_rect_flow(1, irv)
         quad%qextl2(isc) = qhalf
         isc = mod_offset(isc + 1, 4, 1)
         quad%qextl1(isc) = qhalf
       else
-        quad%qextl2(isc) = quad%get_rectflow(1, irv)
+        quad%qextl2(isc) = quad%get_rect_flow(1, irv)
         isc = mod_offset(isc + 1, 4, 1)
-        quad%qextl1(isc) = quad%get_rectflow(2, irv)
+        quad%qextl1(isc) = quad%get_rect_flow(2, irv)
       end if
     end do
     qdisttopbot = 2.5d-1 * (quad%defn%get_distflow() &


### PR DESCRIPTION
* remove unneeded `get_npolyverts()` routines from `MethodDisv` and `CellDefn`
* refactor routine to get rectangular dimensions/rotation without unneeded args
* rough benchmark comparing `shared_face()` with `shared_edge()` performance