### PR TITLE
docs(DEVELOPER.md): mention ifx support, show pixi and native cmds

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -421,7 +421,7 @@ To run tests in parallel:
 
 ```shell
 pytest -v -n auto  # from autotest/
-pixi run autotest -v <file>  # from project root
+pixi run autotest  # from project root
 ```
 
 The Pixi `autotest` task includes options to run tests in parallel, show test runtimes, and save failed test results in `autotest/.failed/`.


### PR DESCRIPTION
* latest ifx (2024.1) supports modflow6 now, update compiler section to reflect this
* show both pixi and native commands for developer tasks