### PR TITLE
ci(release): fix dylib path to hide on macos-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,8 +174,10 @@ jobs:
       - name: Hide dylibs (macOS)
         if: matrix.os == 'macos-14'
         run: |
-          mv /opt/homebrew/opt/gcc/lib/gcc/current/libgfortran.5.dylib /opt/homebrew/opt/gcc/lib/gcc/current/libgfortran.5.dylib.bak
-          mv /opt/homebrew/opt/gcc/lib/gcc/current/libquadmath.0.dylib /opt/homebrew/opt/gcc/lib/gcc/current/libquadmath.0.dylib.bak
+          version="${{ matrix.version }}"
+          libpath="/opt/homebrew/opt/gcc@$version/lib/gcc/$version"
+          mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak 
+          mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak 
 
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
* fix [failing nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/runs/9152654770/job/25160466230)