### PR TITLE
test: mark some parallel tests developmode

### DIFF
--- a/autotest/test_par_gwe_split_analyt.py
+++ b/autotest/test_par_gwe_split_analyt.py
@@ -29,6 +29,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_par_gwf_idomain.py
+++ b/autotest/test_par_gwf_idomain.py
@@ -31,6 +31,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
+@pytest.mark.developmodel
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_par_gwf_idomain.py
+++ b/autotest/test_par_gwf_idomain.py
@@ -31,7 +31,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
-@pytest.mark.developmodel
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_par_gwf_newton.py
+++ b/autotest/test_par_gwf_newton.py
@@ -33,6 +33,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_par_gwf_rewet.py
+++ b/autotest/test_par_gwf_rewet.py
@@ -31,6 +31,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_par_gwt_adv01.py
+++ b/autotest/test_par_gwt_adv01.py
@@ -11,6 +11,7 @@ cases = ["par_adv01a_gwtgwt", "par_adv01b_gwtgwt", "par_adv01c_gwtgwt"]
 
 
 @pytest.mark.parallel
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     from test_gwt_adv01_gwtgwt import build_models

--- a/autotest/test_par_gwt_adv02.py
+++ b/autotest/test_par_gwt_adv02.py
@@ -11,6 +11,7 @@ cases = ["par_adv01a_gwtgwt", "par_adv01b_gwtgwt", "par_adv01c_gwtgwt"]
 
 
 @pytest.mark.parallel
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     from test_gwt_adv02_gwtgwt import build_models

--- a/autotest/test_par_gwt_subset.py
+++ b/autotest/test_par_gwt_subset.py
@@ -28,6 +28,7 @@ def build_models(idx, test):
 
 
 @pytest.mark.parallel
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     from test_gwt_subset import check_output


### PR DESCRIPTION
Add the `developmode` marker to parallel tests that reuse models from tests that use dev options