### PR TITLE
ci: fix developmode parallel test conditions

### DIFF
--- a/.github/actions/test-par-win/action.yml
+++ b/.github/actions/test-par-win/action.yml
@@ -19,10 +19,23 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: pixi run get-exes
 
+    - name: Convert unix2dos
+      run: |
+        unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\test_modflow6.bat" "%TEMP%\test_modflow6.bat"
+
     - name: Test programs
+      if: github.ref_name != 'master'
       shell: cmd 
       env:
         REPOS_PATH: ${{ github.workspace }}
       run: |
-        unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\test_modflow6.bat" "%TEMP%\test_modflow6.bat"
+        "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "%TEMP%\test_modflow6.bat"
+
+    - name: Test programs
+      if: github.ref_name == 'master'
+      shell: cmd 
+      env:
+        REPOS_PATH: ${{ github.workspace }}
+        MARKERS: not developmode
+      run: |
         "%ONEAPI_ROOT%\setvars.bat" intel64 vs2022 && "%TEMP%\test_modflow6.bat"

--- a/.github/actions/test-par-win/action.yml
+++ b/.github/actions/test-par-win/action.yml
@@ -20,12 +20,13 @@ runs:
       run: pixi run get-exes
 
     - name: Convert unix2dos
+      shell: cmd
       run: |
         unix2dos -n "%GITHUB_WORKSPACE%\modflow6\.github\common\test_modflow6.bat" "%TEMP%\test_modflow6.bat"
 
     - name: Test programs
       if: github.ref_name != 'master'
-      shell: cmd 
+      shell: cmd
       env:
         REPOS_PATH: ${{ github.workspace }}
       run: |
@@ -33,7 +34,7 @@ runs:
 
     - name: Test programs
       if: github.ref_name == 'master'
-      shell: cmd 
+      shell: cmd
       env:
         REPOS_PATH: ${{ github.workspace }}
         MARKERS: not developmode

--- a/.github/common/test_modflow6.bat
+++ b/.github/common/test_modflow6.bat
@@ -1,4 +1,4 @@
 cd "%GITHUB_WORKSPACE%\modflow6\autotest"
 where libpetsc.dll
 ldd ..\bin\mf6
-pixi run autotest --parallel -k "test_par"
+pixi run autotest --parallel -k "test_par" -m "%MARKERS%"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,8 +208,14 @@ jobs:
         uses: ./modflow6/.github/actions/build-par-win
 
       - name: Build and test binaries (Windows)
-        if: runner.os == 'Windows' && matrix.parallel && inputs.run_tests
+        if: runner.os == 'Windows' && matrix.parallel && inputs.run_tests && inputs.developmode
         uses: ./modflow6/.github/actions/test-par-win
+
+      - name: Build and test binaries (Windows)
+        if: runner.os == 'Windows' && matrix.parallel && inputs.run_tests && !inputs.developmode
+        uses: ./modflow6/.github/actions/test-par-win
+        env:
+          MARKERS: not developmode
 
       - name: Copy deps to bin dir
         if: runner.os == 'Windows' && matrix.parallel

--- a/autotest/test_par_gwt_dsp01.py
+++ b/autotest/test_par_gwt_dsp01.py
@@ -24,6 +24,7 @@ def check_output(idx, test):
 
 
 @pytest.mark.parallel
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(


### PR DESCRIPTION
Apply `not developmode` marker when testing parallel mf6 in `test-par-win` action
* on `master` branch, generally
* if `developmode` is false in the release workflow