### PR TITLE
docs(prt): improve docstrings, use LENBOUNDNAME in mf6io

### DIFF
--- a/doc/mf6io/framework/binaryoutput.tex
+++ b/doc/mf6io/framework/binaryoutput.tex
@@ -771,7 +771,7 @@ Particle Track Output subsection of the Particle Tracking (PRT) Model Input and 
 \noindent Field 12: \texttt{`X'} {\color{red} \footnotesize{DOUBLE}} \\
 \noindent Field 13: \texttt{`Y'} {\color{red} \footnotesize{DOUBLE}} \\
 \noindent Field 14: \texttt{`Z'} {\color{red} \footnotesize{DOUBLE}} \\
-\noindent Field 15: \texttt{`NAME'} {\color{red} \footnotesize{CHARACTER(LEN=40)}} \\
+\noindent Field 15: \texttt{`NAME'} {\color{red} \footnotesize{CHARACTER(LEN=LENBOUNDNAME)}} \\
 
 \vspace{4mm}
 \noindent The ``NAME'' field may be empty.

--- a/doc/mf6io/prt/prt.tex
+++ b/doc/mf6io/prt/prt.tex
@@ -41,7 +41,7 @@ The PRT Model supports both binary and CSV particle track output files. A partic
 \noindent Column 12: \texttt{`X'} {\color{red} \footnotesize{DOUBLE}} \\
 \noindent Column 13: \texttt{`Y'} {\color{red} \footnotesize{DOUBLE}} \\
 \noindent Column 14: \texttt{`Z'} {\color{red} \footnotesize{DOUBLE}} \\
-\noindent Column 15: \texttt{`NAME'} {\color{red} \footnotesize{CHARACTER(LEN=40)}} \\
+\noindent Column 15: \texttt{`NAME'} {\color{red} \footnotesize{CHARACTER(LEN=LENBOUNDNAME)}} \\
 
 \vspace{2mm}
 \noindent where

--- a/src/Utilities/GeomUtil.f90
+++ b/src/Utilities/GeomUtil.f90
@@ -389,7 +389,7 @@ contains
 
   !> @brief Find the lateral face shared by two cells.
   !!
-  !! Find the lateral (horizontal) face shared by the given cells.
+  !! Find the lateral (x-y plane) face shared by the given cells.
   !! The iface return argument will be 0 if they share no such face,
   !! otherwise the index of the shared face in cell 1's vertex array,
   !! where face N connects vertex N to vertex N + 1 going clockwise.


### PR DESCRIPTION
* add optional `tol` dummy arg to `nudge()` routine in `MethodSubcellTernary`, better dummy arg naming, improve docstring
* use `LENBOUNDNAME` instead of hardcoded 40 in mf6io document
* clarify docstring for `shared_face()` routine in `GeomUtil`