### PR TITLE
fix(update_version.py): fix pixi.toml version string substitution

### DIFF
--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -336,7 +336,7 @@ def update_pixi(version: Version):
     tag = "version ="
     with open(path, "w") as fp:
         for line in lines:
-            if tag in line:
+            if line.startswith(tag):
                 line = f'{tag} "{version}"\n'
             fp.write(line)
 


### PR DESCRIPTION
The `update-version` task was getting substituted too