### PR TITLE
fix: build windows parallel with ifort 2021.12

### DIFF
--- a/.github/actions/setup-par-oneapi/action.yml
+++ b/.github/actions/setup-par-oneapi/action.yml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       if: steps.oneapi-cache.outputs.cache-hit != 'true'
       run: |
-        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5cb30fb9-21e9-47e8-82da-a91e00191670/w_BaseKit_p_2024.0.1.45_offline.exe"
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7dff44ba-e3af-4448-841c-0d616c8da6e7/w_BaseKit_p_2024.1.0.595_offline.exe"
         cmp="intel.oneapi.win.mkl.devel"
         "$GITHUB_WORKSPACE/modflow6/.github/common/install_intel_windows.bat" $url $cmp
         rm -rf $TEMP/webimage.exe
@@ -34,7 +34,7 @@ runs:
       shell: bash
       if: steps.oneapi-cache.outputs.cache-hit != 'true'
       run: |
-        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/7a6db8a1-a8b9-4043-8e8e-ca54b56c34e4/w_HPCKit_p_2024.0.1.35_offline.exe"
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c95a3b26-fc45-496c-833b-df08b10297b9/w_HPCKit_p_2024.1.0.561_offline.exe"
         cmp="intel.oneapi.win.cpp-dpcpp-common:intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel"
         "$GITHUB_WORKSPACE/modflow6/.github/common/install_intel_windows.bat" $url $cmp
         rm -rf $TEMP/webimage.exe


### PR DESCRIPTION
The Windows parallel distribution was built with Intel Fortran Classic (`ifort`) 2021.11.1 until now. When running PRT models, Win parallel distributions built with this version of the compiler produce a runtime error in `MethodSubcellPool.f90` when the method pool's pointers to tracking methods are deallocated &mdash; evidently a compiler bug?

```
forrtl: severe (153): allocatable array or pointer is not allocated
Image              PC                Routine            Line        Source             
mf6.exe            00007FF6CF304F37  METHODSUBCELLPOOL          26  MethodSubcellPool.f90
mf6.exe            00007FF6CF02D366  PRTMODULE_mp_PRT_         718  prt.f90
mf6.exe            00007FF6CEF1372A  MF6COREMODULE_mp_         173  mf6core.f90
mf6.exe            00007FF6CEF116C2  MF6COREMODULE_mp_          57  mf6core.f90
mf6.exe            00007FF6CEF11042  MAIN__                     11  mf6.f90
mf6.exe            00007FF6CF4BBE6B  Unknown               Unknown  Unknown
mf6.exe            00007FF6CF4BC339  Unknown               Unknown  Unknown
mf6.exe            00007FF6CF4BC25E  Unknown               Unknown  Unknown
mf6.exe            00007FF6CF4BC11E  Unknown               Unknown  Unknown
mf6.exe            00007FF6CF4BC3AE  Unknown               Unknown  Unknown
KERNEL32.DLL       00007FFAA0317344  Unknown               Unknown  Unknown
ntdll.dll          00007FFAA0AC26B1  Unknown               Unknown  Unknown
```

This only affects the Windows parallel distribution because we use `ifort` 2021.7 to build the other Intel distributions. The reason we did not use 2021.7 to build the Win parallel dist is parallel requires the oneAPI base kit, and I've been unable to find the installer URL for that base kit (Intel conceals all but the latest). Luckily the latest `ifort` (2021.12.0) doesn't have the same issue, so we can simply switch the Win parallel dist to 2021.12.0.

The macos CI failure is a separate issue, to be addressed shortly