### PR TITLE
chore(codespell): update .codespell.ignore, fix spelling in sfr.tex

### DIFF
--- a/.codespell.ignore
+++ b/.codespell.ignore
@@ -17,3 +17,5 @@ shft
 lsat
 thi
 thckstrt
+rin
+checkin

--- a/doc/mf6io/gwf/sfr.tex
+++ b/doc/mf6io/gwf/sfr.tex
@@ -100,7 +100,7 @@ Where irregular cross sections are used to define cross-sectional stream geometr
 \begin{figure}[ht]
 	\centering
 	\includegraphics[scale=1.0]{../Figures/n-point-cross-section-wetted-perimeter}
-	\caption[Illustrations of variously defined n-point cross-sections that show how wetted perimeter will vary depending on the stage and the number of points used to define the cross-section]{Example irregular cross-section geometries showing the corresponding wetted perimeter based on the number of points that define a cross-section and the simulated stage.  (A-C) Wetted perimeters (orange lines) for variously configured 2-point cross-sections.  (D-F) Wetted perimeters for variously configurated 4-point cross-sections}
+	\caption[Illustrations of variously defined n-point cross-sections that show how wetted perimeter will vary depending on the stage and the number of points used to define the cross-section]{Example irregular cross-section geometries showing the corresponding wetted perimeter based on the number of points that define a cross-section and the simulated stage.  (A-C) Wetted perimeters (orange lines) for variously configured 2-point cross-sections.  (D-F) Wetted perimeters for variously configured 4-point cross-sections}
 	\label{fig:sfr-n-point-wp}
 \end{figure}
 


### PR DESCRIPTION
The codespell 2.3.0 update broke our spellchecks, add "rin" and "checkin" to `.codespell.ignore` and fix a typo in `sfr.tex`