### PR TITLE
ci(macos-14): use gcc12 on macos-14, workaround is_recursive symbol missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,11 +216,11 @@ jobs:
           repository: MODFLOW-USGS/modflow6-examples
           path: modflow6-examples
       
-      - name: Setup ${{ env.FC }} ${{ env.FC_V }}
+      - name: Setup ${{ env.FC }} ${{ contains(fromJSON('["macos-14"]'), matrix.os) && 12 || env.FC_V }}
         uses: fortran-lang/setup-fortran@v1
         with:
           compiler: gcc
-          version: ${{ env.FC_V }}
+          version: ${{ contains(fromJSON('["macos-14"]'), matrix.os) && 12 || env.FC_V }}
 
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.8.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,13 +127,13 @@ jobs:
             bash
             powershell
 
-      - name: Setup ${{ matrix.compiler }} ${{ matrix.version }}
+      - name: Setup ${{ matrix.compiler }} ${{ contains(fromJSON('["macos-14"]'), matrix.os) && 12 || matrix.version }}
         if: (!(runner.os == 'Windows' && matrix.parallel))
         id: setup-fortran
         uses: fortran-lang/setup-fortran@v1
         with:
           compiler: ${{ matrix.compiler }}
-          version: ${{ matrix.version }}
+          version: ${{ contains(fromJSON('["macos-14"]'), matrix.os) && 12 || matrix.version }}
       
       - name: Set version number
         id: set_version


### PR DESCRIPTION
With gcc 13.3+ (from brew) on ARM macs we get [this](https://github.com/MODFLOW-USGS/modflow6/actions/runs/9417146166/job/25942390320#step:9:505)
```
Undefined symbols for architecture arm64:
  "_is_recursive.16.0", referenced from:
      ___characterstringmodule_MOD_assign_to_charstring in libmf6core.a(Utilities_CharString.f90.o)
ld: symbol(s) not found for architecture arm64
collect2: error: ld returned 1 exit status
```

It reproduces locally. On inspection of the symbol table, `_is_recursive.16.0` has type "U" (undefined) while there are several others with the same name and different index `_is_recursive.N` which have type "b" (local bss section symbol). Seems like a GCC bug? Maybe worth building from source and digging deeper, but that is not trivial. Falling back to gcc 12 for now.