### PR TITLE
refactor(memorystore) Rename all references to the memorylist to memorystore

### DIFF
--- a/src/Distributed/MappedMemory.f90
+++ b/src/Distributed/MappedMemory.f90
@@ -2,7 +2,7 @@ module MappedMemoryModule
   use KindModule, only: I4B, LGP
   use ConstantsModule, only: LENMEMPATH, LENVARNAME
   use MemoryTypeModule, only: MemoryType
-  use MemoryManagerModule, only: get_from_memorylist
+  use MemoryManagerModule, only: get_from_memorystore
 
   implicit none
   private
@@ -48,8 +48,8 @@ contains
 
     if (.not. associated(this%src)) then
       ! cache
-      call get_from_memorylist(this%src_name, this%src_path, this%src, found)
-      call get_from_memorylist(this%tgt_name, this%tgt_path, this%tgt, found)
+      call get_from_memorystore(this%src_name, this%src_path, this%src, found)
+      call get_from_memorystore(this%tgt_name, this%tgt_path, this%tgt, found)
     end if
 
     if (this%skip_sync()) return

--- a/src/Distributed/VirtualBase.f90
+++ b/src/Distributed/VirtualBase.f90
@@ -4,7 +4,7 @@ module VirtualBaseModule
   use ConstantsModule, only: LENVARNAME, LENMEMPATH, LENCOMPONENTNAME
   use MemoryTypeModule, only: MemoryType
   use MemoryManagerModule, only: mem_allocate, mem_deallocate, &
-                                 get_from_memorylist
+                                 get_from_memorystore
   implicit none
   private
 
@@ -145,8 +145,8 @@ contains
     ! local
     logical(LGP) :: found
 
-    call get_from_memorylist(this%var_name, this%mem_path, &
-                             this%virtual_mt, found)
+    call get_from_memorystore(this%var_name, this%mem_path, &
+                              this%virtual_mt, found)
 
   end subroutine vm_link
 

--- a/src/Distributed/VirtualDataContainer.f90
+++ b/src/Distributed/VirtualDataContainer.f90
@@ -6,7 +6,7 @@ module VirtualDataContainerModule
   use STLVecIntModule
   use ConstantsModule, only: LENCOMPONENTNAME, LENMEMPATH, LENCONTEXTNAME
   use MemoryHelperModule, only: create_mem_path
-  use MemoryManagerModule, only: get_from_memorylist
+  use MemoryManagerModule, only: get_from_memorystore
   implicit none
   private
 
@@ -268,7 +268,7 @@ contains
       ! create new virtual memory item
       vm_pth = this%get_vrt_mem_path(vd%var_name, vd%subcmp_name)
       call vd%vm_allocate(vd%var_name, vm_pth, shape)
-      call get_from_memorylist(vd%var_name, vm_pth, vd%virtual_mt, found)
+      call get_from_memorystore(vd%var_name, vm_pth, vd%virtual_mt, found)
       if (vd%map_type > 0) then
         vd%remote_to_virtual => this%element_luts(vd%map_type)%remote_to_virtual
         vd%remote_elem_shift => this%element_maps(vd%map_type)%remote_elem_shift

--- a/src/Model/Discretization/Dis.f90
+++ b/src/Model/Discretization/Dis.f90
@@ -12,7 +12,7 @@ module DisModule
                        store_error_filename
   use SimVariablesModule, only: errmsg, idm_context
   use MemoryManagerModule, only: mem_allocate, mem_deallocate
-  use MemoryManagerExtModule, only: mem_set_value, memorylist_remove
+  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove
   use TdisModule, only: kstp, kper, pertim, totim, delt
 
   implicit none
@@ -155,7 +155,7 @@ contains
     class(DisType) :: this
     !
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name_model, 'DIS', idm_context)
+    call memorystore_remove(this%name_model, 'DIS', idm_context)
     !
     ! -- DisBaseType deallocate
     call this%DisBaseType%dis_da()

--- a/src/Model/Discretization/Dis2d.f90
+++ b/src/Model/Discretization/Dis2d.f90
@@ -12,7 +12,7 @@ module Dis2dModule
                        store_error_filename
   use SimVariablesModule, only: errmsg, idm_context
   use MemoryManagerModule, only: mem_allocate, mem_deallocate
-  use MemoryManagerExtModule, only: mem_set_value, memorylist_remove
+  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove
   use TdisModule, only: kstp, kper, pertim, totim, delt
 
   implicit none
@@ -151,7 +151,7 @@ contains
     class(Dis2dType) :: this
     !
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name_model, 'DIS2D', idm_context)
+    call memorystore_remove(this%name_model, 'DIS2D', idm_context)
     !
     ! -- DisBaseType deallocate
     call this%DisBaseType%dis_da()

--- a/src/Model/Discretization/Disu.f90
+++ b/src/Model/Discretization/Disu.f90
@@ -13,7 +13,7 @@ module DisuModule
   use BaseDisModule, only: DisBaseType
   use MemoryManagerModule, only: mem_allocate, mem_deallocate, &
                                  mem_reallocate, mem_setptr
-  use MemoryManagerExtModule, only: mem_set_value, memorylist_remove
+  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove
   use TdisModule, only: kstp, kper, pertim, totim, delt
   use DisvGeom, only: line_unit_vector
 
@@ -433,9 +433,9 @@ contains
     class(DisuType) :: this
     !
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name_model, 'DISU', idm_context)
-    call memorylist_remove(component=this%name_model, &
-                           context=idm_context)
+    call memorystore_remove(this%name_model, 'DISU', idm_context)
+    call memorystore_remove(component=this%name_model, &
+                            context=idm_context)
     !
     ! -- scalars
     call mem_deallocate(this%njausr)

--- a/src/Model/Discretization/Disv.f90
+++ b/src/Model/Discretization/Disv.f90
@@ -13,7 +13,7 @@ module DisvModule
   use SimVariablesModule, only: errmsg, idm_context
   use DisvGeom, only: DisvGeomType, line_unit_vector
   use MemoryManagerModule, only: mem_allocate, mem_deallocate, mem_setptr
-  use MemoryManagerExtModule, only: mem_set_value, memorylist_remove
+  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove
   use TdisModule, only: kstp, kper, pertim, totim, delt
 
   implicit none
@@ -171,9 +171,9 @@ contains
     class(DisvType) :: this
     !
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name_model, 'DISV', idm_context)
-    call memorylist_remove(component=this%name_model, &
-                           context=idm_context)
+    call memorystore_remove(this%name_model, 'DISV', idm_context)
+    call memorystore_remove(component=this%name_model, &
+                            context=idm_context)
     !
     ! -- DisBaseType deallocate
     call this%DisBaseType%dis_da()

--- a/src/Model/Discretization/Disv1d.f90
+++ b/src/Model/Discretization/Disv1d.f90
@@ -1095,7 +1095,7 @@ contains
   subroutine disv1d_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(Disv1dType) :: this
@@ -1103,7 +1103,7 @@ contains
     logical(LGP) :: deallocate_vertices
     !
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name_model, 'DISV1D', idm_context)
+    call memorystore_remove(this%name_model, 'DISV1D', idm_context)
     !
     ! -- scalars
     deallocate_vertices = (this%nvert > 0)

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -13,7 +13,7 @@ module Disv2dModule
   use SimVariablesModule, only: errmsg, idm_context
   use DisvGeom, only: DisvGeomType, line_unit_vector
   use MemoryManagerModule, only: mem_allocate, mem_deallocate, mem_setptr
-  use MemoryManagerExtModule, only: mem_set_value, memorylist_remove
+  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove
   use TdisModule, only: kstp, kper, pertim, totim, delt
 
   implicit none
@@ -152,14 +152,14 @@ contains
   subroutine disv2d_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(Disv2dType) :: this
     ! -- local
 
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name_model, 'DISV2D', idm_context)
+    call memorystore_remove(this%name_model, 'DISV2D', idm_context)
 
     ! -- scalars
     call mem_deallocate(this%nvert)
@@ -190,8 +190,8 @@ contains
   !   class(Disv2dType) :: this
   !   !
   !   ! -- Deallocate idm memory
-  !   call memorylist_remove(this%name_model, 'DISV', idm_context)
-  !   call memorylist_remove(component=this%name_model, &
+  !   call memorystore_remove(this%name_model, 'DISV', idm_context)
+  !   call memorystore_remove(component=this%name_model, &
   !                          context=idm_context)
   !   !
   !   ! -- DisBaseType deallocate

--- a/src/Model/GroundWaterEnergy/gwe-cnd.f90
+++ b/src/Model/GroundWaterEnergy/gwe-cnd.f90
@@ -459,14 +459,14 @@ contains
   subroutine cnd_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(GweCndType) :: this
     ! -- local
     !
     ! -- Deallocate input memory
-    call memorylist_remove(this%name_model, 'CND', idm_context)
+    call memorystore_remove(this%name_model, 'CND', idm_context)
     !
     ! -- deallocate arrays
     if (this%inunit /= 0) then

--- a/src/Model/GroundWaterEnergy/gwe.f90
+++ b/src/Model/GroundWaterEnergy/gwe.f90
@@ -606,7 +606,7 @@ contains
   subroutine gwe_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(GweModelType) :: this
@@ -615,8 +615,8 @@ contains
     class(BndType), pointer :: packobj
     !
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name, 'NAM', idm_context)
-    call memorylist_remove(component=this%name, context=idm_context)
+    call memorystore_remove(this%name, 'NAM', idm_context)
+    call memorystore_remove(component=this%name, context=idm_context)
     !
     ! -- Internal flow packages deallocate
     call this%dis%dis_da()

--- a/src/Model/GroundWaterFlow/gwf-ic.f90
+++ b/src/Model/GroundWaterFlow/gwf-ic.f90
@@ -104,13 +104,13 @@ contains
   subroutine ic_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(GwfIcType) :: this
     !
     ! -- deallocate IDM memory
-    call memorylist_remove(this%name_model, 'IC', idm_context)
+    call memorystore_remove(this%name_model, 'IC', idm_context)
     !
     ! -- deallocate arrays
     call mem_deallocate(this%strt)

--- a/src/Model/GroundWaterFlow/gwf-npf.f90
+++ b/src/Model/GroundWaterFlow/gwf-npf.f90
@@ -974,13 +974,13 @@ contains
   !<
   subroutine npf_da(this)
     ! -- modules
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(GwfNpftype) :: this
     !
     ! -- Deallocate input memory
-    call memorylist_remove(this%name_model, 'NPF', idm_context)
+    call memorystore_remove(this%name_model, 'NPF', idm_context)
     !
     ! -- TVK
     if (this%intvk /= 0) then

--- a/src/Model/GroundWaterFlow/gwf.f90
+++ b/src/Model/GroundWaterFlow/gwf.f90
@@ -1082,7 +1082,7 @@ contains
   subroutine gwf_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(GwfModelType) :: this
@@ -1091,8 +1091,8 @@ contains
     class(BndType), pointer :: packobj
     !
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name, 'NAM', idm_context)
-    call memorylist_remove(component=this%name, context=idm_context)
+    call memorystore_remove(this%name, 'NAM', idm_context)
+    call memorystore_remove(component=this%name, context=idm_context)
     !
     ! -- Internal flow packages deallocate
     call this%dis%dis_da()

--- a/src/Model/GroundWaterTransport/gwt-dsp.f90
+++ b/src/Model/GroundWaterTransport/gwt-dsp.f90
@@ -448,14 +448,14 @@ contains
   subroutine dsp_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(GwtDspType) :: this
     ! -- local
     !
     ! -- Deallocate input memory
-    call memorylist_remove(this%name_model, 'DSP', idm_context)
+    call memorystore_remove(this%name_model, 'DSP', idm_context)
     !
     ! -- deallocate arrays
     if (this%inunit /= 0) then

--- a/src/Model/GroundWaterTransport/gwt.f90
+++ b/src/Model/GroundWaterTransport/gwt.f90
@@ -612,7 +612,7 @@ contains
   subroutine gwt_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(GwtModelType) :: this
@@ -621,8 +621,8 @@ contains
     class(BndType), pointer :: packobj
     !
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name, 'NAM', idm_context)
-    call memorylist_remove(component=this%name, context=idm_context)
+    call memorystore_remove(this%name, 'NAM', idm_context)
+    call memorystore_remove(component=this%name, context=idm_context)
     !
     ! -- Internal flow packages deallocate
     call this%dis%dis_da()

--- a/src/Model/ParticleTracking/prt-mip.f90
+++ b/src/Model/ParticleTracking/prt-mip.f90
@@ -6,7 +6,7 @@ module PrtMipModule
   use BlockParserModule, only: BlockParserType
   use BaseDisModule, only: DisBaseType
   use MemoryManagerModule, only: mem_allocate, mem_deallocate
-  use MemoryManagerExtModule, only: mem_set_value, memorylist_remove
+  use MemoryManagerExtModule, only: mem_set_value, memorystore_remove
   use SimVariablesModule, only: idm_context
   use SimModule, only: store_error
   use PrtMipInputModule, only: PrtMipParamFoundType
@@ -70,7 +70,7 @@ contains
     class(PrtMipType) :: this
     !
     ! -- Deallocate input memory
-    call memorylist_remove(this%name_model, 'MIP', idm_context)
+    call memorystore_remove(this%name_model, 'MIP', idm_context)
     !
     ! -- Deallocate parent package
     call this%NumericalPackageType%da()

--- a/src/Model/ParticleTracking/prt.f90
+++ b/src/Model/ParticleTracking/prt.f90
@@ -687,7 +687,7 @@ contains
   subroutine prt_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     use MethodPoolModule, only: destroy_method_pool
     use MethodCellPoolModule, only: destroy_method_cell_pool
@@ -699,8 +699,8 @@ contains
     class(BndType), pointer :: packobj
 
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name, 'NAM', idm_context)
-    call memorylist_remove(component=this%name, context=idm_context)
+    call memorystore_remove(this%name, 'NAM', idm_context)
+    call memorystore_remove(component=this%name, context=idm_context)
 
     ! -- Internal packages
     call this%dis%dis_da()

--- a/src/Model/SurfaceWaterFlow/swf-cxs.f90
+++ b/src/Model/SurfaceWaterFlow/swf-cxs.f90
@@ -528,13 +528,13 @@ contains
   subroutine cxs_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(SwfCxsType) :: this
     !
     ! -- Deallocate input memory
-    call memorylist_remove(this%name_model, 'CXS', idm_context)
+    call memorystore_remove(this%name_model, 'CXS', idm_context)
     !
     ! -- Scalars
     call mem_deallocate(this%nsections)

--- a/src/Model/SurfaceWaterFlow/swf-dfw.f90
+++ b/src/Model/SurfaceWaterFlow/swf-dfw.f90
@@ -1262,13 +1262,13 @@ contains
   subroutine dfw_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(SwfDfwType) :: this
     !
     ! Deallocate input memory
-    call memorylist_remove(this%name_model, 'DFW', idm_context)
+    call memorystore_remove(this%name_model, 'DFW', idm_context)
 
     ! Deallocate arrays
     call mem_deallocate(this%manningsn)

--- a/src/Model/SurfaceWaterFlow/swf-ic.f90
+++ b/src/Model/SurfaceWaterFlow/swf-ic.f90
@@ -104,13 +104,13 @@ contains
   subroutine ic_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(SwfIcType) :: this
     !
     ! -- deallocate IDM memory
-    call memorylist_remove(this%name_model, 'IC', idm_context)
+    call memorystore_remove(this%name_model, 'IC', idm_context)
     !
     ! -- deallocate arrays
     call mem_deallocate(this%strt)

--- a/src/Model/SurfaceWaterFlow/swf.f90
+++ b/src/Model/SurfaceWaterFlow/swf.f90
@@ -875,7 +875,7 @@ contains
   subroutine swf_da(this)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(SwfModelType) :: this
@@ -884,8 +884,8 @@ contains
     class(BndType), pointer :: packobj
     !
     ! -- Deallocate idm memory
-    call memorylist_remove(this%name, 'NAM', idm_context)
-    call memorylist_remove(component=this%name, context=idm_context)
+    call memorystore_remove(this%name, 'NAM', idm_context)
+    call memorystore_remove(component=this%name, context=idm_context)
     !
     ! -- Internal flow packages deallocate
     call this%dis%dis_da()

--- a/src/Utilities/Idm/IdmLoad.f90
+++ b/src/Utilities/Idm/IdmLoad.f90
@@ -87,7 +87,7 @@ contains
     use SimVariablesModule, only: idm_context
     use MemoryManagerModule, only: mem_setptr
     use MemoryHelperModule, only: create_mem_path, split_mem_path
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use CharacterStringModule, only: CharacterStringType
     integer(I4B), intent(in) :: iout
     type(CharacterStringType), dimension(:), contiguous, &
@@ -106,15 +106,15 @@ contains
       mempath = mempaths(n)
       if (mempath /= '') then
         call split_mem_path(mempath, exg_comp, exg_subcomp)
-        call memorylist_remove(exg_comp, exg_subcomp, idm_context)
+        call memorystore_remove(exg_comp, exg_subcomp, idm_context)
       end if
     end do
     !
     ! -- deallocate input context SIM paths
-    call memorylist_remove('UTL', 'HPC', idm_context)
-    call memorylist_remove('SIM', 'TDIS', idm_context)
-    call memorylist_remove('SIM', 'NAM', idm_context)
-    call memorylist_remove(component='SIM', context=idm_context)
+    call memorystore_remove('UTL', 'HPC', idm_context)
+    call memorystore_remove('SIM', 'TDIS', idm_context)
+    call memorystore_remove('SIM', 'NAM', idm_context)
+    call memorystore_remove(component='SIM', context=idm_context)
     !
     ! -- return
     return

--- a/src/Utilities/Idm/InputLoadType.f90
+++ b/src/Utilities/Idm/InputLoadType.f90
@@ -228,14 +228,14 @@ contains
   !<
   subroutine dynamic_destroy(this)
     use MemoryManagerModule, only: mem_deallocate
-    use MemoryManagerExtModule, only: memorylist_remove
+    use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     class(DynamicPkgLoadType), intent(inout) :: this
     !
     ! -- deallocate package static and dynamic input context
-    call memorylist_remove(this%mf6_input%component_name, &
-                           this%mf6_input%subcomponent_name, &
-                           idm_context)
+    call memorystore_remove(this%mf6_input%component_name, &
+                            this%mf6_input%subcomponent_name, &
+                            idm_context)
     !
     return
   end subroutine dynamic_destroy

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -286,7 +286,7 @@ contains
   recursive subroutine parse_block(this, iblk, recursive_call)
     ! -- modules
     use MemoryTypeModule, only: MemoryType
-    use MemoryManagerModule, only: get_from_memorylist
+    use MemoryManagerModule, only: get_from_memorystore
     ! -- dummy
     class(LoadMf6FileType) :: this
     integer(I4B), intent(in) :: iblk
@@ -305,8 +305,8 @@ contains
         this%mf6_input%pkgtype == 'DISV2D6') then
       if (this%mf6_input%block_dfns(iblk)%blockname == 'VERTICES' .or. &
           this%mf6_input%block_dfns(iblk)%blockname == 'CELL2D') then
-        call get_from_memorylist('NVERT', this%mf6_input%mempath, mt, found, &
-                                 .false.)
+        call get_from_memorystore('NVERT', this%mf6_input%mempath, mt, found, &
+                                  .false.)
         if (.not. found) return
         if (mt%intsclr == 0) return
       end if

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -31,7 +31,7 @@ module MemoryManagerModule
   public :: mem_write_usage
   public :: mem_da
   public :: mem_set_print_option
-  public :: get_from_memorylist
+  public :: get_from_memorystore
 
   public :: get_mem_type
   public :: get_mem_rank
@@ -40,10 +40,10 @@ module MemoryManagerModule
   public :: get_isize
   public :: copy_dbl1d
 
-  public :: memorylist
+  public :: memorystore
   public :: mem_print_detailed
 
-  type(MemoryStoreType) :: memorylist
+  type(MemoryStoreType) :: memorystore
   type(TableType), pointer :: memtab => null()
   integer(I8B) :: nvalues_alogical = 0
   integer(I8B) :: nvalues_astr = 0
@@ -152,7 +152,7 @@ contains
     ! -- code
     mt => null()
     var_type = 'UNKNOWN'
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     if (found) then
       var_type = mt%memtype
     end if
@@ -178,7 +178,7 @@ contains
     rank = -1
     !
     ! -- get the entry from the memory manager
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     !
     ! -- set rank
     if (found) then
@@ -217,7 +217,7 @@ contains
     size = -1
     !
     ! -- get the entry from the memory manager
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     !
     ! -- set memory size
     if (found) then
@@ -243,7 +243,7 @@ contains
     ! -- code
     !
     ! -- get the entry from the memory manager
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     !
     ! -- set shape
     if (found) then
@@ -290,7 +290,7 @@ contains
     terminate = .false.
     !
     ! -- get the entry from the memory manager
-    call get_from_memorylist(name, mem_path, mt, found, terminate)
+    call get_from_memorystore(name, mem_path, mt, found, terminate)
     !
     ! -- set isize
     if (found) then
@@ -306,7 +306,7 @@ contains
   !! Default value for @par check is .true. which means that this
   !! routine will kill the program when the memory entry cannot be found.
   !<
-  subroutine get_from_memorylist(name, mem_path, mt, found, check)
+  subroutine get_from_memorystore(name, mem_path, mt, found, check)
     character(len=*), intent(in) :: name !< variable name
     character(len=*), intent(in) :: mem_path !< path where the variable is stored
     type(MemoryType), pointer, intent(inout) :: mt !< memory type entry
@@ -316,7 +316,7 @@ contains
     ! -- local
     logical(LGP) check_opt
     ! -- code
-    mt => memorylist%get(name, mem_path)
+    mt => memorystore%get(name, mem_path)
     found = associated(mt)
 
     check_opt = .true.
@@ -334,7 +334,7 @@ contains
     !
     ! -- return
     return
-  end subroutine get_from_memorylist
+  end subroutine get_from_memorystore
 
   !> @brief Issue allocation error message and stop program execution
   !<
@@ -397,7 +397,7 @@ contains
     write (mt%memtype, "(a)") 'LOGICAL'
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -449,7 +449,7 @@ contains
     write (mt%memtype, "(a,' LEN=',i0)") 'STRING', ilen
     !
     ! -- add defined length string to the memory manager list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -518,7 +518,7 @@ contains
     write (mt%memtype, "(a,' LEN=',i0,' (',i0,')')") 'STRING', ilen, nrow
     !
     ! -- add deferred length character array to the memory manager list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -578,7 +578,7 @@ contains
     write (mt%memtype, "(a,' LEN=',i0,' (',i0,')')") 'STRING', ilen, nrow
     !
     ! -- add deferred length character array to the memory manager list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -619,7 +619,7 @@ contains
     write (mt%memtype, "(a)") 'INTEGER'
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -665,7 +665,7 @@ contains
     write (mt%memtype, "(a,' (',i0,')')") 'INTEGER', isize
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -712,7 +712,7 @@ contains
     write (mt%memtype, "(a,' (',i0,',',i0,')')") 'INTEGER', ncol, nrow
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
   end subroutine allocate_int2d
@@ -760,7 +760,7 @@ contains
       nrow, nlay
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -801,7 +801,7 @@ contains
     write (mt%memtype, "(a)") 'DOUBLE'
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -847,7 +847,7 @@ contains
     write (mt%memtype, "(a,' (',i0,')')") 'DOUBLE', isize
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -894,7 +894,7 @@ contains
     write (mt%memtype, "(a,' (',i0,',',i0,')')") 'DOUBLE', ncol, nrow
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -943,7 +943,7 @@ contains
       nrow, nlay
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -985,7 +985,7 @@ contains
     mt%masterPath = mem_path2
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -1028,7 +1028,7 @@ contains
     mt%masterPath = mem_path2
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -1070,7 +1070,7 @@ contains
     mt%masterPath = mem_path2
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -1113,7 +1113,7 @@ contains
     mt%masterPath = mem_path2
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -1157,7 +1157,7 @@ contains
     mt%masterPath = mem_path2
     !
     ! -- add memory type to the memory list
-    call memorylist%add(mt)
+    call memorystore%add(mt)
     !
     ! -- return
     return
@@ -1182,7 +1182,7 @@ contains
     integer(I4B) :: n
     !
     ! -- Find and assign mt
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     !
     ! -- reallocate astr1d
     if (found) then
@@ -1271,7 +1271,7 @@ contains
     string = ''
     !
     ! -- Find and assign mt
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     !
     ! -- reallocate astr1d
     if (found) then
@@ -1355,7 +1355,7 @@ contains
     ! -- code
     !
     ! -- Find and assign mt
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     !
     ! -- Allocate aint and then refill
     isize = nrow
@@ -1402,7 +1402,7 @@ contains
     ! -- code
     !
     ! -- Find and assign mt
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     !
     ! -- Allocate aint and then refill
     ishape = shape(mt%aint2d)
@@ -1450,7 +1450,7 @@ contains
     ! -- code
     !
     ! -- Find and assign mt
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     !
     ! -- Allocate adbl and then refill
     isize = nrow
@@ -1498,7 +1498,7 @@ contains
     ! -- code
     !
     ! -- Find and assign mt
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     !
     ! -- Allocate adbl and then refill
     ishape = shape(mt%adbl2d)
@@ -1538,7 +1538,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     sclr => mt%logicalsclr
     !
     ! -- return
@@ -1555,7 +1555,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     sclr => mt%intsclr
     !
     ! -- return
@@ -1572,7 +1572,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     aint => mt%aint1d
     !
     ! -- return
@@ -1589,7 +1589,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     aint => mt%aint2d
     !
     ! -- return
@@ -1606,7 +1606,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     aint => mt%aint3d
     !
     ! -- return
@@ -1623,7 +1623,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     sclr => mt%dblsclr
     !
     ! -- return
@@ -1640,7 +1640,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     adbl => mt%adbl1d
     !
     ! -- return
@@ -1657,7 +1657,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     adbl => mt%adbl2d
     !
     ! -- return
@@ -1674,7 +1674,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     adbl => mt%adbl3d
     !
     ! -- return
@@ -1691,7 +1691,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     asrt => mt%strsclr
     !
     ! -- return
@@ -1709,7 +1709,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     astr1d => mt%astr1d
     !
     ! -- return
@@ -1727,7 +1727,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     acharstr1d => mt%acharstr1d
     !
     ! -- return
@@ -1748,7 +1748,7 @@ contains
     logical(LGP) :: found
     integer(I4B) :: n
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     aint => null()
     ! -- check the copy into the memory manager
     if (present(mem_path_copy)) then
@@ -1782,7 +1782,7 @@ contains
     integer(I4B) :: ncol
     integer(I4B) :: nrow
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     aint => null()
     ncol = size(mt%aint2d, dim=1)
     nrow = size(mt%aint2d, dim=2)
@@ -1817,7 +1817,7 @@ contains
     logical(LGP) :: found
     integer(I4B) :: n
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     adbl => null()
     ! -- check the copy into the memory manager
     if (present(mem_path_copy)) then
@@ -1851,7 +1851,7 @@ contains
     integer(I4B) :: ncol
     integer(I4B) :: nrow
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     adbl => null()
     ncol = size(mt%adbl2d, dim=1)
     nrow = size(mt%adbl2d, dim=2)
@@ -1883,7 +1883,7 @@ contains
     logical(LGP) :: found
     integer(I4B) :: n
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
+    call get_from_memorystore(name, mem_path, mt, found)
     do n = 1, size(mt%adbl1d)
       adbl(n) = mt%adbl1d(n)
     end do
@@ -1905,8 +1905,8 @@ contains
     type(MemoryType), pointer :: mt2
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
-    call get_from_memorylist(name_target, mem_path_target, mt2, found)
+    call get_from_memorystore(name, mem_path, mt, found)
+    call get_from_memorystore(name_target, mem_path_target, mt2, found)
     if (associated(sclr)) then
       nvalues_aint = nvalues_aint - 1
       deallocate (sclr)
@@ -1939,8 +1939,8 @@ contains
     type(MemoryType), pointer :: mt2
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
-    call get_from_memorylist(name_target, mem_path_target, mt2, found)
+    call get_from_memorystore(name, mem_path, mt, found)
+    call get_from_memorystore(name_target, mem_path_target, mt2, found)
     if (size(aint) > 0) then
       nvalues_aint = nvalues_aint - size(aint)
       deallocate (aint)
@@ -1975,8 +1975,8 @@ contains
     integer(I4B) :: ncol
     integer(I4B) :: nrow
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
-    call get_from_memorylist(name_target, mem_path_target, mt2, found)
+    call get_from_memorystore(name, mem_path, mt, found)
+    call get_from_memorystore(name_target, mem_path_target, mt2, found)
     if (size(aint) > 0) then
       nvalues_aint = nvalues_aint - size(aint)
       deallocate (aint)
@@ -2011,8 +2011,8 @@ contains
     type(MemoryType), pointer :: mt2
     logical(LGP) :: found
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
-    call get_from_memorylist(name_target, mem_path_target, mt2, found)
+    call get_from_memorystore(name, mem_path, mt, found)
+    call get_from_memorystore(name_target, mem_path_target, mt2, found)
     if (size(adbl) > 0) then
       nvalues_adbl = nvalues_adbl - size(adbl)
       deallocate (adbl)
@@ -2047,8 +2047,8 @@ contains
     integer(I4B) :: ncol
     integer(I4b) :: nrow
     ! -- code
-    call get_from_memorylist(name, mem_path, mt, found)
-    call get_from_memorylist(name_target, mem_path_target, mt2, found)
+    call get_from_memorystore(name, mem_path, mt, found)
+    call get_from_memorystore(name_target, mem_path_target, mt2, found)
     if (size(adbl) > 0) then
       nvalues_adbl = nvalues_adbl - size(adbl)
       deallocate (adbl)
@@ -2083,10 +2083,10 @@ contains
     ! -- code
     found = .false.
     if (present(name) .and. present(mem_path)) then
-      call get_from_memorylist(name, mem_path, mt, found)
+      call get_from_memorystore(name, mem_path, mt, found)
       nullify (mt%strsclr)
     else
-      itr = memorylist%iterator()
+      itr = memorystore%iterator()
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
@@ -2127,10 +2127,10 @@ contains
     ! -- process optional variables
     found = .false.
     if (present(name) .and. present(mem_path)) then
-      call get_from_memorylist(name, mem_path, mt, found)
+      call get_from_memorystore(name, mem_path, mt, found)
       nullify (mt%astr1d)
     else
-      itr = memorylist%iterator()
+      itr = memorystore%iterator()
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
@@ -2172,10 +2172,10 @@ contains
     ! -- process optional variables
     found = .false.
     if (present(name) .and. present(mem_path)) then
-      call get_from_memorylist(name, mem_path, mt, found)
+      call get_from_memorystore(name, mem_path, mt, found)
       nullify (mt%acharstr1d)
     else
-      itr = memorylist%iterator()
+      itr = memorystore%iterator()
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
@@ -2211,7 +2211,7 @@ contains
     type(MemoryContainerIteratorType), allocatable :: itr
     ! -- code
     found = .false.
-    itr = memorylist%iterator()
+    itr = memorystore%iterator()
     do while (itr%has_next())
       call itr%next()
       mt => itr%value()
@@ -2246,7 +2246,7 @@ contains
     type(MemoryContainerIteratorType), allocatable :: itr
     ! -- code
     found = .false.
-    itr = memorylist%iterator()
+    itr = memorystore%iterator()
     do while (itr%has_next())
       call itr%next()
       mt => itr%value()
@@ -2280,7 +2280,7 @@ contains
     type(MemoryContainerIteratorType), allocatable :: itr
     ! -- code
     found = .false.
-    itr = memorylist%iterator()
+    itr = memorystore%iterator()
     do while (itr%has_next())
       call itr%next()
       mt => itr%value()
@@ -2319,10 +2319,10 @@ contains
     ! -- process optional variables
     found = .false.
     if (present(name) .and. present(mem_path)) then
-      call get_from_memorylist(name, mem_path, mt, found)
+      call get_from_memorystore(name, mem_path, mt, found)
       nullify (mt%aint1d)
     else
-      itr = memorylist%iterator()
+      itr = memorystore%iterator()
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
@@ -2362,10 +2362,10 @@ contains
     ! -- process optional variables
     found = .false.
     if (present(name) .and. present(mem_path)) then
-      call get_from_memorylist(name, mem_path, mt, found)
+      call get_from_memorystore(name, mem_path, mt, found)
       nullify (mt%aint2d)
     else
-      itr = memorylist%iterator()
+      itr = memorystore%iterator()
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
@@ -2405,10 +2405,10 @@ contains
     ! -- process optional variables
     found = .false.
     if (present(name) .and. present(mem_path)) then
-      call get_from_memorylist(name, mem_path, mt, found)
+      call get_from_memorystore(name, mem_path, mt, found)
       nullify (mt%aint3d)
     else
-      itr = memorylist%iterator()
+      itr = memorystore%iterator()
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
@@ -2448,10 +2448,10 @@ contains
     ! -- process optional variables
     found = .false.
     if (present(name) .and. present(mem_path)) then
-      call get_from_memorylist(name, mem_path, mt, found)
+      call get_from_memorystore(name, mem_path, mt, found)
       nullify (mt%adbl1d)
     else
-      itr = memorylist%iterator()
+      itr = memorystore%iterator()
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
@@ -2491,10 +2491,10 @@ contains
     ! -- process optional variables
     found = .false.
     if (present(name) .and. present(mem_path)) then
-      call get_from_memorylist(name, mem_path, mt, found)
+      call get_from_memorystore(name, mem_path, mt, found)
       nullify (mt%adbl2d)
     else
-      itr = memorylist%iterator()
+      itr = memorystore%iterator()
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
@@ -2534,10 +2534,10 @@ contains
     ! -- process optional variables
     found = .false.
     if (present(name) .and. present(mem_path)) then
-      call get_from_memorylist(name, mem_path, mt, found)
+      call get_from_memorystore(name, mem_path, mt, found)
       nullify (mt%adbl3d)
     else
-      itr = memorylist%iterator()
+      itr = memorystore%iterator()
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
@@ -2891,7 +2891,7 @@ contains
         nreal = 0
         bytes = DZERO
         ilen = len_trim(cunique(icomp))
-        itr = memorylist%iterator()
+        itr = memorystore%iterator()
         do while (itr%has_next())
           call itr%next()
           mt => itr%value()
@@ -2944,8 +2944,8 @@ contains
     class(MemoryType), pointer :: mt
     type(MemoryContainerIteratorType), allocatable :: itr
 
-    call mem_detailed_table(iout, memorylist%count())
-    itr = memorylist%iterator()
+    call mem_detailed_table(iout, memorystore%count())
+    itr = memorystore%iterator()
     do while (itr%has_next())
       call itr%next()
       mt => itr%value()
@@ -2964,7 +2964,7 @@ contains
     type(MemoryType), pointer :: mt
 
     vmem_size = DZERO
-    itr = memorylist%iterator()
+    itr = memorystore%iterator()
     do while (itr%has_next())
       call itr%next()
       mt => itr%value()
@@ -2987,7 +2987,7 @@ contains
     character(len=LENVARNAME) :: ucname
     type(MemoryContainerIteratorType), allocatable :: itr
     ! -- code
-    itr = memorylist%iterator()
+    itr = memorystore%iterator()
     do while (itr%has_next())
       call itr%next()
       mt => itr%value()
@@ -3020,7 +3020,7 @@ contains
       ! -- deallocate instance of memory type
       deallocate (mt)
     end do
-    call memorylist%clear()
+    call memorystore%clear()
     if (count_errors() > 0) then
       call store_error('Could not clear memory list.', terminate=.TRUE.)
     end if
@@ -3052,7 +3052,7 @@ contains
     allocate (cunique(0))
     !
     ! -- find unique origins
-    itr = memorylist%iterator()
+    itr = memorystore%iterator()
     do while (itr%has_next())
       call itr%next()
       mt => itr%value()

--- a/src/Utilities/Memory/MemoryManagerExt.f90
+++ b/src/Utilities/Memory/MemoryManagerExt.f90
@@ -3,13 +3,13 @@ module MemoryManagerExtModule
   use KindModule, only: DP, LGP, I4B, I8B
   use SimModule, only: store_error
   use MemoryTypeModule, only: MemoryType
-  use MemoryManagerModule, only: memorylist, get_from_memorylist
+  use MemoryManagerModule, only: memorystore, get_from_memorystore
   use MemoryContainerIteratorModule, only: MemoryContainerIteratorType
 
   implicit none
   private
   public :: mem_set_value
-  public :: memorylist_remove
+  public :: memorystore_remove
 
   interface mem_set_value
     module procedure mem_set_value_logical, mem_set_value_int, &
@@ -23,7 +23,7 @@ module MemoryManagerExtModule
 
 contains
 
-  subroutine memorylist_remove(component, subcomponent, context)
+  subroutine memorystore_remove(component, subcomponent, context)
     use MemoryHelperModule, only: create_mem_path
     use ConstantsModule, only: LENMEMPATH
     character(len=*), intent(in) :: component !< name of the solution, model, or exchange
@@ -39,7 +39,7 @@ contains
 
     do while (removed)
       removed = .false.
-      itr = memorylist%iterator()
+      itr = memorystore%iterator()
       do while (itr%has_next())
         call itr%next()
         mt => itr%value()
@@ -50,7 +50,7 @@ contains
         end if
       end do
     end do
-  end subroutine memorylist_remove
+  end subroutine memorystore_remove
 
   !> @brief Set pointer to value of memory list logical variable
   !<
@@ -62,7 +62,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       if (mt%intsclr == 0) then
@@ -83,7 +83,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       p_mem = mt%intsclr
@@ -99,7 +99,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
 
     p_mem = setval
@@ -117,7 +117,7 @@ contains
     logical(LGP) :: checkfail = .false.
     integer(I4B) :: i
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
       do i = 1, size(str_list)
@@ -139,7 +139,7 @@ contains
     logical(LGP) :: checkfail = .false.
     integer(I4B) :: n
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       if (size(mt%aint1d) /= size(p_mem)) then
@@ -165,7 +165,7 @@ contains
     logical(LGP) :: checkfail = .false.
     integer(I4B) :: n
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       if (associated(map)) then
@@ -195,7 +195,7 @@ contains
     logical(LGP) :: checkfail = .false.
     integer(I4B) :: i, j
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       if (size(mt%aint2d, dim=1) /= size(p_mem, dim=1) .or. &
@@ -222,7 +222,7 @@ contains
     logical(LGP) :: checkfail = .false.
     integer(I4B) :: i, j, k
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'INTEGER') then
       if (size(mt%aint3d, dim=1) /= size(p_mem, dim=1) .or. &
@@ -251,7 +251,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       p_mem = mt%dblsclr
@@ -269,7 +269,7 @@ contains
     logical(LGP) :: checkfail = .false.
     integer(I4B) :: n
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       if (size(mt%adbl1d) /= size(p_mem)) then
@@ -295,7 +295,7 @@ contains
     logical(LGP) :: checkfail = .false.
     integer(I4B) :: n
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       if (associated(map)) then
@@ -325,7 +325,7 @@ contains
     logical(LGP) :: checkfail = .false.
     integer(I4B) :: i, j
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       if (size(mt%adbl2d, dim=1) /= size(p_mem, dim=1) .or. &
@@ -352,7 +352,7 @@ contains
     logical(LGP) :: checkfail = .false.
     integer(I4B) :: i, j, k
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'DOUBLE') then
       if (size(mt%adbl3d, dim=1) /= size(p_mem, dim=1) .or. &
@@ -379,7 +379,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: checkfail = .false.
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
       p_mem = mt%strsclr
@@ -397,7 +397,7 @@ contains
     logical(LGP) :: checkfail = .false.
     integer(I4B) :: n
 
-    call get_from_memorylist(varname, memory_path, mt, found, checkfail)
+    call get_from_memorystore(varname, memory_path, mt, found, checkfail)
     if (.not. found) return
     if (mt%memtype(1:index(mt%memtype, ' ')) == 'STRING') then
       do n = 1, size(mt%acharstr1d)

--- a/src/Utilities/Memory/MemorySetHandler.f90
+++ b/src/Utilities/Memory/MemorySetHandler.f90
@@ -2,7 +2,7 @@ module MemorySetHandlerModule
   use KindModule, only: I4B, LGP
   use ListModule, only: ListType
   use MemoryTypeModule, only: MemoryType
-  use MemoryManagerModule, only: get_from_memorylist
+  use MemoryManagerModule, only: get_from_memorystore
   use ConstantsModule, only: LENMEMPATH, LENVARNAME
 
   implicit none
@@ -62,7 +62,7 @@ contains
     ! now set it to the memory item
     mt => null()
     found = .false.
-    call get_from_memorylist(var_name, mem_path, mt, found)
+    call get_from_memorystore(var_name, mem_path, mt, found)
     mt%set_handler_idx = handler_idx
 
   end subroutine
@@ -86,7 +86,7 @@ contains
     ! get the handler data and cast
     mt => null()
     found = .false.
-    call get_from_memorylist(var_name, mem_path, mt, found)
+    call get_from_memorystore(var_name, mem_path, mt, found)
     if (mt%set_handler_idx == 0) then
       ! nothing to be done
       status = 0

--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -27,7 +27,7 @@ module mf6bmi
   use CharacterStringModule
   use MemoryManagerModule, only: mem_setptr, get_mem_elem_size, get_isize, &
                                  get_mem_rank, get_mem_shape, get_mem_type, &
-                                 memorylist
+                                 memorystore
   use MemoryContainerIteratorModule, only: MemoryContainerIteratorType
   use MemoryTypeModule, only: MemoryType
   use MemoryHelperModule, only: create_mem_address
@@ -208,7 +208,7 @@ contains
     integer(kind=c_int), intent(out) :: count !< the number of input variables
     integer(kind=c_int) :: bmi_status !< BMI status code
 
-    count = memorylist%count()
+    count = memorystore%count()
 
     bmi_status = BMI_SUCCESS
 
@@ -225,7 +225,7 @@ contains
     integer(kind=c_int), intent(out) :: count !< the number of output variables
     integer(kind=c_int) :: bmi_status !< BMI status code
 
-    count = memorylist%count()
+    count = memorystore%count()
 
     bmi_status = BMI_SUCCESS
 
@@ -258,7 +258,7 @@ contains
     character(len=LENMEMADDRESS) :: var_address
 
     start = 1
-    itr = memorylist%iterator()
+    itr = memorystore%iterator()
     do while (itr%has_next())
       call itr%next()
       mt => itr%value()
@@ -293,7 +293,7 @@ contains
     character(len=LENMEMADDRESS) :: var_address
 
     start = 1
-    itr = memorylist%iterator()
+    itr = memorystore%iterator()
     do while (itr%has_next())
       call itr%next()
       mt => itr%value()

--- a/srcbmi/mf6bmiUtil.f90
+++ b/srcbmi/mf6bmiUtil.f90
@@ -90,7 +90,7 @@ contains
   !<
   subroutine check_mem_address(mem_path, var_name, found)
     ! -- modules
-    use MemoryManagerModule, only: get_from_memorylist
+    use MemoryManagerModule, only: get_from_memorystore
     use MemoryTypeModule, only: MemoryType
     ! -- dummy variables
     character(len=LENMEMPATH), intent(in) :: mem_path !< memory path used by the memory manager
@@ -103,7 +103,7 @@ contains
     mt => null()
 
     ! check = false: otherwise stop is called when the variable does not exist
-    call get_from_memorylist(var_name, mem_path, mt, found, check=.false.)
+    call get_from_memorystore(var_name, mem_path, mt, found, check=.false.)
 
   end subroutine check_mem_address
 


### PR DESCRIPTION
In PR #1701 the MemoryList type has been renamed to MemoryStore. 
This commit contains some cleanup actions. It renames all references to the memorylist to memorystore.
It doesn't contain any functional changes.