### PR TITLE
ci(pr-template): modify pr template and move location

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,14 @@
-Feel free to remove check-list items that aren't relevant to your change.
+Checklist of items for pull request
 
-- [ ] Closes #xxxx (where xxxx is the corresponding issue number, if relevant)
-- [ ] Added a new test or modified an existing test to verify change
-- [ ] Formatted Fortran source files with `fprettify`
-- [ ] Updated meson files, makefiles, and Visual Studio project files if new source files added
-- [ ] Updated definition (*.dfn) files with new or modified input descriptions
-- [ ] Described new options, features or behavior changes in release notes (./doc/ReleaseNotes/develop.tex)
-- [ ] Updated user input and output descriptions in ./doc/mf6io
+- [ ] Closed issue #xxxx
+- [ ] Referenced issue or pull request #xxxx
+- [ ] Added new test or modified an existing test
+- [ ] Formatted new and modified Fortran source files with `fprettify`
+- [ ] Added doxygen comments to new and modified procedures
+- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
+- [ ] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
+- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; requred for changes that may affect users
+- [ ] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
+- [ ] Removed checklist items not relevant to this pull request
+
+For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Feel free to remove check-list items that aren't relevant to your change.
+
+- [ ] Closes #xxxx (where xxxx is the corresponding issue number, if relevant)
+- [ ] Added a new test or modified an existing test to verify change
+- [ ] Formatted Fortran source files with `fprettify`
+- [ ] Updated meson files, makefiles, and Visual Studio project files if new source files added
+- [ ] Updated definition (*.dfn) files with new or modified input descriptions
+- [ ] Described new options, features or behavior changes in release notes (./doc/ReleaseNotes/develop.tex)
+- [ ] Updated user input and output descriptions in ./doc/mf6io

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Checklist of items for pull request
 - [ ] Added doxygen comments to new and modified procedures
 - [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
 - [ ] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
-- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; requred for changes that may affect users
+- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
 - [ ] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
 - [ ] Removed checklist items not relevant to this pull request
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,8 +1,0 @@
-Feel free to remove check-list items that aren't relevant to your change.
-
-- [ ] Closes #xxxx
-- [ ] Passed autotests
-- [ ] Formatted source files with `fprettify`
-- [ ] Updated definition (*.dfn) files with new or modified options
-- [ ] Described new options, features or behavior changes in release notes
-- [ ] Updated meson files, makefiles, and Visual Studio project files if new source files added


### PR DESCRIPTION
Based on [this](https://stackoverflow.com/questions/52139192/github-pull-requests-template-not-showing), renamed and moved pr template.  Also made minor modifications to template list of tasks.