### PR TITLE
test(test_gwf_maw04.py): switch deprecated np.unicode_ -> np.str_

### DIFF
--- a/autotest/test_gwf_maw04.py
+++ b/autotest/test_gwf_maw04.py
@@ -237,7 +237,7 @@ def build_model(idx, ws, mf6):
         node_data["rskin"] = np.array([sradius[name[-1]], sradius[name[-1]]])
         hks = hk * skin_mult[name[-1]]
         node_data["kskin"] = np.array([hks, hks])
-        dtype = [("wellid", np.unicode_, 20), ("qdes", "<f8")]
+        dtype = [("wellid", np.str_, 20), ("qdes", "<f8")]
         spd0 = np.zeros(1, dtype=dtype)
         spd0["wellid"] = "well1"
         spd1 = np.zeros(1, dtype=dtype)


### PR DESCRIPTION
NumPy 2.0.0 deprecates `np.unicode_` in favor of `np.str_`, see https://numpy.org/devdocs/release/2.0.0-notes.html#numpy-2-0-python-api-removals

___

Checklist of items for pull request

- [x] Added new test or modified an existing test
- [x] Ran `black` on new and modified autotests
- [x] Removed checklist items not relevant to this pull request