### PR TITLE
fix(idm): set correct file and exit with timeseries read error

### DIFF
--- a/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
@@ -221,7 +221,6 @@ contains
 
   subroutine bndlist_ts_link_bnd(this, structvector, ts_strloc)
     ! -- modules
-    use SimModule, only: count_errors, store_error_filename
     use TimeSeriesLinkModule, only: TimeSeriesLinkType
     use TimeSeriesManagerModule, only: read_value_or_time_series
     use StructVectorModule, only: StructVectorType, TSStringLocType
@@ -260,18 +259,12 @@ contains
       end if
     end if
     !
-    ! -- terminate if errors were detected
-    if (count_errors() > 0) then
-      call store_error_filename(this%input_name)
-    end if
-    !
     ! -- return
     return
   end subroutine bndlist_ts_link_bnd
 
   subroutine bndlist_ts_link_aux(this, structvector, ts_strloc)
     ! -- modules
-    use SimModule, only: count_errors, store_error_filename
     use TimeSeriesLinkModule, only: TimeSeriesLinkType
     use TimeSeriesManagerModule, only: read_value_or_time_series
     use StructVectorModule, only: StructVectorType, TSStringLocType
@@ -311,17 +304,13 @@ contains
       !
     end if
     !
-    ! -- terminate if errors were detected
-    if (count_errors() > 0) then
-      call store_error_filename(this%input_name)
-    end if
-    !
     ! -- return
     return
   end subroutine bndlist_ts_link_aux
 
   subroutine bndlist_ts_update(this, structarray)
     ! -- modules
+    use SimModule, only: count_errors, store_error_filename
     use StructVectorModule, only: TSStringLocType
     use StructVectorModule, only: StructVectorType
     ! -- dummy
@@ -346,6 +335,11 @@ contains
         call sv%clear()
       end if
     end do
+    !
+    ! -- terminate if errors were detected
+    if (count_errors() > 0) then
+      call store_error_filename(this%input_name)
+    end if
     !
     ! -- return
     return

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
@@ -221,6 +221,7 @@ contains
 
   subroutine bndlist_ts_link_bnd(this, structvector, ts_strloc)
     ! -- modules
+    use SimModule, only: count_errors, store_error_filename
     use TimeSeriesLinkModule, only: TimeSeriesLinkType
     use TimeSeriesManagerModule, only: read_value_or_time_series
     use StructVectorModule, only: StructVectorType, TSStringLocType
@@ -259,12 +260,18 @@ contains
       end if
     end if
     !
+    ! -- terminate if errors were detected
+    if (count_errors() > 0) then
+      call store_error_filename(this%input_name)
+    end if
+    !
     ! -- return
     return
   end subroutine bndlist_ts_link_bnd
 
   subroutine bndlist_ts_link_aux(this, structvector, ts_strloc)
     ! -- modules
+    use SimModule, only: count_errors, store_error_filename
     use TimeSeriesLinkModule, only: TimeSeriesLinkType
     use TimeSeriesManagerModule, only: read_value_or_time_series
     use StructVectorModule, only: StructVectorType, TSStringLocType
@@ -302,6 +309,11 @@ contains
         tsLinkAux%BndName = boundname
       end if
       !
+    end if
+    !
+    ! -- terminate if errors were detected
+    if (count_errors() > 0) then
+      call store_error_filename(this%input_name)
     end if
     !
     ! -- return


### PR DESCRIPTION
Checklist of items for pull request

- [x] Closed issue #1892 
- [x] Referenced issue or pull request #1892
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Removed checklist items not relevant to this pull request

Updated error report:
```
ERROR REPORT:

  1. Error in list input. Expected numeric value or time-series name, but
     found 'tswrong'.

UNIT ERROR REPORT:

  1. ERROR OCCURRED WHILE READING FILE 'ts01.wel'
```

With multiple errors:
```
ERROR REPORT:

  1. Error in list input. Expected numeric value or time-series name, but
     found 'tswrong2'.
  2. Error in list input. Expected numeric value or time-series name, but
     found 'tswrong'.

UNIT ERROR REPORT:

  1. ERROR OCCURRED WHILE READING FILE 'ts01.wel'
```