### PR TITLE
fix(rtd) Restore the requirements.rtd.txt file

### DIFF
--- a/.build_rtd_docs/requirements.rtd.txt
+++ b/.build_rtd_docs/requirements.rtd.txt
@@ -1,0 +1,14 @@
+numpy
+bmipy
+sphinx>=4
+sphinx_markdown_tables
+nbsphinx
+nbsphinx_link
+ipython
+ipykernel
+rtds_action
+myst-parser
+sphinx_rtd_theme>=1
+pytest
+filelock
+modflow-devtools

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,3 +20,8 @@ sphinx:
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  install:
+    - requirements: .build_rtd_docs/requirements.rtd.txt


### PR DESCRIPTION
In a previous commit the requirements.rtd.txt had been removed in favor of creating a pixi rtd environment. However the ReadTheDocs site doesn't support pixi and requires either pip or conda.

This commit restores the requirements.rtd.txt to satisfy that requirement

Checklist of items for pull request

- [ ] Closed issue #xxxx
- [ ] Referenced issue or pull request #xxxx
- [ ] Added new test or modified an existing test
- [ ] Ran `black` on new and modified autotests
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).