### PR TITLE
ci(release): omit backwards particle tracking examples

### DIFF
--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -123,8 +123,14 @@ def setup_examples(
     download_and_unzip(asset["browser_download_url"], examples_path, verbose=True)
 
     # filter examples for models selected for release
+    # and omit any excluded models
+    excluded = ["ex-prt-mp7-p02", "ex-prt-mp7-p04"]
     for p in examples_path.glob("*"):
         if not any(m in p.stem for m in models):
+            print(f"Omitting example due to model selection: {p.stem}")
+            rmtree(p)
+        if any(e in p.stem for e in excluded):
+            print(f"Omitting deliberately excluded example: {p.stem}")
             rmtree(p)
 
     # list folders with mfsim.nam (recursively)


### PR DESCRIPTION
Temporary hack to exclude backwards tracking examples from the distribution until supported without a Python post-processing step, see https://github.com/MODFLOW-USGS/modflow6-examples/pull/214. That PR should merge first so this is CI tested with the backwards tracking examples.

___

Checklist of items for pull request

- [x] Removed checklist items not relevant to this pull request