### PR TITLE
fix(msvs): preprocess SourceLoad.F90

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,8 @@
+Replace this paragraph with a written description of the pull request.  Include images and files as necessary to help with the documentation.  Descriptions for trivial and minor pull requests should be brief.
+
 Checklist of items for pull request
 
+- [ ] Replaced section above with description of pull request
 - [ ] Closed issue #xxxx
 - [ ] Referenced issue or pull request #xxxx
 - [ ] Added new test or modified an existing test

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -456,7 +456,15 @@
 		<File RelativePath="..\src\Utilities\Idm\ModelPackageInputs.f90"/>
 		<File RelativePath="..\src\Utilities\Idm\ModflowInput.f90"/>
 		<File RelativePath="..\src\Utilities\Idm\SourceCommon.f90"/>
-		<File RelativePath="..\src\Utilities\Idm\SourceLoad.F90"/></Filter>
+		<File RelativePath="..\src\Utilities\Idm\SourceLoad.F90">
+		<FileConfiguration Name="Debug|Win32">
+				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
+			<FileConfiguration Name="Release|x64">
+				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
+			<FileConfiguration Name="Debug|x64">
+				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration>
+			<FileConfiguration Name="Release|Win32">
+				<Tool Name="VFFortranCompilerTool" Preprocess="preprocessYes"/></FileConfiguration></File></Filter>
 		<Filter Name="Libraries">
 		<File RelativePath="..\src\Utilities\Libraries\blas\blas1_d.f90"/>
 		<File RelativePath="..\src\Utilities\Libraries\daglib\dag_module.f90"/>


### PR DESCRIPTION
* in the msvs project filie, the SourceLoad.f90 file needs to be explicitly marked as requiring preprocessing
* includes minor update to pull request template

Checklist of items for pull request

- [x] Updated meson files, makefiles, and Visual Studio project files for new source files
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).