### PR TITLE
chore(scripts): update mf6 examples zipfile name in build_dist.py

### DIFF
--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -117,7 +117,7 @@ def setup_examples(
     latest = get_release("MODFLOW-USGS/modflow6-examples", "latest")
     assets = latest["assets"]
     asset = next(
-        iter([a for a in assets if a["name"] == "modflow6-examples.zip"]), None
+        iter([a for a in assets if a["name"] == "mf6examples.zip"]), None
     )
     # download example models zip asset
     download_and_unzip(asset["browser_download_url"], examples_path, verbose=True)


### PR DESCRIPTION
Update the MF6 examples zipfile name in `distribution/build_dist.py`, as per https://github.com/MODFLOW-USGS/modflow6-examples/pull/217.

___

Checklist of items for pull request

- [x] Removed checklist items not relevant to this pull request