### PR TITLE
refactor(oc): introduce module/type for time step selection

### DIFF
--- a/autotest/TestTimeStepSelect.f90
+++ b/autotest/TestTimeStepSelect.f90
@@ -1,0 +1,122 @@
+module TestTimeStepSelect
+  use testdrive, only: error_type, unittest_type, new_unittest, check
+  use TimeStepSelectModule, only: TimeStepSelectType
+  use ConstantsModule, only: LINELENGTH
+
+  implicit none
+  private
+  public :: collect_timestepselect
+
+contains
+
+  subroutine collect_timestepselect(testsuite)
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    testsuite = [ &
+                new_unittest("first", test_first), &
+                new_unittest("last", test_last), &
+                new_unittest("all", test_all), &
+                new_unittest("freq", test_freq), &
+                new_unittest("step", test_step) &
+                ]
+  end subroutine collect_timestepselect
+
+  subroutine test_first(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(TimeStepSelectType) :: steps
+    character(len=LINELENGTH) :: line
+
+    line = "FIRST"
+
+    call steps%init()
+    call steps%read(line)
+
+    call check(error, steps%is_selected(1, .false.))
+    if (allocated(error)) return
+
+    call check(error, steps%is_selected(1, .true.))
+    if (allocated(error)) return
+
+    call check(error,.not. steps%is_selected(2, .false.))
+    if (allocated(error)) return
+
+  end subroutine test_first
+
+  subroutine test_last(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(TimeStepSelectType) :: steps
+    character(len=LINELENGTH) :: line
+
+    line = "LAST"
+
+    call steps%init()
+    call steps%read(line)
+
+    call check(error,.not. steps%is_selected(1, .false.))
+    if (allocated(error)) return
+
+    call check(error, steps%is_selected(1, .true.))
+    if (allocated(error)) return
+
+  end subroutine test_last
+
+  subroutine test_all(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(TimeStepSelectType) :: steps
+    character(len=LINELENGTH) :: line
+
+    line = "ALL"
+
+    call steps%init()
+    call steps%read(line)
+
+    call check(error, steps%is_selected(1, .true.))
+    if (allocated(error)) return
+
+    call check(error, steps%is_selected(1, .false.))
+    if (allocated(error)) return
+
+  end subroutine test_all
+
+  subroutine test_freq(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(TimeStepSelectType) :: steps
+    character(len=LINELENGTH) :: line
+
+    line = "FREQUENCY 2"
+
+    call steps%init()
+    call steps%read(line)
+
+    call check(error,.not. steps%is_selected(1, .false.))
+    if (allocated(error)) return
+
+    call check(error, steps%is_selected(2, .false.))
+    if (allocated(error)) return
+
+    call check(error,.not. steps%is_selected(3, .false.))
+    if (allocated(error)) return
+
+    call check(error, steps%is_selected(4, .false.))
+    if (allocated(error)) return
+
+  end subroutine test_freq
+
+  subroutine test_step(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(TimeStepSelectType) :: steps
+    character(len=LINELENGTH) :: line
+
+    line = "STEPS 1"
+
+    call steps%init()
+    call steps%read(line)
+
+    call check(error, steps%is_selected(1, .false.))
+    if (allocated(error)) return
+
+    call check(error,.not. steps%is_selected(2, .false.))
+    if (allocated(error)) return
+
+  end subroutine test_step
+
+end module TestTimeStepSelect

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -16,7 +16,8 @@ if test_drive.found() and not fc_id.contains('intel')
     'PtrHashTable',
     'Sim',
     'SwfUtils',
-    'TimeSelect'
+    'TimeSelect',
+    'TimeStepSelect'
   ]
 
   test_srcs = files(

--- a/autotest/tester.f90
+++ b/autotest/tester.f90
@@ -18,6 +18,7 @@ program tester
   use TestSim, only: collect_sim
   use TestSwfUtils, only: collect_swfutils
   use TestTimeSelect, only: collect_timeselect
+  use TestTimeStepSelect, only: collect_timestepselect
   implicit none
   integer :: stat, is
   character(len=:), allocatable :: suite_name, test_name
@@ -42,7 +43,8 @@ program tester
                new_testsuite("PtrHashTable", collect_ptrhashtable), &
                new_testsuite("Sim", collect_sim), &
                new_testsuite("SwfUtils", collect_swfutils), &
-               new_testsuite("TimeSelect", collect_timeselect) &
+               new_testsuite("TimeSelect", collect_timeselect), &
+               new_testsuite("TimeStepSelect", collect_timestepselect) &
                ]
 
   call get_argument(1, suite_name)

--- a/make/makedefaults
+++ b/make/makedefaults
@@ -72,11 +72,11 @@ endif
 # set the ldflgs
 ifeq ($(detected_OS), Windows)
 	ifeq ($(FC), $(filter $(FC), gfortran))
-		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm -Wl,-ld_classic
+		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm
 	endif
 else
 	ifeq ($(FC), gfortran)
-		LDFLAGS ?= -lc -Wl,-ld_classic
+		LDFLAGS ?= -lc
 	endif
 	ifeq ($(FC), $(filter $(FC), ifort mpiifort))
 		LDFLAGS ?= -lc

--- a/make/makedefaults
+++ b/make/makedefaults
@@ -1,4 +1,4 @@
-# makedefaults created by pymake (version 1.2.10) for the 'mf6' executable.
+# makedefaults created by pymake (version 1.2.11.dev0) for the 'mf6' executable.
 
 # determine OS
 ifeq ($(OS), Windows_NT)
@@ -72,11 +72,11 @@ endif
 # set the ldflgs
 ifeq ($(detected_OS), Windows)
 	ifeq ($(FC), $(filter $(FC), gfortran))
-		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm
+		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm -Wl,-ld_classic
 	endif
 else
 	ifeq ($(FC), gfortran)
-		LDFLAGS ?= -lc
+		LDFLAGS ?= -lc -Wl,-ld_classic
 	endif
 	ifeq ($(FC), $(filter $(FC), ifort mpiifort))
 		LDFLAGS ?= -lc

--- a/make/makefile
+++ b/make/makefile
@@ -1,48 +1,48 @@
-# makefile created by pymake (version 1.2.10) for the 'mf6' executable.
+# makefile created by pymake (version 1.2.11.dev0) for the 'mf6' executable.
 
 
 include ./makedefaults
 
 # Define the source file directories
 SOURCEDIR1=../src
-SOURCEDIR2=../src/Exchange
-SOURCEDIR3=../src/Idm
-SOURCEDIR4=../src/Idm/selector
-SOURCEDIR5=../src/Timing
-SOURCEDIR6=../src/Model
-SOURCEDIR7=../src/Model/Connection
-SOURCEDIR8=../src/Model/Discretization
-SOURCEDIR9=../src/Model/ModelUtilities
-SOURCEDIR10=../src/Model/GroundWaterFlow
-SOURCEDIR11=../src/Model/GroundWaterFlow/submodules
-SOURCEDIR12=../src/Model/Geometry
-SOURCEDIR13=../src/Model/TransportModel
-SOURCEDIR14=../src/Model/GroundWaterTransport
-SOURCEDIR15=../src/Model/SurfaceWaterFlow
-SOURCEDIR16=../src/Model/ParticleTracking
-SOURCEDIR17=../src/Model/GroundWaterEnergy
-SOURCEDIR18=../src/Solution
-SOURCEDIR19=../src/Solution/ParticleTracker
-SOURCEDIR20=../src/Solution/LinearMethods
-SOURCEDIR21=../src/Solution/PETSc
-SOURCEDIR22=../src/Distributed
-SOURCEDIR23=../src/Utilities
+SOURCEDIR2=../src/Idm
+SOURCEDIR3=../src/Idm/selector
+SOURCEDIR4=../src/Exchange
+SOURCEDIR5=../src/Distributed
+SOURCEDIR6=../src/Solution
+SOURCEDIR7=../src/Solution/LinearMethods
+SOURCEDIR8=../src/Solution/ParticleTracker
+SOURCEDIR9=../src/Solution/PETSc
+SOURCEDIR10=../src/Timing
+SOURCEDIR11=../src/Utilities
+SOURCEDIR12=../src/Utilities/Idm
+SOURCEDIR13=../src/Utilities/Idm/mf6blockfile
+SOURCEDIR14=../src/Utilities/TimeSeries
+SOURCEDIR15=../src/Utilities/Memory
+SOURCEDIR16=../src/Utilities/OutputControl
+SOURCEDIR17=../src/Utilities/ArrayRead
+SOURCEDIR18=../src/Utilities/Libraries
+SOURCEDIR19=../src/Utilities/Libraries/rcm
+SOURCEDIR20=../src/Utilities/Libraries/blas
+SOURCEDIR21=../src/Utilities/Libraries/sparskit2
+SOURCEDIR22=../src/Utilities/Libraries/daglib
+SOURCEDIR23=../src/Utilities/Libraries/sparsekit
 SOURCEDIR24=../src/Utilities/Export
-SOURCEDIR25=../src/Utilities/TimeSeries
-SOURCEDIR26=../src/Utilities/Idm
-SOURCEDIR27=../src/Utilities/Idm/mf6blockfile
-SOURCEDIR28=../src/Utilities/ArrayRead
-SOURCEDIR29=../src/Utilities/Memory
-SOURCEDIR30=../src/Utilities/Matrix
-SOURCEDIR31=../src/Utilities/Vector
-SOURCEDIR32=../src/Utilities/Observation
-SOURCEDIR33=../src/Utilities/OutputControl
-SOURCEDIR34=../src/Utilities/Libraries
-SOURCEDIR35=../src/Utilities/Libraries/rcm
-SOURCEDIR36=../src/Utilities/Libraries/sparskit2
-SOURCEDIR37=../src/Utilities/Libraries/sparsekit
-SOURCEDIR38=../src/Utilities/Libraries/blas
-SOURCEDIR39=../src/Utilities/Libraries/daglib
+SOURCEDIR25=../src/Utilities/Vector
+SOURCEDIR26=../src/Utilities/Matrix
+SOURCEDIR27=../src/Utilities/Observation
+SOURCEDIR28=../src/Model
+SOURCEDIR29=../src/Model/Connection
+SOURCEDIR30=../src/Model/ParticleTracking
+SOURCEDIR31=../src/Model/SurfaceWaterFlow
+SOURCEDIR32=../src/Model/GroundWaterTransport
+SOURCEDIR33=../src/Model/ModelUtilities
+SOURCEDIR34=../src/Model/GroundWaterFlow
+SOURCEDIR35=../src/Model/GroundWaterFlow/submodules
+SOURCEDIR36=../src/Model/Discretization
+SOURCEDIR37=../src/Model/TransportModel
+SOURCEDIR38=../src/Model/Geometry
+SOURCEDIR39=../src/Model/GroundWaterEnergy
 
 VPATH = \
 ${SOURCEDIR1} \
@@ -235,6 +235,7 @@ $(OBJDIR)/Subcell.o \
 $(OBJDIR)/TrackData.o \
 $(OBJDIR)/TimeSelect.o \
 $(OBJDIR)/prt-fmi.o \
+$(OBJDIR)/TimeStepSelect.o \
 $(OBJDIR)/sort.o \
 $(OBJDIR)/SfrCrossSectionUtils.o \
 $(OBJDIR)/TernarySolveTrack.o \

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -288,6 +288,7 @@
 		<File RelativePath="..\src\Model\ModelUtilities\SfrCrossSectionUtils.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\SwfCxsUtils.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\TimeSelect.f90"/>
+		<File RelativePath="..\src\Model\ModelUtilities\TimeStepSelect.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\TrackData.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\TspAdvOptions.f90"/>
 		<File RelativePath="..\src\Model\ModelUtilities\UzfCellGroup.f90"/>

--- a/src/Model/GroundWaterFlow/gwf-oc.f90
+++ b/src/Model/GroundWaterFlow/gwf-oc.f90
@@ -71,7 +71,7 @@ contains
     ! -- Initialize variables
     inodata = 0
     nocdobj = 2
-    allocate (this%ocdobj(nocdobj))
+    allocate (this%ocds(nocdobj))
     do i = 1, nocdobj
       call ocd_cr(ocdobjptr)
       select case (i)
@@ -84,7 +84,7 @@ contains
                                 'COLUMNS 10 WIDTH 11 DIGITS 4 GENERAL ', &
                                 this%iout, dnodata)
       end select
-      this%ocdobj(i) = ocdobjptr
+      this%ocds(i) = ocdobjptr
       deallocate (ocdobjptr)
     end do
     !

--- a/src/Model/GroundWaterTransport/gwt-ist.f90
+++ b/src/Model/GroundWaterTransport/gwt-ist.f90
@@ -49,8 +49,10 @@ module GwtIstModule
   !<
   type, extends(BndType) :: GwtIstType
 
-    type(TspFmiType), pointer :: fmi => null() !< pointer to fmi object
-    type(GwtMstType), pointer :: mst => null() !< pointer to mst object
+    type(TspFmiType), pointer :: fmi => null() !< flow model interface
+    type(GwtMstType), pointer :: mst => null() !< mobile storage and transfer
+    type(BudgetType), pointer :: budget => null() !< budget
+    type(OutputControlDataType), pointer :: ocd => null() !< output control data
 
     integer(I4B), pointer :: icimout => null() !< unit number for binary cim output
     integer(I4B), pointer :: ibudgetout => null() !< binary budget output file
@@ -58,23 +60,20 @@ module GwtIstModule
     integer(I4B), pointer :: idcy => null() !< order of decay rate (0:none, 1:first, 2:zero)
     integer(I4B), pointer :: isrb => null() !< sorption active flag (0:off, 1:on); only linear is supported in ist
     integer(I4B), pointer :: kiter => null() !< picard iteration counter
-    real(DP), dimension(:), pointer, contiguous :: cim => null() !< concentration for immobile domain
-    real(DP), dimension(:), pointer, contiguous :: cimnew => null() !< immobile concentration at end of current time step
-    real(DP), dimension(:), pointer, contiguous :: cimold => null() !< immobile concentration at end of last time step
-    real(DP), dimension(:), pointer, contiguous :: zetaim => null() !< mass transfer rate to immobile domain
-    real(DP), dimension(:), pointer, contiguous :: porosity => null() !< immobile domain porosity defined as volume of immobile voids per volume of immobile domain
-    real(DP), dimension(:), pointer, contiguous :: volfrac => null() !< volume fraction of the immobile domain defined as volume of immobile domain per aquifer volume
-    real(DP), dimension(:), pointer, contiguous :: bulk_density => null() !< bulk density of immobile domain defined as mass of solids in immobile domain per volume of immobile domain
-    real(DP), dimension(:), pointer, contiguous :: distcoef => null() !< distribution coefficient
-    real(DP), dimension(:), pointer, contiguous :: decay => null() !< first or zero order rate constant for liquid
-    real(DP), dimension(:), pointer, contiguous :: decaylast => null() !< decay rate used for last iteration (needed for zero order decay)
-    real(DP), dimension(:), pointer, contiguous :: decayslast => null() !< sorbed decay rate used for last iteration (needed for zero order decay)
-    real(DP), dimension(:), pointer, contiguous :: decay_sorbed => null() !< first or zero order rate constant for sorbed mass
-    real(DP), dimension(:), pointer, contiguous :: strg => null() !< mass transfer rate
-    real(DP), dimension(2, NBDITEMS) :: budterm !< immmobile domain mass summaries
-
-    type(BudgetType), pointer :: budget => null() !< budget object
-    type(OutputControlDataType), pointer :: ocd => null() !< output control object for cim
+    real(DP), pointer, contiguous :: cim(:) => null() !< concentration for immobile domain
+    real(DP), pointer, contiguous :: cimnew(:) => null() !< immobile concentration at end of current time step
+    real(DP), pointer, contiguous :: cimold(:) => null() !< immobile concentration at end of last time step
+    real(DP), pointer, contiguous :: zetaim(:) => null() !< mass transfer rate to immobile domain
+    real(DP), pointer, contiguous :: porosity(:) => null() !< immobile domain porosity defined as volume of immobile voids per volume of immobile domain
+    real(DP), pointer, contiguous :: volfrac(:) => null() !< volume fraction of the immobile domain defined as volume of immobile domain per aquifer volume
+    real(DP), pointer, contiguous :: bulk_density(:) => null() !< bulk density of immobile domain defined as mass of solids in immobile domain per volume of immobile domain
+    real(DP), pointer, contiguous :: distcoef(:) => null() !< distribution coefficient
+    real(DP), pointer, contiguous :: decay(:) => null() !< first or zero order rate constant for liquid
+    real(DP), pointer, contiguous :: decaylast(:) => null() !< decay rate used for last iteration (needed for zero order decay)
+    real(DP), pointer, contiguous :: decayslast(:) => null() !< sorbed decay rate used for last iteration (needed for zero order decay)
+    real(DP), pointer, contiguous :: decay_sorbed(:) => null() !< first or zero order rate constant for sorbed mass
+    real(DP), pointer, contiguous :: strg(:) => null() !< mass transfer rate
+    real(DP) :: budterm(2, NBDITEMS) !< immmobile domain mass summaries
 
   contains
 

--- a/src/Model/ModelUtilities/TimeStepSelect.f90
+++ b/src/Model/ModelUtilities/TimeStepSelect.f90
@@ -1,0 +1,175 @@
+!> @brief Time step selection module.
+module TimeStepSelectModule
+
+  use KindModule, only: DP, I4B, LGP
+  use ArrayHandlersModule, only: expandarray
+  use SimVariablesModule, only: errmsg
+  use SimModule, only: store_error
+  use InputOutputModule, only: urword
+
+  implicit none
+  private
+  public :: TimeStepSelectType
+
+  !> @brief Time step selection type.
+  !!
+  !! Represents a selection of time steps as configured in an input file's
+  !! period block settings. The object should be initiated with the init()
+  !! procedure. The read() procedure accepts a character string of form:
+  !!
+  !!   ALL
+  !!   STEPS 1 4 5 6
+  !!   FIRST
+  !!   LAST
+  !!   FREQUENCY 4
+  !!
+  !! The is_selected() function indicates whether the given time step is
+  !! active. This function accepts an optional argument, indicating that
+  !! the time step is the last in the stress period.
+  !<
+  type :: TimeStepSelectType
+    logical(LGP) :: all
+    logical(LGP) :: first
+    logical(LGP) :: last
+    integer(I4B) :: freq
+    integer(I4B), allocatable :: steps(:)
+  contains
+    procedure :: deallocate
+    procedure :: init
+    procedure :: log
+    procedure :: read
+    procedure :: is_selected
+    procedure :: any_selected
+  end type TimeStepSelectType
+
+contains
+
+  !> @brief Deallocate the time step selection object.
+  subroutine deallocate (this)
+    class(TimeSTepSelectType) :: this
+    deallocate (this%steps)
+  end subroutine deallocate
+
+  !> @brief Initialize the time step selection object.
+  subroutine init(this)
+    class(TimeStepSelectType) :: this !< this instance
+
+    if (allocated(this%steps)) deallocate (this%steps)
+    allocate (this%steps(0))
+    this%freq = 0
+    this%first = .false.
+    this%last = .false.
+    this%all = .false.
+  end subroutine init
+
+  subroutine log(this, iout, verb)
+    ! dummy
+    class(TimeStepSelectType) :: this !< this instance
+    integer(I4B), intent(in) :: iout !< output unit
+    character(len=*), intent(in) :: verb !< selection name
+    ! formats
+    character(len=*), parameter :: fmt_steps = &
+      &"(6x,'THE FOLLOWING STEPS WILL BE ',A,': ',50(I0,' '))"
+    character(len=*), parameter :: fmt_freq = &
+      &"(6x,'THE FOLLOWING FREQUENCY WILL BE ',A,': ',I0)"
+
+    if (this%all) then
+      write (iout, "(6x,a,a)") 'ALL TIME STEPS WILL BE ', verb
+    else if (this%first) then
+      write (iout, "(6x,a,a)") 'THE FIRST TIME STEP WILL BE ', verb
+    else if (this%last) then
+      write (iout, "(6x,a,a)") 'THE LAST TIME STEP WILL BE ', verb
+    else if (size(this%steps) > 0) then
+      write (iout, fmt_steps) verb, this%steps
+    else if (this%freq > 0) then
+      write (iout, fmt_freq) verb, this%freq
+    end if
+  end subroutine log
+
+  !> @brief Read a line of input and prepare the selection object.
+  subroutine read (this, line)
+    class(TimeStepSelectType) :: this !< this instance
+    character(len=*), intent(in) :: line !< input line
+
+    character(len=len(line)) :: l
+    integer(I4B) :: n, lloc, istart, istop, ival
+    real(DP) :: rval
+
+    l(:) = line(:)
+    lloc = 1
+
+    call urword(l, lloc, istart, istop, 1, ival, rval, 0, 0)
+    select case (l(istart:istop))
+    case ('ALL')
+      this%all = .true.
+    case ('STEPS')
+      listsearch: do
+        call urword(l, lloc, istart, istop, 2, ival, rval, -1, 0)
+        if (ival > 0) then
+          n = size(this%steps)
+          call expandarray(this%steps)
+          this%steps(n + 1) = ival
+          cycle listsearch
+        end if
+        exit listsearch
+      end do listsearch
+    case ('FREQUENCY')
+      call urword(l, lloc, istart, istop, 2, ival, rval, -1, 0)
+      this%freq = ival
+    case ('FIRST')
+      this%first = .true.
+    case ('LAST')
+      this%last = .true.
+    case default
+      write (errmsg, '(2a)') &
+        'Looking for ALL, STEPS, FIRST, LAST, OR FREQUENCY. Found: ', &
+        trim(adjustl(line))
+      call store_error(errmsg, terminate=.TRUE.)
+    end select
+  end subroutine read
+
+  !> @brief Indicates whether the given time step is selected.
+  logical function is_selected(this, kstp, endofperiod)
+    ! dummy
+    class(TimeStepSelectType) :: this !< this instance
+    integer(I4B), intent(in) :: kstp !< current time step
+    logical(LGP), intent(in), optional :: endofperiod !< whether last step of stress period
+    ! local
+    integer(I4B) :: i, n
+    logical(LGP) :: lend
+
+    if (present(endofperiod)) then
+      lend = endofperiod
+    else
+      lend = .false.
+    end if
+
+    is_selected = .false.
+    if (this%all) is_selected = .true.
+    if (kstp == 1 .and. this%first) is_selected = .true.
+    if (lend .and. this%last) is_selected = .true.
+    if (this%freq > 0) then
+      if (mod(kstp, this%freq) == 0) is_selected = .true.
+    end if
+    n = size(this%steps)
+    if (n > 0) then
+      do i = 1, n
+        if (kstp == this%steps(i)) then
+          is_selected = .true.
+          exit
+        end if
+      end do
+    end if
+  end function is_selected
+
+  !> @brief Indicates whether any time steps are selected.
+  logical function any_selected(this)
+    class(TimeStepSelectType) :: this !< this instance
+    any_selected = (this%all .or. &
+                    this%first .or. &
+                    this%last .or. &
+                    this%freq > 0 .or. &
+                    size(this%steps) > 0)
+  end function any_selected
+
+end module TimeStepSelectModule

--- a/src/Model/ParticleTracking/prt-oc.f90
+++ b/src/Model/ParticleTracking/prt-oc.f90
@@ -120,7 +120,7 @@ contains
     call this%tracktimes%init()
     inodata = 0
     nocdobj = 1
-    allocate (this%ocdobj(nocdobj))
+    allocate (this%ocds(nocdobj))
     do i = 1, nocdobj
       call ocd_cr(ocdobjptr)
       select case (i)
@@ -129,7 +129,7 @@ contains
                                 'COLUMNS 10 WIDTH 11 DIGITS 4 GENERAL ', &
                                 this%iout, dnodata)
       end select
-      this%ocdobj(i) = ocdobjptr
+      this%ocds(i) = ocdobjptr
       deallocate (ocdobjptr)
     end do
 
@@ -147,10 +147,10 @@ contains
 
     call this%tracktimes%deallocate()
 
-    do i = 1, size(this%ocdobj)
-      call this%ocdobj(i)%ocd_da()
+    do i = 1, size(this%ocds)
+      call this%ocds(i)%ocd_da()
     end do
-    deallocate (this%ocdobj)
+    deallocate (this%ocds)
 
     deallocate (this%name_model)
     call mem_deallocate(this%inunit)
@@ -332,8 +332,8 @@ contains
 
         ! -- check if we're done
         if (.not. found) then
-          do ipos = 1, size(this%ocdobj)
-            ocdobjptr => this%ocdobj(ipos)
+          do ipos = 1, size(this%ocds)
+            ocdobjptr => this%ocds(ipos)
             if (keyword == trim(ocdobjptr%cname)) then
               found = .true.
               exit

--- a/src/Model/SurfaceWaterFlow/swf-oc.f90
+++ b/src/Model/SurfaceWaterFlow/swf-oc.f90
@@ -71,7 +71,7 @@ contains
     ! -- Initialize variables
     inodata = 0
     nocdobj = 2
-    allocate (this%ocdobj(nocdobj))
+    allocate (this%ocds(nocdobj))
     do i = 1, nocdobj
       call ocd_cr(ocdobjptr)
       select case (i)
@@ -84,7 +84,7 @@ contains
                                 'COLUMNS 10 WIDTH 11 DIGITS 4 GENERAL ', &
                                 this%iout, dnodata)
       end select
-      this%ocdobj(i) = ocdobjptr
+      this%ocds(i) = ocdobjptr
       deallocate (ocdobjptr)
     end do
     !

--- a/src/Model/TransportModel/tsp-oc.f90
+++ b/src/Model/TransportModel/tsp-oc.f90
@@ -37,7 +37,7 @@ contains
     ! -- Create the object
     allocate (ocobj)
     !
-    ! -- Allocate scalars
+    ! -- Allocate variables
     call ocobj%allocate_scalars(name_model)
     !
     ! -- Save unit numbers
@@ -72,7 +72,7 @@ contains
     ! -- Initialize variables
     inodata = 0
     nocdobj = 2
-    allocate (this%ocdobj(nocdobj))
+    allocate (this%ocds(nocdobj))
     do i = 1, nocdobj
       call ocd_cr(ocdobjptr)
       select case (i)
@@ -85,7 +85,7 @@ contains
                                 'COLUMNS 10 WIDTH 11 DIGITS 4 GENERAL ', &
                                 this%iout, dnodata)
       end select
-      this%ocdobj(i) = ocdobjptr
+      this%ocds(i) = ocdobjptr
       deallocate (ocdobjptr)
     end do
     !

--- a/src/Utilities/OutputControl/OutputControl.f90
+++ b/src/Utilities/OutputControl/OutputControl.f90
@@ -1,10 +1,4 @@
-!> @brief This module contains the OutputControlModule
-!!
-!! This module defines the OutputControlType.  This type
-!! is overridden by GWF and GWT to create an Output Control
-!! package for the model.
-!!
-!<
+!> @brief Model output control.
 module OutputControlModule
 
   use KindModule, only: DP, I4B
@@ -18,10 +12,7 @@ module OutputControlModule
   private
   public OutputControlType, oc_cr
 
-  !> @ brief OutputControlType
-  !!
-  !!  Generalized output control package
-  !<
+  !> @ brief Controls model output. Overridden for each model type.
   type OutputControlType
     character(len=LENMEMPATH) :: memoryPath !< path to data stored in the memory manager
     character(len=LENMODELNAME), pointer :: name_model => null() !< name of the model
@@ -30,15 +21,14 @@ module OutputControlModule
     integer(I4B), pointer :: ibudcsv => null() !< unit number for budget csv output file
     integer(I4B), pointer :: iperoc => null() !< stress period number for next output control
     integer(I4B), pointer :: iocrep => null() !< output control repeat flag (period 0 step 0)
-    type(OutputControlDataType), dimension(:), &
-      pointer, contiguous :: ocdobj => null() !< output control objects
+    type(OutputControlDataType), pointer, contiguous :: ocds(:) => null() !< output control objects
     type(BlockParserType) :: parser
   contains
     procedure :: oc_df
     procedure :: oc_rp
     procedure :: oc_ot
     procedure :: oc_da
-    procedure :: allocate_scalars
+    procedure :: allocate_scalars => allocate
     procedure :: read_options
     procedure :: oc_save
     procedure :: oc_print
@@ -48,69 +38,41 @@ module OutputControlModule
 
 contains
 
-  !> @ brief Create OutputControlType
-  !!
-  !!  Create by allocating a new OutputControlType object and initializing
-  !!  member variables.
-  !!
-  !<
-  subroutine oc_cr(ocobj, name_model, inunit, iout)
-    ! -- dummy
-    type(OutputControlType), pointer :: ocobj !< OutputControlType object
+  !> @brief Create a new output control object.
+  subroutine oc_cr(oc, name_model, inunit, iout)
+    type(OutputControlType), pointer :: oc !< OutputControlType object
     character(len=*), intent(in) :: name_model !< name of the model
     integer(I4B), intent(in) :: inunit !< unit number for input
     integer(I4B), intent(in) :: iout !< unit number for output
-    !
-    ! -- Create the object
-    allocate (ocobj)
-    !
-    ! -- Allocate scalars
-    call ocobj%allocate_scalars(name_model)
-    !
-    ! -- Save unit numbers
-    ocobj%inunit = inunit
-    ocobj%iout = iout
-    !
-    ! -- Initialize block parser
-    call ocobj%parser%Initialize(inunit, iout)
-    !
-    ! -- Return
-    return
+
+    allocate (oc)
+    call oc%allocate_scalars(name_model)
+    oc%inunit = inunit
+    oc%iout = iout
+    call oc%parser%Initialize(inunit, iout)
   end subroutine oc_cr
 
-  !> @ brief Define OutputControlType
-  !!
-  !!  Placeholder routine for the moment.
-  !!
-  !<
+  !> @ brief Define the output control type. Placeholder routine.
   subroutine oc_df(this)
-    ! -- dummy
-    class(OutputControlType) :: this !< OutputControlType object
-    !
-    ! -- Return
-    return
+    class(OutputControlType) :: this !< this instance
   end subroutine oc_df
 
-  !> @ brief Read and prepare OutputControlType
-  !!
-  !!  Read a period data block.
-  !!
-  !<
+  !> @ brief Read period block options and prepare the output control type.
   subroutine oc_rp(this)
-    ! -- modules
+    ! modules
     use TdisModule, only: kper, nper
     use ConstantsModule, only: LINELENGTH
     use SimModule, only: store_error, store_error_unit, count_errors
-    ! -- dummy
-    class(OutputControlType) :: this !< OutputControlType object
-    ! -- local
+    ! dummy
+    class(OutputControlType) :: this !< this instance
+    ! local
     integer(I4B) :: ierr, ival, ipos
     logical :: isfound, found, endOfBlock
     character(len=:), allocatable :: line
     character(len=LINELENGTH) :: ermsg, keyword1, keyword2
     character(len=LINELENGTH) :: printsave
     class(OutputControlDataType), pointer :: ocdobjptr
-    ! -- formats
+    ! formats
     character(len=*), parameter :: fmtboc = &
       &"(1X,/1X,'BEGIN READING OUTPUT CONTROL FOR STRESS PERIOD ',I0)"
     character(len=*), parameter :: fmteoc = &
@@ -124,35 +86,35 @@ contains
       &"(1x,'CURRENT STRESS PERIOD GREATER THAN PERIOD IN OUTPUT CONTROL.')"
     character(len=*), parameter :: fmtpererr2 = &
       &"(1x,'CURRENT STRESS PERIOD: ',I0,' SPECIFIED STRESS PERIOD: ',I0)"
-    !
-    ! -- Read next block header if kper greater than last one read
+
+    ! Read next block header if kper greater than last one read
     if (this%iperoc < kper) then
-      !
-      ! -- Get period block
+
+      ! Get period block
       call this%parser%GetBlock('PERIOD', isfound, ierr, &
                                 supportOpenClose=.true., &
                                 blockRequired=.false.)
-      !
-      ! -- If end of file, set iperoc past kper, else parse line
+
+      ! If end of file, set iperoc past kper, else parse line
       if (ierr < 0) then
         this%iperoc = nper + 1
         write (this%iout, '(/,1x,a)') 'END OF FILE DETECTED IN OUTPUT CONTROL.'
         write (this%iout, '(1x,a)') 'CURRENT OUTPUT CONTROL SETTINGS WILL BE '
         write (this%iout, '(1x,a)') 'REPEATED UNTIL THE END OF THE SIMULATION.'
       else
-        !
-        ! -- Read period number
+
+        ! Read period number
         ival = this%parser%GetInteger()
-        !
-        ! -- Check to see if this is a valid kper
+
+        ! Check to see if this is a valid kper
         if (ival <= 0 .or. ival > nper) then
           write (ermsg, '(a,i0)') 'PERIOD NOT VALID IN OUTPUT CONTROL: ', ival
           call store_error(ermsg)
           write (ermsg, '(a, a)') 'LINE: ', trim(adjustl(line))
           call store_error(ermsg)
         end if
-        !
-        ! -- Check to see if specified is less than kper
+
+        ! Check to see if specified is less than kper
         if (ival < kper) then
           write (ermsg, fmtpererr)
           call store_error(ermsg)
@@ -161,46 +123,46 @@ contains
           write (ermsg, '(a, a)') 'LINE: ', trim(adjustl(line))
           call store_error(ermsg)
         end if
-        !
-        ! -- Stop or set iperoc and continue
+
+        ! Stop or set iperoc and continue
         if (count_errors() > 0) then
           call this%parser%StoreErrorUnit()
         end if
         this%iperoc = ival
       end if
     end if
-    !
-    ! -- Read the stress period block
+
+    ! Read the stress period block
     if (this%iperoc == kper) then
-      !
-      ! -- Clear io flags
-      do ipos = 1, size(this%ocdobj)
-        ocdobjptr => this%ocdobj(ipos)
-        call ocdobjptr%psmobj%init()
+
+      ! Clear io flags
+      do ipos = 1, size(this%ocds)
+        ocdobjptr => this%ocds(ipos)
+        call ocdobjptr%psm%init()
       end do
-      !
-      ! -- Output control time step matches simulation time step.
+
+      ! Output control time step matches simulation time step.
       write (this%iout, fmtboc) this%iperoc
-      !
-      ! -- loop to read records
+
+      ! loop to read records
       recordloop: do
-        !
-        ! -- Read the line
+
+        ! Read the line
         call this%parser%GetNextLine(endOfBlock)
         if (endOfBlock) exit
         call this%parser%GetStringCaps(keyword1)
-        !
-        ! -- Set printsave string and then read the record type (e.g.
-        !    BUDGET, HEAD)
+
+        ! Set printsave string and then read the record type (e.g.
+        ! BUDGET, HEAD)
         printsave = keyword1
         call this%parser%GetStringCaps(keyword2)
-        !
-        ! -- Look through the output control data objects that are
-        !    available and set ocdobjptr to the correct one based on
-        !    cname.  Set found to .false. if not a valid record type.
+
+        ! Look through the output control data objects that are
+        ! available and set ocdobjptr to the correct one based on
+        ! cname.  Set found to .false. if not a valid record type.
         found = .false.
-        do ipos = 1, size(this%ocdobj)
-          ocdobjptr => this%ocdobj(ipos)
+        do ipos = 1, size(this%ocds)
+          ocdobjptr => this%ocds(ipos)
           if (keyword2 == trim(ocdobjptr%cname)) then
             found = .true.
             exit
@@ -215,51 +177,42 @@ contains
           call this%parser%StoreErrorUnit()
         end if
         call this%parser%GetRemainingLine(line)
-        call ocdobjptr%psmobj%rp(trim(printsave)//' '//line, &
-                                 this%iout)
+        call ocdobjptr%psm%read(trim(printsave)//' '//line, &
+                                this%iout)
         call ocdobjptr%ocd_rp_check(this%parser%iuactive)
-        !
-        ! -- End of recordloop
       end do recordloop
       write (this%iout, fmteoc) this%iperoc
     else
-      !
-      ! -- Write message that output control settings are from a previous
-      !    stress period.
+
+      ! Write message that output control settings are from a previous
+      ! stress period.
       write (this%iout, fmtroc) kper
     end if
-    !
-    ! -- return
-    return
   end subroutine oc_rp
 
-  !> @ brief Output method for OutputControlType
+  !> @ brief Write output.
   !!
-  !!  Go through each output control data type and output, which will print
-  !!  and/or save data based on user-specified controls.
-  !!
+  !! Go through each output control data type and print
+  !! and/or save data based on user-specified controls.
   !<
   subroutine oc_ot(this, ipflg)
-    ! -- modules
+    ! modules
     use TdisModule, only: kstp, endofperiod
-    ! -- dummy
+    ! dummy
     class(OutputControlType) :: this !< OutputControlType object
     integer(I4B), intent(inout) :: ipflg !< flag indicating if data was printed
-    ! -- local
+    ! local
     integer(I4B) :: ipos
     type(OutputControlDataType), pointer :: ocdobjptr
-    !
-    ! -- Clear printout flag(ipflg).  This flag indicates that an array was
-    !    printed to the listing file.
+
+    ! Clear printout flag(ipflg).  This flag indicates that an array was
+    ! printed to the listing file.
     ipflg = 0
-    !
-    do ipos = 1, size(this%ocdobj)
-      ocdobjptr => this%ocdobj(ipos)
+
+    do ipos = 1, size(this%ocds)
+      ocdobjptr => this%ocds(ipos)
       call ocdobjptr%ocd_ot(ipflg, kstp, endofperiod, this%iout)
     end do
-    !
-    ! -- Return
-    return
   end subroutine oc_ot
 
   !> @ brief Deallocate method for OutputControlType
@@ -268,74 +221,60 @@ contains
   !!
   !<
   subroutine oc_da(this)
-    ! -- modules
+    ! modules
     use MemoryManagerModule, only: mem_deallocate
-    ! -- dummy
+    ! dummy
     class(OutputControlType) :: this !< OutputControlType object
-    ! -- local
+    ! local
     integer(I4B) :: i
-    !
-    do i = 1, size(this%ocdobj)
-      call this%ocdobj(i)%ocd_da()
+
+    do i = 1, size(this%ocds)
+      call this%ocds(i)%ocd_da()
     end do
-    deallocate (this%ocdobj)
-    !
+    deallocate (this%ocds)
+
     deallocate (this%name_model)
     call mem_deallocate(this%inunit)
     call mem_deallocate(this%iout)
     call mem_deallocate(this%ibudcsv)
     call mem_deallocate(this%iperoc)
     call mem_deallocate(this%iocrep)
-    !
-    ! -- return
-    return
   end subroutine oc_da
 
-  !> @ brief Allocate scalars method for OutputControlType
-  !!
-  !!  Allocate and initialize member variables.
-  !!
-  !<
-  subroutine allocate_scalars(this, name_model)
-    ! -- modules
+  !> @ brief Allocate variables for the output control object
+  subroutine allocate (this, name_model)
+    ! modules
     use MemoryManagerModule, only: mem_allocate
     use MemoryHelperModule, only: create_mem_path
-    ! -- dummy
-    class(OutputControlType) :: this !< OutputControlType object
+    ! dummy
+    class(OutputControlType) :: this !< this instance
     character(len=*), intent(in) :: name_model !< name of model
-    !
+
     this%memoryPath = create_mem_path(name_model, 'OC')
-    !
+
     allocate (this%name_model)
     call mem_allocate(this%inunit, 'INUNIT', this%memoryPath)
     call mem_allocate(this%iout, 'IOUT', this%memoryPath)
     call mem_allocate(this%ibudcsv, 'IBUDCSV', this%memoryPath)
     call mem_allocate(this%iperoc, 'IPEROC', this%memoryPath)
     call mem_allocate(this%iocrep, 'IOCREP', this%memoryPath)
-    !
+
     this%name_model = name_model
     this%inunit = 0
     this%iout = 0
     this%ibudcsv = 0
     this%iperoc = 0
     this%iocrep = 0
-    !
-    ! -- return
-    return
-  end subroutine allocate_scalars
+  end subroutine allocate
 
-  !> @ brief Read options for OutputControlType
-  !!
-  !!  Read options block and set member variables.
-  !!
-  !<
+  !> @ brief Read the output control options block
   subroutine read_options(this)
-    ! -- modules
+    ! modules
     use ConstantsModule, only: LINELENGTH
     use SimModule, only: store_error, store_error_unit
-    ! -- dummy
-    class(OutputControlType) :: this !< OutputControlType object
-    ! -- local
+    ! dummy
+    class(OutputControlType) :: this !< this instance
+    ! local
     character(len=LINELENGTH) :: keyword
     character(len=LINELENGTH) :: keyword2
     character(len=LINELENGTH) :: fname
@@ -344,12 +283,12 @@ contains
     integer(I4B) :: ipos
     logical :: isfound, found, endOfBlock
     type(OutputControlDataType), pointer :: ocdobjptr
-    !
-    ! -- get options block
+
+    ! get options block
     call this%parser%GetBlock('OPTIONS', isfound, ierr, &
                               supportOpenClose=.true., blockRequired=.false.)
-    !
-    ! -- parse options block if detected
+
+    ! parse options block if detected
     if (isfound) then
       write (this%iout, '(/,1x,a,/)') 'PROCESSING OC OPTIONS'
       do
@@ -373,8 +312,8 @@ contains
         end if
 
         if (.not. found) then
-          do ipos = 1, size(this%ocdobj)
-            ocdobjptr => this%ocdobj(ipos)
+          do ipos = 1, size(this%ocds)
+            ocdobjptr => this%ocds(ipos)
             if (keyword == trim(ocdobjptr%cname)) then
               found = .true.
               exit
@@ -391,82 +330,61 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF OC OPTIONS'
     end if
-    !
-    ! -- return
-    return
   end subroutine read_options
 
-  !> @ brief Save data to file
-  !!
-  !!  Go through data and save if requested by user.
-  !!
-  !<
+  !> @ brief Determine if it is time to save.
   logical function oc_save(this, cname)
-    ! -- modules
+    ! modules
     use TdisModule, only: kstp, endofperiod
-    ! -- dummy
+    ! dummy
     class(OutputControlType) :: this !< OutputControlType object
     character(len=*), intent(in) :: cname !< character string for data name
-    ! -- local
+    ! local
     integer(I4B) :: ipos
     logical :: found
     class(OutputControlDataType), pointer :: ocdobjptr
     !
     oc_save = .false.
     found = .false.
-    do ipos = 1, size(this%ocdobj)
-      ocdobjptr => this%ocdobj(ipos)
+    do ipos = 1, size(this%ocds)
+      ocdobjptr => this%ocds(ipos)
       if (cname == trim(ocdobjptr%cname)) then
         found = .true.
         exit
       end if
     end do
     if (found) then
-      oc_save = ocdobjptr%psmobj%kstp_to_save(kstp, endofperiod)
+      oc_save = ocdobjptr%psm%should_save(kstp, endofperiod)
     end if
-    !
-    ! -- Return
-    return
   end function oc_save
 
-  !> @ brief Determine if time to print
-  !!
-  !!  Determine if it is time to print the data corresponding to cname.
-  !!
-  !<
+  !> @ brief Determine if it is time to print.
   logical function oc_print(this, cname)
-    ! -- modules
+    ! modules
     use TdisModule, only: kstp, endofperiod
-    ! -- dummy
+    ! dummy
     class(OutputControlType) :: this !< OutputControlType object
     character(len=*), intent(in) :: cname !< character string for data name
-    ! -- local
+    ! local
     integer(I4B) :: ipos
     logical :: found
     class(OutputControlDataType), pointer :: ocdobjptr
-    !
+
     oc_print = .false.
     found = .false.
-    do ipos = 1, size(this%ocdobj)
-      ocdobjptr => this%ocdobj(ipos)
+    do ipos = 1, size(this%ocds)
+      ocdobjptr => this%ocds(ipos)
       if (cname == trim(ocdobjptr%cname)) then
         found = .true.
         exit
       end if
     end do
     if (found) then
-      oc_print = ocdobjptr%psmobj%kstp_to_print(kstp, endofperiod)
+      oc_print = ocdobjptr%psm%should_print(kstp, endofperiod)
     end if
-    !
-    ! -- Return
-    return
   end function oc_print
 
   !> @ brief Determine unit number for saving
-  !!
-  !!  Determine the unit number for saving cname.
-  !!
-  !<
   function oc_save_unit(this, cname)
     ! -- modules
     ! -- return
@@ -481,8 +399,8 @@ contains
     !
     oc_save_unit = 0
     found = .false.
-    do ipos = 1, size(this%ocdobj)
-      ocdobjptr => this%ocdobj(ipos)
+    do ipos = 1, size(this%ocds)
+      ocdobjptr => this%ocds(ipos)
       if (cname == trim(ocdobjptr%cname)) then
         found = .true.
         exit
@@ -491,16 +409,9 @@ contains
     if (found) then
       oc_save_unit = ocdobjptr%idataun
     end if
-    !
-    ! -- Return
-    return
   end function oc_save_unit
 
-  !> @ brief Set the print flag
-  !!
-  !!  Set the print flag based on convergence and simulation parameters.
-  !!
-  !<
+  !> @ brief Set the print flag based on convergence and other parameters
   function set_print_flag(this, cname, icnvg, endofperiod) result(iprint_flag)
     ! -- modules
     use SimVariablesModule, only: isimcontinue
@@ -526,9 +437,6 @@ contains
     !
     ! -- if it's the end of the period, then set flag to print
     if (endofperiod) iprint_flag = 1
-    !
-    ! -- Return
-    return
   end function set_print_flag
 
 end module OutputControlModule

--- a/src/Utilities/OutputControl/OutputControlData.f90
+++ b/src/Utilities/OutputControl/OutputControlData.f90
@@ -1,42 +1,36 @@
-!> @brief This module contains the OutputControlDataModule
-!!
-!! This module defines the OutputControlDataType.  This type
-!! can be assigned to different model variables, such as head
-!! or concentration.  The variables are then printed and/or
-!! saved in a consistent manner.
-!!
-!<
+!> @brief Output control data module.
 module OutputControlDataModule
 
   use BaseDisModule, only: DisBaseType
   use InputOutputModule, only: print_format
   use KindModule, only: DP, I4B, LGP
-  use PrintSaveManagerModule, only: PrintSaveManagerType
+  use PrintSaveManagerModule, only: PrintSaveManagerType, create_psm
 
   implicit none
   private
   public OutputControlDataType, ocd_cr
 
-  !> @ brief OutputControlDataType
+  !> @brief Output control data type.
   !!
-  !!  Object for storing information and determining whether or
-  !!  not model data should be printed to a list file or saved to disk.
+  !! Determines whether output data should be printed to a list file or saved to disk.
+  !! This type can be assigned to different variables, such as head or concentration.
+  !! This type controls the logging and saving of output data in a consistent manner.
   !<
   type OutputControlDataType
+    class(DisBaseType), pointer :: dis => null() !< discretization package
+    type(PrintSaveManagerType), pointer :: psm => null() !< print/save manager
     character(len=16), pointer :: cname => null() !< name of variable, such as HEAD
     character(len=60), pointer :: cdatafmp => null() !< fortran format for printing
-    integer(I4B), pointer :: idataun => null() !< fortran unit number for binary output
     character(len=1), pointer :: editdesc => null() !< fortran format type (I, G, F, S, E)
+    integer(I4B), pointer :: idataun => null() !< fortran unit number for binary output
     integer(I4B), pointer :: nvaluesp => null() !< number of values per line for printing
     integer(I4B), pointer :: nwidthp => null() !< width of the number for printing
-    real(DP), pointer :: dnodata => null() !< no data value
     integer(I4B), pointer :: inodata => null() !< integer no data value
-    real(DP), dimension(:), pointer, contiguous :: dblvec => null() !< pointer to double precision data array
-    integer(I4B), dimension(:), pointer, contiguous :: intvec => null() !< pointer to integer data array
-    class(DisBaseType), pointer :: dis => null() !< pointer to discretization package
-    type(PrintSaveManagerType), pointer :: psmobj => null() !< print/save manager object
+    real(DP), pointer :: dnodata => null() !< no data value
+    integer(I4B), pointer, contiguous :: intdata(:) => null() !< integer data array
+    real(DP), pointer, contiguous :: dbldata(:) => null() !< double precision data array
   contains
-    procedure :: allocate_scalars
+    procedure :: allocate_scalars => allocate
     procedure :: init_int
     procedure :: init_dbl
     procedure :: set_option
@@ -47,46 +41,30 @@ module OutputControlDataModule
 
 contains
 
-  !> @ brief Create OutputControlDataType
-  !!
-  !!  Create by allocating a new OutputControlDataType object
-  !!
-  !<
+  !> @ brief Create a new output control data type.
   subroutine ocd_cr(ocdobj)
-    ! -- dummy
-    type(OutputControlDataType), pointer :: ocdobj !< OutputControlDataType object
-    !
-    ! -- Create the object
+    type(OutputControlDataType), pointer :: ocdobj !< this instance
     allocate (ocdobj)
-    !
-    ! -- Allocate scalars
     call ocdobj%allocate_scalars()
-    !
-    ! -- Return
-    return
   end subroutine ocd_cr
 
-  !> @ brief Check OutputControlDataType object
-  !!
-  !!  Perform a consistency check
-  !!
-  !<
+  !> @ brief Check the output control data type for consistency.
   subroutine ocd_rp_check(this, inunit)
-    ! -- modules
+    ! modules
     use ConstantsModule, only: LINELENGTH
     use SimModule, only: store_error, count_errors, store_error_unit
-    ! -- dummy
-    class(OutputControlDataType) :: this !< OutputControlDataType object
-    integer(I4B), intent(in) :: inunit !< Unit number for input
-    ! -- locals
+    ! dummy
+    class(OutputControlDataType) :: this !< this instance
+    integer(I4B), intent(in) :: inunit !< output unit number
+    ! locals
     character(len=LINELENGTH) :: errmsg
-    ! -- formats
+    ! formats
     character(len=*), parameter :: fmtocsaveerr = &
       "(1X,'REQUESTING TO SAVE ',A,' BUT ',A,' SAVE FILE NOT SPECIFIED. ', &
        &A,' SAVE FILE MUST BE SPECIFIED IN OUTPUT CONTROL OPTIONS.')"
-    !
-    ! -- Check to make sure save file was specified
-    if (this%psmobj%save_detected) then
+
+    ! If saving is enabled, make sure an output file was specified
+    if (this%psm%save_steps%any_selected()) then
       if (this%idataun == 0) then
         write (errmsg, fmtocsaveerr) trim(adjustl(this%cname)), &
           trim(adjustl(this%cname)), &
@@ -94,23 +72,15 @@ contains
         call store_error(errmsg)
       end if
     end if
-    !
+
     if (count_errors() > 0) then
       call store_error_unit(inunit)
     end if
-    !
-    ! -- return
-    return
   end subroutine ocd_rp_check
 
-  !> @ brief Output data
-  !!
-  !!  Depending on the settings, print the data to a listing file and/or
-  !!  save the data to a binary file.
-  !!
-  !<
+  !> @brief Write to list file and/or save to binary file, depending on settings.
   subroutine ocd_ot(this, ipflg, kstp, endofperiod, iout, iprint_opt, isav_opt)
-    ! -- dummy
+    ! dummy
     class(OutputControlDataType) :: this !< OutputControlDataType object
     integer(I4B), intent(inout) :: ipflg !< Flag indicating if something was printed
     integer(I4B), intent(in) :: kstp !< Current time step
@@ -118,66 +88,55 @@ contains
     integer(I4B), intent(in) :: iout !< Unit number for output
     integer(I4B), optional, intent(in) :: iprint_opt !< Optional print flag override
     integer(I4B), optional, intent(in) :: isav_opt !< Optional save flag override
-    ! -- local
+    ! local
     integer(I4B) :: iprint
     integer(I4B) :: idataun
-    !
-    ! -- initialize
+
+    ! Initialize
     iprint = 0
     ipflg = 0
     idataun = 0
-    !
-    ! -- Determine whether or not to print the array.  The present
-    !    check allows a caller to override the print/save manager
+
+    ! Determine whether or not to print the array.  The present
+    ! check allows a caller to override the print/save manager
     if (present(iprint_opt)) then
       if (iprint_opt /= 0) then
         iprint = 1
         ipflg = 1
       end if
     else
-      if (this%psmobj%kstp_to_print(kstp, endofperiod)) then
+      if (this%psm%should_print(kstp, endofperiod)) then
         iprint = 1
         ipflg = 1
       end if
     end if
-    !
-    ! -- determine whether or not to save the array to a file
+
+    ! Determine whether to save the array to a file
     if (present(isav_opt)) then
       if (isav_opt /= 0) then
         idataun = this%idataun
       end if
     else
-      if (this%psmobj%kstp_to_save(kstp, endofperiod)) idataun = this%idataun
+      if (this%psm%should_save(kstp, endofperiod)) idataun = this%idataun
     end if
-    !
-    ! -- Record double precision array
-    if (associated(this%dblvec)) &
-      call this%dis%record_array(this%dblvec, iout, iprint, idataun, &
+
+    ! Record double precision array
+    if (associated(this%dbldata)) &
+      call this%dis%record_array(this%dbldata, iout, iprint, idataun, &
                                  this%cname, this%cdatafmp, this%nvaluesp, &
                                  this%nwidthp, this%editdesc, this%dnodata)
-    !
-    ! -- Record integer array (not supported yet)
+
+    ! Record integer array (not supported yet)
     !if(associated(this%intvec)) &
     !call this%dis%record_array(this%intvec, iout, iprint, idataun, &
     !                               this%cname, this%cdatafmp, this%nvaluesp, &
     !                               this%nwidthp, this%editdesc, this%inodata)
-    !
-    ! -- Return
-    return
   end subroutine ocd_ot
 
-  !> @ brief Deallocate OutputControlDataType
-  !!
-  !!  Deallocate members of this type
-  !!
-  !<
+  !> @brief Deallocate the output control data type
   subroutine ocd_da(this)
-    ! -- modules
-    use ConstantsModule, only: DZERO
-    ! -- dummy
     class(OutputControlDataType) :: this
-    !
-    ! -- deallocate
+
     deallocate (this%cname)
     deallocate (this%cdatafmp)
     deallocate (this%idataun)
@@ -186,20 +145,11 @@ contains
     deallocate (this%nwidthp)
     deallocate (this%dnodata)
     deallocate (this%inodata)
-    deallocate (this%psmobj)
-    !
-    ! -- return
-    return
   end subroutine ocd_da
 
-  !> @ brief Initialize this OutputControlDataType as double precision data
-  !!
-  !!  Initialize this object as a double precision data type
-  !!
-  !<
+  !> @brief Initialize the output control data type for double precision data.
   subroutine init_dbl(this, cname, dblvec, dis, cdefpsm, cdeffmp, iout, &
                       dnodata)
-    ! -- dummy
     class(OutputControlDataType) :: this !< OutputControlDataType object
     character(len=*), intent(in) :: cname !< Name of variable
     real(DP), dimension(:), pointer, contiguous, intent(in) :: dblvec !< Data array that will be managed by this object
@@ -208,28 +158,19 @@ contains
     character(len=*), intent(in) :: cdeffmp !< String for print format
     integer(I4B), intent(in) :: iout !< Unit number for output
     real(DP), intent(in) :: dnodata !< No data value
-    !
+
     this%cname = cname
-    this%dblvec => dblvec
+    this%dbldata => dblvec
     this%dis => dis
     this%dnodata = dnodata
-    call this%psmobj%init()
-    if (cdefpsm /= '') call this%psmobj%rp(cdefpsm, iout)
+    if (cdefpsm /= '') call this%psm%read(cdefpsm, iout)
     call print_format(cdeffmp, this%cdatafmp, &
                       this%editdesc, this%nvaluesp, this%nwidthp, 0)
-    !
-    ! -- return
-    return
   end subroutine init_dbl
 
-  !> @ brief Initialize this OutputControlDataType as integer data
-  !!
-  !!  Initialize this object as an integer data type
-  !!
-  !<
+  !> @ brief Initialize the output control data type for integer data.
   subroutine init_int(this, cname, intvec, dis, cdefpsm, cdeffmp, iout, &
                       inodata)
-    ! -- dummy
     class(OutputControlDataType) :: this !< OutputControlDataType object
     character(len=*), intent(in) :: cname !< Name of variable
     integer(I4B), dimension(:), pointer, contiguous, intent(in) :: intvec !< Data array that will be managed by this object
@@ -238,32 +179,24 @@ contains
     character(len=*), intent(in) :: cdeffmp !< String for print format
     integer(I4B), intent(in) :: iout !< Unit number for output
     integer(I4B), intent(in) :: inodata !< No data value
-    !
+
     this%cname = cname
-    this%intvec => intvec
+    this%intdata => intvec
     this%dis => dis
     this%inodata = inodata
     this%editdesc = 'I'
-    call this%psmobj%init()
-    if (cdefpsm /= '') call this%psmobj%rp(cdefpsm, iout)
+    if (cdefpsm /= '') call this%psm%read(cdefpsm, iout)
     call print_format(cdeffmp, this%cdatafmp, this%editdesc, this%nvaluesp, &
                       this%nwidthp, 0)
-    !
-    ! -- return
-    return
   end subroutine init_int
 
-  !> @ brief Allocate OutputControlDataType members
-  !!
-  !!  Allocate and initialize member variables
-  !!
-  !<
-  subroutine allocate_scalars(this)
-    ! -- modules
+  !> @ brief Allocate scalar variables
+  subroutine allocate (this)
+    ! modules
     use ConstantsModule, only: DZERO
-    ! -- dummy
+    ! dummy
     class(OutputControlDataType) :: this !< OutputControlDataType object
-    !
+
     allocate (this%cname)
     allocate (this%cdatafmp)
     allocate (this%idataun)
@@ -272,8 +205,7 @@ contains
     allocate (this%nwidthp)
     allocate (this%dnodata)
     allocate (this%inodata)
-    allocate (this%psmobj)
-    !
+
     this%cname = ''
     this%cdatafmp = ''
     this%idataun = 0
@@ -282,36 +214,30 @@ contains
     this%nwidthp = 0
     this%dnodata = DZERO
     this%inodata = 0
-    !
-    ! -- return
-    return
-  end subroutine allocate_scalars
+    this%psm => create_psm()
+  end subroutine allocate
 
-  !> @ brief Set options for this object based on an input string
-  !!
-  !!  Set FILEOUT and PRINT_FORMAT options for this object.
-  !!
-  !<
+  !> @ brief Set FILEOUT and PRINT_FORMAT based on an input string.
   subroutine set_option(this, linein, inunit, iout)
-    ! -- modules
+    ! modules
     use ConstantsModule, only: MNORMAL
     use OpenSpecModule, only: access, form
     use InputOutputModule, only: urword, getunit, openfile
     use SimModule, only: store_error, store_error_unit, count_errors
-    ! -- dummy
+    ! dummy
     class(OutputControlDataType) :: this !< OutputControlDataType object
     character(len=*), intent(in) :: linein !< Character string with options
     integer(I4B), intent(in) :: inunit !< Unit number for input
     integer(I4B), intent(in) :: iout !< Unit number for output
-    ! -- local
+    ! local
     character(len=len(linein)) :: line
     integer(I4B) :: lloc, istart, istop, ival
     real(DP) :: rval
-    ! -- format
+    ! format
     character(len=*), parameter :: fmtocsave = &
       "(4X,A,' INFORMATION WILL BE WRITTEN TO:', &
       &/,6X,'UNIT NUMBER: ', I0,/,6X, 'FILE NAME: ', A)"
-    !
+
     line(:) = linein(:)
     lloc = 1
     call urword(line, lloc, istart, istop, 1, ival, rval, 0, 0)
@@ -332,9 +258,6 @@ contains
       call store_error(trim(adjustl(line)))
       call store_error_unit(inunit)
     end select
-    !
-    ! -- return
-    return
   end subroutine set_option
 
 end module OutputControlDataModule

--- a/src/Utilities/OutputControl/PrintSaveManager.f90
+++ b/src/Utilities/OutputControl/PrintSaveManager.f90
@@ -1,284 +1,131 @@
-!> @brief This module contains the PrintSaveManagerModule
-!!
-!! This module defines the PrintSaveManagerType, which can be used
-!! to determine when something should be printed and/or saved. The
-!! object should be initiated with the following call:
-!!   call psm_obj%init()
-!!
-!! The set method will configure the members based on the following
-!! keywords when set is called as follows:
-!!   call psm_obj%set(nstp, line)
-!! where line may be in the following form:
-!!   PRINT ALL
-!!   PRINT STEPS 1 4 5 6
-!!   PRINT FIRST
-!!   PRINT LAST
-!!   PRINT FREQUENCY 4
-!!   SAVE ALL
-!!   SAVE STEPS 1 4 5 6
-!!   SAVE FIRST
-!!   SAVE LAST
-!!   SAVE FREQUENCY 4
-!!
-!! Based on the keywords, the object can be called with
-!!   psm_obj%time_to_print(kstp, kper)
-!!   psm_obj%time_to_save(kstp, kper)
-!! to return a logical flag indicating whether or not it
-!! it is time to print or time to save
-!!
-!<
+!> @brief Print/save manager module.
 module PrintSaveManagerModule
 
   use KindModule, only: DP, I4B, LGP
   use ArrayHandlersModule, only: expandarray
-  use SimVariablesModule, only: errmsg
   use SimModule, only: store_error
   use InputOutputModule, only: urword
+  use TimeStepSelectModule, only: TimeStepSelectType
 
   implicit none
   private
   public :: PrintSaveManagerType
+  public :: create_psm
 
-  !> @ brief PrintSaveManagerType
+  !> @brief Print/save manager type.
   !!
-  !!  Object for storing information and determining whether or
-  !!  not data should be printed to a list file or saved to disk.
+  !! Stores user settings as configured in an input file's period block
+  !! and determines whether data should be printed to a list (log) file
+  !! or saved to disk.
+  !!
+  !! The object should be initiated with the init() procedure.
+  !!
+  !! The rp() procedure will read a character string and configure the
+  !! manager, where the character string may be of the following form:
+  !!
+  !!   PRINT ALL
+  !!   PRINT STEPS 1 4 5 6
+  !!   PRINT FIRST
+  !!   PRINT LAST
+  !!   PRINT FREQUENCY 4
+  !!   SAVE ALL
+  !!   SAVE STEPS 1 4 5 6
+  !!   SAVE FIRST
+  !!   SAVE LAST
+  !!   SAVE FREQUENCY 4
+  !!
+  !! The should_print() and should_save() functions indicate whether
+  !! to save or print during the current time step.
   !<
   type :: PrintSaveManagerType
-    integer(I4B), allocatable, dimension(:) :: kstp_list_print
-    integer(I4B), allocatable, dimension(:) :: kstp_list_save
-    integer(I4B) :: ifreq_print
-    integer(I4B) :: ifreq_save
-    logical :: print_first
-    logical :: save_first
-    logical :: print_last
-    logical :: save_last
-    logical :: print_all
-    logical :: save_all
-    logical :: save_detected
-    logical :: print_detected
+    private
+    type(TimeStepSelectType), pointer, public :: save_steps
+    type(TimeStepSelectType), pointer, public :: print_steps
   contains
+    procedure :: allocate
+    procedure :: deallocate
     procedure :: init
-    procedure :: rp
-    procedure :: kstp_to_print
-    procedure :: kstp_to_save
+    procedure :: read
+    procedure :: should_print
+    procedure :: should_save
   end type PrintSaveManagerType
 
 contains
 
-  !> @ brief Initialize PrintSaveManager
-  !!
-  !!  Initializes variables of a PrintSaveManagerType
-  !!
-  !<
+  !> @brief Initialize or clear the print/save manager.
+  function create_psm() result(psm)
+    type(PrintSaveManagerType), pointer :: psm !< the print/save manager
+    allocate (psm)
+    call psm%allocate()
+  end function create_psm
+
+  subroutine allocate (this)
+    class(PrintSaveManagerType) :: this
+    allocate (this%save_steps)
+    allocate (this%print_steps)
+    call this%save_steps%init()
+    call this%print_steps%init()
+  end subroutine allocate
+
+  subroutine deallocate (this)
+    class(PrintSaveManagerType) :: this !< this instance
+    if (associated(this%save_steps)) deallocate (this%save_steps)
+    if (associated(this%print_steps)) deallocate (this%print_steps)
+  end subroutine deallocate
+
   subroutine init(this)
-    ! -- dummy
-    class(PrintSaveManagerType) :: this !< psm object to initialize
-    !
-    ! -- Initialize members to their defaults
-    if (allocated(this%kstp_list_print)) deallocate (this%kstp_list_print)
-    if (allocated(this%kstp_list_save)) deallocate (this%kstp_list_save)
-    allocate (this%kstp_list_print(0))
-    allocate (this%kstp_list_save(0))
-    this%ifreq_print = 0
-    this%ifreq_save = 0
-    this%save_first = .false.
-    this%save_last = .false.
-    this%save_all = .false.
-    this%print_first = .false.
-    this%print_last = .false.
-    this%print_all = .false.
-    this%save_detected = .false.
-    this%print_detected = .false.
-    !
-    ! -- return
-    return
+    class(PrintSaveManagerType) :: this
+    call this%deallocate()
+    call this%allocate()
   end subroutine init
 
-  !> @ brief Read and prepare for PrintSaveManager
-  !!
-  !!  Parse information in the line and assign settings for the
-  !!  PrintSaveManagerType.
-  !!
-  !<
-  subroutine rp(this, linein, iout)
-    ! -- dummy
-    class(PrintSaveManagerType) :: this !< psm object
-    character(len=*), intent(in) :: linein !< character line of information
-    integer(I4B), intent(in) :: iout !< unit number of output file
-    ! -- local
+  !> @ brief Read a line of input and prepare the manager.
+  subroutine read (this, linein, iout)
+    ! dummy
+    class(PrintSaveManagerType) :: this !< this instance
+    character(len=*), intent(in) :: linein !< input line
+    integer(I4B), intent(in) :: iout !< output file unit
+    ! local
     character(len=len(linein)) :: line
-    logical lp, ls
-    integer(I4B) :: n
     integer(I4B) :: lloc, istart, istop, ival
     real(DP) :: rval
-    ! -- formats
-    character(len=*), parameter :: fmt_steps = &
-      &"(6x,'THE FOLLOWING STEPS WILL BE ',A,': ',50(I0,' '))"
-    character(len=*), parameter :: fmt_freq = &
-      &"(6x,'THE FOLLOWING FREQUENCY WILL BE ',A,': ',I0)"
-    !
-    ! -- Set the values based on line
-    ! -- Get keyword to use in assignment
+
     line(:) = linein(:)
     lloc = 1
     call urword(line, lloc, istart, istop, 1, ival, rval, 0, 0)
-    !
-    ! -- set dimension for print or save
-    lp = .false.
-    ls = .false.
+
     select case (line(istart:istop))
     case ('PRINT')
-      lp = .true.
+      call this%print_steps%read(line(istop + 2:))
+      if (iout > 0) &
+        call this%print_steps%log(iout, verb="PRINTED")
     case ('SAVE')
-      ls = .true.
+      call this%save_steps%read(line(istop + 2:))
+      if (iout > 0) &
+        call this%save_steps%log(iout, verb="SAVED")
     case default
-      write (errmsg, '(2a)') &
-        'Looking for PRINT or SAVE. Found:', trim(adjustl(line))
-      call store_error(errmsg, terminate=.TRUE.)
+      call store_error( &
+        'Looking for PRINT or SAVE. Found: '//trim(adjustl(line)), &
+        terminate=.TRUE.)
     end select
-    !
-    ! -- set member variables
-    this%save_detected = ls
-    this%print_detected = lp
-    !
-    ! -- set the steps to print or save
-    call urword(line, lloc, istart, istop, 1, ival, rval, 0, 0)
-    select case (line(istart:istop))
-    case ('ALL')
-      if (lp) then
-        this%print_all = .true.
-        if (iout > 0) write (iout, "(6x,a)") 'ALL TIME STEPS WILL BE PRINTED'
-      end if
-      if (ls) then
-        this%save_all = .true.
-        if (iout > 0) write (iout, "(6x,a)") 'ALL TIME STEPS WILL BE SAVED'
-      end if
-    case ('STEPS')
-      listsearch: do
-        call urword(line, lloc, istart, istop, 2, ival, rval, -1, 0)
-        if (ival > 0) then
-          if (lp) then
-            n = size(this%kstp_list_print)
-            call expandarray(this%kstp_list_print)
-            this%kstp_list_print(n + 1) = ival
-          end if
-          if (ls) then
-            n = size(this%kstp_list_save)
-            call expandarray(this%kstp_list_save)
-            this%kstp_list_save(n + 1) = ival
-          end if
-          cycle listsearch
-        end if
-        exit listsearch
-      end do listsearch
-      if (iout > 0) then
-        if (lp) write (iout, fmt_steps) 'PRINTED', this%kstp_list_print
-        if (ls) write (iout, fmt_steps) 'SAVED', this%kstp_list_save
-      end if
-    case ('FREQUENCY')
-      call urword(line, lloc, istart, istop, 2, ival, rval, -1, 0)
-      if (lp) this%ifreq_print = ival
-      if (ls) this%ifreq_save = ival
-      if (iout > 0) then
-        if (lp) write (iout, fmt_freq) 'PRINTED', this%ifreq_print
-        if (ls) write (iout, fmt_freq) 'SAVED', this%ifreq_save
-      end if
-    case ('FIRST')
-      if (lp) then
-        this%print_first = .true.
-        if (iout > 0) write (iout, "(6x,a)") 'THE FIRST TIME STEP WILL BE PRINTED'
-      end if
-      if (ls) then
-        this%save_first = .true.
-        if (iout > 0) write (iout, "(6x,a)") 'THE FIRST TIME STEP WILL BE SAVED'
-      end if
-    case ('LAST')
-      if (lp) then
-        this%print_last = .true.
-        if (iout > 0) write (iout, "(6x,a)") 'THE LAST TIME STEP WILL BE PRINTED'
-      end if
-      if (ls) then
-        this%save_last = .true.
-        if (iout > 0) write (iout, "(6x,a)") 'THE LAST TIME STEP WILL BE SAVED'
-      end if
-    case default
-      write (errmsg, '(2a)') &
-        'Looking for ALL, STEPS, FIRST, LAST, OR FREQUENCY. Found: ', &
-        trim(adjustl(line))
-      call store_error(errmsg, terminate=.TRUE.)
-    end select
-    !
-    ! -- return
-    return
-  end subroutine rp
+  end subroutine read
 
-  !> @ brief Determine if it is time to print the data
-  !!
-  !!  Determine if data should be printed based on kstp and endofperiod
-  !!
-  !<
-  logical function kstp_to_print(this, kstp, endofperiod)
-    ! -- dummy
-    class(PrintSaveManagerType) :: this !< psm object
+  !> @ brief Determine if printing is enabled for this time step.
+  logical function should_print(this, kstp, endofperiod)
+    class(PrintSaveManagerType) :: this !< this instance
     integer(I4B), intent(in) :: kstp !< current time step
-    logical(LGP), intent(in) :: endofperiod !< flag indicating end of stress period
-    ! -- local
-    integer(I4B) :: i, n
-    !
-    kstp_to_print = .false.
-    if (this%print_all) kstp_to_print = .true.
-    if (kstp == 1 .and. this%print_first) kstp_to_print = .true.
-    if (endofperiod .and. this%print_last) kstp_to_print = .true.
-    if (this%ifreq_print > 0) then
-      if (mod(kstp, this%ifreq_print) == 0) kstp_to_print = .true.
-    end if
-    n = size(this%kstp_list_print)
-    if (n > 0) then
-      do i = 1, n
-        if (kstp == this%kstp_list_print(i)) then
-          kstp_to_print = .true.
-          exit
-        end if
-      end do
-    end if
-    !
-    ! -- Return
-    return
-  end function kstp_to_print
+    logical(LGP), intent(in) :: endofperiod !< whether last step of stress period
 
-  !> @ brief Determine if it is time to save the data
-  !!
-  !!  Determine if data should be saved based on kstp and endofperiod
-  !!
-  !<
-  logical function kstp_to_save(this, kstp, endofperiod)
-    ! -- dummy
-    class(PrintSaveManagerType) :: this !< psm object
+    should_print = this%print_steps%is_selected(kstp, endofperiod)
+  end function should_print
+
+  !> @ brief Determine if saving is enabled for this time step.
+  logical function should_save(this, kstp, endofperiod)
+    class(PrintSaveManagerType) :: this !< this instance
     integer(I4B), intent(in) :: kstp !< current time step
-    logical(LGP), intent(in) :: endofperiod !< flag indicating end of stress period
-    ! -- local
-    integer(I4B) :: i, n
-    !
-    kstp_to_save = .false.
-    if (this%save_all) kstp_to_save = .true.
-    if (kstp == 1 .and. this%save_first) kstp_to_save = .true.
-    if (endofperiod .and. this%save_last) kstp_to_save = .true.
-    if (this%ifreq_save > 0) then
-      if (mod(kstp, this%ifreq_save) == 0) kstp_to_save = .true.
-    end if
-    n = size(this%kstp_list_save)
-    if (n > 0) then
-      do i = 1, n
-        if (kstp == this%kstp_list_save(i)) then
-          kstp_to_save = .true.
-          exit
-        end if
-      end do
-    end if
-    !
-    ! -- Return
-    return
-  end function kstp_to_save
+    logical(LGP), intent(in) :: endofperiod !< whether last step of stress period
+
+    should_save = this%save_steps%is_selected(kstp, endofperiod)
+  end function should_save
 
 end module PrintSaveManagerModule

--- a/src/meson.build
+++ b/src/meson.build
@@ -215,6 +215,7 @@ modflow_sources = files(
     'Model' / 'ModelUtilities' / 'SwfCxsUtils.f90',
     'Model' / 'ModelUtilities' / 'TspAdvOptions.f90',
     'Model' / 'ModelUtilities' / 'TimeSelect.f90',
+    'Model' / 'ModelUtilities' / 'TimeStepSelect.f90',
     'Model' / 'ModelUtilities' / 'TrackData.f90',
     'Model' / 'ModelUtilities' / 'UzfCellGroup.f90',
     'Model' / 'ModelUtilities' / 'VectorInterpolation.f90',

--- a/utils/mf5to6/make/makedefaults
+++ b/utils/mf5to6/make/makedefaults
@@ -72,11 +72,11 @@ endif
 # set the ldflgs
 ifeq ($(detected_OS), Windows)
 	ifeq ($(FC), $(filter $(FC), gfortran))
-		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm -Wl,-ld_classic
+		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm
 	endif
 else
 	ifeq ($(FC), gfortran)
-		LDFLAGS ?= -lc -Wl,-ld_classic
+		LDFLAGS ?= -lc
 	endif
 	ifeq ($(FC), $(filter $(FC), ifort mpiifort))
 		LDFLAGS ?= -lc

--- a/utils/mf5to6/make/makedefaults
+++ b/utils/mf5to6/make/makedefaults
@@ -1,4 +1,4 @@
-# makedefaults created by pymake (version 1.2.10) for the 'mf5to6' executable.
+# makedefaults created by pymake (version 1.2.11.dev0) for the 'mf5to6' executable.
 
 # determine OS
 ifeq ($(OS), Windows_NT)
@@ -72,11 +72,11 @@ endif
 # set the ldflgs
 ifeq ($(detected_OS), Windows)
 	ifeq ($(FC), $(filter $(FC), gfortran))
-		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm
+		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm -Wl,-ld_classic
 	endif
 else
 	ifeq ($(FC), gfortran)
-		LDFLAGS ?= -lc
+		LDFLAGS ?= -lc -Wl,-ld_classic
 	endif
 	ifeq ($(FC), $(filter $(FC), ifort mpiifort))
 		LDFLAGS ?= -lc

--- a/utils/mf5to6/make/makefile
+++ b/utils/mf5to6/make/makefile
@@ -1,14 +1,14 @@
-# makefile created by pymake (version 1.2.10) for the 'mf5to6' executable.
+# makefile created by pymake (version 1.2.11.dev0) for the 'mf5to6' executable.
 
 
 include ./makedefaults
 
 # Define the source file directories
 SOURCEDIR1=../src
-SOURCEDIR2=../src/MF2005
-SOURCEDIR3=../src/NWT
-SOURCEDIR4=../src/LGR
-SOURCEDIR5=../src/Preproc
+SOURCEDIR2=../src/NWT
+SOURCEDIR3=../src/LGR
+SOURCEDIR4=../src/Preproc
+SOURCEDIR5=../src/MF2005
 SOURCEDIR6=../../../src/Utilities/Memory
 SOURCEDIR7=../../../src/Utilities/TimeSeries
 SOURCEDIR8=../../../src/Utilities

--- a/utils/zonebudget/make/makedefaults
+++ b/utils/zonebudget/make/makedefaults
@@ -72,11 +72,11 @@ endif
 # set the ldflgs
 ifeq ($(detected_OS), Windows)
 	ifeq ($(FC), $(filter $(FC), gfortran))
-		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm -Wl,-ld_classic
+		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm
 	endif
 else
 	ifeq ($(FC), gfortran)
-		LDFLAGS ?= -lc -Wl,-ld_classic
+		LDFLAGS ?= -lc
 	endif
 	ifeq ($(FC), $(filter $(FC), ifort mpiifort))
 		LDFLAGS ?= -lc

--- a/utils/zonebudget/make/makedefaults
+++ b/utils/zonebudget/make/makedefaults
@@ -1,4 +1,4 @@
-# makedefaults created by pymake (version 1.2.10) for the 'zbud6' executable.
+# makedefaults created by pymake (version 1.2.11.dev0) for the 'zbud6' executable.
 
 # determine OS
 ifeq ($(OS), Windows_NT)
@@ -72,11 +72,11 @@ endif
 # set the ldflgs
 ifeq ($(detected_OS), Windows)
 	ifeq ($(FC), $(filter $(FC), gfortran))
-		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm
+		LDFLAGS ?= -static -static-libgfortran -static-libgcc -static-libstdc++ -lm -Wl,-ld_classic
 	endif
 else
 	ifeq ($(FC), gfortran)
-		LDFLAGS ?= -lc
+		LDFLAGS ?= -lc -Wl,-ld_classic
 	endif
 	ifeq ($(FC), $(filter $(FC), ifort mpiifort))
 		LDFLAGS ?= -lc

--- a/utils/zonebudget/make/makefile
+++ b/utils/zonebudget/make/makefile
@@ -1,4 +1,4 @@
-# makefile created by pymake (version 1.2.10) for the 'zbud6' executable.
+# makefile created by pymake (version 1.2.11.dev0) for the 'zbud6' executable.
 
 
 include ./makedefaults


### PR DESCRIPTION
In the spirit of `TimeSelect`, factor out a module and type `TimeStepSelect` for time step selections. This simplifies `PrintSaveManager` which can compose two of the latter. Add unit tests. Cleanup docstrings, comments, and style in base and concrete OC types.

This can also be used by PRT, to come in a separate PR which cleans up particle release logic.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated meson files, makefiles, and Visual Studio project files for new source files
- [x] Removed checklist items not relevant to this pull request