### PR TITLE
fix(meson.build): separate parallel/extended dependencies

### DIFF
--- a/.github/actions/test-extended/action.yml
+++ b/.github/actions/test-extended/action.yml
@@ -74,7 +74,7 @@ runs:
       shell: bash
       working-directory: modflow6
       run: |
-        pixi run setup -Dparallel=true builddir
+        pixi run setup -Dextended=true builddir
         pixi run build builddir
         pixi run test builddir
 

--- a/meson.build
+++ b/meson.build
@@ -214,7 +214,7 @@ compile_args += extra_cmp_args
 add_project_arguments(fc.get_supported_arguments(compile_args), language: 'fortran')
 add_project_link_arguments(fc.get_supported_arguments(link_args), language: 'fortran')
 
-if is_extended_build and build_machine.system() == 'windows'
+if is_parallel_build and build_machine.system() == 'windows'
   message('Compiling PETSc Fortran modules')
   petsc_incdir = include_directories([petsc_dir_rel / 'include', petsc_compiled_rel / 'include'])
   petsc_src = petsc_dir_abs / 'src'

--- a/meson.build
+++ b/meson.build
@@ -100,16 +100,14 @@ endif
 
 # parallel build options
 is_extended_build = get_option('extended')
+is_parallel_build = get_option('parallel') or is_extended_build
 is_cray = get_option('cray')
 is_mpich = get_option('mpich')
 if is_cray and build_machine.system() != 'linux'
-  error('cray=true only supported on linux systems')
+  error('cray only supported on linux systems')
 endif
-if not is_extended_build
- is_extended_build = get_option('parallel')
-endif
-if is_cray and not is_extended_build
-  is_extended_build = true
+if is_cray and not is_parallel_build
+  is_parallel_build = true
   is_mpich = true
 endif
 if is_mpich
@@ -119,7 +117,12 @@ if is_mpich
     mpifort_name = 'mpichfort'
   endif
 endif
-message('Extended build:', is_extended_build)
+
+if is_extended_build
+  message('Extended build:', is_extended_build)
+elif is_parallel_build
+  message('Parallel build:', is_parallel_build)
+endif
 
 # windows options for petsc
 petsc_dir_rel = '..' /'petsc'
@@ -140,7 +143,7 @@ dependencies = [ ]
 extra_cmp_args = [ ]
 
 # load petsc, mpi, and netcdf dependencies/libraries
-if is_extended_build
+if is_parallel_build
   # find petsc
   if build_machine.system() != 'windows'
     petsc = dependency('PETSc', required : true)
@@ -162,7 +165,12 @@ if is_extended_build
   endif
   extra_cmp_args += [ '-D__WITH_MPI__']
   with_mpi = true
+else
+  with_petsc = false
+  with_mpi = false
+endif
 
+if is_extended_build
   # find netcdf
   if build_machine.system() != 'windows'
     netcdff = dependency('netcdf', language : 'fortran', required : false)
@@ -181,8 +189,6 @@ if is_extended_build
   endif
 else
   with_netcdf = false
-  with_petsc = false
-  with_mpi = false
 endif
 
 # GCC profile options need to be netcdf aware due to HDF5 issue

--- a/meson.build
+++ b/meson.build
@@ -143,7 +143,7 @@ dependencies = [ ]
 extra_cmp_args = [ ]
 
 # load petsc, mpi, and netcdf dependencies/libraries
-if is_parallel_build
+if is_parallel_build or is_extended_build
   # find petsc
   if build_machine.system() != 'windows'
     petsc = dependency('PETSc', required : true)


### PR DESCRIPTION
Separate logic for parallel and extended builds. Previously a netcdf dependency was declared even for a parallel-only (not extended) build. This can cause issues if meson detects a netcdf that has been improperly installed or incompletely setup as seems to now be the case on Mac CI runner images

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Removed checklist items not relevant to this pull request