### PR TITLE
doc(namefile.tex): mention of mve package was missing in gwe namefile table

### DIFF
--- a/doc/mf6io/gwe/namefile.tex
+++ b/doc/mf6io/gwe/namefile.tex
@@ -38,6 +38,7 @@ SFE6 & Streamflow Energy Transport Package & * \\
 LKE6 & Lake Energy Transport Package & * \\
 MWE6 & Multi-Aquifer Well Energy Transport Package & * \\
 UZE6 & Unsaturated-Zone Energy Transport Package & * \\
+MVE6 & Mover Energy Transport Package \\
 OBS6 & Observations Option \\
 \hline 
 \end{tabular*}


### PR DESCRIPTION
Per @rbwinst-usgs's #1916, mention of the `MVE` package was missing from a table that listed which packages are available to the GWE model.  The table in question is located in the description of the namefile for the GWE model.

- [x] Replaced section above with description of pull request
- [x] Closes issue #1916