### PR TITLE
doc(mf6io): fix PRT MIP section in IO guide

### DIFF
--- a/doc/mf6io/prt/mip.tex
+++ b/doc/mf6io/prt/mip.tex
@@ -2,7 +2,7 @@ Model Input (MIP) Package information is read from the file that is specified by
 
 \vspace{5mm}
 \subsubsection{Structure of Blocks}
-%%\lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-mip-options.dat}
+\lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-mip-options.dat}
 \lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-mip-griddata.dat}
 
 \vspace{5mm}


### PR DESCRIPTION
MIP options block was omitted from structure of blocks section.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Closes #1929
- [x] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [x] Removed checklist items not relevant to this pull request