### PR TITLE
fix(oc): fix TimeStepSelect logging

### DIFF
--- a/autotest/TestTimeStepSelect.f90
+++ b/autotest/TestTimeStepSelect.f90
@@ -16,7 +16,8 @@ contains
                 new_unittest("last", test_last), &
                 new_unittest("all", test_all), &
                 new_unittest("freq", test_freq), &
-                new_unittest("step", test_step) &
+                new_unittest("step", test_step), &
+                new_unittest("multiple", test_multiple) &
                 ]
   end subroutine collect_timestepselect
 
@@ -118,5 +119,32 @@ contains
     if (allocated(error)) return
 
   end subroutine test_step
+
+  subroutine test_multiple(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(TimeStepSelectType) :: steps
+    character(len=LINELENGTH) :: line
+
+    call steps%init()
+
+    line = "FIRST"
+    call steps%read(line)
+
+    line = "LAST"
+    call steps%read(line)
+
+    line = "STEPS 2"
+    call steps%read(line)
+
+    call check(error, steps%is_selected(1, .false.))
+    if (allocated(error)) return
+
+    call check(error, steps%is_selected(2, .false.))
+    if (allocated(error)) return
+
+    call check(error, steps%is_selected(3, .true.))
+    if (allocated(error)) return
+
+  end subroutine test_multiple
 
 end module TestTimeStepSelect

--- a/src/Model/ModelUtilities/TimeStepSelect.f90
+++ b/src/Model/ModelUtilities/TimeStepSelect.f90
@@ -23,6 +23,16 @@ module TimeStepSelectModule
   !!   LAST
   !!   FREQUENCY 4
   !!
+  !! The read() procedure may be invoked multiple times to select multiple
+  !! time steps. Note that a character string re-using a keyword which has
+  !! been used for a previous read() invocation will override the previous
+  !! setting using that keyword. To combine multiple settings, be sure the
+  !! keywords are different on each invocation, e.g.:
+  !!
+  !!   FIRST
+  !!   LAST
+  !!   STEPS 2
+  !!
   !! The is_selected() function indicates whether the given time step is
   !! active. This function accepts an optional argument, indicating that
   !! the time step is the last in the stress period.
@@ -75,14 +85,18 @@ contains
 
     if (this%all) then
       write (iout, "(6x,a,a)") 'ALL TIME STEPS WILL BE ', verb
-    else if (this%first) then
-      write (iout, "(6x,a,a)") 'THE FIRST TIME STEP WILL BE ', verb
-    else if (this%last) then
-      write (iout, "(6x,a,a)") 'THE LAST TIME STEP WILL BE ', verb
-    else if (size(this%steps) > 0) then
+    end if
+    if (size(this%steps) > 0) then
       write (iout, fmt_steps) verb, this%steps
-    else if (this%freq > 0) then
+    end if
+    if (this%freq > 0) then
       write (iout, fmt_freq) verb, this%freq
+    end if
+    if (this%first) then
+      write (iout, "(6x,a,a)") 'THE FIRST TIME STEP WILL BE ', verb
+    end if
+    if (this%last) then
+      write (iout, "(6x,a,a)") 'THE LAST TIME STEP WILL BE ', verb
     end if
   end subroutine log
 


### PR DESCRIPTION
#1923 introduced a module/type for time step selections, with a `log()` routine to handle logging of selected steps. This routine did not work properly when selecting multiple time steps with different keyword options (as supported by OC period-block settings). To restore the desired logging behavior, switch exclusive to inclusive conditionals, and reorder the conditions to preserve the original order of lines written to the list file. Also add a unit test for multiple selections.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Removed checklist items not relevant to this pull request