### PR TITLE
fix(utils): address memory leaks in CharacterStringType, Idm

### DIFF
--- a/src/Utilities/CharString.f90
+++ b/src/Utilities/CharString.f90
@@ -31,6 +31,7 @@ module CharacterStringModule
     procedure :: charstring_eq_charstring
     procedure :: write_unformatted
     procedure :: strlen
+    procedure :: destroy
     generic :: assignment(=) => assign_to_charstring, assign_from_charstring
     generic :: operator(==) => character_eq_charstring, &
       charstring_eq_character, &
@@ -38,7 +39,6 @@ module CharacterStringModule
     ! not supported by gfortran 5 and 6
     ! disable for now
     ! generic :: write (unformatted) => write_unformatted
-    final :: destruct
   end type CharacterStringType
 
 contains
@@ -128,9 +128,9 @@ contains
     end if
   end function strlen
 
-  subroutine destruct(this)
-    type(CharacterStringType), intent(inout) :: this
+  subroutine destroy(this)
+    class(CharacterStringType), intent(inout) :: this
     if (allocated(this%charstring)) deallocate (this%charstring)
-  end subroutine destruct
+  end subroutine destroy
 
 end module CharacterStringModule

--- a/src/Utilities/CharString.f90
+++ b/src/Utilities/CharString.f90
@@ -38,6 +38,7 @@ module CharacterStringModule
     ! not supported by gfortran 5 and 6
     ! disable for now
     ! generic :: write (unformatted) => write_unformatted
+    final :: destruct
   end type CharacterStringType
 
 contains
@@ -126,5 +127,10 @@ contains
       length = 0
     end if
   end function strlen
+
+  subroutine destruct(this)
+    type(CharacterStringType), intent(inout) :: this
+    if (allocated(this%charstring)) deallocate (this%charstring)
+  end subroutine destruct
 
 end module CharacterStringModule

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileGridInput.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileGridInput.f90
@@ -219,7 +219,11 @@ contains
 
   subroutine bndgrid_destroy(this)
     class(BoundGridInputType), intent(inout) :: this !< Mf6FileGridInputType
+    !
+    ! deallocate objects
+    call this%tasmanager%da()
     deallocate (this%tasmanager)
+    nullify (this%tasmanager)
   end subroutine bndgrid_destroy
 
   subroutine bndgrid_reset(this)

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileGridInput.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileGridInput.f90
@@ -220,7 +220,7 @@ contains
   subroutine bndgrid_destroy(this)
     class(BoundGridInputType), intent(inout) :: this !< Mf6FileGridInputType
     !
-    ! deallocate objects
+    ! deallocate tasmanager
     call this%tasmanager%da()
     deallocate (this%tasmanager)
     nullify (this%tasmanager)

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
@@ -170,7 +170,7 @@ contains
   subroutine bndlist_destroy(this)
     class(BoundListInputType), intent(inout) :: this !< BoundListInputType
     !
-    ! deallocate objects
+    ! deallocate tsmanager
     call this%tsmanager%da()
     deallocate (this%tsmanager)
     nullify (this%tsmanager)

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
@@ -169,7 +169,13 @@ contains
 
   subroutine bndlist_destroy(this)
     class(BoundListInputType), intent(inout) :: this !< BoundListInputType
+    !
+    ! deallocate objects
+    call this%tsmanager%da()
     deallocate (this%tsmanager)
+    nullify (this%tsmanager)
+    !
+    ! deallocate StructArray
     call destructStructArray(this%structarray)
     call this%bound_context%destroy()
   end subroutine bndlist_destroy

--- a/src/Utilities/Idm/mf6blockfile/StructArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/StructArray.f90
@@ -481,6 +481,7 @@ contains
                           this%mempath)
         do i = 1, this%nrow
           p_charstr1d(i) = this%struct_vectors(icol)%charstr1d(i)
+          call this%struct_vectors(icol)%charstr1d(i)%destroy()
         end do
       end if
 
@@ -668,6 +669,7 @@ contains
 
           do i = 1, this%struct_vectors(j)%size
             p_charstr1d(i) = this%struct_vectors(j)%charstr1d(i)
+            call this%struct_vectors(j)%charstr1d(i)%destroy()
           end do
 
           deallocate (this%struct_vectors(j)%charstr1d)

--- a/src/Utilities/Memory/Memory.f90
+++ b/src/Utilities/Memory/Memory.f90
@@ -99,6 +99,7 @@ contains
 
   subroutine mt_deallocate(this)
     class(MemoryType) :: this
+    integer(I4B) :: n
 
     if (associated(this%strsclr)) then
       if (this%master) deallocate (this%strsclr)
@@ -156,7 +157,12 @@ contains
     end if
 
     if (associated(this%acharstr1d)) then
-      if (this%master) deallocate (this%acharstr1d)
+      if (this%master) then
+        do n = 1, size(this%acharstr1d)
+          call this%acharstr1d(n)%destroy()
+        end do
+        deallocate (this%acharstr1d)
+      end if
       nullify (this%acharstr1d)
     end if
   end subroutine mt_deallocate

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -1223,6 +1223,7 @@ contains
       ! -- copy existing values
       do n = 1, nrow_old
         astrtemp(n) = acharstr1d(n)
+        call acharstr1d(n)%destroy()
       end do
       !
       ! -- fill new values with missing values
@@ -1242,6 +1243,7 @@ contains
       ! -- fill the reallocated character array
       do n = 1, nrow
         acharstr1d(n) = astrtemp(n)
+        call astrtemp(n)%destroy()
       end do
       !
       ! -- deallocate temporary storage
@@ -2009,6 +2011,7 @@ contains
     type(MemoryType), pointer :: mt
     logical(LGP) :: found
     type(MemoryContainerIteratorType), allocatable :: itr
+    integer(I4B) :: n
     ! -- code
     !
     ! -- process optional variables
@@ -2033,6 +2036,9 @@ contains
                        terminate=.TRUE.)
     else
       if (mt%master) then
+        do n = 1, size(astr1d)
+          call astr1d(n)%destroy()
+        end do
         deallocate (astr1d)
       else
         nullify (astr1d)


### PR DESCRIPTION
Current valgrind log associated with PR: [valgrind.log](https://github.com/user-attachments/files/16235351/valgrind.log)
  - Linux x86_64 compiling with gfortran 11.4
  - ```test_gwf_csub_zdisp02.py``` as in issue description

Issue #1943 

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #xxxx
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).