### PR TITLE
fix(mem): address memory leak related to the MemoryStore

### DIFF
--- a/src/Utilities/Memory/MemoryContainerIterator.f90
+++ b/src/Utilities/Memory/MemoryContainerIterator.f90
@@ -29,10 +29,10 @@ contains
   !!
   !<
   function constructor(container_iterator) result(iterator)
-    class(IteratorType) :: container_iterator
+    class(IteratorType), allocatable :: container_iterator
     type(MemoryContainerIteratorType) :: iterator
 
-    iterator%container_iterator = container_iterator
+    call move_alloc(container_iterator, iterator%container_iterator)
 
   end function constructor
 

--- a/src/Utilities/Memory/MemoryManagerExt.f90
+++ b/src/Utilities/Memory/MemoryManagerExt.f90
@@ -46,6 +46,7 @@ contains
         if (mt%path == memory_path .and. mt%mt_associated()) then
           call mt%mt_deallocate()
           removed = .true.
+          deallocate(itr)
           exit
         end if
       end do

--- a/src/Utilities/Memory/MemoryManagerExt.f90
+++ b/src/Utilities/Memory/MemoryManagerExt.f90
@@ -46,7 +46,7 @@ contains
         if (mt%path == memory_path .and. mt%mt_associated()) then
           call mt%mt_deallocate()
           removed = .true.
-          deallocate(itr)
+          deallocate (itr)
           exit
         end if
       end do

--- a/src/Utilities/Memory/MemoryStore.f90
+++ b/src/Utilities/Memory/MemoryStore.f90
@@ -31,7 +31,7 @@ contains
     class(MemoryStoreType) :: this
     type(MemoryContainerIteratorType) :: itr
 
-    itr = MemoryContainerIteratorType(this%container%Iterator())
+    itr = MemoryContainerIteratorType(this%container%iterator())
   end function
 
   !> @brief Add a MemoryType to the container

--- a/src/Utilities/Memory/MemoryStore.f90
+++ b/src/Utilities/Memory/MemoryStore.f90
@@ -12,7 +12,7 @@ module MemoryStoreModule
 
   type :: MemoryStoreType
     private
-    type(PtrHashTableType), private :: container
+    type(PtrHashTableType) :: container
   contains
     procedure :: iterator
     procedure :: add
@@ -27,11 +27,13 @@ contains
   !!
   !<
   function iterator(this) result(itr)
-    ! -- dummy
     class(MemoryStoreType) :: this
     type(MemoryContainerIteratorType) :: itr
-
-    itr = MemoryContainerIteratorType(this%container%iterator())
+    ! -- local
+    class(IteratorType), allocatable :: container_iterator
+    
+    allocate(container_iterator, source=this%container%iterator())
+    itr = MemoryContainerIteratorType(container_iterator)
   end function
 
   !> @brief Add a MemoryType to the container

--- a/src/Utilities/Memory/MemoryStore.f90
+++ b/src/Utilities/Memory/MemoryStore.f90
@@ -31,8 +31,8 @@ contains
     type(MemoryContainerIteratorType) :: itr
     ! -- local
     class(IteratorType), allocatable :: container_iterator
-    
-    allocate(container_iterator, source=this%container%iterator())
+
+    allocate (container_iterator, source=this%container%iterator())
     itr = MemoryContainerIteratorType(container_iterator)
   end function
 


### PR DESCRIPTION
Fixes the memory leaks present in the PtrHashTableIterator and PtrHashTable

Checklist of items for pull request

- [ ] Replaced section above with description of pull request
- [ ] Closed issue #xxxx
- [x] Referenced issue or pull request #1943 
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request
