### PR TITLE
(fix) Fix compilation on the HPC

### DIFF
--- a/src/Utilities/PtrHashTable.f90
+++ b/src/Utilities/PtrHashTable.f90
@@ -18,9 +18,8 @@ module PtrHashTableModule
   !!
   !<
   type PtrHashTableType
-    private
-    type(KeyValueListType) :: buckets(BUCKET_SIZE) !< the HashTable buckets
-    integer(I4B) :: cnt = 0 !< the number of items in the HashTable
+    type(KeyValueListType), public :: buckets(BUCKET_SIZE) !< the HashTable buckets
+    integer(I4B), private :: cnt = 0 !< the number of items in the HashTable
   contains
     procedure :: iterator
     procedure :: add

--- a/src/Utilities/PtrHashTable.f90
+++ b/src/Utilities/PtrHashTable.f90
@@ -18,8 +18,9 @@ module PtrHashTableModule
   !!
   !<
   type PtrHashTableType
-    type(KeyValueListType), public :: buckets(BUCKET_SIZE) !< the HashTable buckets
-    integer(I4B), private :: cnt = 0 !< the number of items in the HashTable
+    private
+    type(KeyValueListType) :: buckets(BUCKET_SIZE) !< the HashTable buckets
+    integer(I4B) :: cnt = 0 !< the number of items in the HashTable
   contains
     procedure :: iterator
     procedure :: add

--- a/src/Utilities/PtrHashTableIterator.f90
+++ b/src/Utilities/PtrHashTableIterator.f90
@@ -12,7 +12,6 @@ module PtrHashTableIteratorModule
   !!
   !<
   type, extends(IteratorType) :: PtrHashTableIteratorType
-    private
     type(KeyValueListType), pointer :: buckets(:) => null() !< the buckets of the PtrHashTable to iterate through
     class(IteratorType), allocatable :: current_bucket_iterator !< the iterator of the bucket to which the current iterator belongs
     integer(I4B) :: curent_bucket_index = 1 !< the bucket in which the current iterator belongs
@@ -31,7 +30,7 @@ contains
   !!
   !<
   function constructor(buckets) Result(iterator)
-    type(KeyValueListType), pointer, intent(in) :: buckets(:)
+    type(KeyValueListType), target, dimension(:), intent(in) :: buckets
     type(PtrHashTableIteratorType) :: iterator
     ! -- local
     type(KeyValueListType), pointer :: first_bucket


### PR DESCRIPTION
This fixes a compilation issue in the PtrHastTable on the HPC by making the buckets variable public

Checklist of items for pull request

- [ ] Replaced section above with description of pull request
- [ ] Closed issue #xxxx
- [ ] Referenced issue or pull request #1954
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request