### PR TITLE
ci(parallel): skip test_par_gwf02 cases d-f, no xdist on windows

### DIFF
--- a/.github/common/test_modflow6.bat
+++ b/.github/common/test_modflow6.bat
@@ -1,4 +1,4 @@
 cd "%GITHUB_WORKSPACE%\modflow6\autotest"
 where libpetsc.dll
 ldd ..\bin\mf6
-pixi run autotest --parallel -k "test_par" -m "%MARKERS%"
+pixi run pytest -v --durations=0 --keep-failed .failed --parallel -k "test_par" -m "%MARKERS%"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,26 +504,6 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./modflow6/.github/actions/test-par-win
 
-      - name: Test serial MF6
-        working-directory: modflow6
-        env:
-          REPOS_PATH: ${{ github.workspace }}
-        run: |
-          markers=""
-          if [[ "${{ github.ref_name }}" == "master" ]]; then
-            markers="not large and not developmode"
-          else
-            markers="not large"
-          fi
-
-          filters=""
-          if [[ "${{ matrix.os }}" == "macos-14" ]]; then
-            # comparison fails on macos-14 with optimization=1
-            filters="not test028_sfr_rewet"
-          fi
-
-          pixi run autotest -m "$markers" -k "$filters"
-
       - name: Upload failed test output
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Checkout modflow6
+      - name: Checkout MF6
         uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.8.1
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.24.2
 
@@ -76,7 +77,7 @@ jobs:
       FC_V: 13
     steps:
 
-      - name: Checkout modflow6
+      - name: Checkout MF6
         uses: actions/checkout@v4
       
       - name: Setup ${{ env.FC }} ${{ env.FC_V }}
@@ -85,21 +86,22 @@ jobs:
           compiler: gcc
           version: ${{ env.FC_V }}
 
-      - uses: prefix-dev/setup-pixi@v0.8.1
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.24.2
 
-      - name: Meson setup
+      - name: Setup MF6
         run: pixi run setup -Dwerror=true builddir
 
-      - name: Meson compile
+      - name: Build MF6
         run: pixi run build builddir
 
       - name: Show build log
         if: failure()
         run: cat builddir/meson-logs/meson-log.txt
 
-      - name: Meson test
+      - name: Unit test MF6
         run: pixi run test builddir
 
   smoke_test:
@@ -112,7 +114,7 @@ jobs:
       FC: gfortran
       FC_V: 13
     steps:
-      - name: Checkout modflow6
+      - name: Checkout MF6
         uses: actions/checkout@v4
         with:
           path: modflow6
@@ -146,7 +148,7 @@ jobs:
           pixi run --manifest-path=../modflow6/pixi.toml meson install -C builddir
           echo "PKG_CONFIG_PATH=$(pwd)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
-      - name: Build modflow6
+      - name: Build MF6
         working-directory: modflow6
         run: |
           pixi run setup builddir
@@ -157,7 +159,7 @@ jobs:
         working-directory: modflow6
         run: cat builddir/meson-logs/meson-log.txt
     
-      - name: Unit test programs
+      - name: Unit test MF6
         working-directory: modflow6
         run: pixi run test builddir
 
@@ -171,7 +173,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pixi run get-exes
 
-      - name: Test programs
+      - name: Test MF6
         working-directory: modflow6
         run: |
           if [ "${{ github.ref_name }}" == "master" ]; then
@@ -188,7 +190,7 @@ jobs:
           path: modflow6/autotest/.failed
 
   test_gfortran:
-    name: Test gnu fortran
+    name: Test GNU fortran
     needs:
       - lint
       - build
@@ -205,18 +207,18 @@ jobs:
       FC: gfortran
       FC_V: 13
     steps:
-      - name: Checkout modflow6
+      - name: Checkout MF6
         uses: actions/checkout@v4
         with:
           path: modflow6
 
-      - name: Checkout modflow6-testmodels
+      - name: Checkout test models
         uses: actions/checkout@v4
         with:
           repository: MODFLOW-USGS/modflow6-testmodels
           path: modflow6-testmodels
       
-      - name: Checkout modflow6-examples
+      - name: Checkout examples
         uses: actions/checkout@v4
         with:
           repository: MODFLOW-USGS/modflow6-examples
@@ -247,7 +249,7 @@ jobs:
             echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
           fi
 
-      - name: Build modflow6
+      - name: Build MF6
         working-directory: modflow6
         run: |
           setupargs=""
@@ -262,7 +264,7 @@ jobs:
         working-directory: modflow6
         run: cat builddir/meson-logs/meson-log.txt
       
-      - name: Unit test programs
+      - name: Unit test MF6
         working-directory: modflow6
         run: pixi run test builddir
 
@@ -276,7 +278,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pixi run get-exes
 
-      - name: Test modflow6
+      - name: Test MF6
         working-directory: modflow6
         env:
           REPOS_PATH: ${{ github.workspace }}
@@ -300,7 +302,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: modflowpy/install-modflow-action@v1
 
-      - name: Test mf6 examples
+      - name: Test MF6 examples
         if: runner.os == 'Linux'
         working-directory: modflow6
         shell: pixi run bash -e {0}
@@ -345,7 +347,7 @@ jobs:
         run: pixi run test-dist-scripts
 
   test_intel_fortran:
-    name: Test intel fortran
+    name: Test Intel fortran
     needs:
       - lint
       - build
@@ -363,18 +365,18 @@ jobs:
         shell: bash
     steps:
 
-      - name: Checkout modflow6
+      - name: Checkout MF6
         uses: actions/checkout@v4
         with:
           path: modflow6
 
-      - name: Checkout modflow6-testmodels
+      - name: Checkout test models
         uses: actions/checkout@v4
         with:
           repository: MODFLOW-USGS/modflow6-testmodels
           path: modflow6-testmodels
       
-      - name: Checkout modflow6-examples
+      - name: Checkout examples
         uses: actions/checkout@v4
         with:
           repository: MODFLOW-USGS/modflow6-examples
@@ -400,7 +402,7 @@ jobs:
         working-directory: modflow6
         run: pixi run update-version
 
-      - name: Build modflow6
+      - name: Build MF6
         working-directory: modflow6
         run: |
           pixi run setup builddir
@@ -411,7 +413,7 @@ jobs:
         working-directory: modflow6
         run: cat builddir/meson-logs/meson-log.txt
 
-      - name: Unit test programs
+      - name: Unit test MF6
         working-directory: modflow6
         run: pixi run test builddir
 
@@ -425,7 +427,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pixi run get-exes
 
-      - name: Test programs
+      - name: Test MF6
         working-directory: modflow6
         env:
           REPOS_PATH: ${{ github.workspace }}
@@ -440,7 +442,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: modflowpy/install-modflow-action@v1
 
-      - name: Test mf6 examples
+      - name: Test examples
         if: runner.os == 'Linux'
         working-directory: modflow6
         shell: pixi run bash -e {0}
@@ -479,7 +481,7 @@ jobs:
     
     steps:
 
-      - name: Checkout modflow6
+      - name: Checkout MF6
         uses: actions/checkout@v4
         with:
           path: modflow6
@@ -501,6 +503,26 @@ jobs:
       - name: Test parallel MF6 (Windows)
         if: runner.os == 'Windows'
         uses: ./modflow6/.github/actions/test-par-win
+
+      - name: Test serial MF6
+        working-directory: modflow6
+        env:
+          REPOS_PATH: ${{ github.workspace }}
+        run: |
+          markers=""
+          if [[ "${{ github.ref_name }}" == "master" ]]; then
+            markers="not large and not developmode"
+          else
+            markers="not large"
+          fi
+
+          filters=""
+          if [[ "${{ matrix.os }}" == "macos-14" ]]; then
+            # comparison fails on macos-14 with optimization=1
+            filters="not test028_sfr_rewet"
+          fi
+
+          pixi run autotest -m "$markers" -k "$filters"
 
       - name: Upload failed test output
         if: failure()
@@ -526,7 +548,7 @@ jobs:
 
     steps:
 
-      - name: Checkout modflow6
+      - name: Checkout MF6
         uses: actions/checkout@v4
         with:
           path: modflow6
@@ -545,7 +567,7 @@ jobs:
         working-directory: modflow6
         run: pixi run pip install xugrid xarray netcdf4
 
-      - name: Test Extended MF6
+      - name: Test extended MF6
         uses: ./modflow6/.github/actions/test-extended
 
       - name: Upload failed test output

--- a/autotest/test_par_gwf02.py
+++ b/autotest/test_par_gwf02.py
@@ -17,6 +17,8 @@ This constant head should reach all domains,
 no matter the topology of partitions
 """
 
+from platform import system
+
 import flopy
 import numpy as np
 import pytest
@@ -239,6 +241,9 @@ def check_output(idx, test):
 @pytest.mark.parallel
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
+    if system() == "Windows" and name.endswith(("d", "e", "f")):
+        pytest.skip("very slow on windows runners")
+
     ncpus = domain_grid[idx][0] * domain_grid[idx][1]
     test = TestFramework(
         name=name,


### PR DESCRIPTION
Skip the slowest parallel test cases on Windows CI. Also don't use xdist to avoid unwanted oversubscription (though we deliberately oversubscribe in the test cases themselves).

TODO: re-enable all autotests for parallel test job, rather than only parallel tests, since we want to make sure the parallel build doesn't regress any serial functionality.

xref https://github.com/actions/runner-images/issues/7320 where many others have reported inexplicably slow Windows runners

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Addresses #1955
- [x] Added new test or modified an existing test
- [x] Removed checklist items not relevant to this pull request