### PR TITLE
ci: add jobs to build/test with gfortran in debug mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
         working-directory: modflow6
         run: |
           setupargs=""
-          if [[ "${{ matrix.debug }}" == "true"]]; then
+          if [[ "${{ matrix.debug }}" == "true" ]]; then
             setupargs="-Ddebug=true -Doptimization=0"
           elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
             setupargs="-Doptimization=1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,17 +201,17 @@ jobs:
       matrix:
         include:
           - os: macos-12
-            debug: false
+            buildtype: release
           - os: macos-14
-            debug: false
+            buildtype: release
           - os: macos-14
-            debug: true
+            buildtype: debug
           - os: ubuntu-22.04
-            debug: false
+            buildtype: release
           - os: ubuntu-22.04
-            debug: true
+            buildtype: debug
           - os: windows-2022
-            debug: false
+            buildtype: release
     defaults:
       run:
         shell: bash
@@ -264,10 +264,8 @@ jobs:
       - name: Build MF6
         working-directory: modflow6
         run: |
-          setupargs=""
-          if [[ "${{ matrix.debug }}" ]]; then
-            setupargs="-Dbuildtype=debug"
-          elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
+          setupargs="-Dbuildtype=${{ matrix.buildtype }}"
+          if [[ ("${{ matrix.buildtype }}" == "release") && ("${{ matrix.os }}" == "macos-14") ]]; then
             setupargs="-Doptimization=1"
           fi
           pixi run setup builddir $setupargs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,17 +201,17 @@ jobs:
       matrix:
         include:
           - os: macos-12
-            buildtype: release
+            debug: false
           - os: macos-14
-            buildtype: release
+            debug: false
           - os: macos-14
-            buildtype: debug
+            debug: true
           - os: ubuntu-22.04
-            buildtype: release
+            debug: false
           - os: ubuntu-22.04
-            buildtype: debug
+            debug: true
           - os: windows-2022
-            buildtype: release
+            debug: false
     defaults:
       run:
         shell: bash
@@ -264,9 +264,9 @@ jobs:
       - name: Build MF6
         working-directory: modflow6
         run: |
-          setupargs="-Dbuildtype=${{ matrix.buildtype }}"
-          if [[ ("${{ matrix.buildtype }}" == "release") && ("${{ matrix.os }}" == "macos-14") ]]; then
-            setupargs="-Doptimization=1"
+          setupargs="-Ddebug=${{ matrix.debug }}"
+          if [[ ("${{ matrix.debug }}" == "false") && ("${{ matrix.os }}" == "macos-14") ]]; then
+            setupargs="$setupargs -Doptimization=1"
           fi
           pixi run setup builddir $setupargs
           pixi run build builddir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-12, macos-14, windows-2022 ]
+        include:
+          - os: macos-12
+            debug: false
+          - os: macos-14
+            debug: false
+          - os: macos-14
+            debug: true
+          - os: ubuntu-22.04
+            debug: false
+          - os: ubuntu-22.04
+            debug: true
+          - os: windows-2022
+            debug: false
     defaults:
       run:
         shell: bash
@@ -253,7 +265,9 @@ jobs:
         working-directory: modflow6
         run: |
           setupargs=""
-          if [[ "${{ matrix.os }}" == "macos-14" ]]; then
+          if [[ "${{ matrix.debug }}" ]]; then
+            setupargs="-Dbuildtype=debug"
+          elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
             setupargs="-Doptimization=1"
           fi
           pixi run setup builddir $setupargs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,9 +264,11 @@ jobs:
       - name: Build MF6
         working-directory: modflow6
         run: |
-          setupargs="-Ddebug=${{ matrix.debug }}"
-          if [[ ("${{ matrix.debug }}" == "false") && ("${{ matrix.os }}" == "macos-14") ]]; then
-            setupargs="$setupargs -Doptimization=1"
+          setupargs=""
+          if [[ "${{ matrix.debug }}" == "true"]]; then
+            setupargs="-Ddebug=true -Doptimization=0"
+          elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
+            setupargs="-Doptimization=1"
           fi
           pixi run setup builddir $setupargs
           pixi run build builddir

--- a/autotest/test_prt_disv1.py
+++ b/autotest/test_prt_disv1.py
@@ -414,7 +414,6 @@ def compare_output(name, mf6_pls, mp7_pls, mp7_eps):
     if "bprp" not in name:
         # pollock's method should be (nearly) identical
         mf6_pls_plck = mf6_pls[mf6_pls.particlegroup == 1]
-        # import pdb; pdb.set_trace()
         assert mf6_pls_plck.shape == mp7_pls.shape
         assert np.allclose(mf6_pls_plck, mp7_pls, atol=1e-3)
 


### PR DESCRIPTION
Add jobs to the gfortran test matrix in `ci.yml` to build and test in debug mode. The intent is to catch situations like the one fixed by #1959. To avoid too much CI burden this PR only adds `macos-14` and `ubuntu-22.04` jobs. This seems to add ~15min to total runtime.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #1959
- [x] Added new test or modified an existing test
- [x] Removed checklist items not relevant to this pull request