### PR TITLE
feat(netcdf): export and input stress period array support

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -128,18 +128,16 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--parallel"):
-        # --parallel given in cli: do not skip parallel tests
-        return
-    skip_parallel = pytest.mark.skip(reason="need --parallel option to run")
-    for item in items:
-        if "parallel" in item.keywords:
-            item.add_marker(skip_parallel)
+    if not config.getoption("--parallel"):
+        skip_parallel = pytest.mark.skip(
+            reason="need --parallel option to run"
+        )
+        for item in items:
+            if "parallel" in item.keywords:
+                item.add_marker(skip_parallel)
 
-    if config.getoption("--netcdf"):
-        # --netcdf given in cli: do not skip netcdf tests
-        return
-    skip_netcdf = pytest.mark.skip(reason="need --netcdf option to run")
-    for item in items:
-        if "netcdf" in item.keywords:
-            item.add_marker(skip_netcdf)
+    if not config.getoption("--netcdf"):
+        skip_netcdf = pytest.mark.skip(reason="need --netcdf option to run")
+        for item in items:
+            if "netcdf" in item.keywords:
+                item.add_marker(skip_netcdf)

--- a/autotest/test_netcdf_gwe_cnd.py
+++ b/autotest/test_netcdf_gwe_cnd.py
@@ -20,14 +20,11 @@ except:
     msg += " pip install flopy"
     raise Exception(msg)
 
-try:
-    import xarray as xa
-    import xugrid as xu
-except ImportError:
-    pytest.skip("xarray and xugrid not found", allow_module_level=True)
-
 from framework import TestFramework
 from test_gwe_cnd import cases
+
+xa = pytest.importorskip("xarray")
+xu = pytest.importorskip("xugrid")
 
 
 def build_models(idx, test, export, gridded_input):
@@ -162,7 +159,6 @@ def check_output(idx, test, export, gridded_input):
     nper = getattr(tdis, "nper").data
     nlay = getattr(dis, "nlay").data
     pd = getattr(tdis, "perioddata").array
-    print(pd)
     timestep = 0
     for i in range(nper):
         for j in range(int(pd[i][1])):

--- a/autotest/test_netcdf_gwf_disv.py
+++ b/autotest/test_netcdf_gwf_disv.py
@@ -13,10 +13,8 @@ import pytest
 from framework import TestFramework
 from test_gwf_disv import cases
 
-try:
-    import xugrid as xu
-except ImportError:
-    pytest.skip("xugrid not found", allow_module_level=True)
+xa = pytest.importorskip("xarray")
+xu = pytest.importorskip("xugrid")
 
 wkt = (
     'PROJCS["NAD83 / UTM zone 18N", '

--- a/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
+++ b/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
@@ -1,0 +1,269 @@
+"""
+NetCDF export test version of test_gwf_lak_wetlakbedarea02.  This test compares
+the temperature and input arrays in the the NetCDF file to those
+in the FloPy binary output head file and package data objects.
+"""
+
+# Imports
+
+import os
+import subprocess
+
+import numpy as np
+import pytest
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+try:
+    import xarray as xa
+    import xugrid as xu
+except ImportError:
+    pytest.skip("xarray and xugrid not found", allow_module_level=True)
+
+from framework import TestFramework
+from test_gwf_lak_wetlakbedarea02 import cases
+
+
+def build_models(idx, test, export, gridded_input):
+    from test_gwf_lak_wetlakbedarea02 import build_models as build
+
+    sim, dummy = build(idx, test)
+    sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
+    gwf = sim.gwf[0]
+    gwf.name_file.export_netcdf = export
+    gwf.dis.export_array_netcdf = True
+    gwf.ic.export_array_netcdf = True
+    gwf.npf.export_array_netcdf = True
+    gwf.rch.export_array_netcdf = True
+    gwf.evt.export_array_netcdf = True
+    print(gwf.rch)
+
+    name = cases[idx]
+    gwfname = "gwf-" + name
+
+    # netcdf config
+    ncf = flopy.mf6.ModflowUtlncf(
+        gwf.dis,
+        filename=f"{gwfname}.dis.ncf",
+    )
+
+    return sim, dummy
+
+
+def check_output(idx, test, export, gridded_input):
+    from test_gwf_lak_wetlakbedarea02 import check_output as check
+
+    name = cases[idx]
+    gwfname = "gwf-" + name
+
+    if gridded_input == "netcdf":
+        # re-run the simulation with model netcdf input
+        input_fname = f"{gwfname}.nc"
+        nc_fname = f"{gwfname}.{export}.nc"
+        subprocess.run(
+            ["mv", test.workspace / input_fname, test.workspace / nc_fname]
+        )
+
+        with open(test.workspace / f"{gwfname}.nam", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  SAVE_FLOWS\n")
+            f.write("  NEWTON\n")
+            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  NETCDF  FILEIN {gwfname}.{export}.nc\n")
+            f.write("END options\n\n")
+            f.write("BEGIN packages\n")
+            f.write(f"  DIS6  {gwfname}.dis  dis\n")
+            f.write(f"  NPF6  {gwfname}.npf  npf\n")
+            f.write(f"  STO6  {gwfname}.sto  sto\n")
+            f.write(f"  IC6  {gwfname}.ic  ic\n")
+            f.write(f"  CHD6  {gwfname}.chd  chd_0\n")
+            f.write(f"  RCH6  {gwfname}.rcha  rcha_0\n")
+            f.write(f"  EVT6  {gwfname}.evta  evta_0\n")
+            f.write(f"  LAK6  {gwfname}.lak  lak-1\n")
+            f.write(f"  OC6  {gwfname}.oc  oc\n")
+            f.write("END packages\n")
+
+        with open(test.workspace / f"{gwfname}.dis", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  LENGTH_UNITS feet\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write(f"  NCF6  FILEIN  {gwfname}.dis.ncf\n")
+            f.write("END options\n\n")
+            f.write("BEGIN dimensions\n")
+            f.write("  NLAY  6\n")
+            f.write("  NROW  17\n")
+            f.write("  NCOL  17\n")
+            f.write("END dimensions\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  delr NETCDF\n")
+            f.write("  delc NETCDF\n")
+            f.write("  top NETCDF\n")
+            f.write("  botm NETCDF\n")
+            f.write("  idomain NETCDF\n")
+            f.write("END griddata\n\n")
+
+        with open(test.workspace / f"{gwfname}.ic", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  strt NETCDF\n")
+            f.write("END griddata\n")
+
+        with open(test.workspace / f"{gwfname}.npf", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  SAVE_SPECIFIC_DISCHARGE\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  icelltype  NETCDF\n")
+            f.write("  k  NETCDF\n")
+            f.write("  k33  NETCDF\n")
+            f.write("END griddata\n")
+
+        with open(test.workspace / f"{gwfname}.rcha", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  READASARRAYS\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN period 1\n")
+            f.write("  recharge NETCDF\n")
+            f.write("END period 1\n")
+
+        with open(test.workspace / f"{gwfname}.evta", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  READASARRAYS\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN period 1\n")
+            f.write("  surface NETCDF\n")
+            f.write("  rate NETCDF\n")
+            f.write("  depth NETCDF\n")
+            f.write("END period 1\n")
+
+        success, buff = flopy.run_model(
+            test.targets["mf6"],
+            test.workspace / "mfsim.nam",
+            model_ws=test.workspace,
+            report=True,
+        )
+
+        assert success
+        test.success = success
+
+    check(idx, test)
+
+    # read transport results from GWF model
+    name = cases[idx]
+    gwfname = "gwf-" + name
+
+    try:
+        # load heads
+        fname = gwfname + ".hds"
+        fpth = os.path.join(test.workspace, fname)
+        hobj = flopy.utils.HeadFile(fpth, precision="double")
+        heads = hobj.get_alldata()
+    except:
+        assert False, f'could not load headfile data from "{fpth}"'
+
+    # Check NetCDF output
+    nc_fpth = os.path.join(test.workspace, f"{gwfname}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
+
+    # Compare NetCDF head arrays with binary headfile temperatures
+    gwf = test.sims[0].gwf[0]
+    dis = getattr(gwf, "dis")
+    tdis = getattr(test.sims[0], "tdis")
+    nper = getattr(tdis, "nper").data
+    nlay = getattr(dis, "nlay").data
+    pd = getattr(tdis, "perioddata").array
+    print(pd)
+    timestep = 0
+    for i in range(nper):
+        for j in range(int(pd[i][1])):
+            rec = hobj.get_data(kstpkper=(j, i))
+            if export == "ugrid":
+                for l in range(nlay):
+                    assert np.allclose(
+                        np.array(rec[l]).flatten(),
+                        # xds[f"head_l{l+1}"][timestep, :].data,
+                        xds[f"head_l{l+1}"][timestep, :]
+                        .fillna(1.00000000e30)
+                        .data,
+                    ), f"NetCDF-temperature comparison failure in timestep {timestep+1}"
+                timestep += 1
+            elif export == "structured":
+                print("compare")
+                print(np.array(rec))
+                print(xds["head"][timestep, :].data)
+                assert np.allclose(
+                    # np.array(rec).flatten(),
+                    np.array(rec),
+                    xds["head"][timestep, :].fillna(1.00000000e30).data,
+                ), f"NetCDF-head comparison failure in timestep {timestep+1}"
+                timestep += 1
+
+    vlist = [
+        "dis_delr",
+        "dis_delc",
+        "dis_top",
+        "dis_botm_l",
+        "dis_idomain_l",
+        "ic_strt_l",
+        "npf_icelltype_l",
+        "npf_k_l",
+    ]
+
+    # Compare NetCDF package input arrays with FloPy arrays
+    gwf = test.sims[0].gwf[0]
+    for i, var in enumerate(vlist):
+        tokens = var.split("_", 1)
+        package_name = tokens[0]
+        array_name = tokens[1].split("_")[0]
+        package = getattr(gwf, package_name)
+        b = getattr(package, array_name).array
+        if export == "ugrid":
+            if var.endswith("_l"):
+                for l in range(nlay):
+                    assert np.allclose(
+                        np.array(b[l]).flatten(), xds[f"{var}{l+1}"].data
+                    ), f"NetCDF input array comparison failure, variable={var}{l+1}"
+            else:
+                assert np.allclose(
+                    np.array(b).flatten(), xds[var].data
+                ), f"NetCDF input array comparison failure, variable={var}"
+        elif export == "structured":
+            var = var.replace("_l", "")
+            assert np.allclose(
+                # np.array(b).flatten(), xds[var].data
+                np.array(b),
+                xds[var].data,
+            ), f"NetCDF input array comparison failure, variable={var}"
+
+
+@pytest.mark.netcdf
+@pytest.mark.parametrize(
+    "idx, name",
+    list(enumerate(cases)),
+)
+@pytest.mark.parametrize("export", ["ugrid", "structured"])
+@pytest.mark.parametrize("gridded_input", ["ascii", "netcdf"])
+def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t, export, gridded_input),
+        check=lambda t: check_output(idx, t, export, gridded_input),
+        targets=targets,
+    )
+    test.run()

--- a/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
+++ b/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
@@ -20,14 +20,11 @@ except:
     msg += " pip install flopy"
     raise Exception(msg)
 
-try:
-    import xarray as xa
-    import xugrid as xu
-except ImportError:
-    pytest.skip("xarray and xugrid not found", allow_module_level=True)
-
 from framework import TestFramework
 from test_gwf_lak_wetlakbedarea02 import cases
+
+xa = pytest.importorskip("xarray")
+xu = pytest.importorskip("xugrid")
 
 
 def build_models(idx, test, export, gridded_input):
@@ -42,7 +39,6 @@ def build_models(idx, test, export, gridded_input):
     gwf.npf.export_array_netcdf = True
     gwf.rch.export_array_netcdf = True
     gwf.evt.export_array_netcdf = True
-    print(gwf.rch)
 
     name = cases[idx]
     gwfname = "gwf-" + name
@@ -187,7 +183,6 @@ def check_output(idx, test, export, gridded_input):
     nper = getattr(tdis, "nper").data
     nlay = getattr(dis, "nlay").data
     pd = getattr(tdis, "perioddata").array
-    print(pd)
     timestep = 0
     for i in range(nper):
         for j in range(int(pd[i][1])):
@@ -203,9 +198,6 @@ def check_output(idx, test, export, gridded_input):
                     ), f"NetCDF-temperature comparison failure in timestep {timestep+1}"
                 timestep += 1
             elif export == "structured":
-                print("compare")
-                print(np.array(rec))
-                print(xds["head"][timestep, :].data)
                 assert np.allclose(
                     # np.array(rec).flatten(),
                     np.array(rec),

--- a/autotest/test_netcdf_gwf_rch01.py
+++ b/autotest/test_netcdf_gwf_rch01.py
@@ -1,0 +1,242 @@
+"""
+NetCDF export test version of test_gwf_rch01.  This test compares
+the temperature and input arrays in the the NetCDF file to those
+in the FloPy binary output head file and package data objects.
+"""
+
+# Imports
+
+import os
+import subprocess
+
+import numpy as np
+import pytest
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+try:
+    import xarray as xa
+    import xugrid as xu
+except ImportError:
+    pytest.skip("xarray and xugrid not found", allow_module_level=True)
+
+from framework import TestFramework
+from test_gwf_rch01 import cases
+
+
+def build_models(idx, test, export, gridded_input):
+    from test_gwf_rch01 import build_models as build
+
+    sim, dummy = build(idx, test)
+    sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
+    gwf = sim.gwf[0]
+    gwf.name_file.export_netcdf = export
+    gwf.dis.export_array_netcdf = True
+    gwf.ic.export_array_netcdf = True
+    gwf.npf.export_array_netcdf = True
+    gwf.rch.export_array_netcdf = True
+    print(gwf.rch)
+
+    name = "rch"
+
+    # netcdf config
+    ncf = flopy.mf6.ModflowUtlncf(
+        gwf.dis,
+        filename=f"{name}.dis.ncf",
+    )
+
+    return sim, dummy
+
+
+def check_output(idx, test, export, gridded_input):
+    from test_gwf_rch01 import check_output as check
+
+    name = "rch"
+
+    if gridded_input == "netcdf":
+        # re-run the simulation with model netcdf input
+        input_fname = f"{name}.nc"
+        nc_fname = f"{name}.{export}.nc"
+        subprocess.run(
+            ["mv", test.workspace / input_fname, test.workspace / nc_fname]
+        )
+
+        with open(test.workspace / f"{name}.nam", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  SAVE_FLOWS\n")
+            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  NETCDF  FILEIN {name}.{export}.nc\n")
+            f.write("END options\n\n")
+            f.write("BEGIN packages\n")
+            f.write(f"  DIS6  {name}.dis  dis\n")
+            f.write(f"  IC6  {name}.ic  ic\n")
+            f.write(f"  NPF6  {name}.npf  npf\n")
+            f.write(f"  STO6  {name}.sto  sto\n")
+            f.write(f"  CHD6  {name}.chd  chd_0\n")
+            f.write(f"  RCH6  {name}.rcha  rcha_0\n")
+            f.write(f"  OC6  {name}.oc  oc\n")
+            f.write("END packages\n")
+
+        with open(test.workspace / f"{name}.dis", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write(f"  NCF6  FILEIN  {name}.dis.ncf\n")
+            f.write("END options\n\n")
+            f.write("BEGIN dimensions\n")
+            f.write("  NLAY  2\n")
+            f.write("  NROW  1\n")
+            f.write("  NCOL  5\n")
+            f.write("END dimensions\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  delr NETCDF\n")
+            f.write("  delc NETCDF\n")
+            f.write("  top NETCDF\n")
+            f.write("  botm NETCDF\n")
+            f.write("END griddata\n\n")
+
+        with open(test.workspace / f"{name}.ic", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  strt NETCDF\n")
+            f.write("END griddata\n")
+
+        with open(test.workspace / f"{name}.npf", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  SAVE_FLOWS\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  icelltype  NETCDF\n")
+            f.write("  k  NETCDF\n")
+            f.write("END griddata\n")
+
+        with open(test.workspace / f"{name}.rcha", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  READASARRAYS\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN period 1\n")
+            if idx > 0:
+                f.write("  irch NETCDF\n")
+            f.write("  recharge NETCDF\n")
+            f.write("END period 1\n")
+
+        success, buff = flopy.run_model(
+            test.targets["mf6"],
+            test.workspace / "mfsim.nam",
+            model_ws=test.workspace,
+            report=True,
+        )
+
+        assert success
+        test.success = success
+
+    check(idx, test)
+
+    # read transport results from GWF model
+    name = "rch"
+
+    try:
+        # load heads
+        fpth = os.path.join(test.workspace, "rch.hds")
+        hobj = flopy.utils.HeadFile(fpth, precision="double")
+        heads = hobj.get_alldata()
+    except:
+        assert False, f'could not load headfile data from "{fpth}"'
+
+    # Check NetCDF output
+    nc_fpth = os.path.join(test.workspace, f"{name}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
+
+    # Compare NetCDF head arrays with binary headfile temperatures
+    gwf = test.sims[0].gwf[0]
+    dis = getattr(gwf, "dis")
+    tdis = getattr(test.sims[0], "tdis")
+    nper = getattr(tdis, "nper").data
+    nlay = getattr(dis, "nlay").data
+    pd = getattr(tdis, "perioddata").array
+    print(pd)
+    timestep = 0
+    for i in range(nper):
+        for j in range(int(pd[i][1])):
+            rec = hobj.get_data(kstpkper=(j, i))
+            if export == "ugrid":
+                for l in range(nlay):
+                    assert np.allclose(
+                        np.array(rec[l]).flatten(),
+                        xds[f"head_l{l+1}"][timestep, :].data,
+                    ), f"NetCDF-temperature comparison failure in timestep {timestep+1}"
+                timestep += 1
+            elif export == "structured":
+                assert np.allclose(
+                    # np.array(rec).flatten(),
+                    np.array(rec),
+                    xds["head"][timestep, :].data,
+                ), f"NetCDF-head comparison failure in timestep {timestep+1}"
+                timestep += 1
+
+    vlist = [
+        "dis_delr",
+        "dis_delc",
+        "dis_top",
+        "dis_botm_l",
+        "ic_strt_l",
+        "npf_icelltype_l",
+        "npf_k_l",
+    ]
+
+    # Compare NetCDF package input arrays with FloPy arrays
+    gwf = test.sims[0].gwf[0]
+    for i, var in enumerate(vlist):
+        tokens = var.split("_", 1)
+        package_name = tokens[0]
+        array_name = tokens[1].split("_")[0]
+        package = getattr(gwf, package_name)
+        b = getattr(package, array_name).array
+        if export == "ugrid":
+            if var.endswith("_l"):
+                for l in range(nlay):
+                    assert np.allclose(
+                        np.array(b[l]).flatten(), xds[f"{var}{l+1}"].data
+                    ), f"NetCDF input array comparison failure, variable={var}{l+1}"
+            else:
+                assert np.allclose(
+                    np.array(b).flatten(), xds[var].data
+                ), f"NetCDF input array comparison failure, variable={var}"
+        elif export == "structured":
+            var = var.replace("_l", "")
+            assert np.allclose(
+                # np.array(b).flatten(), xds[var].data
+                np.array(b),
+                xds[var].data,
+            ), f"NetCDF input array comparison failure, variable={var}"
+
+
+@pytest.mark.netcdf
+@pytest.mark.parametrize(
+    "idx, name",
+    list(enumerate(cases)),
+)
+@pytest.mark.parametrize("export", ["ugrid", "structured"])
+@pytest.mark.parametrize("gridded_input", ["ascii", "netcdf"])
+def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t, export, gridded_input),
+        check=lambda t: check_output(idx, t, export, gridded_input),
+        targets=targets,
+    )
+    test.run()

--- a/autotest/test_netcdf_gwf_rch03.py
+++ b/autotest/test_netcdf_gwf_rch03.py
@@ -1,0 +1,248 @@
+"""
+NetCDF export test version of test_gwf_rch03.  This test compares
+the temperature and input arrays in the the NetCDF file to those
+in the FloPy binary output head file and package data objects.
+"""
+
+# Imports
+
+import os
+import subprocess
+
+import numpy as np
+import pytest
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+try:
+    import xarray as xa
+    import xugrid as xu
+except ImportError:
+    pytest.skip("xarray and xugrid not found", allow_module_level=True)
+
+from framework import TestFramework
+from test_gwf_rch03 import cases
+
+
+def build_models(idx, test, export, gridded_input):
+    from test_gwf_rch03 import build_models as build
+
+    sim, dummy = build(idx, test)
+    sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
+    gwf = sim.gwf[0]
+    gwf.name_file.export_netcdf = export
+    gwf.dis.export_array_netcdf = True
+    gwf.ic.export_array_netcdf = True
+    gwf.npf.export_array_netcdf = True
+    gwf.rch.export_array_netcdf = True
+    print(gwf.rch)
+
+    # name = "gwf-" + cases[idx]
+    name = "rch"
+
+    # netcdf config
+    ncf = flopy.mf6.ModflowUtlncf(
+        gwf.dis,
+        filename=f"{name}.dis.ncf",
+    )
+
+    return sim, dummy
+
+
+def check_output(idx, test, export, gridded_input):
+    from test_gwf_rch03 import check_output as check
+
+    name = "rch"
+
+    if gridded_input == "netcdf":
+        # re-run the simulation with model netcdf input
+        input_fname = f"{name}.nc"
+        nc_fname = f"{name}.{export}.nc"
+        subprocess.run(
+            ["mv", test.workspace / input_fname, test.workspace / nc_fname]
+        )
+
+        with open(test.workspace / f"{name}.nam", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  SAVE_FLOWS\n")
+            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  NETCDF  FILEIN {name}.{export}.nc\n")
+            f.write("END options\n\n")
+            f.write("BEGIN packages\n")
+            f.write(f"  DIS6  {name}.dis  dis\n")
+            f.write(f"  IC6  {name}.ic  ic\n")
+            f.write(f"  NPF6  {name}.npf  npf\n")
+            f.write(f"  CHD6  {name}.chd  chd_0\n")
+            f.write(f"  RCH6  {name}.rcha  rcha_0\n")
+            f.write(f"  OC6  {name}.oc  oc\n")
+            f.write("END packages\n")
+
+        with open(test.workspace / f"{name}.dis", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write(f"  NCF6  FILEIN  {name}.dis.ncf\n")
+            f.write("END options\n\n")
+            f.write("BEGIN dimensions\n")
+            f.write("  NLAY  2\n")
+            f.write("  NROW  4\n")
+            f.write("  NCOL  5\n")
+            f.write("END dimensions\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  delr NETCDF\n")
+            f.write("  delc NETCDF\n")
+            f.write("  top NETCDF\n")
+            f.write("  botm NETCDF\n")
+            f.write("  idomain NETCDF\n")
+            f.write("END griddata\n\n")
+
+        with open(test.workspace / f"{name}.ic", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  strt NETCDF\n")
+            f.write("END griddata\n")
+
+        with open(test.workspace / f"{name}.npf", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  SAVE_FLOWS\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  icelltype  NETCDF\n")
+            f.write("  k  NETCDF\n")
+            f.write("END griddata\n")
+
+        with open(test.workspace / f"{name}.rcha", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  READASARRAYS\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN period 1\n")
+            f.write("  irch NETCDF\n")
+            f.write("  recharge NETCDF\n")
+            f.write("END period 1\n")
+
+        success, buff = flopy.run_model(
+            test.targets["mf6"],
+            test.workspace / "mfsim.nam",
+            model_ws=test.workspace,
+            report=True,
+        )
+
+        assert success
+        test.success = success
+
+    check(idx, test)
+
+    # read transport results from GWF model
+    name = "rch"
+
+    try:
+        # load heads
+        fpth = os.path.join(test.workspace, "rch.hds")
+        hobj = flopy.utils.HeadFile(fpth, precision="double")
+        heads = hobj.get_alldata()
+    except:
+        assert False, f'could not load headfile data from "{fpth}"'
+
+    # Check NetCDF output
+    nc_fpth = os.path.join(test.workspace, f"{name}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
+
+    # Compare NetCDF head arrays with binary headfile temperatures
+    gwf = test.sims[0].gwf[0]
+    dis = getattr(gwf, "dis")
+    tdis = getattr(test.sims[0], "tdis")
+    nper = getattr(tdis, "nper").data
+    nlay = getattr(dis, "nlay").data
+    pd = getattr(tdis, "perioddata").array
+    print(pd)
+    timestep = 0
+    for i in range(nper):
+        for j in range(int(pd[i][1])):
+            rec = hobj.get_data(kstpkper=(j, i))
+            if export == "ugrid":
+                for l in range(nlay):
+                    assert np.allclose(
+                        np.array(rec[l]).flatten(),
+                        xds[f"head_l{l+1}"][timestep, :]
+                        .fillna(1.00000000e30)
+                        .data,
+                    ), f"NetCDF-temperature comparison failure in timestep {timestep+1}"
+                timestep += 1
+            elif export == "structured":
+                print("compare")
+                print(np.array(rec))
+                print(xds["head"][timestep, :].data)
+                assert np.allclose(
+                    # np.array(rec).flatten(),
+                    np.array(rec),
+                    xds["head"][timestep, :].fillna(1.00000000e30).data,
+                ), f"NetCDF-head comparison failure in timestep {timestep+1}"
+                timestep += 1
+
+    vlist = [
+        "dis_delr",
+        "dis_delc",
+        "dis_top",
+        "dis_botm_l",
+        "dis_idomain_l",
+        "ic_strt_l",
+        "npf_icelltype_l",
+        "npf_k_l",
+    ]
+
+    # Compare NetCDF package input arrays with FloPy arrays
+    gwf = test.sims[0].gwf[0]
+    for i, var in enumerate(vlist):
+        tokens = var.split("_", 1)
+        package_name = tokens[0]
+        array_name = tokens[1].split("_")[0]
+        package = getattr(gwf, package_name)
+        b = getattr(package, array_name).array
+        if export == "ugrid":
+            if var.endswith("_l"):
+                for l in range(nlay):
+                    assert np.allclose(
+                        np.array(b[l]).flatten(), xds[f"{var}{l+1}"].data
+                    ), f"NetCDF input array comparison failure, variable={var}{l+1}"
+            else:
+                assert np.allclose(
+                    np.array(b).flatten(), xds[var].data
+                ), f"NetCDF input array comparison failure, variable={var}"
+        elif export == "structured":
+            var = var.replace("_l", "")
+            assert np.allclose(
+                # np.array(b).flatten(), xds[var].data
+                np.array(b),
+                xds[var].data,
+            ), f"NetCDF input array comparison failure, variable={var}"
+
+
+@pytest.mark.netcdf
+@pytest.mark.parametrize(
+    "idx, name",
+    list(enumerate(cases)),
+)
+@pytest.mark.parametrize("export", ["ugrid", "structured"])
+@pytest.mark.parametrize("gridded_input", ["ascii", "netcdf"])
+def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t, export, gridded_input),
+        check=lambda t: check_output(idx, t, export, gridded_input),
+        targets=targets,
+    )
+    test.run()

--- a/autotest/test_netcdf_gwf_sto01.py
+++ b/autotest/test_netcdf_gwf_sto01.py
@@ -11,11 +11,8 @@ import pytest
 from framework import TestFramework
 from test_gwf_sto01 import cases
 
-try:
-    import xarray as xa
-    import xugrid as xu
-except ImportError:
-    pytest.skip("xarray and xugrid not found", allow_module_level=True)
+xa = pytest.importorskip("xarray")
+xu = pytest.importorskip("xugrid")
 
 htol = [None for _ in range(len(cases))]
 

--- a/autotest/test_netcdf_gwf_vsc03_sfr.py
+++ b/autotest/test_netcdf_gwf_vsc03_sfr.py
@@ -1,0 +1,276 @@
+"""
+NetCDF export test version of test_gwf_vsc03_sfr.  This test compares
+the temperature and input arrays in the the NetCDF file to those
+in the FloPy binary output head file and package data objects.
+"""
+
+# Imports
+
+import os
+import subprocess
+
+import numpy as np
+import pytest
+
+try:
+    import flopy
+except:
+    msg = "Error. FloPy package is not available.\n"
+    msg += "Try installing using the following command:\n"
+    msg += " pip install flopy"
+    raise Exception(msg)
+
+try:
+    import xarray as xa
+    import xugrid as xu
+except ImportError:
+    pytest.skip("xarray and xugrid not found", allow_module_level=True)
+
+from framework import TestFramework
+from test_gwf_vsc03_sfr import cases
+
+
+def build_models(idx, test, export, gridded_input):
+    from test_gwf_vsc03_sfr import build_models as build
+
+    sim, dummy = build(idx, test)
+    sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
+    gwf = sim.gwf[0]
+    gwf.name_file.export_netcdf = export
+    gwf.dis.export_array_netcdf = True
+    gwf.ic.export_array_netcdf = True
+    gwf.npf.export_array_netcdf = True
+    gwf.sto.export_array_netcdf = True
+    gwf.rcha.export_array_netcdf = True
+    assert gwf.rcha
+    assert gwf.sto
+
+    name = "gwf-" + cases[idx]
+
+    # netcdf config
+    ncf = flopy.mf6.ModflowUtlncf(
+        gwf.dis,
+        filename=f"{name}.dis.ncf",
+    )
+
+    return sim, dummy
+
+
+def check_output(idx, test, export, gridded_input):
+    from test_gwf_vsc03_sfr import check_output as check
+
+    name = "gwf-" + test.name
+
+    if gridded_input == "netcdf":
+        # re-run the simulation with model netcdf input
+        input_fname = f"{name}.nc"
+        nc_fname = f"{name}.{export}.nc"
+        subprocess.run(
+            ["mv", test.workspace / input_fname, test.workspace / nc_fname]
+        )
+
+        with open(test.workspace / f"{name}.nam", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  SAVE_FLOWS\n")
+            f.write("  NEWTON\n")
+            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  NETCDF  FILEIN {name}.{export}.nc\n")
+            f.write("END options\n\n")
+            f.write("BEGIN packages\n")
+            f.write(f"  DIS6  {name}.dis  dis\n")
+            f.write(f"  NPF6  {name}.npf  npf\n")
+            f.write(f"  STO6  {name}.sto  sto\n")
+            f.write(f"  IC6  {name}.ic  ic\n")
+            if idx == 1:
+                f.write("  VSC6  gwf-vsc-sfr01.vsc  vsc\n")
+            f.write(f"  OC6  {name}.oc  oc\n")
+            f.write(f"  RCH6  {name}.rcha  rcha-1\n")
+            f.write(f"  EVT6  {name}.evt  evt-1\n")
+            f.write(f"  SFR6  {name}.sfr  sfr-1\n")
+            f.write("END packages\n")
+
+        with open(test.workspace / f"{name}.dis", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  LENGTH_UNITS m\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write(f"  NCF6  FILEIN  {name}.dis.ncf\n")
+            f.write("END options\n\n")
+            f.write("BEGIN dimensions\n")
+            f.write("  NLAY  1\n")
+            f.write("  NROW  60\n")
+            f.write("  NCOL  200\n")
+            f.write("END dimensions\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  delr NETCDF\n")
+            f.write("  delc NETCDF\n")
+            f.write("  top NETCDF\n")
+            f.write("  botm NETCDF\n")
+            f.write("END griddata\n\n")
+
+        with open(test.workspace / f"{name}.ic", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  strt NETCDF\n")
+            f.write("END griddata\n")
+
+        with open(test.workspace / f"{name}.npf", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  SAVE_SPECIFIC_DISCHARGE\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  icelltype  NETCDF\n")
+            f.write("  k  NETCDF\n")
+            f.write("END griddata\n")
+
+        with open(test.workspace / f"{name}.sto", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN griddata\n")
+            f.write("  iconvert  NETCDF\n")
+            f.write("  ss  NETCDF\n")
+            f.write("  sy  NETCDF\n")
+            f.write("END griddata\n")
+            f.write("BEGIN period 1\n")
+            f.write("  STEADY-STATE\n")
+            f.write("END period 1\n")
+            f.write("BEGIN period 2\n")
+            f.write("  TRANSIENT\n")
+            f.write("END period 2\n")
+
+        with open(test.workspace / f"{name}.rcha", "w") as f:
+            f.write("BEGIN options\n")
+            f.write("  READASARRAYS\n")
+            f.write("  auxiliary  TEMPERATURE\n")
+            f.write("  PRINT_FLOWS\n")
+            f.write("  EXPORT_ARRAY_NETCDF\n")
+            f.write("END options\n\n")
+            f.write("BEGIN period 1\n")
+            f.write("  irch NETCDF\n")
+            f.write("  recharge NETCDF\n")
+            f.write("  TEMPERATURE  NETCDF\n")
+            f.write("END period 1\n")
+
+        success, buff = flopy.run_model(
+            test.targets["mf6"],
+            test.workspace / "mfsim.nam",
+            model_ws=test.workspace,
+            report=True,
+        )
+
+        assert success
+        test.success = success
+
+    check(idx, test)
+
+    # read transport results from GWF model
+    name = "gwf-" + cases[idx]
+
+    try:
+        # load heads
+        fpth = os.path.join(test.workspace, f"{name}.hds")
+        hobj = flopy.utils.HeadFile(fpth, precision="double")
+        heads = hobj.get_alldata()
+    except:
+        assert False, f'could not load headfile data from "{fpth}"'
+
+    # Check NetCDF output
+    nc_fpth = os.path.join(test.workspace, f"{name}.nc")
+    if export == "ugrid":
+        ds = xu.open_dataset(nc_fpth)
+        xds = ds.ugrid.to_dataset()
+    elif export == "structured":
+        xds = xa.open_dataset(nc_fpth)
+
+    # Compare NetCDF head arrays with binary headfile temperatures
+    gwf = test.sims[0].gwf[0]
+    dis = getattr(gwf, "dis")
+    tdis = getattr(test.sims[0], "tdis")
+    nper = getattr(tdis, "nper").data
+    nlay = getattr(dis, "nlay").data
+    pd = getattr(tdis, "perioddata").array
+    print(pd)
+    timestep = 0
+    for i in range(nper):
+        for j in range(int(pd[i][1])):
+            rec = hobj.get_data(kstpkper=(j, i))
+            if export == "ugrid":
+                for l in range(nlay):
+                    assert np.allclose(
+                        np.array(rec[l]).flatten(),
+                        # xds[f"head_l{l+1}"][timestep, :].data,
+                        xds[f"head_l{l+1}"][timestep, :]
+                        .fillna(1.00000000e30)
+                        .data,
+                    ), f"NetCDF-temperature comparison failure in timestep {timestep+1}"
+                timestep += 1
+            elif export == "structured":
+                print("compare")
+                print(np.array(rec))
+                print(xds["head"][timestep, :].data)
+                assert np.allclose(
+                    # np.array(rec).flatten(),
+                    np.array(rec),
+                    xds["head"][timestep, :].fillna(1.00000000e30).data,
+                ), f"NetCDF-head comparison failure in timestep {timestep+1}"
+                timestep += 1
+
+    vlist = [
+        "dis_delr",
+        "dis_delc",
+        "dis_top",
+        "dis_botm_l",
+        "ic_strt_l",
+        "npf_icelltype_l",
+        "npf_k_l",
+        "sto_iconvert_l",
+        "sto_ss_l",
+        "sto_sy_l",
+    ]
+
+    # Compare NetCDF package input arrays with FloPy arrays
+    gwf = test.sims[0].gwf[0]
+    for i, var in enumerate(vlist):
+        tokens = var.split("_", 1)
+        package_name = tokens[0]
+        array_name = tokens[1].split("_")[0]
+        package = getattr(gwf, package_name)
+        b = getattr(package, array_name).array
+        if export == "ugrid":
+            if var.endswith("_l"):
+                for l in range(nlay):
+                    assert np.allclose(
+                        np.array(b[l]).flatten(), xds[f"{var}{l+1}"].data
+                    ), f"NetCDF input array comparison failure, variable={var}{l+1}"
+            else:
+                assert np.allclose(
+                    np.array(b).flatten(), xds[var].data
+                ), f"NetCDF input array comparison failure, variable={var}"
+        elif export == "structured":
+            var = var.replace("_l", "")
+            assert np.allclose(
+                # np.array(b).flatten(), xds[var].data
+                np.array(b),
+                xds[var].data,
+            ), f"NetCDF input array comparison failure, variable={var}"
+
+
+@pytest.mark.netcdf
+@pytest.mark.parametrize(
+    "idx, name",
+    list(enumerate(cases)),
+)
+@pytest.mark.parametrize("export", ["ugrid", "structured"])
+@pytest.mark.parametrize("gridded_input", ["ascii", "netcdf"])
+def test_mf6model(idx, name, function_tmpdir, targets, export, gridded_input):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t, export, gridded_input),
+        check=lambda t: check_output(idx, t, export, gridded_input),
+        targets=targets,
+    )
+    test.run()

--- a/autotest/test_netcdf_gwt_dsp01.py
+++ b/autotest/test_netcdf_gwt_dsp01.py
@@ -11,11 +11,8 @@ import pytest
 from framework import TestFramework
 from test_gwt_dsp01 import cases, xt3d
 
-try:
-    import xarray as xa
-    import xugrid as xu
-except ImportError:
-    pytest.skip("xarray and xugrid not found", allow_module_level=True)
+xa = pytest.importorskip("xarray")
+xu = pytest.importorskip("xugrid")
 
 
 def build_models(idx, test, export, gridded_input):

--- a/autotest/test_netcdf_gwt_prudic2004t2.py
+++ b/autotest/test_netcdf_gwt_prudic2004t2.py
@@ -11,11 +11,8 @@ import pytest
 from framework import TestFramework
 from test_gwt_prudic2004t2 import cases
 
-try:
-    import xarray as xa
-    import xugrid as xu
-except ImportError:
-    pytest.skip("xarray and xugrid not found", allow_module_level=True)
+xa = pytest.importorskip("xarray")
+xu = pytest.importorskip("xugrid")
 
 
 def build_models(idx, test, export, gridded_input):

--- a/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
@@ -141,6 +141,14 @@ optional false
 longname obs6 input filename
 description REPLACE obs6_filename {'{#1}': 'Evapotranspiration'}
 
+block options
+name export_array_netcdf
+type keyword
+reader urword
+optional true
+mf6internal export_nc
+longname export array variables to netcdf output files.
+description keyword that specifies input griddata arrays should be written to the model output netcdf file.
 
 # --------------------- gwf evta period ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-evta.dfn
@@ -209,6 +209,6 @@ type double precision
 shape (ncol*nrow; ncpl)
 reader readarray
 time_series true
-longname auxiliary variable iaux
+longname evapotranspiration auxiliary variable iaux
 description is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.
 mf6internal auxvar

--- a/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
@@ -141,6 +141,14 @@ optional false
 longname obs6 input filename
 description REPLACE obs6_filename {'{#1}': 'Recharge'}
 
+block options
+name export_array_netcdf
+type keyword
+reader urword
+optional true
+mf6internal export_nc
+longname export array variables to netcdf output files.
+description keyword that specifies input griddata arrays should be written to the model output netcdf file.
 
 # --------------------- gwf rcha period ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-rcha.dfn
@@ -192,6 +192,6 @@ shape (ncol*nrow; ncpl)
 reader readarray
 time_series true
 optional true
-longname auxiliary variable iaux
+longname recharge auxiliary variable iaux
 description is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array.
 mf6internal auxvar

--- a/src/Idm/gwf-evtaidm.f90
+++ b/src/Idm/gwf-evtaidm.f90
@@ -26,6 +26,7 @@ module GwfEvtaInputModule
     logical :: obs_filerecord = .false.
     logical :: obs6 = .false.
     logical :: obs6_filename = .false.
+    logical :: export_nc = .false.
     logical :: ievt = .false.
     logical :: surface = .false.
     logical :: rate = .false.
@@ -294,6 +295,24 @@ module GwfEvtaInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
+    gwfevta_export_nc = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'EVTA', & ! subcomponent
+    'OPTIONS', & ! block
+    'EXPORT_ARRAY_NETCDF', & ! tag name
+    'EXPORT_NC', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'export array variables to netcdf output files.', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
     gwfevta_ievt = InputParamDefinitionType &
     ( &
     'GWF', & ! component
@@ -400,6 +419,7 @@ module GwfEvtaInputModule
     gwfevta_obs_filerecord, &
     gwfevta_obs6, &
     gwfevta_obs6_filename, &
+    gwfevta_export_nc, &
     gwfevta_ievt, &
     gwfevta_surface, &
     gwfevta_rate, &

--- a/src/Idm/gwf-evtaidm.f90
+++ b/src/Idm/gwf-evtaidm.f90
@@ -394,7 +394,7 @@ module GwfEvtaInputModule
     'AUXVAR', & ! fortran variable
     'DOUBLE2D', & ! type
     'NAUX NCPL', & ! shape
-    'auxiliary variable iaux', & ! longname
+    'evapotranspiration auxiliary variable iaux', & ! longname
     .true., & ! required
     .false., & ! multi-record
     .false., & ! preserve case

--- a/src/Idm/gwf-rchaidm.f90
+++ b/src/Idm/gwf-rchaidm.f90
@@ -26,6 +26,7 @@ module GwfRchaInputModule
     logical :: obs_filerecord = .false.
     logical :: obs6 = .false.
     logical :: obs6_filename = .false.
+    logical :: export_nc = .false.
     logical :: irch = .false.
     logical :: recharge = .false.
     logical :: auxvar = .false.
@@ -292,6 +293,24 @@ module GwfRchaInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
+    gwfrcha_export_nc = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'RCHA', & ! subcomponent
+    'OPTIONS', & ! block
+    'EXPORT_ARRAY_NETCDF', & ! tag name
+    'EXPORT_NC', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'export array variables to netcdf output files.', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
     gwfrcha_irch = InputParamDefinitionType &
     ( &
     'GWF', & ! component
@@ -362,6 +381,7 @@ module GwfRchaInputModule
     gwfrcha_obs_filerecord, &
     gwfrcha_obs6, &
     gwfrcha_obs6_filename, &
+    gwfrcha_export_nc, &
     gwfrcha_irch, &
     gwfrcha_recharge, &
     gwfrcha_auxvar &

--- a/src/Idm/gwf-rchaidm.f90
+++ b/src/Idm/gwf-rchaidm.f90
@@ -356,7 +356,7 @@ module GwfRchaInputModule
     'AUXVAR', & ! fortran variable
     'DOUBLE2D', & ! type
     'NAUX NCPL', & ! shape
-    'auxiliary variable iaux', & ! longname
+    'recharge auxiliary variable iaux', & ! longname
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case

--- a/src/Utilities/Export/DisNCMesh.f90
+++ b/src/Utilities/Export/DisNCMesh.f90
@@ -1065,7 +1065,7 @@ contains
     if (iper > 0) then
       fill_value = DNODATA
     else
-      fill_value = NF90_FILL_INT
+      fill_value = NF90_FILL_DOUBLE
     end if
     !
     allocate (var_id(dis%nlay))

--- a/src/Utilities/Export/DisvNCMesh.f90
+++ b/src/Utilities/Export/DisvNCMesh.f90
@@ -856,7 +856,7 @@ contains
     if (iper > 0) then
       fill_value = DNODATA
     else
-      fill_value = NF90_FILL_INT
+      fill_value = NF90_FILL_DOUBLE
     end if
     !
     allocate (var_id(disv%nlay))

--- a/src/Utilities/Export/MeshNCModel.f90
+++ b/src/Utilities/Export/MeshNCModel.f90
@@ -26,7 +26,7 @@ module MeshModelModule
   public :: ncvar_deflate
   public :: ncvar_gridmap
   public :: ncvar_mf6attr
-  public :: export_varname, export_longname
+  public :: export_varname
 
   !> @brief type for storing model export dimension ids
   !<
@@ -247,11 +247,6 @@ contains
         if (export_arrays > 0) then
           pkgtype = idm_subcomponent_type(this%modeltype, ptype)
           param_dfns => param_definitions(this%modeltype, pkgtype)
-          !if (idm_multi_package(this%modeltype, pkgtype)) then
-          !  call this%export_input_arrays(pname, mempath, param_dfns)
-          !else
-          !  call this%export_input_arrays(pkgtype, mempath, param_dfns)
-          !end if
           call this%export_input_arrays(ptype, pname, mempath, param_dfns)
         end if
       end if
@@ -498,6 +493,8 @@ contains
                                 'start_index', 1), this%nc_fname)
   end subroutine create_mesh
 
+  !> @brief define variable chunking
+  !<
   subroutine ncvar_chunk(ncid, varid, chunk_face, nc_fname)
     integer(I4B), intent(in) :: ncid
     integer(I4B), intent(in) :: varid
@@ -511,6 +508,8 @@ contains
     end if
   end subroutine ncvar_chunk
 
+  !> @brief define variable compression
+  !<
   subroutine ncvar_deflate(ncid, varid, deflate, shuffle, nc_fname)
     integer(I4B), intent(in) :: ncid
     integer(I4B), intent(in) :: varid
@@ -525,6 +524,8 @@ contains
     end if
   end subroutine ncvar_deflate
 
+  !> @brief put variable gridmap attributes
+  !<
   subroutine ncvar_gridmap(ncid, varid, gridmap_name, nc_fname)
     integer(I4B), intent(in) :: ncid
     integer(I4B), intent(in) :: varid
@@ -539,6 +540,8 @@ contains
     end if
   end subroutine ncvar_gridmap
 
+  !> @brief put variable internal attributes
+  !<
   subroutine ncvar_mf6attr(ncid, varid, layer, iper, iaux, nc_tag, nc_fname)
     integer(I4B), intent(in) :: ncid
     integer(I4B), intent(in) :: varid
@@ -568,6 +571,8 @@ contains
     end if
   end subroutine ncvar_mf6attr
 
+  !> @brief build netcdf variable name
+  !<
   function export_varname(varname, layer, iper, iaux) result(vname)
     use InputOutputModule, only: lowcase
     character(len=*), intent(in) :: varname
@@ -598,34 +603,5 @@ contains
       end if
     end if
   end function export_varname
-
-  function export_longname(longname, pkgname, tagname, layer, iper) result(lname)
-    use InputOutputModule, only: lowcase
-    character(len=*), intent(in) :: longname
-    character(len=*), intent(in) :: pkgname
-    character(len=*), intent(in) :: tagname
-    integer(I4B), intent(in) :: layer
-    integer(I4B), optional, intent(in) :: iper
-    character(len=LINELENGTH) :: lname
-    character(len=LINELENGTH) :: pname, vname
-    !
-    pname = pkgname
-    vname = tagname
-    !call lowcase(pname)
-    !call lowcase(vname)
-    if (longname == '') then
-      lname = trim(pname)//' '//trim(vname)
-    else
-      lname = longname
-    end if
-    if (layer > 0) then
-      write (lname, '(a,i0)') trim(lname)//' layer=', layer
-    end if
-    if (present(iper)) then
-      if (iper > 0) then
-        write (lname, '(a,i0)') trim(lname)//' period=', iper
-      end if
-    end if
-  end function export_longname
 
 end module MeshModelModule

--- a/src/Utilities/Export/ModelExport.f90
+++ b/src/Utilities/Export/ModelExport.f90
@@ -216,7 +216,7 @@ contains
     class(ExportModelType), intent(inout) :: this
     !
     if (associated(this%nc_export)) then
-      call this%nc_export%step_rp()
+      call this%nc_export%export_input()
     end if
   end subroutine post_prepare
 

--- a/src/Utilities/Export/NCModel.f90
+++ b/src/Utilities/Export/NCModel.f90
@@ -9,23 +9,41 @@ module NCModelExportModule
 
   use KindModule, only: DP, I4B, LGP
   use ConstantsModule, only: LINELENGTH, LENCOMPONENTNAME, LENMODELNAME, &
-                             LENMEMPATH, LENBIGLINE, DIS, DISU, DISV
+                             LENMEMPATH, LENBIGLINE, LENVARNAME, DIS, DISU, DISV
   use SimVariablesModule, only: errmsg
   use SimModule, only: store_error, store_error_filename
+  use InputLoadTypeModule, only: ModelDynamicPkgsType
+  use ModflowInputModule, only: ModflowInputType
+  use BoundInputContextModule, only: ReadStateVarType, rsv_name
+  use ListModule, only: ListType
 
   implicit none
   private
   public :: NCBaseModelExportType, NCModelExportType
   public :: NCExportAnnotation
+  public :: ExportPackageType
   public :: NETCDF_UNDEF, NETCDF_STRUCTURED, NETCDF_UGRID
 
   !> @brief netcdf export types enumerator
   !<
   ENUM, BIND(C)
     ENUMERATOR :: NETCDF_UNDEF = 0 !< undefined netcdf export type
-    ENUMERATOR :: NETCDF_STRUCTURED = 1 !< netcdf structrured export
-    ENUMERATOR :: NETCDF_UGRID = 2 !< netcdf mesh export
+    ENUMERATOR :: NETCDF_UGRID = 1 !< netcdf mesh export
+    ENUMERATOR :: NETCDF_STRUCTURED = 2 !< netcdf structrured export
   END ENUM
+
+  type :: ExportPackageType
+    type(ModflowInputType) :: mf6_input !< description of modflow6 input
+    character(len=LINELENGTH), dimension(:), allocatable :: param_names !< dynamic param tagnames
+    type(ReadStateVarType), dimension(:), allocatable :: param_reads !< param read states
+    integer(I4B), dimension(:), pointer, contiguous :: mshape => null() !< model shape
+    integer(I4B), pointer :: iper !< most recent package rp load
+    integer(I4B) :: iper_export !< most recent period of netcdf package export
+    integer(I4B) :: nparam !< number of in scope params
+  contains
+    procedure :: init => epkg_init
+    procedure :: destroy => epkg_destroy
+  end type ExportPackageType
 
   !> @brief netcdf export attribute annotations
   !<
@@ -45,11 +63,12 @@ module NCModelExportModule
   !> @brief base class for an export model
   !<
   type :: NCModelExportType
+    type(ListType) :: pkglist
     character(len=LENMODELNAME) :: modelname !< name of model
     character(len=LENCOMPONENTNAME) :: modeltype !< type of model
     character(len=LINELENGTH) :: modelfname !< name of model input file
     character(len=LINELENGTH) :: nc_fname !< name of netcdf export file
-    character(len=LINELENGTH) :: gridmap_name = 'projection' !< name of grid mapping variable
+    character(len=LINELENGTH) :: gridmap_name !< name of grid mapping variable
     character(len=LINELENGTH) :: mesh_name = 'mesh' !< name of mesh container variable
     character(len=LENMEMPATH) :: dis_mempath !< discretization input mempath
     character(len=LENMEMPATH) :: ncf_mempath !< netcdf utility package input mempath
@@ -70,6 +89,8 @@ module NCModelExportModule
     logical(LGP) :: chunking_active !< have chunking parameters been provided
   contains
     procedure :: init => export_init
+    procedure :: get => export_get
+    procedure :: input_attribute
     procedure :: destroy => export_destroy
   end type NCModelExportType
 
@@ -77,24 +98,90 @@ module NCModelExportModule
   !<
   type, abstract, extends(NCModelExportType) :: NCBaseModelExportType
   contains
-    procedure(model_define_if), deferred :: df
-    procedure(model_step_if), deferred :: step
+    procedure :: step_rp
+    procedure(model_define), deferred :: df
+    procedure(model_step), deferred :: step
+    procedure(model_export_period), deferred :: export_period
+    procedure(model_export_period_ilayer), deferred :: export_period_ilayer
   end type NCBaseModelExportType
 
   !> @brief abstract interfaces for model netcdf export type
   !<
   abstract interface
-    subroutine model_define_if(this)
+    subroutine model_define(this)
       import NCBaseModelExportType
       class(NCBaseModelExportType), intent(inout) :: this
     end subroutine
-    subroutine model_step_if(this)
+    subroutine model_step(this)
       import NCBaseModelExportType
       class(NCBaseModelExportType), intent(inout) :: this
+    end subroutine
+    subroutine model_export_period(this, export_pkg)
+      import NCBaseModelExportType, ExportPackageType
+      class(NCBaseModelExportType), intent(inout) :: this
+      class(ExportPackageType), intent(in) :: export_pkg
+    end subroutine
+    subroutine model_export_period_ilayer(this, export_pkg, ilayer_varname, &
+                                          ilayer)
+      import NCBaseModelExportType, ExportPackageType, I4B
+      class(NCBaseModelExportType), intent(inout) :: this
+      class(ExportPackageType), intent(in) :: export_pkg
+      character(len=*), intent(in) :: ilayer_varname
+      integer(I4B), intent(in) :: ilayer
     end subroutine
   end interface
 
 contains
+
+  subroutine epkg_init(this, mf6_input, mshape, param_names, &
+                       nparam)
+    use SimVariablesModule, only: idm_context
+    use MemoryManagerModule, only: mem_setptr
+    use MemoryManagerExtModule, only: mem_set_value
+    use MemoryHelperModule, only: create_mem_path
+    ! -- dummy
+    class(ExportPackageType), intent(inout) :: this
+    type(ModflowInputType), intent(in) :: mf6_input
+    integer(I4B), dimension(:), pointer, contiguous, intent(in) :: mshape !< model shape
+    character(len=LINELENGTH), dimension(:), allocatable, &
+      intent(in) :: param_names
+    integer(I4B), intent(in) :: nparam
+    integer(I4B) :: n
+    character(len=LENVARNAME) :: rs_varname
+    character(len=LENMEMPATH) :: input_mempath
+    integer(I4B), pointer :: rsvar
+    !
+    this%mf6_input = mf6_input
+    this%mshape => mshape
+    this%nparam = nparam
+    this%iper_export = 0
+    !
+    input_mempath = create_mem_path(component=mf6_input%component_name, &
+                                    subcomponent=mf6_input%subcomponent_name, &
+                                    context=idm_context)
+    !
+    ! -- allocate param arrays
+    allocate (this%param_names(nparam))
+    allocate (this%param_reads(nparam))
+    !
+    ! -- set param arrays
+    do n = 1, nparam
+      this%param_names(n) = param_names(n)
+      rs_varname = rsv_name(param_names(n))
+      call mem_setptr(rsvar, rs_varname, mf6_input%mempath)
+      this%param_reads(n)%invar => rsvar
+    end do
+    !
+    ! -- set pointer to loaded input period
+    call mem_setptr(this%iper, 'IPER', mf6_input%mempath)
+  end subroutine epkg_init
+
+  subroutine epkg_destroy(this)
+    use InputDefinitionModule, only: InputParamDefinitionType
+    ! -- dummy
+    class(ExportPackageType), intent(inout) :: this
+    if (allocated(this%param_names)) deallocate (this%param_names)
+  end subroutine epkg_destroy
 
   !> @brief set netcdf file scoped attributes
   !<
@@ -197,7 +284,7 @@ contains
     this%modeltype = modeltype
     this%modelfname = modelfname
     this%nc_fname = trim(modelname)//'.nc'
-    call lowcase(this%nc_fname)
+    this%gridmap_name = ''
     this%ncf_mempath = ''
     this%ogc_wkt = ''
     this%datetime = ''
@@ -212,6 +299,8 @@ contains
     this%chunk_time = -1
     this%iout = iout
     this%chunking_active = .false.
+    !
+    call lowcase(this%nc_fname)
     !
     ! -- set file scoped attributes
     call this%annotation%set(modelname, modeltype, modelfname, nctype)
@@ -260,6 +349,10 @@ contains
                          found%chunk_time)
     end if
     !
+    if (found%ogc_wkt) then
+      this%gridmap_name = 'projection'
+    end if
+    !
     ! -- ATTR_OFF turns off modflow 6 input attributes
     if (found%attr_off) then
       this%input_attr = 0
@@ -278,12 +371,86 @@ contains
     this%totnstp = sum(nstp)
   end subroutine export_init
 
+  function export_get(this, idx) result(res)
+    use ListModule, only: ListType
+    class(NCModelExportType), intent(inout) :: this
+    integer(I4B), intent(in) :: idx
+    class(ExportPackageType), pointer :: res
+    class(*), pointer :: obj
+    !
+    nullify (res)
+    obj => this%pkglist%GetItem(idx)
+    if (associated(obj)) then
+      select type (obj)
+      class is (ExportPackageType)
+        res => obj
+      end select
+    end if
+  end function export_get
+
+  function input_attribute(this, pkgname, idt) result(attr)
+    use InputOutputModule, only: lowcase
+    use MemoryHelperModule, only: memPathSeparator
+    use InputDefinitionModule, only: InputParamDefinitionType
+    class(NCModelExportType), intent(inout) :: this
+    character(len=*), intent(in) :: pkgname
+    type(InputParamDefinitionType), pointer, intent(in) :: idt
+    character(len=LINELENGTH) :: attr
+    !
+    attr = ''
+    !
+    if (this%input_attr > 0) then
+      attr = trim(this%modelname)//memPathSeparator//trim(pkgname)// &
+             memPathSeparator//trim(idt%mf6varname)
+    end if
+  end function input_attribute
+
+  !> @brief netcdf export rp_step
+  !<
+  subroutine step_rp(this)
+    use TdisModule, only: kper
+    use ArrayHandlersModule, only: ifind
+    class(NCBaseModelExportType), intent(inout) :: this
+    integer(I4B) :: idx, ilayer
+    class(ExportPackageType), pointer :: export_pkg
+    character(len=LENVARNAME) :: ilayer_varname
+    !
+    do idx = 1, this%pkglist%Count()
+      !
+      export_pkg => this%get(idx)
+      ! -- last loaded data is not current period
+      if (export_pkg%iper /= kper) cycle
+      ! -- period input already exported
+      if (export_pkg%iper_export >= export_pkg%iper) cycle
+      ! -- set exported iper
+      export_pkg%iper_export = export_pkg%iper
+      !
+      ! -- initialize ilayer
+      ilayer = 0
+      !
+      ! -- set expected ilayer index variable name
+      ilayer_varname = 'I'//trim(export_pkg%mf6_input%subcomponent_type(1:3))
+      !
+      ! -- is ilayer variable in param name list
+      ilayer = ifind(export_pkg%param_names, ilayer_varname)
+      !
+      ! -- layer index variable is required to be first defined in period block
+      if (ilayer == 1) then
+        call this%export_period_ilayer(export_pkg, ilayer_varname, ilayer)
+      else
+        call this%export_period(export_pkg)
+      end if
+      !
+    end do
+  end subroutine step_rp
+
   !> @brief destroy model netcdf export object
   !<
   subroutine export_destroy(this)
     use MemoryManagerExtModule, only: memorystore_remove
     use SimVariablesModule, only: idm_context
     class(NCModelExportType), intent(inout) :: this
+    !
     ! -- override in derived class
     deallocate (this%deflate)
     deallocate (this%shuffle)

--- a/src/Utilities/Idm/BoundInputContext.f90
+++ b/src/Utilities/Idm/BoundInputContext.f90
@@ -20,6 +20,7 @@ module BoundInputContextModule
   private
   public :: BoundInputContextType
   public :: ReadStateVarType
+  public :: rsv_name
 
   !> @brief Pointer type for read state variable
   !<
@@ -357,18 +358,9 @@ contains
     character(len=*), intent(in) :: mf6varname
     ! -- local
     character(len=LENVARNAME) :: varname
-    integer(I4B) :: ilen
     integer(I4B), pointer :: intvar
-    character(len=2) :: prefix = 'IN'
     !
-    ! -- assign first column as the block number
-    ilen = len_trim(mf6varname)
-    !
-    if (ilen > (LENVARNAME - len(prefix))) then
-      varname = prefix//mf6varname(1:(LENVARNAME - len(prefix)))
-    else
-      varname = prefix//trim(mf6varname)
-    end if
+    varname = rsv_name(mf6varname)
     !
     call mem_allocate(intvar, varname, this%mf6_input%mempath)
     intvar = -1
@@ -423,5 +415,30 @@ contains
     ! -- return
     return
   end subroutine bound_params
+
+  !> @brief create read state variable name
+  !!
+  !<
+  function rsv_name(mf6varname) result(varname)
+    ! -- modules
+    use ConstantsModule, only: LENVARNAME
+    ! -- dummy
+    character(len=*), intent(in) :: mf6varname
+    ! -- local
+    character(len=LENVARNAME) :: varname
+    integer(I4B) :: ilen
+    character(len=2) :: prefix = 'IN'
+    !
+    ilen = len_trim(mf6varname)
+    !
+    if (ilen > (LENVARNAME - len(prefix))) then
+      varname = prefix//mf6varname(1:(LENVARNAME - len(prefix)))
+    else
+      varname = prefix//trim(mf6varname)
+    end if
+    !
+    ! -- return
+    return
+  end function rsv_name
 
 end module BoundInputContextModule

--- a/src/Utilities/Idm/IdmLoad.f90
+++ b/src/Utilities/Idm/IdmLoad.f90
@@ -583,7 +583,7 @@ contains
     return
   end subroutine dynamic_da
 
-  !> @brief return sim input context PRINT_INTPUT value
+  !> @brief return sim input context PRINT_INPUT value
   !<
   function input_param_log() result(paramlog)
     use MemoryHelperModule, only: create_mem_path

--- a/src/Utilities/Idm/ModelPackageInputs.f90
+++ b/src/Utilities/Idm/ModelPackageInputs.f90
@@ -181,7 +181,13 @@ contains
     !
     ! -- set pkgname if empty
     if (this%pkgnames(this%pnum) == '') then
-      write (pname, '(a,i0)') trim(this%subcomponent_type)//'-', this%pnum
+      if (multi_pkg_type(mtype_component, &
+                         this%subcomponent_type, &
+                         filetype)) then
+        write (pname, '(a,i0)') trim(this%subcomponent_type)//'-', this%pnum
+      else
+        write (pname, '(a,i0)') trim(this%subcomponent_type)
+      end if
       this%pkgnames(this%pnum) = pname
     end if
     !

--- a/src/Utilities/Idm/SourceLoad.F90
+++ b/src/Utilities/Idm/SourceLoad.F90
@@ -21,7 +21,8 @@ module SourceLoadModule
   public :: open_source_file
   public :: load_modelnam, load_simnam, load_simtdis
   public :: remote_model_ndim
-  public :: export_cr, export_post_step, export_da
+  public :: export_cr, export_da
+  public :: export_post_prepare, export_post_step
   public :: nc_close
   public :: netcdf_context
 
@@ -65,7 +66,7 @@ contains
     ! -- initialize loader
     call loader%init(mf6_input, component_name, component_fname, input_fname)
     !
-    ! -- initialize loader netcdf variables structure
+    ! -- initialize loader netcdf variables data structure
     if (present(nc_vars)) then
       call nc_vars%create_varlists(component_name, sc_name, loader%nc_vars)
     else
@@ -362,6 +363,14 @@ contains
     end if
   end subroutine export_cr
 
+  !> @brief model exports post prepare step actions
+  !<
+  subroutine export_post_prepare()
+    ! -- modules
+    use ModelExportModule, only: modelexports_post_prepare
+    call modelexports_post_prepare()
+  end subroutine export_post_prepare
+
   !> @brief model exports post step actions
   !<
   subroutine export_post_step()
@@ -406,7 +415,7 @@ contains
 #if defined(__WITH_NETCDF__)
     use NCContextBuildModule, only: open_ncfile, create_netcdf_context
 #endif
-    ! -- drummy
+    ! -- dummy
     character(len=*), intent(in) :: modeltype
     character(len=*), intent(in) :: component_type
     character(len=*), intent(in) :: modelname

--- a/src/Utilities/Idm/mf6blockfile/LoadNCInput.F90
+++ b/src/Utilities/Idm/mf6blockfile/LoadNCInput.F90
@@ -45,7 +45,7 @@ contains
   !> @brief Read a NetCDF integer 1d array
   !<
   subroutine nc_read_int1d(int1d, mshape, idt, mf6_input, nc_vars, input_fname, &
-                           iout)
+                           iout, kper)
     integer(I4B), dimension(:), pointer, contiguous, intent(in) :: int1d
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: mshape !< model shape
     type(InputParamDefinitionType), intent(in) :: idt !< input data type object describing this record
@@ -53,9 +53,10 @@ contains
     type(NCPackageVarsType), pointer, intent(in) :: nc_vars
     character(len=*), intent(in) :: input_fname
     integer(I4B), intent(in) :: iout
+    integer(I4B), optional, intent(in) :: kper
 #if defined(__WITH_NETCDF__)
     call netcdf_array_load(int1d, mshape, idt, mf6_input, nc_vars, input_fname, &
-                           iout)
+                           iout, kper)
 #else
     call error_and_exit(idt%tagname, input_fname)
 #endif
@@ -102,7 +103,7 @@ contains
   !> @brief Read a NetCDF double 1d array
   !<
   subroutine nc_read_dbl1d(dbl1d, mshape, idt, mf6_input, nc_vars, input_fname, &
-                           iout)
+                           iout, kper, iaux)
     real(DP), dimension(:), pointer, contiguous, intent(in) :: dbl1d
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: mshape !< model shape
     type(InputParamDefinitionType), intent(in) :: idt !< input data type object describing this record
@@ -110,9 +111,11 @@ contains
     type(NCPackageVarsType), pointer, intent(in) :: nc_vars
     character(len=*), intent(in) :: input_fname
     integer(I4B), intent(in) :: iout
+    integer(I4B), optional, intent(in) :: kper
+    integer(I4B), optional, intent(in) :: iaux
 #if defined(__WITH_NETCDF__)
     call netcdf_array_load(dbl1d, mshape, idt, mf6_input, nc_vars, input_fname, &
-                           iout)
+                           iout, kper=kper, iaux=iaux)
 #else
     call error_and_exit(idt%tagname, input_fname)
 #endif

--- a/src/Utilities/Idm/netcdf/NCContextBuild.f90
+++ b/src/Utilities/Idm/netcdf/NCContextBuild.f90
@@ -73,11 +73,13 @@ contains
     character(len=NETCDF_ATTR_STRLEN) :: input_str
     character(len=LENCOMPONENTNAME) :: c_name, sc_name
     character(len=LINELENGTH) :: mempath, varname
-    integer(I4B) :: layer, mf6_layer
+    integer(I4B) :: layer, period, iaux, mf6_layer, mf6_period, mf6_iaux
     logical(LGP) :: success
     !
     ! -- initialize
     layer = -1
+    period = -1
+    iaux = -1
     varname = ''
     c_name = ''
     sc_name = ''
@@ -104,8 +106,20 @@ contains
           layer = mf6_layer
         end if
         !
+        ! -- check for optional period attribute
+        if (nf90_get_att(nc_vars%ncid, varid, &
+                         'modflow6_iper', mf6_period) == NF90_NOERR) then
+          period = mf6_period
+        end if
+        !
+        ! -- check for optional period attribute
+        if (nf90_get_att(nc_vars%ncid, varid, &
+                         'modflow6_iaux', mf6_iaux) == NF90_NOERR) then
+          iaux = mf6_iaux
+        end if
+        !
         ! -- add the variable to netcdf description
-        call nc_vars%add(sc_name, varname, layer, varid)
+        call nc_vars%add(sc_name, varname, layer, period, iaux, varid)
       else
         errmsg = 'NetCDF variable invalid modflow6_input attribute: "'// &
                  trim(input_str)//'".'

--- a/src/mf6core.f90
+++ b/src/mf6core.f90
@@ -488,6 +488,7 @@ contains
     use SimModule, only: converge_reset
     use SimVariablesModule, only: isim_mode
     use IdmLoadModule, only: idm_rp
+    use SourceLoadModule, only: export_post_prepare
     ! -- local variables
     class(BaseModelType), pointer :: mp => null()
     class(BaseExchangeType), pointer :: ep => null()
@@ -572,6 +573,9 @@ contains
       sp => GetBaseSolutionFromList(basesolutionlist, is)
       call sp%sln_dt()
     end do
+    !
+    ! -- update exports
+    call export_post_prepare()
     !
     ! -- set time step
     call tdis_set_timestep()


### PR DESCRIPTION
NetCDF support for input and export stress period array data:
  - ```ugrid``` and ```structured``` netcdf files supported
  - primarily focused on index layer variable based packages (```evta```, ```rcha```)
  - will need minor updates to support non-index layer variable based packages
  - layer variable is stored as a layer variable (```ncpl```) in the netcdf file
  - to support visualization, period data variables are stored fully gridded in the netcdf file
  - added use of ```modflow6_iper``` and ```modflow6_iaux``` internal attributes
  - netcdf documentation will be in a separate, forthcoming PR

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Added new test or modified an existing test
- [X] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Added doxygen comments to new and modified procedures
- [X] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).