### PR TITLE
fix(compiler) Fixes a compilation error occurring when using the intel 19.* compiler on windows

### DIFF
--- a/src/Exchange/DisConnExchange.f90
+++ b/src/Exchange/DisConnExchange.f90
@@ -202,7 +202,7 @@ contains
     ! -- dummy
     class(DisConnExchangeType) :: this !< instance of exchange object
     class(NumericalModelType), pointer, intent(in) :: model
-    integer(I4B), dimension(:), pointer, intent(in) :: cellid
+    integer(I4B), dimension(:), intent(in) :: cellid
     integer(I4B), intent(in) :: iout !< the output file unit
     integer(I4B) :: noder, node
     !
@@ -231,7 +231,7 @@ contains
     ! -- dummy
     class(DisConnExchangeType) :: this !< instance of exchange object
     integer(I4B) :: ndim !< model DIS dimension
-    integer(I4B), dimension(:), pointer, intent(in) :: cellid
+    integer(I4B), dimension(:), intent(in) :: cellid
     integer(I4B), intent(in) :: iout !< the output file unit
     character(len=20) :: cellstr
     character(len=*), parameter :: fmtndim1 = &

--- a/src/Exchange/exg-swfgwf.f90
+++ b/src/Exchange/exg-swfgwf.f90
@@ -562,7 +562,7 @@ contains
     ! -- dummy
     class(SwfGwfExchangeType) :: this !< instance of exchange object
     class(NumericalModelType), pointer, intent(in) :: model
-    integer(I4B), dimension(:), pointer, intent(in) :: cellid
+    integer(I4B), dimension(:), intent(in) :: cellid
     integer(I4B), intent(in) :: iout !< the output file unit
     integer(I4B) :: noder, node
     !
@@ -591,7 +591,7 @@ contains
     ! -- dummy
     class(SwfGwfExchangeType) :: this !< instance of exchange object
     class(NumericalModelType), pointer, intent(in) :: model
-    integer(I4B), dimension(:), pointer, intent(in) :: cellid
+    integer(I4B), dimension(:), intent(in) :: cellid
     integer(I4B), intent(in) :: iout !< the output file unit
     character(len=20) :: cellstr
     character(len=*), parameter :: fmtndim1 = &


### PR DESCRIPTION
While compiling MODFLOW on windows using a intel fortran 19.* compiler the error as stated below is produced.
This commit fixes it. It removes the the pointer definition making the variable a reference.

```
FAILED: src/libmf6core.a.p/Exchange_DisConnExchange.f90.obj src/libmf6core.a.p/disconnexchangemodule.mod
"ifort" "-Isrc\libmf6core.a.p" "-Isrc" "-I..\src" "-Isrc\libmf6_external.a.p" "/MTd" "/nologo" "/warn:general" "/warn:truncated_source" "/stand:f08" "/Zi" "/traceback" "/O2" "/fpe:0" "/heap-arrays:0" "/traceback" "/fpp" "/Qdiag-disable:7416" "/Qdiag-disable:7025" "/Qdiag-disable:5268" "/Qdiag-disable:10448" "/Fdsrc\libmf6core.a.p\Exchange_DisConnExchange.f90.pdb" "/module:src\libmf6core.a.p" /Fosrc/libmf6core.a.p/Exchange_DisConnExchange.f90.obj "/c" ../src/Exchange/DisConnExchange.f90
../src/Exchange\DisConnExchange.f90(323): error #7121: A ptr dummy may only be argument associated with a ptr, and this array element or section does not inherit the POINTER attr from its parent array.   [CELLIDM1]
        nodem1 = this%noder(this%model1, cellidm1(:, iexg), iout)
-----------------------------------------^
../src/Exchange\DisConnExchange.f90(333): error #7121: A ptr dummy may only be argument associated with a ptr, and this array element or section does not inherit the POINTER attr from its parent array.   [CELLIDM2]
        nodem2 = this%noder(this%model2, cellidm2(:, iexg), iout)
-----------------------------------------^
../src/Exchange\DisConnExchange.f90(354): error #7121: A ptr dummy may only be argument associated with a ptr, and this array element or section does not inherit the POINTER attr from its parent array.   [CELLIDM1]
        cellstr1 = this%cellstr(ndim1, cellidm1(:, iexg), iout)
---------------------------------------^
../src/Exchange\DisConnExchange.f90(355): error #7121: A ptr dummy may only be argument associated with a ptr, and this array element or section does not inherit the POINTER attr from its parent array.   [CELLIDM2]
        cellstr2 = this%cellstr(ndim2, cellidm2(:, iexg), iout)
---------------------------------------^
../src/Exchange\DisConnExchange.f90(373): error #7121: A ptr dummy may only be argument associated with a ptr, and this array element or section does not inherit the POINTER attr from its parent array.   [CELLIDM1]
          cellstr1 = this%cellstr(ndim1, cellidm1(:, iexg), iout)
-----------------------------------------^
../src/Exchange\DisConnExchange.f90(385): error #7121: A ptr dummy may only be argument associated with a ptr, and this array element or section does not inherit the POINTER attr from its parent array.   [CELLIDM2]
          cellstr2 = this%cellstr(ndim2, cellidm2(:, iexg), iout)
-----------------------------------------^
compilation aborted for ../src/Exchange/DisConnExchange.f90 (code 1)
[334/541] Compiling Fortran object src/libmf6core.a.p/Distributed_VirtualGwfExchange.f90.obj
ninja: build stopped: subcommand failed.
Could not rebuild C:\dev\modflow6\builddir
```

- [ ] Replaced section above with description of pull request
- [ ] Closed issue #xxxx
- [ ] Referenced issue or pull request #xxxx
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).