### PR TITLE
fix(par): header receive counter was allocated to the wrong size

### DIFF
--- a/src/Distributed/MpiRouter.f90
+++ b/src/Distributed/MpiRouter.f90
@@ -364,6 +364,7 @@ contains
   !!     and maps, from the virtual data containers, and cache
   !<
   subroutine compose_messages(this, unit, stage, body_snd_t, body_rcv_t)
+    use SimModule, only: ustop
     class(MpiRouterType) :: this
     integer(I4B) :: unit
     integer(I4B) :: stage
@@ -402,7 +403,7 @@ contains
     allocate (hdr_rcv_t(this%receivers%size))
     allocate (hdr_snd_t(this%senders%size))
     allocate (headers(max_headers, this%receivers%size))
-    allocate (hdr_rcv_cnt(max_headers))
+    allocate (hdr_rcv_cnt(this%receivers%size))
 
     ! allocate map data
     allocate (map_snd_t(this%senders%size))

--- a/src/Distributed/MpiRouter.f90
+++ b/src/Distributed/MpiRouter.f90
@@ -364,7 +364,6 @@ contains
   !!     and maps, from the virtual data containers, and cache
   !<
   subroutine compose_messages(this, unit, stage, body_snd_t, body_rcv_t)
-    use SimModule, only: ustop
     class(MpiRouterType) :: this
     integer(I4B) :: unit
     integer(I4B) :: stage


### PR DESCRIPTION
which was causing a problem for the model in issue #1964 

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #1964
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).