### PR TITLE
fix(gwf-uzf): write msg to listing file when UZF finishes processing PACKAGEDATA block

### DIFF
--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -34,7 +34,7 @@
 		\item Add a warning if saving convergence data for the CSUB package when delay beds are not included in a simulation. Also modified the convergence output data so that it is clear that DVMAX and DSTORAGEMAX data and locations are not calculated in this case (by writing `-\,-' to the output file). 
 		\item When using SFT in a model where some of the stream reaches are not connected to an active GWF cell (the cellid parameter is set equal to either 0 or NONE) memory access violations were occurring.  The program was fixed by setting the correct number of reaches connected to GWF cells.  The program was tested using a new example with a DISU grid type and multiple GWF cells deactivated (idomain equals 0) that host SFR reaches.
 		\item Support for temperature observations was missing in the Observation (OBS) utility for a GWE model and has been added.
-		\item UZF was not writing a message to the GWF listing file when it had finished reading the PACKAGEDATA block.  An appropriate message is not written to the GWF listing file.
+		\item UZF was not writing a message to the GWF listing file when it had finished reading the PACKAGEDATA block.  An appropriate message is now written to the GWF listing file.
 
 	%	\item xxx
 	\end{itemize}

--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -34,6 +34,7 @@
 		\item Add a warning if saving convergence data for the CSUB package when delay beds are not included in a simulation. Also modified the convergence output data so that it is clear that DVMAX and DSTORAGEMAX data and locations are not calculated in this case (by writing `-\,-' to the output file). 
 		\item When using SFT in a model where some of the stream reaches are not connected to an active GWF cell (the cellid parameter is set equal to either 0 or NONE) memory access violations were occurring.  The program was fixed by setting the correct number of reaches connected to GWF cells.  The program was tested using a new example with a DISU grid type and multiple GWF cells deactivated (idomain equals 0) that host SFR reaches.
 		\item Support for temperature observations was missing in the Observation (OBS) utility for a GWE model and has been added.
+		\item UZF was not writing a message to the GWF listing file when it had finished reading the PACKAGEDATA block.  An appropriate message is not written to the GWF listing file.
 
 	%	\item xxx
 	\end{itemize}

--- a/src/Model/GroundWaterFlow/gwf-uzf.f90
+++ b/src/Model/GroundWaterFlow/gwf-uzf.f90
@@ -2045,6 +2045,8 @@ contains
         end if
         !
       end do
+      write (this%iout, '(1x,3a)') &
+        'END OF ', trim(adjustl(this%text)), ' PACKAGEDATA'
     else
       call store_error('Required packagedata block not found.')
     end if


### PR DESCRIPTION
On the [FloPy repo](https://github.com/modflowpy/flopy), an [issue was reported that UZF was not writing a message](https://github.com/modflowpy/flopy/issues/2277) to the GWF listing file when it had finished processing UZF's `PACKAGEDATA` block.  A line of code was added to gwf-uzf.f90 to insert the missing line into the standard output file for a GWF model.  A new test isn't needed for this change, however, the following screen grabs were collected from one of the autotests before and after the change to confirm that the expected line is now written.

**Before**:
![before](https://github.com/user-attachments/assets/d12c7893-bace-47cb-a5e7-c7ab2785c42b)

**After**:
![after](https://github.com/user-attachments/assets/7e22faae-16af-425b-b117-e5e2d0715d69)

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Relates to issue [#2277](https://github.com/modflowpy/flopy/issues/2277) on the FloPy repo
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix (or change) that may affect users
