### PR TITLE
fix(gwf-uzf): variable name NTRAIL should be NTRAIL_PVAR

### DIFF
--- a/src/Model/GroundWaterFlow/gwf-uzf.f90
+++ b/src/Model/GroundWaterFlow/gwf-uzf.f90
@@ -2650,7 +2650,7 @@ contains
     call mem_allocate(this%ibudgetout, 'IBUDGETOUT', this%memoryPath)
     call mem_allocate(this%ibudcsv, 'IBUDCSV', this%memoryPath)
     call mem_allocate(this%ipakcsv, 'IPAKCSV', this%memoryPath)
-    call mem_allocate(this%ntrail_pvar, 'NTRAIL', this%memoryPath)
+    call mem_allocate(this%ntrail_pvar, 'NTRAIL_PVAR', this%memoryPath)
     call mem_allocate(this%nsets, 'NSETS', this%memoryPath)
     call mem_allocate(this%nodes, 'NODES', this%memoryPath)
     call mem_allocate(this%istocb, 'ISTOCB', this%memoryPath)


### PR DESCRIPTION
The fix included in this PR looks like it was originally implemented in #1742:

![orig_implementation](https://github.com/user-attachments/assets/4c10cb8a-1031-4d01-918f-a8a24dbd67be)

But somewhere along the way was lost and is resulting in the following warning message:

![warning_uzf](https://github.com/user-attachments/assets/282490c9-3b55-4ec6-a1f2-9168cdcbf3d3)

This PR restores the updated variable name in order to turn off the warning message.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #1742
