### PR TITLE
fix(gwe-est): add error checks for user-specified values of 0.0

### DIFF
--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -35,6 +35,7 @@
 		\item When using SFT in a model where some of the stream reaches are not connected to an active GWF cell (the cellid parameter is set equal to either 0 or NONE) memory access violations were occurring.  The program was fixed by setting the correct number of reaches connected to GWF cells.  The program was tested using a new example with a DISU grid type and multiple GWF cells deactivated (idomain equals 0) that host SFR reaches.
 		\item Support for temperature observations was missing in the Observation (OBS) utility for a GWE model and has been added.
 		\item UZF was not writing a message to the GWF listing file when it had finished reading the PACKAGEDATA block.  An appropriate message is now written to the GWF listing file.
+		\item Error checking was added to the EST package to ensure that the inputs HEAT\_CAPACITY\_WATER and DENSITY\_WATER are not 0.0.  Values of 0.0 for either parameter result in a divide by zero error.
 
 	%	\item xxx
 	\end{itemize}

--- a/src/Model/GroundWaterEnergy/gwe-cnd.f90
+++ b/src/Model/GroundWaterEnergy/gwe-cnd.f90
@@ -653,7 +653,7 @@ contains
     if (this%idisp > 0) then
       if (.not. (found%alh .and. found%ath1)) then
         write (errmsg, '(1x,a)') &
-          'if dispersivities are specified then ALH and ATH1 are required.'
+          'If dispersivities are specified then ALH and ATH1 are required.'
         call store_error(errmsg)
       end if
       ! -- If alv not specified then point it to alh

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -680,14 +680,30 @@ contains
           write (this%iout, fmtidcy2)
         case ('HEAT_CAPACITY_WATER')
           this%cpw = this%parser%GetDouble()
-          write (this%iout, '(4x,a,1pg15.6)') &
-            'Heat capacity of the water has been set to: ', &
-            this%cpw
+          if (this%cpw <= 0.0) then
+            write (errmsg, '(a)') 'SPECIFIED VALUE FOR THE HEAT CAPACITY OF &
+              &WATER MUST BE GREATER THAN 0.0 OR A DIVIDE BY ZERO ERROR &
+              &WILL OCCUR.'
+            call store_error(errmsg)
+            call this%parser%StoreErrorUnit()
+          else
+            write (this%iout, '(4x,a,1pg15.6)') &
+              'Heat capacity of the water has been set to: ', &
+              this%cpw
+          end if
         case ('DENSITY_WATER')
           this%rhow = this%parser%GetDouble()
-          write (this%iout, '(4x,a,1pg15.6)') &
-            'Density of the water has been set to: ', &
-            this%rhow
+          if (this%rhow <= 0.0) then
+            write (errmsg, '(a)') 'SPECIFIED VALUE FOR THE DENSITY OF &
+              &WATER MUST BE GREATER THAN 0.0 OR A DIVIDE BY ZERO ERROR &
+              &WILL OCCUR.'
+            call store_error(errmsg)
+            call this%parser%StoreErrorUnit()
+          else
+            write (this%iout, '(4x,a,1pg15.6)') &
+              'Density of the water has been set to: ', &
+              this%rhow
+          end if
         case ('LATENT_HEAT_VAPORIZATION')
           this%latheatvap = this%parser%GetDouble()
           write (this%iout, '(4x,a,1pg15.6)') &

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -681,9 +681,8 @@ contains
         case ('HEAT_CAPACITY_WATER')
           this%cpw = this%parser%GetDouble()
           if (this%cpw <= 0.0) then
-            write (errmsg, '(a)') 'SPECIFIED VALUE FOR THE HEAT CAPACITY OF &
-              &WATER MUST BE GREATER THAN 0.0 OR A DIVIDE BY ZERO ERROR &
-              &WILL OCCUR.'
+            write (errmsg, '(a)') 'Specified value for the heat capacity of &
+              &water must be greater than 0.0.'
             call store_error(errmsg)
             call this%parser%StoreErrorUnit()
           else
@@ -694,9 +693,8 @@ contains
         case ('DENSITY_WATER')
           this%rhow = this%parser%GetDouble()
           if (this%rhow <= 0.0) then
-            write (errmsg, '(a)') 'SPECIFIED VALUE FOR THE DENSITY OF &
-              &WATER MUST BE GREATER THAN 0.0 OR A DIVIDE BY ZERO ERROR &
-              &WILL OCCUR.'
+            write (errmsg, '(a)') 'Specified value for the density of &
+              &water must be greater than 0.0.'
             call store_error(errmsg)
             call this%parser%StoreErrorUnit()
           else
@@ -710,7 +708,7 @@ contains
             'Latent heat of vaporization of the water has been set to: ', &
             this%latheatvap
         case default
-          write (errmsg, '(a,a)') 'UNKNOWN EST OPTION: ', trim(keyword)
+          write (errmsg, '(a,a)') 'Unknown EST option: ', trim(keyword)
           call store_error(errmsg)
           call this%parser%StoreErrorUnit()
         end select
@@ -785,45 +783,45 @@ contains
                                         aname(4))
           lname(4) = .true.
         case default
-          write (errmsg, '(a,a)') 'UNKNOWN GRIDDATA TAG: ', trim(keyword)
+          write (errmsg, '(a,a)') 'Unknown griddata tag: ', trim(keyword)
           call store_error(errmsg)
           call this%parser%StoreErrorUnit()
         end select
       end do
       write (this%iout, '(1x,a)') 'END PROCESSING GRIDDATA'
     else
-      write (errmsg, '(a)') 'REQUIRED GRIDDATA BLOCK NOT FOUND.'
+      write (errmsg, '(a)') 'Required griddata block not found.'
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()
     end if
     !
     ! -- Check for required porosity
     if (.not. lname(1)) then
-      write (errmsg, '(a)') 'POROSITY NOT SPECIFIED IN GRIDDATA BLOCK.'
+      write (errmsg, '(a)') 'Porosity not specified in griddata block.'
       call store_error(errmsg)
     end if
     if (.not. lname(3)) then
-      write (errmsg, '(a)') 'CPS NOT SPECIFIED IN GRIDDATA BLOCK.'
+      write (errmsg, '(a)') 'CPS not specified in griddata block.'
       call store_error(errmsg)
     end if
     if (.not. lname(4)) then
-      write (errmsg, '(a)') 'RHOS NOT SPECIFIED IN GRIDDATA BLOCK.'
+      write (errmsg, '(a)') 'RHOS not specified in griddata block.'
       call store_error(errmsg)
     end if
     !
     ! -- Check for required decay/production rate coefficients
     if (this%idcy > 0) then
       if (.not. lname(2)) then
-        write (errmsg, '(a)') 'FIRST OR ZERO ORDER DECAY IS &
-          &ACTIVE BUT THE FIRST RATE COEFFICIENT IS NOT SPECIFIED.  DECAY &
-          &MUST BE SPECIFIED IN GRIDDATA BLOCK.'
+        write (errmsg, '(a)') 'First or zero order decay is &
+          &active but the first rate coefficient is not specified.  Decay &
+          &must be specified in griddata block.'
         call store_error(errmsg)
       end if
     else
       if (lname(2)) then
-        write (warnmsg, '(a)') 'FIRST OR ZERO ORER DECAY &
-          &IS NOT ACTIVE BUT DECAY WAS SPECIFIED.  DECAY WILL &
-          &HAVE NO AFFECT ON SIMULATION RESULTS.'
+        write (warnmsg, '(a)') 'First or zero orer decay &
+          &is not active but decay was specified.  Decay will &
+          &have no affect on simulation results.'
         call store_warning(warnmsg)
         write (this%iout, '(1x,a)') 'WARNING.  '//warnmsg
       end if

--- a/src/Model/GroundWaterEnergy/gwe-lke.f90
+++ b/src/Model/GroundWaterEnergy/gwe-lke.f90
@@ -209,7 +209,7 @@ contains
     !
     ! -- Error if flow package not found
     if (.not. found) then
-      write (errmsg, '(a)') 'COULD NOT FIND FLOW PACKAGE WITH NAME '&
+      write (errmsg, '(a)') 'Could not find flow package with name '&
                             &//trim(adjustl(this%flowpackagename))//'.'
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()

--- a/src/Model/GroundWaterEnergy/gwe-mwe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-mwe.f90
@@ -202,7 +202,7 @@ contains
     !
     ! -- Error if flow package not found
     if (.not. found) then
-      write (errmsg, '(a)') 'COULD NOT FIND FLOW PACKAGE WITH NAME '&
+      write (errmsg, '(a)') 'Could not find flow package with name '&
                             &//trim(adjustl(this%flowpackagename))//'.'
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()

--- a/src/Model/GroundWaterEnergy/gwe-sfe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-sfe.f90
@@ -208,7 +208,7 @@ contains
     !
     ! -- Error if flow package not found
     if (.not. found) then
-      write (errmsg, '(a)') 'COULD NOT FIND FLOW PACKAGE WITH NAME '&
+      write (errmsg, '(a)') 'Could not find flow package with name '&
                             &//trim(adjustl(this%flowpackagename))//'.'
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()

--- a/src/Model/GroundWaterEnergy/gwe-uze.f90
+++ b/src/Model/GroundWaterEnergy/gwe-uze.f90
@@ -200,7 +200,7 @@ contains
     !
     ! -- Error if flow package not found
     if (.not. found) then
-      write (errmsg, '(a)') 'COULD NOT FIND FLOW PACKAGE WITH NAME '&
+      write (errmsg, '(a)') 'Could not find flow package with name '&
                             &//trim(adjustl(this%flowpackagename))//'.'
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()


### PR DESCRIPTION
In the EST package, inadvertently setting `HEAT_CAPACITY_WATER` and `DENSITY_WATER` to 0.0 results in a divide by zero error.  Error added to the src code and checked manually.  No dedicated test problem added.

- [x] Replaced section above with description of pull request
- [x] Formatted existing Fortran source file with `fprettify`
- [x] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
