### PR TITLE
Update pixi_auto_update.yml

### DIFF
--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -22,7 +22,7 @@ jobs:
           rm pixi.lock
           pixi global install pixi-diff-to-markdown
           printf "Update pixi dependencies to the latest version\n\n" >> diff.md
-          pixi update --no-install --json | pixi exec pixi-diff-to-markdown >> diff.md
+          pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
 
       - uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
Turns out `--no-install` doesn't work if `pypi-dependencies` are present