### PR TITLE
fix(netcdf): address export hpc compile issues

### DIFF
--- a/.hpc/cray-hovenweep-meson-build.slurm.batch
+++ b/.hpc/cray-hovenweep-meson-build.slurm.batch
@@ -12,8 +12,9 @@ set -euxo pipefail
 
 # load appropriate modules
 module switch PrgEnv-${PE_ENV,,} PrgEnv-intel
-module load petsc/3.15.5 meson/1.2.1 ninja/1.11.1
+module load petsc/3.15.5 cray-netcdf cray-hdf5 meson/1.2.1 ninja/1.11.1
 export PKG_CONFIG_PATH=$CRAY_MPICH_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=$NETCDF_DIR/lib/pkgconfig:$HDF5_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
 
 # list loaded modules
 module list

--- a/.hpc/cray-meson-build.slurm.batch
+++ b/.hpc/cray-meson-build.slurm.batch
@@ -12,8 +12,9 @@ set -euxo pipefail
 
 # load appropriate modules
 module switch PrgEnv-${PE_ENV,,} PrgEnv-intel
-module load cray-petsc meson ninja
-export PKG_CONFIG_PATH=/opt/cray/pe/mpt/7.7.19/gni/mpich-intel/16.0/lib/pkgconfig:/opt/cray/pe/petsc/3.14.5.0/real/INTEL/19.1/x86_skylake/lib/pkgconfig:$PKG_CONFIG_PATH
+module load cray-petsc cray-netcdf cray-hdf5 meson ninja
+export PKG_CONFIG_PATH=$CRAY_MPICH_DIR/lib/pkgconfig:$PETSC_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=$NETCDF_DIR/lib/pkgconfig:$HDF5_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
 
 # list loaded modules
 module list

--- a/meson.build
+++ b/meson.build
@@ -107,6 +107,7 @@ if is_cray and build_machine.system() != 'linux'
   error('cray only supported on linux systems')
 endif
 if is_cray and not is_parallel_build
+  is_extended_build = true
   is_parallel_build = true
   is_mpich = true
 endif

--- a/src/Utilities/Export/DisNCMesh.f90
+++ b/src/Utilities/Export/DisNCMesh.f90
@@ -24,7 +24,7 @@ module MeshDisModelModule
 
   ! -- UGRID layered mesh (ULM) DIS
   type, extends(Mesh2dModelType) :: Mesh2dDisExportType
-    class(DisType), pointer :: dis => null() !< pointer to model dis package
+    type(DisType), pointer :: dis => null() !< pointer to model dis package
     integer(I4B) :: x_dim !< ncol dimension id
     integer(I4B) :: y_dim !< nrow dimension id
   contains

--- a/src/Utilities/Export/DisNCStructured.f90
+++ b/src/Utilities/Export/DisNCStructured.f90
@@ -50,7 +50,7 @@ module DisNCStructuredModule
   type, extends(NCBaseModelExportType) :: DisNCStructuredType
     type(StructuredNCDimIdType) :: dim_ids !< structured dimension ids type
     type(StructuredNCVarIdType) :: var_ids !< structured variable ids type
-    class(DisType), pointer :: dis => null() !< pointer to model dis package
+    type(DisType), pointer :: dis => null() !< pointer to model dis package
     integer(I4B) :: nlay !< number of layers
     real(DP), dimension(:), pointer, contiguous :: lat => null() !< lat input array pointer
     real(DP), dimension(:), pointer, contiguous :: lon => null() !< lon input array pointer

--- a/src/Utilities/Export/DisvNCMesh.f90
+++ b/src/Utilities/Export/DisvNCMesh.f90
@@ -24,7 +24,7 @@ module MeshDisvModelModule
 
   ! -- UGRID layered mesh DISV
   type, extends(Mesh2dModelType) :: Mesh2dDisvExportType
-    class(DisvType), pointer :: disv => null() !< pointer to model disv package
+    type(DisvType), pointer :: disv => null() !< pointer to model disv package
   contains
     procedure :: init => disv_export_init
     procedure :: destroy => disv_export_destroy

--- a/src/Utilities/Export/NCModel.f90
+++ b/src/Utilities/Export/NCModel.f90
@@ -15,7 +15,7 @@ module NCModelExportModule
 
   implicit none
   private
-  public :: NCBaseModelExportType
+  public :: NCBaseModelExportType, NCModelExportType
   public :: NCExportAnnotation
   public :: NETCDF_UNDEF, NETCDF_STRUCTURED, NETCDF_UGRID
 


### PR DESCRIPTION
Tested on Hovenweep as described in issue.  Updates to meson build script and slurm batch scripts included.

- [X] Replaced section above with description of pull request
- [X] Referenced issue or pull request #1984
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).