### PR TITLE
refactor(mf6bmiutil): simplify string_to_char_array

### DIFF
--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -611,7 +611,7 @@ contains
       call mem_setptr(srcstr, var_name, mem_path)
       call get_mem_elem_size(var_name, mem_path, ilen)
       call c_f_pointer(c_arr_ptr, tgtstr, shape=[ilen + 1])
-      tgtstr(1:len(srcstr) + 1) = trim(srcstr)//c_null_char
+      tgtstr(1:len(srcstr) + 1) = string_to_char_array(trim(srcstr))
 
     else if (rank == 1) then
       ! an array of strings
@@ -633,7 +633,7 @@ contains
       allocate (character(ilen) :: tempstr)
       do i = 1, isize
         tempstr = srccharstr1d(i)
-        tgtstr1d(1:ilen + 1, i) = trim(tempstr)//c_null_char
+        tgtstr1d(1:ilen + 1, i) = string_to_char_array(trim(tempstr))
       end do
       deallocate (tempstr)
     else
@@ -1171,7 +1171,7 @@ contains
 
     call get_mem_type(var_name, mem_path, mem_type)
     c_var_type(1:len(trim(mem_type)) + 1) = &
-      trim(mem_type)//c_null_char
+      string_to_char_array(trim(mem_type))
 
     if (mem_type == 'UNKNOWN') then
       write (bmi_last_error, fmt_general_err) 'unknown memory type'

--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -46,9 +46,8 @@ contains
     ! -- dummy variables
     character(kind=c_char), intent(out) :: name(BMI_LENCOMPONENTNAME)
     integer(kind=c_int) :: bmi_status !< BMI status code
-    ! -- local variables
 
-    name = 'MODFLOW 6'//c_null_char
+    name = string_to_char_array('MODFLOW 6')
     bmi_status = BMI_SUCCESS
 
   end function bmi_get_component_name

--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -48,7 +48,7 @@ contains
     integer(kind=c_int) :: bmi_status !< BMI status code
     ! -- local variables
 
-    name = string_to_char_array('MODFLOW 6', 9)
+    name = 'MODFLOW 6'//c_null_char
     bmi_status = BMI_SUCCESS
 
   end function bmi_get_component_name
@@ -612,7 +612,7 @@ contains
       call mem_setptr(srcstr, var_name, mem_path)
       call get_mem_elem_size(var_name, mem_path, ilen)
       call c_f_pointer(c_arr_ptr, tgtstr, shape=[ilen + 1])
-      tgtstr(1:len(srcstr) + 1) = string_to_char_array(srcstr, len(srcstr))
+      tgtstr(1:len(srcstr) + 1) = trim(srcstr)//c_null_char
 
     else if (rank == 1) then
       ! an array of strings
@@ -634,7 +634,7 @@ contains
       allocate (character(ilen) :: tempstr)
       do i = 1, isize
         tempstr = srccharstr1d(i)
-        tgtstr1d(1:ilen + 1, i) = string_to_char_array(tempstr, ilen)
+        tgtstr1d(1:ilen + 1, i) = trim(tempstr)//c_null_char
       end do
       deallocate (tempstr)
     else
@@ -1172,7 +1172,7 @@ contains
 
     call get_mem_type(var_name, mem_path, mem_type)
     c_var_type(1:len(trim(mem_type)) + 1) = &
-      string_to_char_array(trim(mem_type), len(trim(mem_type)))
+      trim(mem_type)//c_null_char
 
     if (mem_type == 'UNKNOWN') then
       write (bmi_last_error, fmt_general_err) 'unknown memory type'

--- a/srcbmi/mf6bmiGrid.f90
+++ b/srcbmi/mf6bmiGrid.f90
@@ -8,7 +8,7 @@
 module mf6bmiGrid
   use mf6bmiUtil
   use mf6bmiError
-  use iso_c_binding, only: c_double, c_ptr, c_loc, c_null_char
+  use iso_c_binding, only: c_double, c_ptr, c_loc
   use ConstantsModule, only: LENMODELNAME, LENMEMPATH
   use KindModule, only: DP, I4B
   use MemoryManagerModule, only: mem_setptr
@@ -81,7 +81,7 @@ contains
     else
       return
     end if
-    grid_type = trim(grid_type_f)//c_null_char
+    grid_type = string_to_char_array(trim(grid_type_f))
     bmi_status = BMI_SUCCESS
   end function get_grid_type
 

--- a/srcbmi/mf6bmiGrid.f90
+++ b/srcbmi/mf6bmiGrid.f90
@@ -8,7 +8,7 @@
 module mf6bmiGrid
   use mf6bmiUtil
   use mf6bmiError
-  use iso_c_binding, only: c_double, c_ptr, c_loc
+  use iso_c_binding, only: c_double, c_ptr, c_loc, c_null_char
   use ConstantsModule, only: LENMODELNAME, LENMEMPATH
   use KindModule, only: DP, I4B
   use MemoryManagerModule, only: mem_setptr
@@ -81,7 +81,7 @@ contains
     else
       return
     end if
-    grid_type = string_to_char_array(trim(grid_type_f), len_trim(grid_type_f))
+    grid_type = trim(grid_type_f)//c_null_char
     bmi_status = BMI_SUCCESS
   end function get_grid_type
 

--- a/srcbmi/mf6bmiUtil.f90
+++ b/srcbmi/mf6bmiUtil.f90
@@ -143,6 +143,17 @@ contains
 
   end function char_array_to_string
 
+  !> @brief Convert Fortran string to C-style character string
+  !<
+  pure function string_to_char_array(string) result(c_array)
+    ! -- dummy variables
+    character(len=*), intent(in) :: string !< string to convert
+    character(kind=c_char, len=1) :: c_array(len(string) + 1) !< C-style character string
+
+    c_array = trim(string)//c_null_char
+
+  end function string_to_char_array
+
   !> @brief Extract the model name from a memory address string
   !<
   function extract_model_name(var_address, success) result(model_name)

--- a/srcbmi/mf6bmiUtil.f90
+++ b/srcbmi/mf6bmiUtil.f90
@@ -143,23 +143,6 @@ contains
 
   end function char_array_to_string
 
-  !> @brief Convert Fortran string to C-style character string
-  !<
-  pure function string_to_char_array(string, length) result(c_array)
-    ! -- dummy variables
-    integer(c_int), intent(in) :: length !< Fortran string length
-    character(len=length), intent(in) :: string !< string to convert
-    character(kind=c_char, len=1) :: c_array(length + 1) !< C-style character string
-    ! -- local variables
-    integer(I4B) :: i
-
-    do i = 1, length
-      c_array(i) = string(i:i)
-    end do
-    c_array(length + 1) = C_NULL_CHAR
-
-  end function string_to_char_array
-
   !> @brief Extract the model name from a memory address string
   !<
   function extract_model_name(var_address, success) result(model_name)

--- a/srcbmi/mf6xmi.F90
+++ b/srcbmi/mf6xmi.F90
@@ -90,7 +90,7 @@ module mf6xmi
   use mf6bmiError
   use Mf6CoreModule
   use KindModule
-  use iso_c_binding, only: c_int, c_char, c_double
+  use iso_c_binding, only: c_int, c_char, c_double, c_null_char
   implicit none
 
   integer(I4B), pointer :: iterationCounter => null() !< the counter for the outer iteration loop, initialized in xmi_prepare_iteration()
@@ -357,7 +357,7 @@ contains
     else
       vstr = VERSIONNUMBER
     end if
-    mf_version = string_to_char_array(vstr, len_trim(vstr))
+    mf_version = trim(vstr)//c_null_char
     bmi_status = BMI_SUCCESS
 
   end function xmi_get_version
@@ -412,7 +412,7 @@ contains
 
     ! convert to c string:
     c_var_address(1:len(trim(mem_address)) + 1) = &
-      string_to_char_array(trim(mem_address), len(trim(mem_address)))
+      trim(mem_address)//c_null_char
 
     bmi_status = BMI_SUCCESS
 

--- a/srcbmi/mf6xmi.F90
+++ b/srcbmi/mf6xmi.F90
@@ -90,7 +90,7 @@ module mf6xmi
   use mf6bmiError
   use Mf6CoreModule
   use KindModule
-  use iso_c_binding, only: c_int, c_char, c_double, c_null_char
+  use iso_c_binding, only: c_int, c_char, c_double
   implicit none
 
   integer(I4B), pointer :: iterationCounter => null() !< the counter for the outer iteration loop, initialized in xmi_prepare_iteration()
@@ -357,7 +357,7 @@ contains
     else
       vstr = VERSIONNUMBER
     end if
-    mf_version = trim(vstr)//c_null_char
+    mf_version = string_to_char_array(trim(vstr))
     bmi_status = BMI_SUCCESS
 
   end function xmi_get_version
@@ -412,7 +412,7 @@ contains
 
     ! convert to c string:
     c_var_address(1:len(trim(mem_address)) + 1) = &
-      trim(mem_address)//c_null_char
+      string_to_char_array(trim(mem_address))
 
     bmi_status = BMI_SUCCESS
 


### PR DESCRIPTION
I think this function can be simplified. The Fortran wiki [claims the older version is still necessary](https://fortranwiki.org/fortran/show/Generating+C+Interfaces#strings), but the relevant section was added [14 years ago](https://fortranwiki.org/fortran/revision/diff/Generating+C+Interfaces/9), and more recently the consensus on the fortran-lang forum is that passing `trim(str) // c_null_char` [suffices](https://fortran-lang.discourse.group/t/best-practices-for-passing-c-strings), corroborated [in a J3 proposal](https://j3-fortran.org/doc/year/18/18-258r2.txt).

Still need to work out some issues