### PR TITLE
ci(ubuntu): reinstate ex-gwe-radial, copy libmf6.so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,12 +316,13 @@ jobs:
         if: runner.os == 'Linux'
         uses: modflowpy/install-modflow-action@v1
 
-      - name: Test MF6 examples
+      - name: Test examples
         if: runner.os == 'Linux'
         working-directory: modflow6
         shell: pixi run bash -e {0}
         run: |
-          cp bin/mf6 $(which mf6)
+          cp bin/mf6 ~/.local/bin/modflow/
+          cp bin/libmf6.so ~/.local/bin/modflow/
           cd ../modflow6-examples/autotest
           pytest -v -n auto test_scripts.py
 
@@ -476,8 +477,7 @@ jobs:
           cp bin/mf6 ~/.local/bin/modflow/
           cp bin/libmf6.so ~/.local/bin/modflow/
           cd ../modflow6-examples/autotest
-          # todo reinstate ex-gwe-radial once memory use reduced
-          pytest -v -n auto test_scripts.py -k "not gwe-radial"
+          pytest -v -n auto test_scripts.py
       
       - name: Upload failed test output
         if: failure()


### PR DESCRIPTION
Follow up on #1980. The radial GWE example has been modified to reduce memory use, don't skip it anymore. Also copy libmf6.so in the gfortran job (missed this in #1980).

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #1980
- [x] Removed checklist items not relevant to this pull request