### PR TITLE
fix(mf6bmiutil): workaround ARM mac char array assignment issue

### DIFF
--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -48,7 +48,7 @@ contains
     integer(kind=c_int) :: bmi_status !< BMI status code
     ! -- local variables
 
-    name = string_to_char_array('MODFLOW 6', 9)
+    call string_to_char_array_2('MODFLOW 6', 9, name)
     bmi_status = BMI_SUCCESS
 
   end function bmi_get_component_name
@@ -612,6 +612,7 @@ contains
       call mem_setptr(srcstr, var_name, mem_path)
       call get_mem_elem_size(var_name, mem_path, ilen)
       call c_f_pointer(c_arr_ptr, tgtstr, shape=[ilen + 1])
+
       tgtstr(1:len(srcstr) + 1) = string_to_char_array(srcstr, len(srcstr))
 
     else if (rank == 1) then

--- a/srcbmi/mf6bmiGrid.f90
+++ b/srcbmi/mf6bmiGrid.f90
@@ -81,7 +81,10 @@ contains
     else
       return
     end if
-    grid_type = string_to_char_array(trim(grid_type_f), len_trim(grid_type_f))
+    call string_to_char_array_2( &
+      trim(grid_type_f), &
+      len_trim(grid_type_f), &
+      grid_type)
     bmi_status = BMI_SUCCESS
   end function get_grid_type
 

--- a/srcbmi/mf6bmiUtil.f90
+++ b/srcbmi/mf6bmiUtil.f90
@@ -160,6 +160,33 @@ contains
 
   end function string_to_char_array
 
+  !> @brief Convert Fortran string to C-style character string.
+  !!
+  !! This workaround is needed on ARM macs because assignment
+  !! from the return value of a function fails with gfortran
+  !! if the LHS and RHS have different lengths, producing a
+  !! runtime error like:
+  !!
+  !! Dimension 1 of array 'c_array' has extent X instead of Y
+  !!
+  !! TODO: remove this and use string_to_char_array instead
+  !! if this is truly a compiler bug and it's fixed someday.
+  !<
+  subroutine string_to_char_array_2(string, length, c_array)
+    ! -- dummy variables
+    character(len=*), intent(in) :: string !< string to convert
+    integer(c_int), intent(in) :: length !< Fortran string length
+    character(kind=c_char, len=1), intent(out) :: c_array(length + 1) !< C-style character string
+    ! -- local variables
+    integer(I4B) :: i
+
+    do i = 1, length
+      c_array(i) = string(i:i)
+    end do
+    c_array(length + 1) = C_NULL_CHAR
+
+  end subroutine string_to_char_array_2
+
   !> @brief Extract the model name from a memory address string
   !<
   function extract_model_name(var_address, success) result(model_name)

--- a/srcbmi/mf6xmi.F90
+++ b/srcbmi/mf6xmi.F90
@@ -357,7 +357,7 @@ contains
     else
       vstr = VERSIONNUMBER
     end if
-    mf_version = string_to_char_array(vstr, len_trim(vstr))
+    call string_to_char_array_2(vstr, len_trim(vstr), mf_version)
     bmi_status = BMI_SUCCESS
 
   end function xmi_get_version


### PR DESCRIPTION
Assignments from the result of `string_to_char_array` fail on ARM mac with GNU Fortran when the LHS and RHS are of different lengths. This seems like a compiler bug? Confirmed with gfortran 12-14. Work around it by introducing a subroutine to do the conversion.

@mjr-deltares and I have discussed and determined as a next step to create a minimal reproduction and post on the Fortran discourse forum. I will add a link here once that's done.

This should resolve the modflowapi macOS CI failures.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Removed checklist items not relevant to this pull request