### PR TITLE
fix(mf6bmiutil): remove subroutine workaround, make args inout

### DIFF
--- a/srcbmi/mf6bmi.f90
+++ b/srcbmi/mf6bmi.f90
@@ -44,11 +44,11 @@ contains
     bind(C, name="get_component_name")
     !DIR$ ATTRIBUTES DLLEXPORT :: bmi_get_component_name
     ! -- dummy variables
-    character(kind=c_char), intent(out) :: name(BMI_LENCOMPONENTNAME)
+    character(kind=c_char), intent(inout) :: name(BMI_LENCOMPONENTNAME)
     integer(kind=c_int) :: bmi_status !< BMI status code
     ! -- local variables
 
-    call string_to_char_array_2('MODFLOW 6', 9, name)
+    name = string_to_char_array('MODFLOW 6', 9)
     bmi_status = BMI_SUCCESS
 
   end function bmi_get_component_name

--- a/srcbmi/mf6bmiGrid.f90
+++ b/srcbmi/mf6bmiGrid.f90
@@ -62,7 +62,7 @@ contains
     !DIR$ ATTRIBUTES DLLEXPORT :: get_grid_type
     ! -- dummy variables
     integer(kind=c_int), intent(in) :: grid_id
-    character(kind=c_char), intent(out) :: grid_type(BMI_LENGRIDTYPE)
+    character(kind=c_char), intent(inout) :: grid_type(BMI_LENGRIDTYPE)
     integer(kind=c_int) :: bmi_status
     ! -- local variables
     character(len=LENGRIDTYPE) :: grid_type_f
@@ -81,10 +81,7 @@ contains
     else
       return
     end if
-    call string_to_char_array_2( &
-      trim(grid_type_f), &
-      len_trim(grid_type_f), &
-      grid_type)
+    grid_type = string_to_char_array(trim(grid_type_f), len_trim(grid_type_f))
     bmi_status = BMI_SUCCESS
   end function get_grid_type
 

--- a/srcbmi/mf6bmiUtil.f90
+++ b/srcbmi/mf6bmiUtil.f90
@@ -160,33 +160,6 @@ contains
 
   end function string_to_char_array
 
-  !> @brief Convert Fortran string to C-style character string.
-  !!
-  !! This workaround is needed on ARM macs because assignment
-  !! from the return value of a function fails with gfortran
-  !! if the LHS and RHS have different lengths, producing a
-  !! runtime error like:
-  !!
-  !! Dimension 1 of array 'c_array' has extent X instead of Y
-  !!
-  !! TODO: remove this and use string_to_char_array instead
-  !! if this is truly a compiler bug and it's fixed someday.
-  !<
-  subroutine string_to_char_array_2(string, length, c_array)
-    ! -- dummy variables
-    character(len=*), intent(in) :: string !< string to convert
-    integer(c_int), intent(in) :: length !< Fortran string length
-    character(kind=c_char, len=1), intent(out) :: c_array(length + 1) !< C-style character string
-    ! -- local variables
-    integer(I4B) :: i
-
-    do i = 1, length
-      c_array(i) = string(i:i)
-    end do
-    c_array(length + 1) = C_NULL_CHAR
-
-  end subroutine string_to_char_array_2
-
   !> @brief Extract the model name from a memory address string
   !<
   function extract_model_name(var_address, success) result(model_name)

--- a/srcbmi/mf6xmi.F90
+++ b/srcbmi/mf6xmi.F90
@@ -347,7 +347,7 @@ contains
     ! -- modules
     use VersionModule, only: VERSIONNUMBER, IDEVELOPMODE
     ! -- dummy variables
-    character(kind=c_char), intent(out) :: mf_version(BMI_LENVERSION)
+    character(kind=c_char), intent(inout) :: mf_version(BMI_LENVERSION)
     integer(kind=c_int) :: bmi_status !< BMI status code
     ! -- local variables
     character(len=BMI_LENVERSION) :: vstr
@@ -357,7 +357,7 @@ contains
     else
       vstr = VERSIONNUMBER
     end if
-    call string_to_char_array_2(vstr, len_trim(vstr), mf_version)
+    mf_version = string_to_char_array(vstr, len_trim(vstr))
     bmi_status = BMI_SUCCESS
 
   end function xmi_get_version


### PR DESCRIPTION
Making the assigned-to argument `intent(inout)` resolves the ARM mac + gfortran assignment problem which #1993 originally solved with a subroutine instead of a function call. Thanks to @scharlton2 for the [suggestion](https://github.com/MODFLOW-USGS/modflow6/pull/1993#issuecomment-2293914993).

@mjr-deltares I will still post on the fortran-lang forum at some point to see if anyone has more info on this behavior.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #1993
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Removed checklist items not relevant to this pull request