### PR TITLE
refactor(modflowapi): move ModflowApi import into api_func

### DIFF
--- a/autotest/test_gwf_libmf6_evt01.py
+++ b/autotest/test_gwf_libmf6_evt01.py
@@ -9,7 +9,6 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 
 cases = ["libgwf_evt01"]
 
@@ -150,6 +149,8 @@ def head2et_wellrate(h):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."

--- a/autotest/test_gwf_libmf6_evt01.py
+++ b/autotest/test_gwf_libmf6_evt01.py
@@ -9,6 +9,7 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 
 cases = ["libgwf_evt01"]
 
@@ -250,6 +251,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_ghb01.py
+++ b/autotest/test_gwf_libmf6_ghb01.py
@@ -11,6 +11,7 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 
 cases = ["libgwf_ghb01"]
 
@@ -274,6 +275,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_ghb01.py
+++ b/autotest/test_gwf_libmf6_ghb01.py
@@ -11,7 +11,6 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 
 cases = ["libgwf_ghb01"]
 
@@ -180,6 +179,8 @@ def api_ghb_pak(hcof, rhs):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."

--- a/autotest/test_gwf_libmf6_ifmod01.py
+++ b/autotest/test_gwf_libmf6_ifmod01.py
@@ -17,7 +17,6 @@ import os
 import flopy
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 
 cases = ["libgwf_ifmod01"]
 name_left = "leftmodel"
@@ -207,6 +206,8 @@ def build_models(idx, test):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     if model_ws is None:
         model_ws = "."
     output_file_path = os.path.join(model_ws, "mfsim.stdout")

--- a/autotest/test_gwf_libmf6_ifmod01.py
+++ b/autotest/test_gwf_libmf6_ifmod01.py
@@ -17,6 +17,7 @@ import os
 import flopy
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 
 cases = ["libgwf_ifmod01"]
 name_left = "leftmodel"
@@ -304,6 +305,7 @@ def check_interface_models(mf6):
                 ), "AREA in interface model does not match"
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_ifmod02.py
+++ b/autotest/test_gwf_libmf6_ifmod02.py
@@ -42,6 +42,7 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 
 cases = ["libgwf_ifmod02"]
 
@@ -402,6 +403,7 @@ def check_interface_models(mf6):
     )
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.developmode
 def test_mf6model(idx, name, function_tmpdir, targets):

--- a/autotest/test_gwf_libmf6_ifmod02.py
+++ b/autotest/test_gwf_libmf6_ifmod02.py
@@ -42,7 +42,6 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 
 cases = ["libgwf_ifmod02"]
 
@@ -303,6 +302,8 @@ def build_models(idx, test):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     if model_ws is None:
         model_ws = "."
 

--- a/autotest/test_gwf_libmf6_ifmod03.py
+++ b/autotest/test_gwf_libmf6_ifmod03.py
@@ -32,6 +32,7 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 
 cases = ["libgwf_ifmod03"]
 
@@ -288,6 +289,7 @@ def check_interface_models(mf6):
     assert abs(ymax - ymin) < 1e-6
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_ifmod03.py
+++ b/autotest/test_gwf_libmf6_ifmod03.py
@@ -32,7 +32,6 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 
 cases = ["libgwf_ifmod03"]
 
@@ -220,6 +219,8 @@ def build_models(idx, test):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     if model_ws is None:
         model_ws = "."
 

--- a/autotest/test_gwf_libmf6_rch01.py
+++ b/autotest/test_gwf_libmf6_rch01.py
@@ -13,7 +13,6 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 
 cases = ["libgwf_rch01"]
 
@@ -147,6 +146,8 @@ def build_models(idx, test):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."

--- a/autotest/test_gwf_libmf6_rch01.py
+++ b/autotest/test_gwf_libmf6_rch01.py
@@ -13,6 +13,7 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 
 cases = ["libgwf_rch01"]
 
@@ -230,6 +231,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_rch02.py
+++ b/autotest/test_gwf_libmf6_rch02.py
@@ -10,7 +10,6 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 
 cases = ["libgwf_rch02"]
 
@@ -180,6 +179,8 @@ def run_perturbation(mf6, max_iter, recharge, tag, rch):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     print("\nBMI implementation test:")
 
     name = cases[idx].upper()

--- a/autotest/test_gwf_libmf6_rch02.py
+++ b/autotest/test_gwf_libmf6_rch02.py
@@ -10,6 +10,7 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 
 cases = ["libgwf_rch02"]
 
@@ -305,6 +306,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_riv01.py
+++ b/autotest/test_gwf_libmf6_riv01.py
@@ -9,6 +9,7 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 
 cases = ["libgwf_riv01"]
 
@@ -247,6 +248,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_riv01.py
+++ b/autotest/test_gwf_libmf6_riv01.py
@@ -9,7 +9,6 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 
 cases = ["libgwf_riv01"]
 
@@ -153,6 +152,8 @@ def build_models(idx, test):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."

--- a/autotest/test_gwf_libmf6_riv02.py
+++ b/autotest/test_gwf_libmf6_riv02.py
@@ -9,7 +9,6 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 
 cases = ["libgwf_riv02"]
 
@@ -167,6 +166,8 @@ def api_riv_pak(stage, h, hcof, rhs):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."

--- a/autotest/test_gwf_libmf6_riv02.py
+++ b/autotest/test_gwf_libmf6_riv02.py
@@ -9,6 +9,7 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 
 cases = ["libgwf_riv02"]
 
@@ -272,6 +273,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(

--- a/autotest/test_gwf_libmf6_sto01.py
+++ b/autotest/test_gwf_libmf6_sto01.py
@@ -10,7 +10,6 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 
 cases = ["libgwf_sto01"]
 
@@ -150,6 +149,8 @@ def build_models(idx, test):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     name = cases[idx].upper()
     if model_ws is None:
         model_ws = "."

--- a/autotest/test_gwf_libmf6_sto01.py
+++ b/autotest/test_gwf_libmf6_sto01.py
@@ -10,6 +10,7 @@ import flopy
 import numpy as np
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 
 cases = ["libgwf_sto01"]
 
@@ -206,6 +207,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.slow
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):

--- a/autotest/test_prt_libmf6_budget.py
+++ b/autotest/test_prt_libmf6_budget.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 from framework import TestFramework
-from modflowapi import ModflowApi
 from test_prt_budget import (
     HorizontalCase,
     build_mp7_sim,
@@ -44,6 +43,8 @@ def build_models(idx, test):
 
 
 def api_func(exe, idx, model_ws=None):
+    from modflowapi import ModflowApi
+
     name = cases[idx].upper()
     if model_ws is None:
         model_ws = Path(".")

--- a/autotest/test_prt_libmf6_budget.py
+++ b/autotest/test_prt_libmf6_budget.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 from framework import TestFramework
+from modflow_devtools.markers import requires_pkg
 from test_prt_budget import (
     HorizontalCase,
     build_mp7_sim,
@@ -98,6 +99,7 @@ def api_func(exe, idx, model_ws=None):
     return True, open(output_file_path).readlines()
 
 
+@requires_pkg("modflowapi")
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets):
     test = TestFramework(


### PR DESCRIPTION
pytest fails with an error if the autotest suite is run and modflowapi is not installed.  By moving the ModflowApi import into api_func, pytest discovery doesn't fail if modflowapi is not available.  This makes it possible to run the test suite (without the libmf6 tests) even if modflowapi isn't available.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).