### PR TITLE
refactor(xmipy): skip test_gwf_tdis if xmipy not installed

### DIFF
--- a/autotest/test_gwf_tdis.py
+++ b/autotest/test_gwf_tdis.py
@@ -3,7 +3,7 @@
 import flopy
 import numpy as np
 import pytest
-from xmipy import XmiWrapper
+from modflow_devtools.markers import requires_pkg
 
 
 @pytest.fixture
@@ -26,9 +26,12 @@ def simple_sim(tmp_path):
     return sim
 
 
+@requires_pkg("xmipy")
 @pytest.mark.parametrize("tsmult", [1.0, 1.2])
 def test_tdis_tsmult(tsmult, simple_sim, targets):
     """Check totim values to ensure they avoid accumulation errors."""
+    from xmipy import XmiWrapper
+
     sim = simple_sim
 
     # Add TDIS package using time variables


### PR DESCRIPTION
Follow up to #1997.  Skip test if xmipy not installed (instead of failing and not running tests)

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #1997 
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).