### PR TITLE
fix(swf-dis): fixes for swf dis functionality

### DIFF
--- a/autotest/test_chf_dfw.py
+++ b/autotest/test_chf_dfw.py
@@ -57,10 +57,10 @@ def build_models(idx, test):
     total_length = dx * nreach
     vertices = []
     vertices = [[j, j * dx, 0.0] for j in range(nreach + 1)]
-    cell2d = []
+    cell1d = []
     for j in range(nreach):
-        cell2d.append([j, 0.5, 2, j, j + 1])
-    nodes = len(cell2d)
+        cell1d.append([j, 0.5, 2, j, j + 1])
+    nodes = len(cell1d)
     nvert = len(vertices)
 
     disv1d = flopy.mf6.ModflowChfdisv1D(
@@ -72,7 +72,7 @@ def build_models(idx, test):
         bottom=0.0,
         idomain=1,
         vertices=vertices,
-        cell2d=cell2d,
+        cell1d=cell1d,
     )
 
     dfw = flopy.mf6.ModflowChfdfw(

--- a/autotest/test_chf_dfw.py
+++ b/autotest/test_chf_dfw.py
@@ -67,7 +67,6 @@ def build_models(idx, test):
         chf,
         nodes=nodes,
         nvert=nvert,
-        length=dx,
         width=50.0,
         bottom=0.0,
         idomain=1,

--- a/autotest/test_chf_dfw_beg2022.py
+++ b/autotest/test_chf_dfw_beg2022.py
@@ -66,10 +66,10 @@ def build_models(idx, test):
     nreach = int(total_length / dx)
     vertices = []
     vertices = [[j, j * dx, 0.0] for j in range(nreach + 1)]
-    cell2d = []
+    cell1d = []
     for j in range(nreach):
-        cell2d.append([j, 0.5, 2, j, j + 1])
-    nodes = len(cell2d)
+        cell1d.append([j, 0.5, 2, j, j + 1])
+    nodes = len(cell1d)
     nvert = len(vertices)
 
     slope = 1.0 / 10000.0
@@ -85,7 +85,7 @@ def build_models(idx, test):
         bottom=z,
         idomain=1,
         vertices=vertices,
-        cell2d=cell2d,
+        cell1d=cell1d,
     )
 
     dfw = flopy.mf6.ModflowChfdfw(

--- a/autotest/test_chf_dfw_beg2022.py
+++ b/autotest/test_chf_dfw_beg2022.py
@@ -80,7 +80,6 @@ def build_models(idx, test):
         chf,
         nodes=nodes,
         nvert=nvert,
-        length=dx,
         width=40.0,
         bottom=z,
         idomain=1,

--- a/autotest/test_chf_dfw_bowl.py
+++ b/autotest/test_chf_dfw_bowl.py
@@ -101,7 +101,6 @@ def build_models(idx, test):
         chf,
         nodes=nodes,
         nvert=nvert,
-        length=dx,
         width=1.0,
         bottom=reach_bottom,
         idomain=1,

--- a/autotest/test_chf_dfw_bowl.py
+++ b/autotest/test_chf_dfw_bowl.py
@@ -91,10 +91,10 @@ def build_models(idx, test):
 
     vertices = []
     vertices = [[j, j * dx, 0.0] for j in range(nreach + 1)]
-    cell2d = []
+    cell1d = []
     for j in range(nreach):
-        cell2d.append([j, 0.5, 2, j, j + 1])
-    nodes = len(cell2d)
+        cell1d.append([j, 0.5, 2, j, j + 1])
+    nodes = len(cell1d)
     nvert = len(vertices)
 
     disv1d = flopy.mf6.ModflowChfdisv1D(
@@ -106,7 +106,7 @@ def build_models(idx, test):
         bottom=reach_bottom,
         idomain=1,
         vertices=vertices,
-        cell2d=cell2d,
+        cell1d=cell1d,
     )
 
     dfw = flopy.mf6.ModflowChfdfw(

--- a/autotest/test_chf_dfw_loop.py
+++ b/autotest/test_chf_dfw_loop.py
@@ -82,7 +82,7 @@ def build_models(idx, test):
         [19, 3000.0, 2500.0],
     ]
 
-    cell2d = [
+    cell1d = [
         [0, 0.5, 2, 0, 1],
         [1, 0.5, 2, 1, 2],
         [2, 0.5, 2, 2, 3],
@@ -218,7 +218,7 @@ def build_models(idx, test):
         (608400, 0, 0),
     ]
 
-    nodes = len(cell2d)
+    nodes = len(cell1d)
     nvert = len(vertices)
 
     disv1d = flopy.mf6.ModflowChfdisv1D(
@@ -230,7 +230,7 @@ def build_models(idx, test):
         bottom=reach_bottom,
         idomain=1,
         vertices=vertices,
-        cell2d=cell2d,
+        cell1d=cell1d,
     )
 
     stage0 = np.array(14 * [3] + 4 * [2])
@@ -411,6 +411,19 @@ def make_plot(test):
     plt.ylabel("flow, in cubic meters per second")
     plt.legend()
     fname = ws / f"{name}.obs.2.png"
+    plt.savefig(fname)
+
+    fig = plt.figure(figsize=(6, 6))
+    ax = fig.add_subplot(1, 1, 1)
+    ax.set_xlim(-100, 6100)
+    ax.set_ylim(-100, 6100)
+    pmv = flopy.plot.PlotMapView(model=chf, ax=ax)
+    pmv.plot_grid()
+    vertices = chf.disv1d.vertices.get_data()
+    ax.plot(vertices["xv"], vertices["yv"], 'bo')
+    for iv, x, y in vertices:
+        ax.text(x, y, f"{iv + 1}")
+    fname = ws / "grid.png"
     plt.savefig(fname)
 
     return

--- a/autotest/test_chf_dfw_loop.py
+++ b/autotest/test_chf_dfw_loop.py
@@ -225,7 +225,6 @@ def build_models(idx, test):
         chf,
         nodes=nodes,
         nvert=nvert,
-        length=reach_length,
         width=1.0,
         bottom=reach_bottom,
         idomain=1,
@@ -420,7 +419,7 @@ def make_plot(test):
     pmv = flopy.plot.PlotMapView(model=chf, ax=ax)
     pmv.plot_grid()
     vertices = chf.disv1d.vertices.get_data()
-    ax.plot(vertices["xv"], vertices["yv"], 'bo')
+    ax.plot(vertices["xv"], vertices["yv"], "bo")
     for iv, x, y in vertices:
         ax.text(x, y, f"{iv + 1}")
     fname = ws / "grid.png"

--- a/autotest/test_chf_dfw_swrt2.py
+++ b/autotest/test_chf_dfw_swrt2.py
@@ -76,10 +76,10 @@ def build_models(idx, test):
 
     vertices = []
     vertices = [[j, j * dx, 0.0] for j in range(nreach + 1)]
-    cell2d = []
+    cell1d = []
     for j in range(nreach):
-        cell2d.append([j, 0.5, 2, j, j + 1])
-    nodes = len(cell2d)
+        cell1d.append([j, 0.5, 2, j, j + 1])
+    nodes = len(cell1d)
     nvert = len(vertices)
 
     reach_bottom = np.linspace(1.05, 0.05, nreach)
@@ -94,7 +94,7 @@ def build_models(idx, test):
         bottom=reach_bottom,
         idomain=1,
         vertices=vertices,
-        cell2d=cell2d,
+        cell1d=cell1d,
     )
 
     dfw = flopy.mf6.ModflowChfdfw(

--- a/autotest/test_chf_dfw_swrt2.py
+++ b/autotest/test_chf_dfw_swrt2.py
@@ -89,7 +89,6 @@ def build_models(idx, test):
         export_array_ascii=True,
         nodes=nodes,
         nvert=nvert,
-        length=dx,
         width=dx,
         bottom=reach_bottom,
         idomain=1,
@@ -226,7 +225,6 @@ def check_output(idx, test):
 
     # ensure export array is working properly
     flist = [
-        "disv1d.length",
         "disv1d.width",
         "disv1d.bottom",
         "disv1d.idomain",

--- a/autotest/test_chf_dfw_swrt2b.py
+++ b/autotest/test_chf_dfw_swrt2b.py
@@ -98,7 +98,6 @@ def build_models(idx, test):
         chf,
         nodes=nodes,
         nvert=nvert,
-        length=dx,
         width=dx,
         bottom=reach_bottom,
         idomain=1,

--- a/autotest/test_chf_dfw_swrt2b.py
+++ b/autotest/test_chf_dfw_swrt2b.py
@@ -86,10 +86,10 @@ def build_models(idx, test):
 
     vertices = []
     vertices = [[j, j * dx, 0.0] for j in range(nreach + 1)]
-    cell2d = []
+    cell1d = []
     for j in range(nreach):
-        cell2d.append([j, 0.5, 2, j, j + 1])
-    nodes = len(cell2d)
+        cell1d.append([j, 0.5, 2, j, j + 1])
+    nodes = len(cell1d)
     nvert = len(vertices)
 
     reach_bottom = np.linspace(1.05, 0.05, nreach)
@@ -103,7 +103,7 @@ def build_models(idx, test):
         bottom=reach_bottom,
         idomain=1,
         vertices=vertices,
-        cell2d=cell2d,
+        cell1d=cell1d,
     )
 
     dfw = flopy.mf6.ModflowChfdfw(

--- a/autotest/test_chf_dis.py
+++ b/autotest/test_chf_dis.py
@@ -1,6 +1,6 @@
 """
 
-Test the disv1d to ensure that it supports IDOMAIN and writes a valid binary 
+Test the disv1d to ensure that it supports IDOMAIN and writes a valid binary
 grid file.
 
 """
@@ -26,9 +26,9 @@ for j in range(nreach):
     cell2d.append([j, 0.5, 2, j, j + 1])
 nodes = len(cell2d)
 nvert = len(vertices)
-xorigin = 100.
-yorigin = 200.
-angrot = 25.
+xorigin = 100.0
+yorigin = 200.0
+angrot = 25.0
 
 idomain = np.ones((nodes,), dtype=int)
 idomain[3:6] = 0
@@ -102,7 +102,7 @@ def add_chf_model_disv1d(sim):
         yorigin=yorigin,
         angrot=angrot,
     )
- 
+
     dfw = flopy.mf6.ModflowChfdfw(
         chf,
         print_flows=True,

--- a/autotest/test_chf_dis.py
+++ b/autotest/test_chf_dis.py
@@ -20,10 +20,10 @@ nreach = 9
 total_length = dx * nreach
 vertices = []
 vertices = [[j, j * dx, 0.0] for j in range(nreach + 1)]
-cell2d = []
+cell1d = []
 for j in range(nreach):
-    cell2d.append([j, 0.5, 2, j, j + 1])
-nodes = len(cell2d)
+    cell1d.append([j, 0.5, 2, j, j + 1])
+nodes = len(cell1d)
 nvert = len(vertices)
 xorigin = 100.0
 yorigin = 200.0
@@ -96,7 +96,7 @@ def add_chf_model_disv1d(sim):
         bottom=0.0,
         idomain=idomain,
         vertices=vertices,
-        cell2d=cell2d,
+        cell1d=cell1d,
         xorigin=xorigin,
         yorigin=yorigin,
         angrot=angrot,

--- a/autotest/test_chf_dis.py
+++ b/autotest/test_chf_dis.py
@@ -1,0 +1,233 @@
+"""
+
+Test the disv1d to ensure that it supports IDOMAIN and writes a valid binary 
+grid file.
+
+"""
+
+import flopy
+from flopy.utils.gridutil import get_disv_kwargs
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = [
+    "chf-disv1d",
+]
+
+# grid size
+dx = 1000.0
+nreach = 9
+total_length = dx * nreach
+vertices = []
+vertices = [[j, j * dx, 0.0] for j in range(nreach + 1)]
+cell2d = []
+for j in range(nreach):
+    cell2d.append([j, 0.5, 2, j, j + 1])
+nodes = len(cell2d)
+nvert = len(vertices)
+xorigin = 100.
+yorigin = 200.
+angrot = 25.
+
+idomain = np.ones((nodes,), dtype=int)
+idomain[3:6] = 0
+
+
+def build_models(idx, test):
+    perlen = [1]  # 1 second
+    nstp = [1]
+    tsmult = [1.0]
+    nper = len(perlen)
+
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+    name = "chf"
+
+    # build MODFLOW 6 files
+    ws = test.workspace
+    sim = flopy.mf6.MFSimulation(
+        sim_name=f"{name}_sim", version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="SECONDS", nper=nper, perioddata=tdis_rc
+    )
+
+    nouter, ninner = 100, 50
+    hclose, rclose, relax = 1e-6, 1e-8, 1.0
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="DBD",
+        under_relaxation_theta=0.9,
+        under_relaxation_kappa=0.0001,
+        under_relaxation_gamma=0.0,
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        # backtracking_number=5,
+        # backtracking_tolerance=1.0,
+        # backtracking_reduction_factor=0.3,
+        # backtracking_residual_limit=100.0,
+    )
+
+    add_chf_model_disv1d(sim)
+
+    return sim, None
+
+
+def add_chf_model_disv1d(sim):
+    name = "channel"
+    chf = flopy.mf6.ModflowChf(sim, modelname=name, save_flows=True)
+
+    disv1d = flopy.mf6.ModflowChfdisv1D(
+        chf,
+        nodes=nodes,
+        nvert=nvert,
+        length=dx,
+        width=50.0,
+        bottom=0.0,
+        idomain=idomain,
+        vertices=vertices,
+        cell2d=cell2d,
+        xorigin=xorigin,
+        yorigin=yorigin,
+        angrot=angrot,
+    )
+ 
+    dfw = flopy.mf6.ModflowChfdfw(
+        chf,
+        print_flows=True,
+        save_flows=True,
+        length_conversion=1.0,
+        time_conversion=86400.0,
+        manningsn=0.035,
+        idcxs=None,
+    )
+
+    ic = flopy.mf6.ModflowChfic(chf, strt=1.0)
+
+    # output control
+    oc = flopy.mf6.ModflowChfoc(
+        chf,
+        budget_filerecord=f"{name}.bud",
+        stage_filerecord=f"{name}.stage",
+        saverecord=[
+            ("STAGE", "ALL"),
+            ("BUDGET", "ALL"),
+        ],
+        printrecord=[
+            ("STAGE", "LAST"),
+            ("BUDGET", "ALL"),
+        ],
+    )
+
+    chd = flopy.mf6.ModflowChfchd(
+        chf,
+        maxbound=1,
+        print_input=True,
+        print_flows=True,
+        stress_period_data=[(0, 0.5), (nodes - 1, 1.0)],
+    )
+
+    return
+
+
+def make_plot(test, mfsim, stage, idx):
+    print("making plots...")
+    import matplotlib.pyplot as plt
+
+    chf = mfsim.chf[0]
+    pmv = flopy.plot.PlotMapView(model=chf)
+    pmv.plot_array(stage, masked_values=[3e30])
+    pmv.plot_grid()
+
+    fname = test.workspace / "results.png"
+    plt.savefig(fname)
+
+
+def check_grb_disv1d(fpth):
+    grb = flopy.mf6.utils.MfGrdFile(fpth)
+    assert grb.grid_type == "DISV1D", "grb grid type not DISV1D"
+    assert grb.ncells == nodes, "grb ncells is incorrect"
+    assert grb._datadict["NCELLS"] == nodes, f"grb nodes is incorrect"
+    assert grb.verts.shape == (
+        nodes + 1,
+        2,
+    ), f"vertices shape is incorrect"
+    assert grb.nja == 14, f"nja in grb file is not 14"
+    assert grb.xorigin == xorigin, f"xorigin in grb file is not correct"
+    assert grb.yorigin == yorigin, f"yorigin in grb file is not correct"
+    assert grb.angrot == angrot, f"angrot in grb file is not correct"
+    assert np.allclose(
+        grb.bot.reshape((nodes,)), np.zeros((nodes,))
+    ), "grb botm not correct"
+    cellx = np.linspace(dx / 2, nreach * dx - dx / 2, nreach)
+    celly = np.zeros(nreach)
+    assert np.allclose(
+        grb._datadict["CELLX"], cellx.flatten()
+    ), "cellx is not right"
+    assert np.allclose(
+        grb._datadict["CELLY"], celly.flatten()
+    ), "celly is not right"
+    assert (
+        grb._datadict["IAVERT"].shape[0] == nodes + 1
+    ), "iavert size not right"
+    assert (
+        grb._datadict["IAVERT"][-1] - 1 == grb._datadict["JAVERT"].shape[0]
+    ), "javert size not right"
+    assert (
+        grb.ia.shape[0] == grb.ncells + 1
+    ), "ia in grb file is not correct size"
+    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
+    assert np.allclose(
+        grb.idomain.reshape((nodes,)), idomain.reshape((nodes,))
+    ), "grb idomain not correct"
+
+
+def check_output(idx, test):
+    print(f"evaluating model for case {idx}...")
+
+    modelname = "channel"
+    ws = test.workspace
+    mfsim = flopy.mf6.MFSimulation.load(sim_ws=ws)
+
+    # read the binary grid file
+    fpth = test.workspace / f"{modelname}.disv1d.grb"
+    check_grb_disv1d(fpth)
+
+    # read binary stage file
+    fpth = test.workspace / f"{modelname}.stage"
+    sobj = flopy.utils.HeadFile(fpth, precision="double", text="STAGE")
+    stage = sobj.get_data().reshape((nodes,))
+    assert np.allclose(
+        stage[idomain == 0], 3.0e30
+    ), "stage should have nodata values where idomain is zero"
+    assert stage[idomain == 1].max() == 1.0, "maximum stage should be 1.0"
+    assert stage[idomain == 1].min() == 0.5, "minimum stage should be 0.5"
+
+    makeplot = False
+    if makeplot:
+        # PlotMapView not working yet for dis2d
+        make_plot(test, mfsim, stage.flatten(), idx)
+
+
+@pytest.mark.developmode
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        targets=targets,
+    )
+    test.run()

--- a/autotest/test_chf_dis.py
+++ b/autotest/test_chf_dis.py
@@ -6,7 +6,6 @@ grid file.
 """
 
 import flopy
-from flopy.utils.gridutil import get_disv_kwargs
 import numpy as np
 import pytest
 from framework import TestFramework
@@ -158,15 +157,15 @@ def check_grb_disv1d(fpth):
     grb = flopy.mf6.utils.MfGrdFile(fpth)
     assert grb.grid_type == "DISV1D", "grb grid type not DISV1D"
     assert grb.ncells == nodes, "grb ncells is incorrect"
-    assert grb._datadict["NCELLS"] == nodes, f"grb nodes is incorrect"
+    assert grb._datadict["NCELLS"] == nodes, "grb nodes is incorrect"
     assert grb.verts.shape == (
         nodes + 1,
         2,
-    ), f"vertices shape is incorrect"
-    assert grb.nja == 14, f"nja in grb file is not 14"
-    assert grb.xorigin == xorigin, f"xorigin in grb file is not correct"
-    assert grb.yorigin == yorigin, f"yorigin in grb file is not correct"
-    assert grb.angrot == angrot, f"angrot in grb file is not correct"
+    ), "vertices shape is incorrect"
+    assert grb.nja == 14, "nja in grb file is not 14"
+    assert grb.xorigin == xorigin, "xorigin in grb file is not correct"
+    assert grb.yorigin == yorigin, "yorigin in grb file is not correct"
+    assert grb.angrot == angrot, "angrot in grb file is not correct"
     assert np.allclose(
         grb.bot.reshape((nodes,)), np.zeros((nodes,))
     ), "grb botm not correct"

--- a/autotest/test_chf_dis.py
+++ b/autotest/test_chf_dis.py
@@ -91,7 +91,6 @@ def add_chf_model_disv1d(sim):
         chf,
         nodes=nodes,
         nvert=nvert,
-        length=dx,
         width=50.0,
         bottom=0.0,
         idomain=idomain,

--- a/autotest/test_chf_dis_fdc.py
+++ b/autotest/test_chf_dis_fdc.py
@@ -22,11 +22,11 @@ nreach = 2
 total_length = dx * nreach
 vertices = []
 vertices = [[j, j * dx, 0.0] for j in range(nreach + 1)]
-cell2d = []
+cell1d = []
 fdc = [0.0, 1.0]
 for j in range(nreach):
-    cell2d.append([j, fdc[j], 2, j, j + 1])
-nodes = len(cell2d)
+    cell1d.append([j, fdc[j], 2, j, j + 1])
+nodes = len(cell1d)
 nvert = len(vertices)
 xorigin = 100.0
 yorigin = 200.0
@@ -102,7 +102,7 @@ def add_chf_model_disv1d(sim):
         bottom=0.0,
         idomain=idomain,
         vertices=vertices,
-        cell2d=cell2d,
+        cell1d=cell1d,
         xorigin=xorigin,
         yorigin=yorigin,
         angrot=angrot,
@@ -152,7 +152,7 @@ def make_plot(test, mfsim, stage, idx):
 
     chf = mfsim.chf[0]
     pmv = flopy.plot.PlotMapView(model=chf)
-    pmv.plot_array(stage, masked_values=[3e30])
+    pmv.plot_array(stage, masked_values=[3e30])  # not working yet
     pmv.plot_grid()
 
     fname = test.workspace / "results.png"

--- a/autotest/test_chf_dis_fdc.py
+++ b/autotest/test_chf_dis_fdc.py
@@ -97,7 +97,6 @@ def add_chf_model_disv1d(sim):
         chf,
         nodes=nodes,
         nvert=nvert,
-        length=dx,
         width=50.0,
         bottom=0.0,
         idomain=idomain,

--- a/autotest/test_chf_gwf.py
+++ b/autotest/test_chf_gwf.py
@@ -92,7 +92,6 @@ def add_chf_model(sim):
         chf,
         nodes=nodes,
         nvert=nvert,
-        length=dx,
         width=50.0,
         bottom=0.0,
         idomain=1,

--- a/autotest/test_chf_gwf.py
+++ b/autotest/test_chf_gwf.py
@@ -82,10 +82,10 @@ def add_chf_model(sim):
     total_length = dx * nreach
     vertices = []
     vertices = [[j, j * dx, 0.0] for j in range(nreach + 1)]
-    cell2d = []
+    cell1d = []
     for j in range(nreach):
-        cell2d.append([j, 0.5, 2, j, j + 1])
-    nodes = len(cell2d)
+        cell1d.append([j, 0.5, 2, j, j + 1])
+    nodes = len(cell1d)
     nvert = len(vertices)
 
     disv1d = flopy.mf6.ModflowChfdisv1D(
@@ -97,7 +97,7 @@ def add_chf_model(sim):
         bottom=0.0,
         idomain=1,
         vertices=vertices,
-        cell2d=cell2d,
+        cell1d=cell1d,
     )
 
     dfw = flopy.mf6.ModflowChfdfw(

--- a/autotest/test_olf_dfw_swrt2dis.py
+++ b/autotest/test_olf_dfw_swrt2dis.py
@@ -73,9 +73,9 @@ def build_models(idx, test):
 
     nrow = 11
     ncol = 11
-    botm = np.empty((nrow, ncol), dtype=float)
+    bottom = np.empty((nrow, ncol), dtype=float)
     for i in range(nrow):
-        botm[i, :] = np.linspace(1.05, 0.05, nrow)
+        bottom[i, :] = np.linspace(1.05, 0.05, nrow)
 
     dis = flopy.mf6.ModflowOlfdis2D(
         olf,
@@ -83,7 +83,7 @@ def build_models(idx, test):
         ncol=ncol,
         delr=dx,
         delc=dx,
-        botm=botm,
+        bottom=bottom,
     )
 
     dfw = flopy.mf6.ModflowOlfdfw(
@@ -206,7 +206,7 @@ def check_output(idx, test):
 
     # at end of simulation, water depth should be 1.0 for all reaches
     olf = mfsim.get_model(olfname)
-    depth = stage_all[-1] - olf.dis.botm.array
+    depth = stage_all[-1] - olf.dis.bottom.array
     assert np.allclose(
         depth, 1.0
     ), f"Simulated depth at end should be 1, but found {depth}"

--- a/autotest/test_olf_dis.py
+++ b/autotest/test_olf_dis.py
@@ -6,9 +6,9 @@ IDOMAIN and have valid binary grid files.
 """
 
 import flopy
-from flopy.utils.gridutil import get_disv_kwargs
 import numpy as np
 import pytest
+from flopy.utils.gridutil import get_disv_kwargs
 from framework import TestFramework
 
 cases = [
@@ -223,12 +223,12 @@ def check_grb_dis2d(fpth):
     grb = flopy.mf6.utils.MfGrdFile(fpth)
     assert grb.grid_type == "DIS2D", "grb grid type not DIS2D"
     assert grb.ncells == nrow * ncol, "grb ncells is incorrect"
-    assert grb.nrow == nrow, f"nrow in grb file is not 10"
-    assert grb.ncol == ncol, f"ncol in grb file is not 10"
-    assert grb.nja == 432, f"nja in grb file is not 432"
-    assert grb.xorigin == xorigin, f"xorigin in grb file is not correct"
-    assert grb.yorigin == yorigin, f"yorigin in grb file is not correct"
-    assert grb.angrot == angrot, f"angrot in grb file is not correct"
+    assert grb.nrow == nrow, "nrow in grb file is not 10"
+    assert grb.ncol == ncol, "ncol in grb file is not 10"
+    assert grb.nja == 432, "nja in grb file is not 432"
+    assert grb.xorigin == xorigin, "xorigin in grb file is not correct"
+    assert grb.yorigin == yorigin, "yorigin in grb file is not correct"
+    assert grb.angrot == angrot, "angrot in grb file is not correct"
     assert np.allclose(grb.delr, dx * np.ones((ncol))), "grb delr not correct"
     assert np.allclose(grb.delc, dx * np.ones((nrow))), "grb delc not correct"
     assert np.allclose(
@@ -247,15 +247,15 @@ def check_grb_disv2d(fpth):
     grb = flopy.mf6.utils.MfGrdFile(fpth)
     assert grb.grid_type == "DISV2D", "grb grid type not DISV2D"
     assert grb.ncells == ncpl, "grb ncells is incorrect"
-    assert grb._datadict["NODES"] == 96, f"grb nodes is incorrect"
+    assert grb._datadict["NODES"] == 96, "grb nodes is incorrect"
     assert grb.verts.shape == (
         (nrow + 1) * (ncol + 1),
         2,
-    ), f"vertices shape is incorrect"
-    assert grb.nja == 432, f"nja in grb file is not 432"
-    assert grb.xorigin == xorigin, f"xorigin in grb file is not correct"
-    assert grb.yorigin == yorigin, f"yorigin in grb file is not correct"
-    assert grb.angrot == angrot, f"angrot in grb file is not correct"
+    ), "vertices shape is incorrect"
+    assert grb.nja == 432, "nja in grb file is not 432"
+    assert grb.xorigin == xorigin, "xorigin in grb file is not correct"
+    assert grb.yorigin == yorigin, "yorigin in grb file is not correct"
+    assert grb.angrot == angrot, "angrot in grb file is not correct"
     assert np.allclose(
         grb.bot.reshape((nrow, ncol)), np.zeros((nrow, ncol))
     ), "grb botm not correct"

--- a/autotest/test_olf_dis.py
+++ b/autotest/test_olf_dis.py
@@ -311,7 +311,6 @@ def check_output(idx, test):
 
     makeplot = False
     if makeplot:
-        # PlotMapView not working yet for dis2d
         make_plot(test, mfsim, stage.flatten(), idx)
 
 

--- a/autotest/test_olf_dis.py
+++ b/autotest/test_olf_dis.py
@@ -1,0 +1,308 @@
+"""
+
+Test the dis2d and disv2d discretization packages so that they support
+IDOMAIN and have valid binary grid files.
+
+"""
+
+import flopy
+from flopy.utils.gridutil import get_disv_kwargs
+import numpy as np
+import pytest
+from framework import TestFramework
+
+cases = [
+    "olf-dis2d",
+    "olf-disv2d",
+]
+
+# grid size
+dx = 1000.0
+nrow = 10
+ncol = 10
+ncpl = nrow * ncol
+xorigin = 75.0
+yorigin = 500.0
+angrot = 32.0
+botm = np.zeros((nrow, ncol), dtype=float)
+idomain = np.ones((nrow, ncol), dtype=int)
+idomain[4:6, 4:6] = 0
+
+
+def build_models(idx, test):
+    perlen = [1]  # 1 second
+    nstp = [1]
+    tsmult = [1.0]
+    nper = len(perlen)
+
+    tdis_rc = []
+    for i in range(nper):
+        tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
+
+    name = "olf"
+
+    # build MODFLOW 6 files
+    ws = test.workspace
+    sim = flopy.mf6.MFSimulation(
+        sim_name=f"{name}_sim", version="mf6", exe_name="mf6", sim_ws=ws
+    )
+    # create tdis package
+    tdis = flopy.mf6.ModflowTdis(
+        sim, time_units="SECONDS", nper=nper, perioddata=tdis_rc
+    )
+
+    nouter, ninner = 100, 50
+    hclose, rclose, relax = 1e-6, 1e-8, 1.0
+    ims = flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=hclose,
+        outer_maximum=nouter,
+        under_relaxation="DBD",
+        under_relaxation_theta=0.9,
+        under_relaxation_kappa=0.0001,
+        under_relaxation_gamma=0.0,
+        inner_maximum=ninner,
+        inner_dvclose=hclose,
+        linear_acceleration="BICGSTAB",
+        scaling_method="NONE",
+        reordering_method="NONE",
+        relaxation_factor=relax,
+        # backtracking_number=5,
+        # backtracking_tolerance=1.0,
+        # backtracking_reduction_factor=0.3,
+        # backtracking_residual_limit=100.0,
+    )
+
+    if idx == 0:
+        add_olf_model_dis2d(sim)
+    elif idx == 1:
+        add_olf_model_disv2d(sim)
+
+    return sim, None
+
+
+def add_olf_model_dis2d(sim):
+    name = "overland"
+    olf = flopy.mf6.ModflowOlf(sim, modelname=name, save_flows=True)
+
+    dis = flopy.mf6.ModflowOlfdis2D(
+        olf,
+        nrow=nrow,
+        ncol=ncol,
+        delr=dx,
+        delc=dx,
+        botm=botm,
+        idomain=idomain,
+        xorigin=xorigin,
+        yorigin=yorigin,
+        angrot=angrot,
+    )
+
+    dfw = flopy.mf6.ModflowOlfdfw(
+        olf,
+        print_flows=True,
+        save_flows=True,
+        length_conversion=1.0,
+        time_conversion=86400.0,
+        manningsn=3.5,
+        idcxs=None,
+    )
+
+    ic = flopy.mf6.ModflowOlfic(olf, strt=1.0)
+
+    # output control
+    oc = flopy.mf6.ModflowOlfoc(
+        olf,
+        budget_filerecord=f"{name}.bud",
+        stage_filerecord=f"{name}.stage",
+        saverecord=[
+            ("STAGE", "ALL"),
+            ("BUDGET", "ALL"),
+        ],
+        printrecord=[
+            ("STAGE", "LAST"),
+            ("BUDGET", "ALL"),
+        ],
+    )
+
+    chd = flopy.mf6.ModflowOlfchd(
+        olf,
+        maxbound=1,
+        print_input=True,
+        print_flows=True,
+        stress_period_data=[(0, 0, 1.0), (nrow - 1, ncol - 1, 0.5)],
+    )
+
+    return
+
+
+def add_olf_model_disv2d(sim):
+    name = "overland"
+    olf = flopy.mf6.ModflowOlf(sim, modelname=name, save_flows=True)
+
+    disvkwargs = get_disv_kwargs(
+        1,
+        nrow,
+        ncol,
+        dx,
+        dx,
+        1.0, # top
+        0., # botm
+        0., # xoffset
+        0., # yoffset
+    )
+
+    _ = disvkwargs.pop("top")
+    _ = disvkwargs.pop("nlay")
+    bottom = disvkwargs.pop("botm").reshape((ncpl,))
+    disvkwargs["nodes"] = disvkwargs.pop("ncpl")
+
+    dis = flopy.mf6.ModflowOlfdisv2D(
+        olf,
+        bottom=bottom,
+        idomain=idomain.reshape((ncpl,)),
+        xorigin=xorigin,
+        yorigin=yorigin,
+        angrot=angrot,
+        **disvkwargs
+    )
+
+    dfw = flopy.mf6.ModflowOlfdfw(
+        olf,
+        print_flows=True,
+        save_flows=True,
+        length_conversion=1.0,
+        time_conversion=86400.0,
+        manningsn=3.5,
+        idcxs=None,
+    )
+
+    ic = flopy.mf6.ModflowOlfic(olf, strt=1.0)
+
+    # output control
+    oc = flopy.mf6.ModflowOlfoc(
+        olf,
+        budget_filerecord=f"{name}.bud",
+        stage_filerecord=f"{name}.stage",
+        saverecord=[
+            ("STAGE", "ALL"),
+            ("BUDGET", "ALL"),
+        ],
+        printrecord=[
+            ("STAGE", "LAST"),
+            ("BUDGET", "ALL"),
+        ],
+    )
+
+    chd = flopy.mf6.ModflowOlfchd(
+        olf,
+        maxbound=1,
+        print_input=True,
+        print_flows=True,
+        stress_period_data=[(0, 1.0), (ncpl - 1, 0.5)],
+    )
+
+    return
+
+
+def make_plot(test, mfsim, stage):
+    print("making plots...")
+    import matplotlib.pyplot as plt
+
+    olf = mfsim.olf[0]
+    pmv = flopy.plot.PlotMapView(model=olf)
+    pmv.plot_array(stage)
+    pmv.plot_grid()
+
+    fname = test.workspace / "results.png"
+    plt.savefig(fname)
+
+
+def check_grb_dis2d(fpth):
+    grb = flopy.mf6.utils.MfGrdFile(fpth)
+    assert grb.grid_type == "DIS2D", "grb grid type not DIS2D"
+    assert grb.ncells == nrow * ncol, "grb ncells is incorrect"
+    assert grb.nrow == nrow, f"nrow in grb file is not 10"
+    assert grb.ncol == ncol, f"ncol in grb file is not 10"
+    assert grb.nja == 432, f"nja in grb file is not 432"
+    assert grb.xorigin == xorigin, f"xorigin in grb file is not correct"
+    assert grb.yorigin == yorigin, f"yorigin in grb file is not correct"
+    assert grb.angrot == angrot, f"angrot in grb file is not correct"
+    assert np.allclose(grb.delr, dx * np.ones((ncol))), "grb delr not correct"
+    assert np.allclose(grb.delc, dx * np.ones((nrow))), "grb delc not correct"
+    assert np.allclose(
+        grb.bot.reshape((nrow, ncol)), np.zeros((nrow, ncol))
+    ), "grb botm not correct"
+    assert (
+        grb.ia.shape[0] == grb.ncells + 1
+    ), "ia in grb file is not correct size"
+    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
+    assert np.allclose(
+        grb.idomain.reshape((nrow, ncol)), idomain
+    ), "grb idomain not correct"
+
+
+def check_grb_disv2d(fpth):
+    grb = flopy.mf6.utils.MfGrdFile(fpth)
+    assert grb.grid_type == "DISV2D", "grb grid type not DISV2D"
+    assert grb.ncells == ncpl, "grb ncells is incorrect"
+    assert grb._datadict["NODES"] == 96, f"grb nodes is incorrect"
+    assert grb.verts.shape[0] == (nrow + 1) * (ncol + 1), f"grb nvert is incorrect"
+    assert grb.nja == 432, f"nja in grb file is not 432"
+    assert grb.xorigin == xorigin, f"xorigin in grb file is not correct"
+    assert grb.yorigin == yorigin, f"yorigin in grb file is not correct"
+    assert grb.angrot == angrot, f"angrot in grb file is not correct"
+    assert np.allclose(
+        grb.bot.reshape((nrow, ncol)), np.zeros((nrow, ncol))
+    ), "grb botm not correct"
+    assert (
+        grb.ia.shape[0] == grb.ncells + 1
+    ), "ia in grb file is not correct size"
+    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
+    assert np.allclose(
+        grb.idomain.reshape((ncpl,)), idomain.reshape((ncpl,))
+    ), "grb idomain not correct"
+
+
+def check_output(idx, test):
+    print(f"evaluating model for case {idx}...")
+
+    modelname = "overland"
+    ws = test.workspace
+    mfsim = flopy.mf6.MFSimulation.load(sim_ws=ws)
+
+    # read the binary grid file
+    if idx == 0:
+        fpth = test.workspace / f"{modelname}.dis2d.grb"
+        check_grb_dis2d(fpth)
+    elif idx == 1:
+        fpth = test.workspace / f"{modelname}.disv2d.grb"
+        check_grb_disv2d(fpth)
+
+    # read binary stage file
+    fpth = test.workspace / f"{modelname}.stage"
+    sobj = flopy.utils.HeadFile(fpth, precision="double", text="STAGE")
+    stage = sobj.get_data().reshape((nrow, ncol))
+    assert np.allclose(stage[idomain==0], 3.e30), "stage should have nodata values where idomain is zero"
+    assert stage[idomain==1].max() == 1.0, "maximum stage should be 1.0"
+    assert stage[idomain==1].min() == 0.5, "minimum stage should be 0.5"
+
+    makeplot = False
+    if makeplot:
+        # PlotMapView not working yet for dis2d
+        make_plot(test, mfsim, stage)
+
+
+
+@pytest.mark.developmode
+@pytest.mark.parametrize("idx, name", enumerate(cases))
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+        targets=targets,
+    )
+    test.run()

--- a/autotest/test_olf_gwf.py
+++ b/autotest/test_olf_gwf.py
@@ -88,7 +88,7 @@ def add_olf_model(sim):
         ncol=ncol,
         delr=dx,
         delc=dx,
-        botm=botm,
+        bottom=botm,
     )
 
     dfw = flopy.mf6.ModflowOlfdfw(

--- a/autotest/test_olf_vcatch.py
+++ b/autotest/test_olf_vcatch.py
@@ -119,7 +119,7 @@ def build_models(idx, test):
     )
     sim.register_ims_package(imsolf, [olf.name])
 
-    botm = land_surface.reshape((nrow, ncol))
+    bottom = land_surface.reshape((nrow, ncol))
     dis = flopy.mf6.ModflowOlfdis2D(
         olf,
         export_array_ascii=True,
@@ -127,7 +127,7 @@ def build_models(idx, test):
         ncol=ncol,
         delr=dx,
         delc=dx,
-        botm=botm,
+        bottom=bottom,
         xorigin=-810,
     )
 
@@ -153,7 +153,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowOlfic(
         olf,
         export_array_ascii=True,
-        strt=botm,
+        strt=bottom,
     )
 
     # output control
@@ -272,7 +272,7 @@ def check_output(idx, test):
 
     # ensure export array is working properly
     flist = [
-        "dis2d.botm",
+        "dis2d.bottom",
         "dis2d.delc",
         "dis2d.delr",
         "dfw.manningsn",

--- a/doc/mf6io/mf6ivar/dfn/chf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-dis2d.dfn
@@ -90,7 +90,7 @@ description is the row spacing in the column direction.
 default_value 1.0
 
 block griddata
-name botm
+name bottom
 type double precision
 shape (ncol, nrow)
 reader readarray

--- a/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
@@ -155,29 +155,29 @@ optional false
 longname y-coordinate for vertex
 description is the y-coordinate for the vertex.
 
-# --------------------- swf disv1d cell2d ---------------------
+# --------------------- swf disv1d cell1d ---------------------
 
-block cell2d
-name cell2d
-type recarray icell2d fdc ncvert icvert
+block cell1d
+name cell1d
+type recarray icell1d fdc ncvert icvert
 shape (nodes)
 reader urword
 optional false
-longname cell2d data
+longname cell1d data
 description
 
-block cell2d
-name icell2d
+block cell1d
+name icell1d
 type integer
 in_record true
 tagged false
 reader urword
 optional false
-longname cell2d number
-description is the cell2d number.  Records in the cell2d block must be listed in consecutive order from the first to the last.
+longname cell1d number
+description is the cell1d number.  Records in the cell1d block must be listed in consecutive order from the first to the last.
 numeric_index true
 
-block cell2d
+block cell1d
 name fdc
 type double precision
 in_record true
@@ -187,7 +187,7 @@ optional false
 longname fractional distance to the cell center
 description is the fractional distance to the cell center. FDC is relative to the first vertex in the ICVERT array. In most cases FDC should be 0.5, which would place the center of the line segment that defines the cell. If the value of FDC is 1, the cell center would located at the last vertex. FDC values of 0 and 1 can be used to place the node at either end of the cell which can be useful for cells with boundary conditions.
 
-block cell2d
+block cell1d
 name ncvert
 type integer
 in_record true
@@ -197,7 +197,7 @@ optional false
 longname number of cell vertices
 description is the number of vertices required to define the cell.  There may be a different number of vertices for each cell.
 
-block cell2d
+block cell1d
 name icvert
 type integer
 shape (ncvert)

--- a/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/chf-disv1d.dfn
@@ -70,17 +70,6 @@ description is the total number of (x, y, z) vertex pairs used to characterize t
 # --------------------- swf disv1d griddata ---------------------
 
 block griddata
-name length
-type double precision
-shape (nodes)
-valid
-reader readarray
-layered false
-optional
-longname length
-description length for each one-dimensional cell
-
-block griddata
 name width
 type double precision
 shape (nodes)

--- a/doc/mf6io/mf6ivar/dfn/olf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/olf-dis2d.dfn
@@ -90,7 +90,7 @@ description is the row spacing in the column direction.
 default_value 1.0
 
 block griddata
-name botm
+name bottom
 type double precision
 shape (ncol, nrow)
 reader readarray

--- a/doc/mf6io/mf6ivar/dfn/swf-dis2d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-dis2d.dfn
@@ -90,7 +90,7 @@ description is the row spacing in the column direction.
 default_value 1.0
 
 block griddata
-name botm
+name bottom
 type double precision
 shape (ncol, nrow)
 reader readarray

--- a/doc/mf6io/mf6ivar/dfn/swf-disv1d.dfn
+++ b/doc/mf6io/mf6ivar/dfn/swf-disv1d.dfn
@@ -70,17 +70,6 @@ description is the total number of (x, y, z) vertex pairs used to characterize t
 # --------------------- swf disv1d griddata ---------------------
 
 block griddata
-name length
-type double precision
-shape (nodes)
-valid
-reader readarray
-layered false
-optional
-longname length
-description length for each one-dimensional cell
-
-block griddata
 name width
 type double precision
 shape (nodes)
@@ -155,29 +144,29 @@ optional false
 longname y-coordinate for vertex
 description is the y-coordinate for the vertex.
 
-# --------------------- swf disv1d cell2d ---------------------
+# --------------------- swf disv1d cell1d ---------------------
 
-block cell2d
-name cell2d
-type recarray icell2d fdc ncvert icvert
+block cell1d
+name cell1d
+type recarray icell1d fdc ncvert icvert
 shape (nodes)
 reader urword
 optional false
-longname cell2d data
+longname cell1d data
 description
 
-block cell2d
-name icell2d
+block cell1d
+name icell1d
 type integer
 in_record true
 tagged false
 reader urword
 optional false
-longname cell2d number
-description is the cell2d number.  Records in the cell2d block must be listed in consecutive order from the first to the last.
+longname cell1d number
+description is the cell1d number.  Records in the cell1d block must be listed in consecutive order from the first to the last.
 numeric_index true
 
-block cell2d
+block cell1d
 name fdc
 type double precision
 in_record true
@@ -187,7 +176,7 @@ optional false
 longname fractional distance to the cell center
 description is the fractional distance to the cell center. FDC is relative to the first vertex in the ICVERT array. In most cases FDC should be 0.5, which would place the center of the line segment that defines the cell. If the value of FDC is 1, the cell center would located at the last vertex. FDC values of 0 and 1 can be used to place the node at either end of the cell which can be useful for cells with boundary conditions.
 
-block cell2d
+block cell1d
 name ncvert
 type integer
 in_record true
@@ -197,7 +186,7 @@ optional false
 longname number of cell vertices
 description is the number of vertices required to define the cell.  There may be a different number of vertices for each cell.
 
-block cell2d
+block cell1d
 name icvert
 type integer
 shape (ncvert)

--- a/src/Idm/chf-dis2didm.f90
+++ b/src/Idm/chf-dis2didm.f90
@@ -22,7 +22,7 @@ module ChfDis2DInputModule
     logical :: ncol = .false.
     logical :: delr = .false.
     logical :: delc = .false.
-    logical :: botm = .false.
+    logical :: bottom = .false.
     logical :: idomain = .false.
   end type ChfDis2dParamFoundType
 
@@ -215,13 +215,13 @@ module ChfDis2DInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfdis2d_botm = InputParamDefinitionType &
+    chfdis2d_bottom = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'DIS2D', & ! subcomponent
     'GRIDDATA', & ! block
-    'BOTM', & ! tag name
-    'BOTM', & ! fortran variable
+    'BOTTOM', & ! tag name
+    'BOTTOM', & ! fortran variable
     'DOUBLE2D', & ! type
     'NCOL NROW', & ! shape
     'cell bottom elevation', & ! longname
@@ -263,7 +263,7 @@ module ChfDis2DInputModule
     chfdis2d_ncol, &
     chfdis2d_delr, &
     chfdis2d_delc, &
-    chfdis2d_botm, &
+    chfdis2d_bottom, &
     chfdis2d_idomain &
     ]
 

--- a/src/Idm/chf-disv1didm.f90
+++ b/src/Idm/chf-disv1didm.f90
@@ -27,7 +27,7 @@ module ChfDisv1DInputModule
     logical :: iv = .false.
     logical :: xv = .false.
     logical :: yv = .false.
-    logical :: icell2d = .false.
+    logical :: icell1d = .false.
     logical :: fdc = .false.
     logical :: ncvert = .false.
     logical :: icvert = .false.
@@ -312,16 +312,16 @@ module ChfDisv1DInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfdisv1d_icell2d = InputParamDefinitionType &
+    chfdisv1d_icell1d = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'DISV1D', & ! subcomponent
-    'CELL2D', & ! block
-    'ICELL2D', & ! tag name
-    'ICELL2D', & ! fortran variable
+    'CELL1D', & ! block
+    'ICELL1D', & ! tag name
+    'ICELL1D', & ! fortran variable
     'INTEGER', & ! type
     '', & ! shape
-    'cell2d number', & ! longname
+    'cell1d number', & ! longname
     .true., & ! required
     .true., & ! multi-record
     .false., & ! preserve case
@@ -334,7 +334,7 @@ module ChfDisv1DInputModule
     ( &
     'CHF', & ! component
     'DISV1D', & ! subcomponent
-    'CELL2D', & ! block
+    'CELL1D', & ! block
     'FDC', & ! tag name
     'FDC', & ! fortran variable
     'DOUBLE', & ! type
@@ -352,7 +352,7 @@ module ChfDisv1DInputModule
     ( &
     'CHF', & ! component
     'DISV1D', & ! subcomponent
-    'CELL2D', & ! block
+    'CELL1D', & ! block
     'NCVERT', & ! tag name
     'NCVERT', & ! fortran variable
     'INTEGER', & ! type
@@ -370,7 +370,7 @@ module ChfDisv1DInputModule
     ( &
     'CHF', & ! component
     'DISV1D', & ! subcomponent
-    'CELL2D', & ! block
+    'CELL1D', & ! block
     'ICVERT', & ! tag name
     'ICVERT', & ! fortran variable
     'INTEGER1D', & ! type
@@ -401,7 +401,7 @@ module ChfDisv1DInputModule
     chfdisv1d_iv, &
     chfdisv1d_xv, &
     chfdisv1d_yv, &
-    chfdisv1d_icell2d, &
+    chfdisv1d_icell1d, &
     chfdisv1d_fdc, &
     chfdisv1d_ncvert, &
     chfdisv1d_icvert &
@@ -426,16 +426,16 @@ module ChfDisv1DInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    chfdisv1d_cell2d = InputParamDefinitionType &
+    chfdisv1d_cell1d = InputParamDefinitionType &
     ( &
     'CHF', & ! component
     'DISV1D', & ! subcomponent
-    'CELL2D', & ! block
-    'CELL2D', & ! tag name
-    'CELL2D', & ! fortran variable
-    'RECARRAY ICELL2D FDC NCVERT ICVERT', & ! type
+    'CELL1D', & ! block
+    'CELL1D', & ! tag name
+    'CELL1D', & ! fortran variable
+    'RECARRAY ICELL1D FDC NCVERT ICVERT', & ! type
     'NODES', & ! shape
-    'cell2d data', & ! longname
+    'cell1d data', & ! longname
     .true., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
@@ -447,7 +447,7 @@ module ChfDisv1DInputModule
     chf_disv1d_aggregate_definitions(*) = &
     [ &
     chfdisv1d_vertices, &
-    chfdisv1d_cell2d &
+    chfdisv1d_cell1d &
     ]
 
   type(InputBlockDefinitionType), parameter :: &
@@ -478,7 +478,7 @@ module ChfDisv1DInputModule
     .false. & ! block_variable
     ), &
     InputBlockDefinitionType( &
-    'CELL2D', & ! blockname
+    'CELL1D', & ! blockname
     .true., & ! required
     .true., & ! aggregate
     .false. & ! block_variable

--- a/src/Idm/chf-disv1didm.f90
+++ b/src/Idm/chf-disv1didm.f90
@@ -20,7 +20,6 @@ module ChfDisv1DInputModule
     logical :: export_ascii = .false.
     logical :: nodes = .false.
     logical :: nvert = .false.
-    logical :: length = .false.
     logical :: width = .false.
     logical :: bottom = .false.
     logical :: idomain = .false.
@@ -179,24 +178,6 @@ module ChfDisv1DInputModule
     '', & ! shape
     'number of columns', & ! longname
     .false., & ! required
-    .false., & ! multi-record
-    .false., & ! preserve case
-    .false., & ! layered
-    .false. & ! timeseries
-    )
-
-  type(InputParamDefinitionType), parameter :: &
-    chfdisv1d_length = InputParamDefinitionType &
-    ( &
-    'CHF', & ! component
-    'DISV1D', & ! subcomponent
-    'GRIDDATA', & ! block
-    'LENGTH', & ! tag name
-    'LENGTH', & ! fortran variable
-    'DOUBLE1D', & ! type
-    'NODES', & ! shape
-    'length', & ! longname
-    .true., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
     .false., & ! layered
@@ -394,7 +375,6 @@ module ChfDisv1DInputModule
     chfdisv1d_export_ascii, &
     chfdisv1d_nodes, &
     chfdisv1d_nvert, &
-    chfdisv1d_length, &
     chfdisv1d_width, &
     chfdisv1d_bottom, &
     chfdisv1d_idomain, &

--- a/src/Idm/olf-dis2didm.f90
+++ b/src/Idm/olf-dis2didm.f90
@@ -22,7 +22,7 @@ module OlfDis2DInputModule
     logical :: ncol = .false.
     logical :: delr = .false.
     logical :: delc = .false.
-    logical :: botm = .false.
+    logical :: bottom = .false.
     logical :: idomain = .false.
   end type OlfDis2dParamFoundType
 
@@ -215,13 +215,13 @@ module OlfDis2DInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    olfdis2d_botm = InputParamDefinitionType &
+    olfdis2d_bottom = InputParamDefinitionType &
     ( &
     'OLF', & ! component
     'DIS2D', & ! subcomponent
     'GRIDDATA', & ! block
-    'BOTM', & ! tag name
-    'BOTM', & ! fortran variable
+    'BOTTOM', & ! tag name
+    'BOTTOM', & ! fortran variable
     'DOUBLE2D', & ! type
     'NCOL NROW', & ! shape
     'cell bottom elevation', & ! longname
@@ -263,7 +263,7 @@ module OlfDis2DInputModule
     olfdis2d_ncol, &
     olfdis2d_delr, &
     olfdis2d_delc, &
-    olfdis2d_botm, &
+    olfdis2d_bottom, &
     olfdis2d_idomain &
     ]
 

--- a/src/Idm/swf-dis2didm.f90
+++ b/src/Idm/swf-dis2didm.f90
@@ -22,7 +22,7 @@ module SwfDis2DInputModule
     logical :: ncol = .false.
     logical :: delr = .false.
     logical :: delc = .false.
-    logical :: botm = .false.
+    logical :: bottom = .false.
     logical :: idomain = .false.
   end type SwfDis2dParamFoundType
 
@@ -215,13 +215,13 @@ module SwfDis2DInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    swfdis2d_botm = InputParamDefinitionType &
+    swfdis2d_bottom = InputParamDefinitionType &
     ( &
     'SWF', & ! component
     'DIS2D', & ! subcomponent
     'GRIDDATA', & ! block
-    'BOTM', & ! tag name
-    'BOTM', & ! fortran variable
+    'BOTTOM', & ! tag name
+    'BOTTOM', & ! fortran variable
     'DOUBLE2D', & ! type
     'NCOL NROW', & ! shape
     'cell bottom elevation', & ! longname
@@ -263,7 +263,7 @@ module SwfDis2DInputModule
     swfdis2d_ncol, &
     swfdis2d_delr, &
     swfdis2d_delc, &
-    swfdis2d_botm, &
+    swfdis2d_bottom, &
     swfdis2d_idomain &
     ]
 

--- a/src/Model/Discretization/Dis2d.f90
+++ b/src/Model/Discretization/Dis2d.f90
@@ -25,7 +25,7 @@ module Dis2dModule
     integer(I4B), pointer :: ncol => null() !< number of columns
     real(DP), dimension(:), pointer, contiguous :: delr => null() !< spacing along a row
     real(DP), dimension(:), pointer, contiguous :: delc => null() !< spacing along a column
-    real(DP), dimension(:, :), pointer, contiguous :: botm => null() !< bottom elevations for each cell (ncol, nrow)
+    real(DP), dimension(:, :), pointer, contiguous :: bottom => null() !< bottom elevations for each cell (ncol, nrow)
     integer(I4B), dimension(:, :), pointer, contiguous :: idomain => null() !< idomain (ncol, nrow)
     real(DP), dimension(:), pointer, contiguous :: cellx => null() !< cell center x coordinate for column j
     real(DP), dimension(:), pointer, contiguous :: celly => null() !< cell center y coordinate for row i
@@ -80,8 +80,7 @@ module Dis2dModule
     logical :: ncol = .false.
     logical :: delr = .false.
     logical :: delc = .false.
-    logical :: top = .false.
-    logical :: botm = .false.
+    logical :: bottom = .false.
     logical :: idomain = .false.
   end type DisFoundtype
 
@@ -167,7 +166,7 @@ contains
     ! -- Deallocate Arrays
     call mem_deallocate(this%nodereduced)
     call mem_deallocate(this%nodeuser)
-    call mem_deallocate(this%botm)
+    call mem_deallocate(this%bottom)
     call mem_deallocate(this%idomain)
     !
   end subroutine dis3d_da
@@ -270,7 +269,7 @@ contains
     call mem_allocate(this%delc, this%nrow, 'DELC', this%memoryPath)
     call mem_allocate(this%idomain, this%ncol, this%nrow, 'IDOMAIN', &
                       this%memoryPath)
-    call mem_allocate(this%botm, this%ncol, this%nrow, 'BOTM', &
+    call mem_allocate(this%bottom, this%ncol, this%nrow, 'BOTTOM', &
                       this%memoryPath)
     call mem_allocate(this%cellx, this%ncol, 'CELLX', this%memoryPath)
     call mem_allocate(this%celly, this%nrow, 'CELLY', this%memoryPath)
@@ -315,7 +314,7 @@ contains
     ! -- update defaults with idm sourced values
     call mem_set_value(this%delr, 'DELR', this%input_mempath, found%delr)
     call mem_set_value(this%delc, 'DELC', this%input_mempath, found%delc)
-    call mem_set_value(this%botm, 'BOTM', this%input_mempath, found%botm)
+    call mem_set_value(this%bottom, 'BOTTOM', this%input_mempath, found%bottom)
     call mem_set_value(this%idomain, 'IDOMAIN', this%input_mempath, found%idomain)
     !
     ! -- log simulation values
@@ -342,12 +341,8 @@ contains
       write (this%iout, '(4x,a)') 'DELC set from input file'
     end if
     !
-    if (found%top) then
-      write (this%iout, '(4x,a)') 'TOP set from input file'
-    end if
-    !
-    if (found%botm) then
-      write (this%iout, '(4x,a)') 'BOTM set from input file'
+    if (found%bottom) then
+      write (this%iout, '(4x,a)') 'BOTTOM set from input file'
     end if
     !
     if (found%idomain) then
@@ -453,7 +448,7 @@ contains
                       DHALF * this%delc(i)
     end do
     !
-    ! -- Move botm into bot, and calculate area
+    ! -- Move bottom into bot, and calculate area
     node = 0
     do i = 1, this%nrow
       do j = 1, this%ncol
@@ -461,7 +456,7 @@ contains
         noder = node
         if (this%nodes < this%nodesuser) noder = this%nodereduced(node)
         if (noder <= 0) cycle
-        this%bot(noder) = this%botm(j, i)
+        this%bot(noder) = this%bottom(j, i)
         this%area(noder) = this%delr(j) * this%delc(i)
         this%xc(noder) = this%cellx(j)
         this%yc(noder) = this%celly(i)
@@ -578,7 +573,7 @@ contains
     write (iunit) this%angrot ! angrot
     write (iunit) this%delr ! delr
     write (iunit) this%delc ! delc
-    write (iunit) this%botm ! botm
+    write (iunit) this%bottom ! bottom
     write (iunit) this%con%iausr ! iausr
     write (iunit) this%con%jausr ! jausr
     write (iunit) this%idomain ! idomain

--- a/src/Model/Discretization/Disv1d.f90
+++ b/src/Model/Discretization/Disv1d.f90
@@ -45,7 +45,7 @@ module Disv1dModule
     procedure :: source_dimensions
     procedure :: source_griddata
     procedure :: source_vertices
-    procedure :: source_cell2d
+    procedure :: source_cell1d
     procedure :: log_options
     procedure :: log_dimensions
     procedure :: log_griddata
@@ -78,7 +78,7 @@ module Disv1dModule
     logical :: iv = .false.
     logical :: xv = .false.
     logical :: yv = .false.
-    logical :: icell2d = .false.
+    logical :: icell1d = .false.
     logical :: fdc = .false.
     logical :: ncvert = .false.
     logical :: icvert = .false.
@@ -268,7 +268,7 @@ contains
     ! If vertices provided by user, read and store vertices
     if (this%nvert > 0) then
       call this%source_vertices()
-      call this%source_cell2d()
+      call this%source_cell1d()
     end if
 
   end subroutine disv1d_load
@@ -383,7 +383,7 @@ contains
     if (this%nvert < 1) then
       call store_warning( &
         'NVERT was not specified or was specified as zero.  The &
-        &VERTICES and CELL2D blocks will not be read for the DISV1D6 &
+        &VERTICES and CELL1D blocks will not be read for the DISV1D6 &
         &Package in model '//trim(this%memoryPath)//'.')
     end if
     !
@@ -562,10 +562,10 @@ contains
     return
   end subroutine source_vertices
 
-  !> @brief Copy cell2d information from input data context
+  !> @brief Copy cell1d information from input data context
   !! to model context
   !<
-  subroutine source_cell2d(this)
+  subroutine source_cell1d(this)
     ! -- modules
     use MemoryHelperModule, only: create_mem_path
     use MemoryManagerModule, only: mem_setptr
@@ -575,7 +575,7 @@ contains
     class(Disv1dType) :: this
     ! -- locals
     character(len=LENMEMPATH) :: idmMemoryPath
-    integer(I4B), dimension(:), contiguous, pointer :: icell2d => null()
+    integer(I4B), dimension(:), contiguous, pointer :: icell1d => null()
     integer(I4B), dimension(:), contiguous, pointer :: ncvert => null()
     integer(I4B), dimension(:), contiguous, pointer :: icvert => null()
     real(DP), dimension(:), contiguous, pointer :: fdc => null()
@@ -586,14 +586,14 @@ contains
     idmMemoryPath = create_mem_path(this%name_model, 'DISV1D', idm_context)
     !
     ! -- set pointers to input path ncvert and icvert
-    call mem_setptr(icell2d, 'ICELL2D', idmMemoryPath)
+    call mem_setptr(icell1d, 'ICELL1D', idmMemoryPath)
     call mem_setptr(ncvert, 'NCVERT', idmMemoryPath)
     call mem_setptr(icvert, 'ICVERT', idmMemoryPath)
     !
     ! --
-    if (associated(icell2d) .and. associated(ncvert) &
+    if (associated(icell1d) .and. associated(ncvert) &
         .and. associated(icvert)) then
-      call this%define_cellverts(icell2d, ncvert, icvert)
+      call this%define_cellverts(icell1d, ncvert, icvert)
     else
       call store_error('Required cell vertex arrays not found.')
     end if
@@ -614,24 +614,24 @@ contains
     !
     ! -- log
     if (this%iout > 0) then
-      write (this%iout, '(1x,a)') 'Setting Discretization CELL2D'
-      write (this%iout, '(1x,a,/)') 'End Setting Discretization CELL2D'
+      write (this%iout, '(1x,a)') 'Setting Discretization CELL1D'
+      write (this%iout, '(1x,a,/)') 'End Setting Discretization CELL1D'
     end if
     !
     ! -- Return
     return
-  end subroutine source_cell2d
+  end subroutine source_cell1d
 
   !> @brief Construct the iavert and javert integer vectors which
   !! are compressed sparse row index arrays that relate the vertices
   !! to reaches
   !<
-  subroutine define_cellverts(this, icell2d, ncvert, icvert)
+  subroutine define_cellverts(this, icell1d, ncvert, icvert)
     ! -- modules
     use SparseModule, only: sparsematrix
     ! -- dummy
     class(Disv1dType) :: this
-    integer(I4B), dimension(:), contiguous, pointer, intent(in) :: icell2d
+    integer(I4B), dimension(:), contiguous, pointer, intent(in) :: icell1d
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: ncvert
     integer(I4B), dimension(:), contiguous, pointer, intent(in) :: icvert
     ! -- locals
@@ -645,7 +645,7 @@ contains
     ! -- add sparse matrix connections from input memory paths
     icv_idx = 1
     do i = 1, this%nodesuser
-      if (icell2d(i) /= i) call store_error('ICELL2D input sequence violation.')
+      if (icell1d(i) /= i) call store_error('ICELL1D input sequence violation.')
       do j = 1, ncvert(i)
         call vert_spm%addconnection(i, icvert(icv_idx), 0)
         if (j == 1) then
@@ -803,7 +803,7 @@ contains
       this%area(noder) = this%length(node)
     end do
 
-    ! create connectivity using vertices and cell2d
+    ! create connectivity using vertices and cell1d
     call this%create_connections()
 
     ! -- Return
@@ -1119,7 +1119,7 @@ contains
     call mem_deallocate(this%bottom)
     call mem_deallocate(this%idomain)
     !
-    ! -- cdl hack for arrays for vertices and cell2d blocks
+    ! -- cdl hack for arrays for vertices and cell1d blocks
     if (deallocate_vertices) then
       call mem_deallocate(this%vertices)
       call mem_deallocate(this%fdc)

--- a/src/Model/Discretization/Disv1d.f90
+++ b/src/Model/Discretization/Disv1d.f90
@@ -404,7 +404,7 @@ contains
       call mem_allocate(this%fdc, this%nodesuser, &
                         'FDC', this%memoryPath)
       call mem_allocate(this%cellxy, 2, this%nodesuser, &
-                        'CELLXYZ', this%memoryPath)
+                        'CELLXY', this%memoryPath)
     end if
     !
     ! -- initialize all cells to be active (idomain = 1)

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -313,10 +313,10 @@ contains
     !
     ! -- Allocate vertices array
     call mem_allocate(this%vertices, 2, this%nvert, 'VERTICES', this%memoryPath)
-    call mem_allocate(this%cellxy, 2, this%nodes, 'CELLXY', this%memoryPath)
+    call mem_allocate(this%cellxy, 2, this%nodesuser, 'CELLXY', this%memoryPath)
     !
     ! -- initialize all cells to be active (idomain = 1)
-    do j = 1, this%nodes
+    do j = 1, this%nodesuser
       this%idomain(j) = 1
     end do
     !
@@ -386,23 +386,24 @@ contains
   !> @brief Finalize grid (check properties, allocate arrays, compute connections)
   !<
   subroutine grid_finalize(this)
-    ! -- dummy
+    ! dummy
     class(Disv2dType) :: this
-    ! -- locals
+    ! locals
     integer(I4B) :: node, noder, j, ncell_count
-    ! -- formats
+    ! formats
     character(len=*), parameter :: fmtnr = &
       "(/1x, 'The specified IDOMAIN results in a reduced number of cells.',&
       &/1x, 'Number of user nodes: ',I0,&
       &/1X, 'Number of nodes in solution: ', I0, //)"
-    !
-    ! -- count active cells
+
+    ! count active cells and set nodes to that number
     ncell_count = 0
-    do j = 1, this%nodes
+    do j = 1, this%nodesuser
       if (this%idomain(j) > 0) ncell_count = ncell_count + 1
     end do
-    !
-    ! -- Check to make sure nodes is a valid number
+    this%nodes = ncell_count
+
+    ! Check to make sure nodes is a valid number
     if (ncell_count == 0) then
       call store_error('Model does not have any active nodes. &
                        &Ensure IDOMAIN array has some values greater &
@@ -410,21 +411,22 @@ contains
       call store_error_filename(this%input_fname)
     end if
 
-    if (count_errors() > 0) then
-      call store_error_filename(this%input_fname)
+    ! Write message if reduced grid
+    if (this%nodes < this%nodesuser) then
+      write (this%iout, fmtnr) this%nodesuser, this%nodes
     end if
-    !
-    ! -- Array size is now known, so allocate
+
+    ! Array size is now known, so allocate
     call this%allocate_arrays()
-    !
-    ! -- Fill the nodereduced array with the reduced nodenumber, or
-    !    a negative number to indicate it is a pass-through cell, or
-    !    a zero to indicate that the cell is excluded from the
-    !    solution.
+
+    ! Fill the nodereduced array with the reduced nodenumber, or
+    ! a negative number to indicate it is a pass-through cell, or
+    ! a zero to indicate that the cell is excluded from the
+    ! solution.
     if (this%nodes < this%nodesuser) then
       node = 1
       noder = 1
-      do j = 1, this%nodes
+      do j = 1, this%nodesuser
         if (this%idomain(j) > 0) then
           this%nodereduced(node) = noder
           noder = noder + 1
@@ -434,12 +436,12 @@ contains
         node = node + 1
       end do
     end if
-    !
-    ! -- allocate and fill nodeuser if a reduced grid
+
+    ! allocate and fill nodeuser if a reduced grid
     if (this%nodes < this%nodesuser) then
       node = 1
       noder = 1
-      do j = 1, this%nodes
+      do j = 1, this%nodesuser
         if (this%idomain(j) > 0) then
           this%nodeuser(noder) = node
           noder = noder + 1
@@ -448,15 +450,10 @@ contains
       end do
     end if
 
-    ! Copy bottom into bot
-    do node = 1, this%nodesuser
-      this%bot(node) = this%bottom(node)
-    end do
-
-    ! -- Move bottom into bot
-    !    and set x and y center coordinates
+    ! Move bottom into bot
+    ! and set x and y center coordinates
     node = 0
-    do j = 1, this%nodes
+    do j = 1, this%nodesuser
       node = node + 1
       noder = node
       if (this%nodes < this%nodesuser) noder = this%nodereduced(node)
@@ -465,10 +462,10 @@ contains
       this%xc(noder) = this%cellxy(1, j)
       this%yc(noder) = this%cellxy(2, j)
     end do
-    !
-    ! -- Build connections
+
+    ! Build connections
     call this%connect()
-    !
+
   end subroutine grid_finalize
 
   !> @brief Load grid vertices from IDM into package
@@ -576,7 +573,7 @@ contains
     !
     ! -- set cell centers
     if (associated(cell_x) .and. associated(cell_y)) then
-      do i = 1, this%nodes
+      do i = 1, this%nodesuser
         this%cellxy(1, i) = cell_x(i)
         this%cellxy(2, i) = cell_y(i)
       end do
@@ -608,7 +605,7 @@ contains
     narea_lt_zero = 0
     !
     ! -- Assign the cell area
-    do j = 1, this%nodes
+    do j = 1, this%nodesuser
       area = this%get_cell2d_area(j)
       noder = this%get_nodenumber(j, 0)
       if (noder > 0) this%area(noder) = area
@@ -651,7 +648,7 @@ contains
     if (this%nodes < this%nodesuser) nrsize = this%nodes
     allocate (this%con)
     call this%con%disvconnections(this%name_model, this%nodes, &
-                                  this%nodes, 1, nrsize, &
+                                  this%nodesuser, 1, nrsize, &
                                   this%nvert, this%vertices, this%iavert, &
                                   this%javert, this%cellxy, &
                                   this%bot, this%bot, &
@@ -737,13 +734,13 @@ contains
     write (txt, '(3a, i0)') 'VERTICES ', 'DOUBLE ', 'NDIM 2 2 ', this%nvert
     txt(lentxt:lentxt) = new_line('a')
     write (iunit) txt
-    write (txt, '(3a, i0)') 'CELLX ', 'DOUBLE ', 'NDIM 1 ', this%nodes
+    write (txt, '(3a, i0)') 'CELLX ', 'DOUBLE ', 'NDIM 1 ', this%nodesuser
     txt(lentxt:lentxt) = new_line('a')
     write (iunit) txt
-    write (txt, '(3a, i0)') 'CELLY ', 'DOUBLE ', 'NDIM 1 ', this%nodes
+    write (txt, '(3a, i0)') 'CELLY ', 'DOUBLE ', 'NDIM 1 ', this%nodesuser
     txt(lentxt:lentxt) = new_line('a')
     write (iunit) txt
-    write (txt, '(3a, i0)') 'IAVERT ', 'INTEGER ', 'NDIM 1 ', this%nodes + 1
+    write (txt, '(3a, i0)') 'IAVERT ', 'INTEGER ', 'NDIM 1 ', this%nodesuser + 1
     txt(lentxt:lentxt) = new_line('a')
     write (iunit) txt
     write (txt, '(3a, i0)') 'JAVERT ', 'INTEGER ', 'NDIM 1 ', size(this%javert)
@@ -773,8 +770,8 @@ contains
     write (iunit) this%angrot ! angrot
     write (iunit) this%bottom ! botm
     write (iunit) this%vertices ! vertices
-    write (iunit) (this%cellxy(1, i), i=1, this%nodes) ! cellx
-    write (iunit) (this%cellxy(2, i), i=1, this%nodes) ! celly
+    write (iunit) (this%cellxy(1, i), i=1, this%nodesuser) ! cellx
+    write (iunit) (this%cellxy(2, i), i=1, this%nodesuser) ! celly
     write (iunit) this%iavert ! iavert
     write (iunit) this%javert ! javert
     write (iunit) this%con%iausr ! iausr
@@ -835,18 +832,18 @@ contains
   !> @brief Get reduced node number from user node number
   !<
   function get_nodenumber_idx1(this, nodeu, icheck) result(nodenumber)
-    ! -- return
+    ! return
     integer(I4B) :: nodenumber
-    ! -- dummy
+    ! dummy
     class(Disv2dType), intent(in) :: this
     integer(I4B), intent(in) :: nodeu
     integer(I4B), intent(in) :: icheck
-    ! -- local
-    !
-    ! -- check the node number if requested
+    ! local
+
+    ! check the node number if requested
     if (icheck /= 0) then
-      !
-      ! -- If within valid range, convert to reduced nodenumber
+
+      ! If within valid range, convert to reduced nodenumber
       if (nodeu < 1 .or. nodeu > this%nodesuser) then
         nodenumber = 0
         write (errmsg, '(a,i0,a,i0,a)') &
@@ -861,7 +858,7 @@ contains
       nodenumber = nodeu
       if (this%nodes < this%nodesuser) nodenumber = this%nodereduced(nodeu)
     end if
-    !
+
   end function get_nodenumber_idx1
 
   !> @brief Get normal vector components between the cell and a given neighbor
@@ -986,13 +983,13 @@ contains
   !> @brief Allocate and initialize arrays
   !<
   subroutine allocate_arrays(this)
-    ! -- dummy
+    ! dummy
     class(Disv2dType) :: this
-    !
-    ! -- Allocate arrays in DisBaseType (mshape, top, bot, area)
+
+    ! Allocate arrays in DisBaseType (mshape, top, bot, area)
     call this%DisBaseType%allocate_arrays()
     !
-    ! -- Allocate arrays for DisvType
+    ! Allocate arrays for DisvType
     if (this%nodes < this%nodesuser) then
       call mem_allocate(this%nodeuser, this%nodes, 'NODEUSER', this%memoryPath)
       call mem_allocate(this%nodereduced, this%nodesuser, 'NODEREDUCED', &
@@ -1001,9 +998,10 @@ contains
       call mem_allocate(this%nodeuser, 1, 'NODEUSER', this%memoryPath)
       call mem_allocate(this%nodereduced, 1, 'NODEREDUCED', this%memoryPath)
     end if
-    ! -- Initialize
-    this%mshape(1) = this%nodes
-    !
+
+    ! Initialize
+    this%mshape(1) = this%nodesuser
+
   end subroutine allocate_arrays
 
   !> @brief Get the signed area of the cell

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -332,7 +332,7 @@ contains
     write (this%iout, '(1x,a)') 'Setting Discretization Dimensions'
     !
     if (found%nodes) then
-      write (this%iout, '(4x,a,i0)') 'NODES = ', this%nodes
+      write (this%iout, '(4x,a,i0)') 'NODES = ', this%nodesuser
     end if
     !
     if (found%nvert) then

--- a/src/Model/ModelUtilities/Connections.f90
+++ b/src/Model/ModelUtilities/Connections.f90
@@ -1040,8 +1040,8 @@ contains
     ! -- fill the isym and jas arrays
     call fillisym(this%nodes, this%nja, this%ia, this%ja, this%isym)
     call filljas(this%nodes, this%nja, this%ia, this%ja, this%isym, this%jas)
-    
-    allocate(cell_length(this%nodes))
+
+    allocate (cell_length(this%nodes))
     do nu = 1, size(reach_length)
       nr = nu
       if (nrsize > 0) nr = nodereduced(nu)
@@ -1053,7 +1053,7 @@ contains
     ! todo: need to handle cell center shifted from center of reach
     call fill_disv1d_symarrays(this%ia, this%ja, this%jas, cell_length, &
                                this%ihc, this%cl1, this%cl2)
-    deallocate(cell_length)
+    deallocate (cell_length)
     !
     ! -- Fill symmetric discretization arrays (ihc,cl1,cl2,hwva,anglex)
     ! do n = 1, this%nodes

--- a/src/Model/ModelUtilities/Connections.f90
+++ b/src/Model/ModelUtilities/Connections.f90
@@ -1,8 +1,8 @@
 module ConnectionsModule
 
   use ArrayReadersModule, only: ReadArray
-  use KindModule, only: DP, I4B
-  use ConstantsModule, only: LENMODELNAME, LENMEMPATH, DHALF
+  use KindModule, only: DP, I4B, LGP
+  use ConstantsModule, only: LENMODELNAME, LENMEMPATH, DHALF, DONE
   use MessageModule, only: write_message
   use SimVariablesModule, only: errmsg
   use BlockParserModule, only: BlockParserType
@@ -954,21 +954,20 @@ contains
 
   !> @brief Fill the connections object for a disv1d package from vertices
   !!
-  !! todo: Still need to handle hwva
-  !! todo: Only unreduced disv1d grids are allowed at the moment
+  !! Note that nothing is done for hwva
   !!
   !<
   subroutine disv1dconnections_verts(this, name_model, nodes, nodesuser, &
                                      nrsize, nvert, &
                                      vertices, iavert, javert, &
-                                     cellxyz, cellfdc, nodereduced, nodeuser, &
+                                     cellxy, cellfdc, nodereduced, nodeuser, &
                                      reach_length)
-    ! -- modules
+    ! modules
     use ConstantsModule, only: DHALF, DZERO, DTHREE, DTWO, DPI
     use SparseModule, only: sparsematrix
     use GeomUtilModule, only: get_node
     use MemoryManagerModule, only: mem_reallocate
-    ! -- dummy
+    ! dummy
     class(ConnectionsType) :: this
     character(len=*), intent(in) :: name_model
     integer(I4B), intent(in) :: nodes
@@ -978,30 +977,28 @@ contains
     real(DP), dimension(3, nvert), intent(in) :: vertices
     integer(I4B), dimension(:), intent(in) :: iavert
     integer(I4B), dimension(:), intent(in) :: javert
-    real(DP), dimension(3, nodesuser), intent(in) :: cellxyz
-    !integer(I4B), dimension(2, nodesuser), intent(in) :: centerverts
+    real(DP), dimension(2, nodesuser), intent(in) :: cellxy
     real(DP), dimension(nodesuser), intent(in) :: cellfdc
     integer(I4B), dimension(:), intent(in) :: nodereduced
     integer(I4B), dimension(:), intent(in) :: nodeuser
     real(DP), dimension(:), intent(in) :: reach_length !< length of each reach
-    ! -- local
+    ! local
     integer(I4B), dimension(:), allocatable :: itemp
     integer(I4B), dimension(:), allocatable :: iavertcells
     integer(I4B), dimension(:), allocatable :: javertcells
-    real(DP), dimension(:), allocatable :: cell_length
     type(sparsematrix) :: sparse, vertcellspm
-    integer(I4B) :: nu, nr, i, j, ierror
-    !
-    ! -- Allocate scalars
+    integer(I4B) :: i, j, ierror
+
+    ! Allocate scalars
     call this%allocate_scalars(name_model)
-    !
-    ! -- Set scalars
+
+    ! Set scalars
     this%nodes = nodes
     this%ianglex = 1
-    !
-    ! -- Create a sparse matrix array with a row for each vertex.  The columns
-    !    in the sparse matrix contains the cells that include that vertex.
-    !    This array will be used to determine cell connectivity.
+
+    ! Create a sparse matrix array with a row for each vertex.  The columns
+    ! in the sparse matrix contains the cells that include that vertex.
+    ! This array will be used to determine cell connectivity.
     allocate (itemp(nvert))
     do i = 1, nvert
       itemp(i) = 4
@@ -1018,88 +1015,118 @@ contains
     allocate (javertcells(vertcellspm%nnz))
     call vertcellspm%filliaja(iavertcells, javertcells, ierror)
     call vertcellspm%destroy()
-    !
-    ! -- Call routine to build a sparse matrix of the connections
+
+    ! Call routine to build a sparse matrix of the connections
     call vertexconnectl(this%nodes, nrsize, 6, nodesuser, sparse, &
                         iavertcells, javertcells, nodereduced)
     this%nja = sparse%nnz
     this%njas = (this%nja - this%nodes) / 2
-    !
-    ! -- cleanup memory
-    deallocate (iavertcells)
-    deallocate (javertcells)
-    !
-    ! -- Allocate index arrays of size nja and symmetric arrays
+
+    ! Allocate index arrays of size nja and symmetric arrays
     call this%allocate_arrays()
-    !
-    ! -- Fill the IA and JA arrays from sparse, then destroy sparse
+
+    ! Fill the IA and JA arrays from sparse, then destroy sparse
     call sparse%sort()
     call sparse%filliaja(this%ia, this%ja, ierror)
     call sparse%destroy()
-    !
-    ! -- fill the isym and jas arrays
+
+    ! fill the isym and jas arrays
     call fillisym(this%nodes, this%nja, this%ia, this%ja, this%isym)
     call filljas(this%nodes, this%nja, this%ia, this%ja, this%isym, this%jas)
 
-    allocate (cell_length(this%nodes))
-    do nu = 1, size(reach_length)
-      nr = nu
-      if (nrsize > 0) nr = nodereduced(nu)
-      if (nr <= 0) cycle
-      cell_length(nr) = reach_length(nu)
-    end do
+    ! fill the ihc, cl1, and cl2 arrays
+    call fill_disv1d_symarrays(this%ia, this%ja, this%jas, reach_length, &
+                               this%ihc, this%cl1, this%cl2, &
+                               nrsize, nodereduced, nodeuser, cellfdc, &
+                               iavert, javert, iavertcells, javertcells)
 
-    ! Fill disv1d symmetric arrays
-    ! todo: need to handle cell center shifted from center of reach
-    call fill_disv1d_symarrays(this%ia, this%ja, this%jas, cell_length, &
-                               this%ihc, this%cl1, this%cl2)
-    deallocate (cell_length)
-    !
-    ! -- Fill symmetric discretization arrays (ihc,cl1,cl2,hwva,anglex)
-    ! do n = 1, this%nodes
-    !   do ipos = this%ia(n) + 1, this%ia(n + 1) - 1
-    !     m = this%ja(ipos)
-    !     if(m < n) cycle
-    !     call geol%cprops(n, m, this%hwva(this%jas(ipos)),                     &
-    !                      this%cl1(this%jas(ipos)), this%cl2(this%jas(ipos)))
-    !   enddo
-    ! enddo
+    ! cleanup memory
+    deallocate (iavertcells)
+    deallocate (javertcells)
 
-    !
-    ! -- If reduced system, then need to build iausr and jausr, otherwise point
-    !    them to ia and ja.
+    ! If reduced system, then need to build iausr and jausr, otherwise point
+    ! them to ia and ja.
     call this%iajausr(nrsize, nodesuser, nodereduced, nodeuser)
-    !
-    ! -- Return
-    return
+
   end subroutine disv1dconnections_verts
 
   !> @brief Fill symmetric connection arrays for disv1d
   !<
-  subroutine fill_disv1d_symarrays(ia, ja, jas, cell_length, ihc, cl1, cl2)
+  subroutine fill_disv1d_symarrays(ia, ja, jas, cell_length, ihc, cl1, cl2, &
+                                   nrsize, nodereduced, nodeuser, fdc, &
+                                   iavert, javert, iavertcells, javertcells)
     ! dummy
     integer(I4B), dimension(:), intent(in) :: ia !< csr pointer array
     integer(I4B), dimension(:), intent(in) :: ja !< csr array
     integer(I4B), dimension(:), intent(in) :: jas !< csr symmetric array
-    real(DP), dimension(:), intent(in) :: cell_length !< length of each cell (active cells only)
+    real(DP), dimension(:), intent(in) :: cell_length !< length of each cell (all cells)
     integer(I4B), dimension(:), intent(out) :: ihc !< horizontal connection flag
     real(DP), dimension(:), intent(out) :: cl1 !< distance from n to shared face with m
     real(DP), dimension(:), intent(out) :: cl2 !< distance from m to shared face with n
+    integer(I4B), intent(in) :: nrsize !< great than zero indicated reduced nodes present
+    integer(I4B), dimension(:), intent(in) :: nodereduced !< map user node to reduced node number
+    integer(I4B), dimension(:), intent(in) :: nodeuser !< map user reduced node to user node number
+    real(DP), dimension(:), intent(in) :: fdc !< fractional distance along cell to reach cell center
+    integer(I4B), dimension(:), intent(in) :: iavert ! csr index array of size (nodeuser + 1) for javert
+    integer(I4B), dimension(:), intent(in) :: javert ! csr array containing vertex numbers that define each cell
+    integer(I4B), dimension(:), intent(in) :: iavertcells ! csr index array of size (nvert + 1) for javert
+    integer(I4B), dimension(:), intent(in) :: javertcells ! csr array containing cells numbers that referenced for a vertex
+
     ! local
-    integer(I4B) :: n
-    integer(I4B) :: m
+    integer(I4B) :: nr, nu
+    integer(I4B) :: mr, mu
     integer(I4B) :: ipos
     integer(I4B) :: isympos
+    real(DP) :: f
 
     ! loop through and set array values
-    do n = 1, size(cell_length)
-      do ipos = ia(n) + 1, ia(n + 1) - 1
-        m = ja(ipos)
-        if (m < n) cycle
+    do nu = 1, size(cell_length)
+
+      ! find reduced node number and cycle if cell does not exist
+      nr = nu
+      if (nrsize > 0) nr = nodereduced(nu)
+      if (nr <= 0) cycle
+
+      ! visit each cell connected to reduced cell nr
+      do ipos = ia(nr) + 1, ia(nr + 1) - 1
+
+        ! process upper triangle by skipping mr cells less than nr
+        mr = ja(ipos)
+        if (mr < nr) cycle
+
+        mu = mr
+        if (nrsize > 0) mu = nodeuser(mr)
+
         isympos = jas(ipos)
         ihc(isympos) = 1
-        cl1(isympos) = DHALF * cell_length(n)
-        cl2(isympos) = DHALF * cell_length(m)
+
+        ! if cell m is connected to the downstream end of cell n, then use
+        ! 1 - fdc times the cell length, otherwise use fdc * length
+        if (fdc(nu) == DHALF) then
+          f = DHALF
+        else
+          if (connected_down_n(nu, mu, iavert, javert, iavertcells, &
+                               javertcells)) then
+            f = (DONE - fdc(nu))
+          else
+            f = fdc(nu)
+          end if
+        end if
+        cl1(isympos) = f * cell_length(nu)
+
+        ! do the opposite for the cl2 distance as it is relative to m
+        if (fdc(mu) == DHALF) then
+          f = DHALF
+        else
+          if (connected_down_n(mu, nu, iavert, javert, iavertcells, &
+                               javertcells)) then
+            f = (DONE - fdc(mu))
+          else
+            f = fdc(mu)
+          end if
+        end if
+        cl2(isympos) = f * cell_length(mu)
+
       end do
     end do
   end subroutine fill_disv1d_symarrays
@@ -1377,43 +1404,42 @@ contains
   subroutine vertexconnectl(nodes, nrsize, maxnnz, nodeuser, sparse, &
                             iavertcells, javertcells, &
                             nodereduced)
-    ! -- modules
+    ! modules
     use SparseModule, only: sparsematrix
     use GeomUtilModule, only: get_node
-    ! -- dummy
-    integer(I4B), intent(in) :: nodes
-    integer(I4B), intent(in) :: nrsize
-    integer(I4B), intent(in) :: maxnnz
-    integer(I4B), intent(in) :: nodeuser
-    type(SparseMatrix), intent(inout) :: sparse
-    integer(I4B), dimension(:), intent(in) :: nodereduced
-    integer(I4B), dimension(:), intent(in) :: iavertcells
-    integer(I4B), dimension(:), intent(in) :: javertcells
-    ! -- local
+    ! dummy
+    integer(I4B), intent(in) :: nodes !< number of active nodes
+    integer(I4B), intent(in) :: nrsize !< if > 0 then reduced grid
+    integer(I4B), intent(in) :: maxnnz !< max number of non zeros
+    integer(I4B), intent(in) :: nodeuser !< number of user nodes
+    type(SparseMatrix), intent(inout) :: sparse !< sparse matrix object
+    integer(I4B), dimension(:), intent(in) :: nodereduced !< map from user to reduced node
+    integer(I4B), dimension(:), intent(in) :: iavertcells !< csr ia index array for vertices
+    integer(I4B), dimension(:), intent(in) :: javertcells !< csr list of cells that use each vertex
+    ! local
     integer(I4B), dimension(:), allocatable :: rowmaxnnz
     integer(I4B) :: i, k, nr, mr, nvert
     integer(I4B) :: con
-    !
-    ! -- Allocate and fill the ia and ja arrays
+
+    !  Setup a sparse object
     allocate (rowmaxnnz(nodes))
     do i = 1, nodes
       rowmaxnnz(i) = maxnnz
     end do
     call sparse%init(nodes, nodes, rowmaxnnz)
     deallocate (rowmaxnnz)
+
+    ! Fill the sparse diagonal
     do nr = 1, nodeuser
-      !
-      ! -- Process diagonal
       mr = nr
       if (nrsize > 0) mr = nodereduced(mr)
       if (mr <= 0) cycle
       call sparse%addconnection(mr, mr, 1)
     end do
-    !
-    ! -- Go through each vertex and connect up all the cells that use
-    !    this vertex in their definition.
-    nvert = size(iavertcells) - 1
 
+    ! Go through each vertex and connect up all the cells that use
+    ! this vertex in their definition.
+    nvert = size(iavertcells) - 1
     do i = 1, nvert
       ! loop through cells that share the vertex
       do k = iavertcells(i), iavertcells(i + 1) - 2
@@ -1430,9 +1456,7 @@ contains
         end do
       end do
     end do
-    !
-    ! -- return
-    return
+
   end subroutine vertexconnectl
 
   !> @brief routine to set a value in the mask array (which has the same shape
@@ -1491,5 +1515,38 @@ contains
     ! -- Return
     return
   end subroutine iac_to_ia
+
+  !> @brief Is cell m is connected to the downstream end of cell n
+  !<
+  function connected_down_n(nu, mu, iavert, javert, iavertcells, javertcells) &
+    result(connected_down)
+    ! dummy
+    integer(I4B), intent(in) :: nu ! user nodenumber for cell n
+    integer(I4B), intent(in) :: mu ! user nodenumber for connected cell m
+    integer(I4B), dimension(:), intent(in) :: iavert ! csr index array of size (nodeuser + 1) for javert
+    integer(I4B), dimension(:), intent(in) :: javert ! csr array containing vertex numbers that define each cell
+    integer(I4B), dimension(:), intent(in) :: iavertcells ! csr index array of size (nvert + 1) for javert
+    integer(I4B), dimension(:), intent(in) :: javertcells ! csr array containing cells numbers that referenced for a vertex
+    ! return
+    logical(LGP) :: connected_down
+    ! - local
+    integer(I4B) :: ipos
+    integer(I4B) :: ivert_down
+
+    ! ivert_down is the last vertex for node nu; the last vertex is considered
+    ! to be the dowstream end of node nu
+    ivert_down = javert(iavert(nu + 1) - 1)
+
+    ! look through vertex ivert_down, and see if mu is in it; if so, then
+    ! that means mu is connected to the downstream end of nu
+    connected_down = .false.
+    do ipos = iavertcells(ivert_down), iavertcells(ivert_down + 1) - 1
+      if (javertcells(ipos) == mu) then
+        connected_down = .true.
+        exit
+      end if
+    end do
+
+  end function connected_down_n
 
 end module ConnectionsModule


### PR DESCRIPTION
Improved capabilities for surface water models:
* added support for IDOMAIN
* added tests to ensure binary grid files are correct
* renamed botm to bottom for the three surface water grid types (DISV1D, DIS2D, DISV2D)

Tests require corresponding changes in flopy ([PR #2295](https://github.com/modflowpy/flopy/pull/2295)) in order to work.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).