### PR TITLE
docs(prt): update structure of blocks section for prp/oc

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -190,7 +190,7 @@ type double precision
 reader urword
 optional true
 longname release time frequency
-description time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and period-block release settings.
+description time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and PERIOD block RELEASESETTING selections.
 
 # --------------------- prt prp dimensions ---------------------
 
@@ -208,7 +208,7 @@ type integer
 reader urword
 optional false
 longname number of particle release times
-description is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASE_TIME_FREQUENCY, RELEASETIMES block, and PERIOD block RELEASESETTING selections.
+description is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASE\_TIME\_FREQUENCY, RELEASETIMES block, and PERIOD block RELEASESETTING selections.
 
 # --------------------- prt prp packagedata ---------------------
 

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -208,7 +208,7 @@ type integer
 reader urword
 optional false
 longname number of particle release times
-description is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASETIMES and PERIOD block RELEASESETTING selections.
+description is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASE_TIME_FREQUENCY, RELEASETIMES block, and PERIOD block RELEASESETTING selections.
 
 # --------------------- prt prp packagedata ---------------------
 

--- a/doc/mf6io/prt/oc.tex
+++ b/doc/mf6io/prt/oc.tex
@@ -4,7 +4,8 @@ Output Control data must be specified using words.  The numeric codes supported 
 
 For the PRINT and SAVE options, there is no option to specify individual layers.  Whenever the budget array is printed or saved, all layers are printed or saved.
 
-\subsection{Tracking Events}
+\vspace{5mm}
+\subsubsection{Tracking Events}
 
 The PRT Model distinguishes a number of tracking events that can trigger writing of particle track information to binary and/or CSV output files. When a particle track record is written to an output file, the record includes an IREASON code that indicates the type of event that triggered the output. IREASON codes and their associated tracking events are enumerated in the Particle Track Output subsection of the PRT Model Input and Output section.
  

--- a/doc/mf6io/prt/oc.tex
+++ b/doc/mf6io/prt/oc.tex
@@ -18,6 +18,8 @@ For instance, to configure PRT output for an endpoint analysis, provide the TRAC
 
 \noindent \textit{FOR EACH SIMULATION}
 \lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-oc-options.dat}
+\lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-oc-dimensions.dat}
+\lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-oc-tracktimes.dat}
 \vspace{5mm}
 \noindent \textit{FOR ANY STRESS PERIOD}
 \lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-oc-period.dat}

--- a/doc/mf6io/prt/prp.tex
+++ b/doc/mf6io/prt/prp.tex
@@ -6,7 +6,7 @@ The PRP Package offers multiple ways to specify particle release times.  Particl
 \subsubsection{Structure of Blocks}
 \lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-prp-options.dat}
 \lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-prp-dimensions.dat}
-%%\lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-prp-griddata.dat}
+\lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-prp-releasetimes.dat}
 \lstinputlisting[style=blockdefinition]{./mf6ivar/tex/prt-prp-packagedata.dat}
 \vspace{5mm}
 \noindent \textit{FOR ANY STRESS PERIOD}


### PR DESCRIPTION
The new dimensions and tracktimes/releasetimes blocks added to output control and particle release packages, respectively, were not mentioned in the mf6io guide. Also fix inconsistent descriptions of the release time schedule in the PRP DFN.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Closes #2002 
- [x] Closes #2003
- [x] Closes #2004
- [x] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [x] Removed checklist items not relevant to this pull request