### PR TITLE
fix(netcdf):  address gcc hdf5 build issue on linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -201,6 +201,12 @@ if fc_id == 'gcc'
     elif profile == 'develop'
       compile_args += ['-fcheck=all', '-ffpe-trap=overflow,zero']
     endif
+  else
+    if profile == 'release'
+      compile_args += ['-ffpe-summary=overflow', '-ffpe-trap=overflow,zero,invalid']
+    elif profile == 'develop'
+      compile_args += ['-fcheck=all', '-ffpe-trap=overflow,zero,invalid']
+    endif
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -194,7 +194,6 @@ endif
 
 # GCC profile options need to be netcdf aware due to HDF5 issue
 if fc_id == 'gcc'
-  #if with_netcdf and build_machine.system() == 'darwin'
   if with_netcdf
     # HDF5 1.14.3 invalid fpe trap issue: https://github.com/HDFGroup/hdf5/issues/3831
     if profile == 'release'
@@ -202,12 +201,6 @@ if fc_id == 'gcc'
     elif profile == 'develop'
       compile_args += ['-fcheck=all', '-ffpe-trap=overflow,zero']
     endif
-  #else
-  #  if profile == 'release'
-  #    compile_args += ['-ffpe-summary=overflow', '-ffpe-trap=overflow,zero,invalid']
-  #  elif profile == 'develop'
-  #    compile_args += ['-fcheck=all', '-ffpe-trap=overflow,zero,invalid']
-  #  endif
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -194,19 +194,20 @@ endif
 
 # GCC profile options need to be netcdf aware due to HDF5 issue
 if fc_id == 'gcc'
-  if with_netcdf and build_machine.system() == 'darwin'
+  #if with_netcdf and build_machine.system() == 'darwin'
+  if with_netcdf
     # HDF5 1.14.3 invalid fpe trap issue: https://github.com/HDFGroup/hdf5/issues/3831
     if profile == 'release'
       compile_args += ['-ffpe-summary=overflow', '-ffpe-trap=overflow,zero']
     elif profile == 'develop'
       compile_args += ['-fcheck=all', '-ffpe-trap=overflow,zero']
     endif
-  else
-    if profile == 'release'
-      compile_args += ['-ffpe-summary=overflow', '-ffpe-trap=overflow,zero,invalid']
-    elif profile == 'develop'
-      compile_args += ['-fcheck=all', '-ffpe-trap=overflow,zero,invalid']
-    endif
+  #else
+  #  if profile == 'release'
+  #    compile_args += ['-ffpe-summary=overflow', '-ffpe-trap=overflow,zero,invalid']
+  #  elif profile == 'develop'
+  #    compile_args += ['-fcheck=all', '-ffpe-trap=overflow,zero,invalid']
+  #  endif
   endif
 endif
 


### PR DESCRIPTION
Applies existing mac workaround to linux environments for HDF5 library issue https://github.com/HDFGroup/hdf5/issues/3831.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).