### PR TITLE
docs(prt): fix PRP package parameter descriptions

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -182,7 +182,7 @@ type double precision
 reader urword
 optional true
 longname release time coincidence tolerance
-description tolerance within which to consider adjacent release times coincident and merge them into a single release time. The default is $\epsilon \times 10^9$.
+description real number indicating the tolerance within which to consider adjacent release times coincident. Coincident release times will be merged into a single release time. The default is $\epsilon \times 10^11$, where $\epsilon$ is machine precision.
 
 block options
 name release_time_frequency
@@ -190,7 +190,7 @@ type double precision
 reader urword
 optional true
 longname release time frequency
-description time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and PERIOD block RELEASESETTING selections.
+description real number indicating the time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and PERIOD block RELEASESETTING selections.
 
 # --------------------- prt prp dimensions ---------------------
 
@@ -333,7 +333,7 @@ tagged false
 in_record true
 reader urword
 longname
-description specifies time steps at which to release a particle. A particle is released at the beginning of each specified time step. For fine control over release timing, specify times explicitly using the RELEASETIMES block. If the beginning of a specified time step coincides with a release time specified in the RELEASETIMES block or configured via RELEASE\_TIME\_FREQUENCY, only one particle is released at that time. Coincidence is evaluated up to the tolerance specified in RELEASE\_TIME\_TOLERANCE, or $\epsilon \times 10^9$ by default.
+description specifies time steps at which to release a particle. A particle is released at the beginning of each specified time step. For fine control over release timing, specify times explicitly using the RELEASETIMES block. If the beginning of a specified time step coincides with a release time specified in the RELEASETIMES block or configured via RELEASE\_TIME\_FREQUENCY, only one particle is released at that time. Coincidence is evaluated up to the tolerance specified in RELEASE\_TIME\_TOLERANCE, or $\epsilon \times 10^11$ by default, where $\epsilon$ is machine precision.
 
 block period
 name all


### PR DESCRIPTION
The description of RELEASE_TIME_TOLERANCE and RELEASE_TIME_FREQUENCY failed to mention that these are real numbers, and did not describe epsilon as machine precision. Moreover the default RELEASE_TIME_TOLERANCE was incorrectly stated to be epsilon times 10^9, where in fact it is epsilon times 10^11.

Thanks to @rbwinst-usgs for catching these mistakes.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Closes #2015
- [x] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Removed checklist items not relevant to this pull request