### PR TITLE
fix(par): PETSc Fortran API has changed in v3.22.0

### DIFF
--- a/src/Utilities/Matrix/PetscMatrix.F90
+++ b/src/Utilities/Matrix/PetscMatrix.F90
@@ -405,7 +405,7 @@ contains
     do irow = 1, this%nrow
       do ipos = this%ia_local(irow), this%ia_local(irow + 1) - 1
         icol = this%ja_local(ipos)
-        call MatGetValues(local_mat, 1, irow - 1, 1, icol - 1, val, ierr)
+        call MatGetValues(local_mat, 1, [irow - 1], 1, [icol - 1], [val], ierr)
         CHKERRQ(ierr)
         this%amat_local(ipos) = val
       end do


### PR DESCRIPTION
From their release notes https://petsc.org/release/changes/322/:

* Change the PETSc Fortran API so that non-array values, v, passed to PETSc routines expecting arrays must be cast with [v] in the calling sequence

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Removed checklist items not relevant to this pull request