### PR TITLE
refactor(dfns): add in_record attr to utl-ts and utl-tas vars

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/utl-tas.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-tas.dfn
@@ -19,6 +19,7 @@ type keyword
 shape
 reader urword
 optional false
+in_record true
 longname
 description xxx
 
@@ -29,6 +30,7 @@ shape any1d
 tagged false
 reader urword
 optional false
+in_record true
 longname
 description Name by which a package references a particular time-array series. The name must be unique among all time-array series used in a package.
 
@@ -48,6 +50,7 @@ type keyword
 shape
 reader urword
 optional false
+in_record true
 longname
 description  xxx
 
@@ -59,6 +62,7 @@ shape
 tagged false
 reader urword
 optional false
+in_record true
 longname
 description Interpolation method, which is either STEPWISE or LINEAR.
 
@@ -78,6 +82,7 @@ type keyword
 shape
 reader urword
 optional false
+in_record true
 longname
 description  xxx
 
@@ -88,6 +93,7 @@ shape time_series_name
 tagged false
 reader urword
 optional false
+in_record true
 longname
 description Scale factor, which will multiply all array values in time series. SFAC is an optional attribute; if omitted, SFAC = 1.0.
 

--- a/doc/mf6io/mf6ivar/dfn/utl-ts.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-ts.dfn
@@ -20,6 +20,7 @@ type keyword
 shape
 reader urword
 optional false
+in_record true
 longname
 description xxx
 
@@ -30,6 +31,7 @@ shape any1d
 tagged false
 reader urword
 optional false
+in_record true
 longname
 description Name by which a package references a particular time-array series. The name must be unique among all time-array series used in a package.
 
@@ -49,6 +51,7 @@ type keyword
 shape
 reader urword
 optional false
+in_record true
 longname
 description  xxx
 
@@ -60,6 +63,7 @@ shape time_series_names
 tagged false
 reader urword
 optional false
+in_record true
 longname
 description Interpolation method, which is either STEPWISE or LINEAR.
 
@@ -109,6 +113,7 @@ type keyword
 shape
 reader urword
 optional false
+in_record true
 longname
 description  xxx
 
@@ -119,6 +124,7 @@ shape <time_series_name
 tagged false
 reader urword
 optional false
+in_record true
 longname
 description Scale factor, which will multiply all array values in time series. SFAC is an optional attribute; if omitted, SFAC = 1.0.
 
@@ -162,6 +168,7 @@ tagged false
 reader urword
 optional false
 repeating false
+in_record true
 longname
 description A numeric time relative to the start of the simulation, in the time unit used in the simulation. Times must be strictly increasing.
 
@@ -172,5 +179,6 @@ shape time_series_names
 tagged false
 reader urword
 optional false
+in_record true
 longname
 description A 2-D array of numeric, floating-point values, or a constant value, readable by the U2DREL array-reading utility.


### PR DESCRIPTION
Add `in_record true` to several record fields in `utl-ts.dfn` and `utl-tas.dfn`. Motivated by https://github.com/modflowpy/flopy/pull/2317. FloPy can infer this, evidently, but a less clever (and ideally much simpler) implementation may require them explicitly. IMO it makes sense to do this anyway for consistency's sake, at least while the DFN specification is flat and record membership cannot be inferred directly from the spec's structure.

This is not necessarily comprehensive, further work may reveal the same (or similar) updates are needed elsewhere.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Removed checklist items not relevant to this pull request