### PR TITLE
refactor(sfr): convert storage_weight to dev variable

### DIFF
--- a/autotest/test_gwf_sfr_kinematic01.py
+++ b/autotest/test_gwf_sfr_kinematic01.py
@@ -127,7 +127,7 @@ def build_models(idx, test):
         gwf,
         print_flows=True,
         storage=True,
-        storage_weight=storage_weights[idx],
+        dev_storage_weight=storage_weights[idx],
         nreaches=nreaches,
         packagedata=pak_data,
         connectiondata=[(0,)],

--- a/doc/MODFLOW6References.bib
+++ b/doc/MODFLOW6References.bib
@@ -3054,3 +3054,23 @@
 	Title = {FloPy v3.7.0dev0 (preliminary)},
 	Year = {2024},
 	Url = {https://doi.org/10.5066/F7BK19FH}}
+
+@article{lal2001modification,
+	author = {Lal, AM Wasantha},
+	journal = {Journal of Hydraulic Engineering},
+	number = {7},
+	pages = {567--576},
+	publisher = {American Society of Civil Engineers},
+	title = {Modification of canal flow due to stream-aquifer interaction},
+	volume = {127},
+	year = {2001}}
+
+@article{pinder1971numerical,
+	author = {Pinder, George F and Sauer, Stanley P},
+	journal = {Water Resources Research},
+	number = {1},
+	pages = {63--70},
+	publisher = {Wiley Online Library},
+	title = {Numerical simulation of flood wave modification due to bank storage effects},
+	volume = {7},
+	year = {1971}}

--- a/doc/ReleaseNotes/ReleaseNotes.bbl
+++ b/doc/ReleaseNotes/ReleaseNotes.bbl
@@ -1,4 +1,4 @@
-\begin{thebibliography}{15}
+\begin{thebibliography}{17}
 \providecommand{\natexlab}[1]{#1}
 \expandafter\ifx\csname urlstyle\endcsname\relax
   \providecommand{\doiagency}[1]{doi:\discretionary{}{}{}#1}\else
@@ -40,6 +40,10 @@ Hughes, J.D., Langevin, C.D., Paulinski, S.R., Larsen, J.D., and Brakenhoff,
   D., 2024, {FloPy} workflows for creating structured and unstructured
   {MODFLOW} models: Groundwater, v.~62, no.~1, p.~124--139,
   \url{https://doi.org/10.1111/gwat.13327}.
+
+\bibitem[{Lal(2001)}]{lal2001modification}
+Lal, A.W., 2001, Modification of canal flow due to stream-aquifer interaction:
+  Journal of Hydraulic Engineering, v. 127, no.~7, p.~567--576.
 
 \bibitem[{Langevin and others(2017)Langevin, Hughes, Provost, Banta, Niswonger,
   and Panday}]{modflow6gwf}
@@ -95,6 +99,11 @@ Peckham, S.D., Hutton, E.W., and Norris, B., 2013, A component-based approach
   to integrated modeling in the geosciences: The design of {CSDMS}: Computers
   \& Geosciences, v.~53, p.~3 -- 12, accessed March 24, 2020, at
   \url{https://doi.org/https://doi.org/10.1016/j.cageo.2012.04.002}.
+
+\bibitem[{Pinder and Sauer(1971)}]{pinder1971numerical}
+Pinder, G.F., and Sauer, S.P., 1971, Numerical simulation of flood wave
+  modification due to bank storage effects: Water Resources Research, v.~7,
+  no.~1, p.~63--70.
 
 \bibitem[{Provost and others(2017)Provost, Langevin, and Hughes}]{modflow6xt3d}
 Provost, A.M., Langevin, C.D., and Hughes, J.D., 2017, Documentation for the

--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -14,7 +14,7 @@
 	\underline{EXAMPLES}
 	\begin{itemize}
 		\item A new Toth example was added to show how the classic groundwater problem consisting of local, intermediate, and regional flow paths can be simulated with MODFLOW.
-	%	\item xxx
+		\item A new Streamflow Routing (SFR) Package example based on the Pinder-Sauer problem \citep{pinder1971numerical} modified by \cite{lal2001modification} was added to demonstrate the capabilities of the kinematic-wave approximation option.
 	%	\item xxx
 	\end{itemize}
 

--- a/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-sfr.dfn
@@ -11,14 +11,6 @@ longname activate reach storage
 description keyword that activates storage contributions to the stream-flow routing package continuity equation.
 
 block options
-name storage_weight
-type double precision
-reader urword
-optional true
-longname reach storage time weighting
-description real number value that defines the time weighting factor used to calculate the change in channel storage. STORAGE\_WEIGHT must have a value between 0.5 and 1. Default STORAGE\_WEIGHT value is 0.5.
-
-block options
 name auxiliary
 type string
 shape (naux)
@@ -342,6 +334,14 @@ reader urword
 optional true
 longname time conversion factor
 description real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\_CONVERSION does not need to be specified if TIME\_UNITS are seconds.
+
+block options
+name dev_storage_weight
+type double precision
+reader urword
+optional true
+longname reach storage time weighting
+description real number value that defines the time weighting factor used to calculate the change in channel storage. STORAGE\_WEIGHT must have a value between 0.5 and 1. Default STORAGE\_WEIGHT value is 1.
 
 
 # --------------------- gwf sfr dimensions ---------------------

--- a/src/Model/GroundWaterFlow/gwf-sfr.f90
+++ b/src/Model/GroundWaterFlow/gwf-sfr.f90
@@ -752,17 +752,6 @@ contains
       this%istorage = 1
       write (this%iout, '(4x,a)') trim(adjustl(this%text))// &
         ' REACH STORAGE IS ACTIVE.'
-    case ('STORAGE_WEIGHT')
-      r = this%parser%GetDouble()
-      if (r < DHALF .or. r > DONE) then
-        write (errmsg, '(a,g0,a)') &
-          "STORAGE_WEIGHT SPECIFIED TO BE '", r, &
-          "' BUT CANNOT BE LESS THAN 0.5 OR GREATER THAN 1.0"
-        call store_error(errmsg)
-      else
-        this%storage_weight = r
-        write (this%iout, fmtstoweight) this%storage_weight
-      end if
     case ('PRINT_STAGE')
       this%iprhed = 1
       write (this%iout, '(4x,a)') trim(adjustl(this%text))// &
@@ -867,6 +856,17 @@ contains
       write (this%iout, '(4x,a)') &
         'A FINAL CONVERGENCE CHECK OF THE CHANGE IN STREAM FLOW ROUTING &
         &STAGES AND FLOWS WILL NOT BE MADE'
+    case ('DEV_STORAGE_WEIGHT')
+      r = this%parser%GetDouble()
+      if (r < DHALF .or. r > DONE) then
+        write (errmsg, '(a,g0,a)') &
+          "STORAGE_WEIGHT SPECIFIED TO BE '", r, &
+          "' BUT CANNOT BE LESS THAN 0.5 OR GREATER THAN 1.0"
+        call store_error(errmsg)
+      else
+        this%storage_weight = r
+        write (this%iout, fmtstoweight) this%storage_weight
+      end if
       !
       ! -- no valid options found
     case default
@@ -4411,7 +4411,7 @@ contains
     ! -- set storage weight if it has not been defined yet
     if (this%istorage == 1) then
       if (this%storage_weight == DNODATA) then
-        this%storage_weight = DHALF
+        this%storage_weight = DONE
         write (this%iout, fmtweight) &
           trim(adjustl(this%packName)), this%storage_weight
       end if


### PR DESCRIPTION
* Add PinderSauer example to ReleaseNotes develop.tex with associated references
* update test_gwf_sfr_kinematic01.py to use revised dev_storage_weight variable name

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).