### PR TITLE
fix(xt3d): iallpc getting adding twice to memory manager

### DIFF
--- a/src/Model/ModelUtilities/Xt3dInterface.f90
+++ b/src/Model/ModelUtilities/Xt3dInterface.f90
@@ -1150,7 +1150,7 @@ contains
   !> @brief Allocate and populate iallpc array. Set lamatsaved.
   subroutine xt3d_iallpc(this)
     ! -- modules
-    use MemoryManagerModule, only: mem_allocate, mem_deallocate
+    use MemoryManagerModule, only: mem_allocate, mem_reallocate
     ! -- dummy
     class(Xt3dType) :: this
     ! -- local
@@ -1212,8 +1212,9 @@ contains
     end if
     !
     if (.not. this%lamatsaved) then
-      call mem_deallocate(this%iallpc)
-      call mem_allocate(this%iallpc, 0, 'IALLPC', this%memoryPath)
+      ! there are no permanently confined connections so deallocate iallpc
+      ! in order to save memory
+      call mem_reallocate(this%iallpc, 0, 'IALLPC', this%memoryPath)
     end if
     !
     ! -- Return


### PR DESCRIPTION
* warning message showing iallpc getting added multiple times to hashtable
* fix by using mem_reallocate instead of mem_deallocate/mem_allocate for the second call

Replace this paragraph with a written description of the pull request.  Include images and files as necessary to help with the documentation.  Descriptions for trivial and minor pull requests should be brief.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).