### PR TITLE
fix(idm): tolerate dimension 0 static list input

### DIFF
--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -632,7 +632,7 @@ contains
       call mem_setptr(nrow, idt%shape, this%mf6_input%mempath)
       nrows = nrow
     else
-      nrows = 0
+      nrows = -1
     end if
     !
     ! -- create a structured array

--- a/src/Utilities/Idm/mf6blockfile/StructArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/StructArray.f90
@@ -90,7 +90,8 @@ contains
     !
     ! -- set rows if known or set deferred
     struct_array%nrow = nrow
-    if (struct_array%nrow == 0) then
+    if (struct_array%nrow == -1) then
+      struct_array%nrow = 0
       struct_array%deferred_shape = .true.
     end if
     !


### PR DESCRIPTION
This change addresses the IDP issue reported in #2025:
  - currently IDM tries to load a dimension 0 static list block without the dimension
  - Loading in this way doesn't support 2d variables in list input (auxiliary variable)
  - This change allows a dimension 0 static list input load to be acted upon in the expected way

- [X] Replaced section above with description of pull request
- [X] Referenced issue or pull request #2025
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).