### PR TITLE
chore(*.f90): reduce code bloat

### DIFF
--- a/src/Distributed/VirtualModel.f90
+++ b/src/Distributed/VirtualModel.f90
@@ -311,8 +311,6 @@ contains
 
     obj_ptr => model_list%GetItem(idx)
     v_model => cast_as_virtual_model(obj_ptr)
-    return
-
   end function get_virtual_model_from_list
 
   function cast_as_virtual_model(obj_ptr) result(v_model)

--- a/src/Exchange/BaseExchange.f90
+++ b/src/Exchange/BaseExchange.f90
@@ -57,9 +57,6 @@ contains
     if (.not. readnewdata) return
     !
     ! -- Nothing to do for RP
-    !
-    ! -- Return
-    return
   end subroutine exg_rp
 
   !> @brief Calculate time step length
@@ -69,9 +66,6 @@ contains
     class(BaseExchangeType) :: this
     !
     ! -- Nothing to do for TU
-    !
-    ! -- Return
-    return
   end subroutine exg_dt
 
   !> @brief Run output routines
@@ -79,9 +73,6 @@ contains
   subroutine exg_ot(this)
     ! -- dummy
     class(BaseExchangeType) :: this
-    !
-    ! -- Return
-    return
   end subroutine exg_ot
 
   !> @brief Final processing
@@ -89,9 +80,6 @@ contains
   subroutine exg_fp(this)
     ! -- dummy
     class(BaseExchangeType) :: this
-    !
-    ! -- Return
-    return
   end subroutine exg_fp
 
   !> @brief Deallocate memory
@@ -99,9 +87,6 @@ contains
   subroutine exg_da(this)
     ! -- dummy
     class(BaseExchangeType) :: this
-    !
-    ! -- Return
-    return
   end subroutine exg_da
 
   !> @brief Should return true when the exchange should be added to the
@@ -115,9 +100,6 @@ contains
     logical(LGP) :: is_connected !< true, when connected
     !
     is_connected = .false.
-    !
-    ! -- Return
-    return
   end function
 
   !> @brief Cast the object passed in as BaseExchangeType and return it
@@ -135,9 +117,6 @@ contains
     class is (BaseExchangeType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsBaseExchangeClass
 
   !> @brief Add the exchange object (BaseExchangeType) to a list
@@ -151,9 +130,6 @@ contains
     !
     obj => exchange
     call list%Add(obj)
-    !
-    ! -- Return
-    return
   end subroutine AddBaseExchangeToList
 
   !> @brief Retrieve a specific BaseExchangeType object from a list
@@ -168,9 +144,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsBaseExchangeClass(obj)
-    !
-    ! -- Return
-    return
   end function GetBaseExchangeFromList
 
 end module BaseExchangeModule

--- a/src/Exchange/DisConnExchange.f90
+++ b/src/Exchange/DisConnExchange.f90
@@ -163,9 +163,6 @@ contains
       write (iout, '(4x,2a)') 'Interface model coupling approach manually &
         &activated for ', trim(this%name)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_options
 
   !> @brief Source dimension from input context
@@ -189,9 +186,6 @@ contains
     end if
     !
     write (iout, '(1x,a)') 'END OF EXCHANGE DIMENSIONS'
-    !
-    ! -- return
-    return
   end subroutine source_dimensions
 
   !> @brief Returns reduced node number from user
@@ -219,9 +213,6 @@ contains
                       model%dis%mshape(3))
     end if
     noder = model%dis%get_nodenumber(node, 0)
-    !
-    ! -- return
-    return
   end function noder
 
   !> @brief
@@ -252,9 +243,6 @@ contains
       write (cellstr, fmtndim3) cellid(1), cellid(2), cellid(3)
     case default
     end select
-    !
-    ! -- return
-    return
   end function cellstr
 
   !> @brief Source exchange data from input context
@@ -400,9 +388,6 @@ contains
       call store_error('Errors encountered in exchange input file.')
       call store_error_filename(this%filename)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_data
 
   !> @brief Allocate scalars and initialize to defaults
@@ -443,9 +428,6 @@ contains
     this%inamedbound = 0
     !
     this%dev_ifmod_on = .false.
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate array data, using the number of
@@ -472,9 +454,6 @@ contains
       allocate (this%boundname(1))
     end if
     this%boundname(:) = ''
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief Should interface model be used to handle these
@@ -489,9 +468,6 @@ contains
     !
     ! use im when one of the models is not local
     use_im = .not. (this%v_model1%is_local .and. this%v_model2%is_local)
-    !
-    ! -- Return
-    return
   end function use_interface_model
 
   !> @brief Clean up all scalars and arrays
@@ -526,9 +502,6 @@ contains
     call mem_deallocate(this%ipakcb)
     call mem_deallocate(this%inamedbound)
     call mem_deallocate(this%dev_ifmod_on)
-    !
-    ! -- Return
-    return
   end subroutine disconnex_da
 
   function CastAsDisConnExchangeClass(obj) result(res)
@@ -545,9 +518,6 @@ contains
     class is (DisConnExchangeType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsDisConnExchangeClass
 
   subroutine AddDisConnExchangeToList(list, exchange)
@@ -560,9 +530,6 @@ contains
     !
     obj => exchange
     call list%Add(obj)
-    !
-    ! -- Return
-    return
   end subroutine AddDisConnExchangeToList
 
   function GetDisConnExchangeFromList(list, idx) result(res)
@@ -577,9 +544,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsDisConnExchangeClass(obj)
-    !
-    ! -- Return
-    return
   end function GetDisConnExchangeFromList
 
 end module DisConnExchangeModule

--- a/src/Exchange/GhostNode.f90
+++ b/src/Exchange/GhostNode.f90
@@ -77,9 +77,6 @@ contains
     ! -- Set variables
     gncobj%inunit = inunit
     gncobj%iout = iout
-    !
-    ! -- Return
-    return
   end subroutine gnc_cr
 
   !> @brief Initialize a gnc object
@@ -128,9 +125,6 @@ contains
         call store_error_unit(this%inunit)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine gnc_df
 
   !> @brief Single or Two-Model GNC Add Connections
@@ -164,9 +158,6 @@ contains
         end do jloop
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine gnc_ac
 
   !> @brief Single or Two-Model GNC Map Connections
@@ -252,9 +243,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine gnc_mc
 
   !> @brief Store the n-m Picard conductance in cond prior to the Newton terms
@@ -282,9 +270,6 @@ contains
       end if
       this%cond(ignc) = cond
     end do gncloop
-    !
-    ! -- Return
-    return
   end subroutine gnc_fmsav
 
   !> @brief Fill matrix terms
@@ -336,9 +321,6 @@ contains
         end if
       end do jloop
     end do gncloop
-    !
-    ! -- Return
-    return
   end subroutine gnc_fc
 
   !> @brief Fill GNC Newton terms
@@ -458,9 +440,6 @@ contains
         end if
       end do jloop
     end do gncloop
-    !
-    ! -- Return
-    return
   end subroutine gnc_fn
 
   !> @brief Single Model GNC Output
@@ -492,9 +471,6 @@ contains
           deltaQgnc, this%cond(ignc)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine gnc_ot
 
   !> @brief Add GNC to flowja
@@ -524,9 +500,6 @@ contains
       flowja(isympos) = flowja(isympos) - deltaQgnc
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine gnc_cq
 
   !> @brief Single Model deltaQgnc (ghost node correction flux)
@@ -566,9 +539,6 @@ contains
       cond = this%cond(ignc)
       deltaQgnc = aterm * cond
     end if
-    !
-    ! -- Return
-    return
   end function deltaQgnc
 
   !> @brief Allocate gnc scalar variables
@@ -594,9 +564,6 @@ contains
     this%i2kn = .false.
     this%nexg = 0
     this%numjs = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate gnc scalar variables
@@ -628,9 +595,6 @@ contains
       call mem_allocate(this%jposinrown, 0, 0, 'JPOSINROWN', this%memoryPath)
       call mem_allocate(this%jposinrowm, 0, 0, 'JPOSINROWM', this%memoryPath)
     end if
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief Deallocate memory
@@ -664,9 +628,6 @@ contains
     !
     ! -- deallocate NumericalPackageType
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine gnc_da
 
   !> @brief Read a gnc options block
@@ -723,9 +684,6 @@ contains
     !
     ! -- Set the iasym flag if the correction is implicit
     if (this%implicit) this%iasym = 1
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @brief Single Model GNC Read Dimensions
@@ -772,9 +730,6 @@ contains
     else
       call store_error('Required DIMENSIONS block not found.', terminate=.TRUE.)
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_dimensions
 
   !> @brief Read a GNCDATA block
@@ -906,9 +861,6 @@ contains
     !
     ! -- deallocate nodesuj array
     deallocate (nodesuj)
-    !
-    ! -- Return
-    return
   end subroutine read_data
 
   !> @brief Convert the user-based node number into a reduced number
@@ -932,9 +884,6 @@ contains
     else
       noder = model%dis%get_nodenumber(nodeu, 0)
     end if
-    !
-    ! -- Return
-    return
   end subroutine nodeu_to_noder
 
 end module GhostNodeModule

--- a/src/Exchange/NumericalExchange.f90
+++ b/src/Exchange/NumericalExchange.f90
@@ -44,9 +44,6 @@ contains
     use InputOutputModule, only: getunit, openfile
     ! -- dummy
     class(NumericalExchangeType) :: this
-    !
-    ! -- Return
-    return
   end subroutine exg_df
 
   !> @brief If an implicit exchange then add connections to sparse
@@ -57,9 +54,6 @@ contains
     ! -- dummy
     class(NumericalExchangeType) :: this
     type(sparsematrix), intent(inout) :: sparse
-    !
-    ! -- Return
-    return
   end subroutine exg_ac
 
   !> @brief Map the connections in the global matrix
@@ -79,9 +73,6 @@ contains
   subroutine exg_ar(this)
     !
     class(NumericalExchangeType) :: this
-    !
-    ! -- Return
-    return
   end subroutine exg_ar
 
   !> @brief Advance
@@ -89,9 +80,6 @@ contains
   subroutine exg_ad(this)
     ! -- dummy
     class(NumericalExchangeType) :: this
-    !
-    ! -- Return
-    return
   end subroutine exg_ad
 
   !> @brief Calculate conductance, and for explicit exchanges, set the
@@ -101,9 +89,6 @@ contains
     ! -- dummy
     class(NumericalExchangeType) :: this
     integer(I4B), intent(in) :: kiter
-    !
-    ! -- Return
-    return
   end subroutine exg_cf
 
   !> @brief Fill the matrix
@@ -115,9 +100,6 @@ contains
     class(MatrixBaseType), pointer :: matrix_sln
     real(DP), dimension(:), intent(inout) :: rhs_sln
     integer(I4B), optional, intent(in) :: inwtflag
-    !
-    ! -- Return
-    return
   end subroutine exg_fc
 
   !> @brief Additional convergence check
@@ -126,9 +108,6 @@ contains
     ! -- dummy
     class(NumericalExchangeType) :: this
     integer(I4B), intent(inout) :: icnvg
-    !
-    ! -- Return
-    return
   end subroutine exg_cc
 
   !> @brief Calculate flow
@@ -141,9 +120,6 @@ contains
     integer(I4B), intent(inout) :: icnvg
     integer(I4B), intent(in) :: isuppress_output
     integer(I4B), intent(in) :: isolnid
-    !
-    ! -- Return
-    return
   end subroutine exg_cq
 
   !> @brief Exchange budget
@@ -156,9 +132,6 @@ contains
     integer(I4B), intent(inout) :: icnvg
     integer(I4B), intent(in) :: isuppress_output
     integer(I4B), intent(in) :: isolnid
-    !
-    ! -- Return
-    return
   end subroutine exg_bd
 
   !> @brief Output
@@ -166,9 +139,6 @@ contains
   subroutine exg_ot(this)
     ! -- dummy
     class(NumericalExchangeType) :: this
-    !
-    ! -- Return
-    return
   end subroutine exg_ot
 
   !> @brief Deallocate memory
@@ -178,9 +148,6 @@ contains
     use MemoryManagerModule, only: mem_deallocate
     ! -- dummy
     class(NumericalExchangeType) :: this
-    !
-    ! -- Return
-    return
   end subroutine exg_da
 
   function get_iasym(this) result(iasym)
@@ -190,9 +157,6 @@ contains
     integer(I4B) :: iasym
     !
     iasym = 0
-    !
-    ! -- Return
-    return
   end function get_iasym
 
   function CastAsNumericalExchangeClass(obj) result(res)
@@ -209,9 +173,6 @@ contains
     class is (NumericalExchangeType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsNumericalExchangeClass
 
   !> @brief Add numerical exchange to a list
@@ -226,9 +187,6 @@ contains
     !
     obj => exchange
     call list%Add(obj)
-    !
-    ! -- Return
-    return
   end subroutine AddNumericalExchangeToList
 
   !> @brief Retrieve a specific numerical exchange from a list
@@ -244,9 +202,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsNumericalExchangeClass(obj)
-    !
-    ! -- Return
-    return
   end function GetNumericalExchangeFromList
 
 end module NumericalExchangeModule

--- a/src/Exchange/exg-gwegwe.f90
+++ b/src/Exchange/exg-gwegwe.f90
@@ -186,9 +186,6 @@ contains
     !
     ! -- Create the obs package
     call obs_cr(exchange%obs, exchange%inobs)
-    !
-    ! -- Return
-    return
   end subroutine gweexchange_create
 
   !> @ brief Define GWE GWE exchange
@@ -244,9 +241,6 @@ contains
     !
     ! -- validate
     call this%validate_exchange()
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_df
 
   !> @brief validate exchange data after reading
@@ -305,9 +299,6 @@ contains
     if (count_errors() > 0) then
       call ustop()
     end if
-    !
-    ! -- Return
-    return
   end subroutine validate_exchange
 
   !> @ brief Allocate and read
@@ -323,9 +314,6 @@ contains
     !
     ! -- Observation AR
     call this%obs%obs_ar()
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_ar
 
   !> @ brief Read and prepare
@@ -346,9 +334,6 @@ contains
     !
     ! -- Read and prepare for observations
     call this%gwe_gwe_rp_obs()
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_rp
 
   !> @ brief Advance
@@ -364,9 +349,6 @@ contains
     !
     ! -- Push simulated values to preceding time step
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_ad
 
   !> @ brief Fill coefficients
@@ -383,9 +365,6 @@ contains
     !
     ! -- Call mvt fc routine
     if (this%inmvt > 0) call this%mvt%mvt_fc(this%gwemodel1%x, this%gwemodel2%x)
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_fc
 
   !> @ brief Budget
@@ -428,9 +407,6 @@ contains
     !
     ! -- Call mvt bd routine
     if (this%inmvt > 0) call this%mvt%mvt_bd(this%gwemodel1%x, this%gwemodel2%x)
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_bd
 
   !> @ brief Budget save
@@ -465,9 +441,6 @@ contains
     if (this%inobs /= 0) then
       call this%gwe_gwe_save_simvals()
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_bdsav
 
   !> @ brief Budget save
@@ -636,9 +609,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_bdsav_model
 
   !> @ brief Output
@@ -693,9 +663,6 @@ contains
     !
     ! -- OBS output
     call this%obs%obs_ot()
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_ot
 
   !> @ brief Source options
@@ -784,9 +751,6 @@ contains
     end if
     !
     write (iout, '(1x,a)') 'END OF GWE-GWE EXCHANGE OPTIONS'
-    !
-    ! -- return
-    return
   end subroutine source_options
 
   !> @ brief Read mover
@@ -808,9 +772,6 @@ contains
                 gwfmodelname1=this%gwfmodelname1, &
                 gwfmodelname2=this%gwfmodelname2, &
                 fmi2=this%gwemodel2%fmi)
-    !
-    ! -- Return
-    return
   end subroutine read_mvt
 
   !> @ brief Allocate scalars
@@ -835,9 +796,6 @@ contains
     !
     call mem_allocate(this%inmvt, 'INMVT', this%memoryPath)
     this%inmvt = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Deallocate
@@ -884,9 +842,6 @@ contains
     !
     ! -- deallocate base
     call this%DisConnExchangeType%disconnex_da()
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_da
 
   !> @ brief Allocate arrays
@@ -955,9 +910,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Define observations
@@ -974,9 +926,6 @@ contains
     !    for gwt-gwt observation type.
     call this%obs%StoreObsType('flow-ja-face', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => gwe_gwe_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_df_obs
 
   !> @ brief Read and prepare observations
@@ -1048,9 +997,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%obs%inputFilename)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_rp_obs
 
   !> @ brief Final processing
@@ -1060,9 +1006,6 @@ contains
   subroutine gwe_gwe_fp(this)
     ! -- dummy
     class(GweExchangeType) :: this !<  GwtExchangeType
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_fp
 
   !> @brief Return true when this exchange provides matrix coefficients for
@@ -1086,9 +1029,6 @@ contains
         is_connected = .true.
       end if
     end select
-    !
-    ! -- Return
-    return
   end function gwe_gwe_connects_model
 
   !> @brief Should interface model be used for this exchange
@@ -1108,9 +1048,6 @@ contains
     ! For now set use_im to .true. since the interface model approach
     ! must currently be used for any GWT-GWT exchange.
     use_im = .true.
-    !
-    ! -- Return
-    return
   end function
 
   !> @ brief Save simulated flow observations
@@ -1155,9 +1092,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_save_simvals
 
   !> @ brief Obs ID processor
@@ -1197,9 +1131,6 @@ contains
       !    is for a named exchange boundary or group of exchange boundaries.
       obsrv%intPak1 = NAMEDBOUNDFLAG
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwe_gwe_process_obsID
 
   !> @ brief Cast polymorphic object as exchange
@@ -1220,9 +1151,6 @@ contains
     class is (GweExchangeType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsGweExchange
 
   !> @ brief Get exchange from list
@@ -1241,9 +1169,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsGweExchange(obj)
-    !
-    ! -- Return
-    return
   end function GetGweExchangeFromList
 
 end module GweGweExchangeModule

--- a/src/Exchange/exg-gwfgwe.f90
+++ b/src/Exchange/exg-gwfgwe.f90
@@ -76,9 +76,6 @@ contains
     !
     ! -- set model pointers
     call exchange%set_model_pointers()
-    !
-    ! -- Return
-    return
   end subroutine gwfgwe_cr
 
   !> @brief Allocate and read
@@ -127,9 +124,6 @@ contains
     ! -- Set a pointer to the GWF bndlist.  This will allow the transport model
     !    to look through the flow packages and establish a link to GWF flows
     gwemodel%fmi%gwfbndlist => gwfmodel%bndlist
-    !
-    ! -- Return
-    return
   end subroutine set_model_pointers
 
   !> @brief Define the GwfGwe Exchange object
@@ -180,9 +174,6 @@ contains
     if (gwemodel%incnd > 0) then
       gwfmodel%npf%icalcspdis = 1
     end if
-    !
-    ! -- Return
-    return
   end subroutine exg_df
 
   !> @brief Allocate and read
@@ -278,9 +269,6 @@ contains
     !
     ! -- connect Connections
     call this%gwfconn2gweconn(gwfmodel, gwemodel)
-    !
-    ! -- Return
-    return
   end subroutine exg_ar
 
   !> @brief Link GWE connections to GWF connections or exchanges
@@ -408,9 +396,6 @@ contains
       end if
       !
     end do gweloop
-    !
-    ! -- Return
-    return
   end subroutine gwfconn2gweconn
 
   !> @brief Links a GWE connection to its GWF counterpart
@@ -452,9 +437,6 @@ contains
     !  gweConn%gweModel%name, &
     !  gweConn%conc, &
     !  gweConn%icbound)
-    !
-    ! -- Return
-    return
   end subroutine link_connections
 
   !> @brief Deallocate memory
@@ -467,9 +449,6 @@ contains
     !
     call mem_deallocate(this%m1_idx)
     call mem_deallocate(this%m2_idx)
-    !
-    ! -- Return
-    return
   end subroutine exg_da
 
   !> @brief Allocate GwfGwe exchange scalars
@@ -484,9 +463,6 @@ contains
     call mem_allocate(this%m2_idx, 'M2ID', this%memoryPath)
     this%m1_idx = 0
     this%m2_idx = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Call routines in FMI that will set pointers to the necessary flow
@@ -538,9 +514,6 @@ contains
         iterm = iterm + 1
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwfbnd2gwefmi
 
 end module GwfGweExchangeModule

--- a/src/Exchange/exg-gwfgwf.f90
+++ b/src/Exchange/exg-gwfgwf.f90
@@ -197,9 +197,6 @@ contains
     !
     ! -- Create the obs package
     call obs_cr(exchange%obs, exchange%inobs)
-    !
-    ! -- Return
-    return
   end subroutine gwfexchange_create
 
   !> @ brief Define GWF GWF exchange
@@ -269,9 +266,6 @@ contains
     !
     ! -- validate
     call this%validate_exchange()
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_df
 
   !> @brief validate exchange data after reading
@@ -360,9 +354,6 @@ contains
         ' in both of the connected models.'
       call store_error(errmsg, terminate=.TRUE.)
     end if
-    !
-    ! -- Return
-    return
   end subroutine validate_exchange
 
   !> @ brief Add connections
@@ -390,9 +381,6 @@ contains
     if (this%ingnc > 0) then
       call this%gnc%gnc_ac(sparse)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_ac
 
   !> @ brief Map connections
@@ -420,9 +408,6 @@ contains
     if (this%ingnc > 0) then
       call this%gnc%gnc_mc(matrix_sln)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_mc
 
   !> @ brief Allocate and read
@@ -441,9 +426,6 @@ contains
     !
     ! -- Observation AR
     call this%obs%obs_ar()
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_ar
 
   !> @ brief Read and prepare
@@ -464,9 +446,6 @@ contains
     !
     ! -- Read and prepare for observations
     call this%gwf_gwf_rp_obs()
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_rp
 
   !> @ brief Advance
@@ -482,9 +461,6 @@ contains
     !
     ! -- Push simulated values to preceding time step
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_ad
 
   !> @ brief Calculate coefficients
@@ -503,9 +479,6 @@ contains
     ! -- Rewet cells across models using the wetdry parameters in each model's
     !    npf package, and the head in the connected model.
     call this%rewet(kiter)
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_cf
 
   !> @ brief Fill coefficients
@@ -574,9 +547,6 @@ contains
                              ictm2_opt=this%gwfmodel2%npf%icelltype)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_fc
 
   !> @ brief Fill Newton
@@ -683,9 +653,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_fn
 
   !> @ brief Calculate flow
@@ -708,9 +675,6 @@ contains
     !
     ! -- add exchange flows to model's flowja diagonal
     call this%gwf_gwf_add_to_flowja()
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_cq
 
   !> @brief Calculate flow rates for the exchanges and store them in a member
@@ -741,9 +705,6 @@ contains
       end if
       this%simvals(i) = rrate
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_calc_simvals
 
   !> @brief Add exchange flow to each model flowja diagonal position so that
@@ -779,9 +740,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_add_to_flowja
 
   !> @brief Set flow rates to the edges in the models
@@ -891,9 +849,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_set_flow_to_npf
 
   !> @ brief Budget
@@ -940,9 +895,6 @@ contains
     !
     ! -- Call mvr bd routine
     if (this%inmvr > 0) call this%mvr%mvr_bd()
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_bd
 
   !> @ brief gwf-gwf-chd-bd
@@ -1006,9 +958,6 @@ contains
       budterm(2, 1) = ratout
       call this%gwfmodel2%model_bdentry(budterm, budtxt, this%name)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_chd_bd
 
   !> @ brief Budget save
@@ -1043,9 +992,6 @@ contains
     if (this%inobs /= 0) then
       call this%gwf_gwf_save_simvals()
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_bdsav
 
   subroutine gwf_gwf_bdsav_model(this, model)
@@ -1204,9 +1150,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_bdsav_model
 
   !> @ brief Output
@@ -1278,9 +1221,6 @@ contains
     !
     ! -- OBS output
     call this%obs%obs_ot()
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_ot
 
   !> @ brief Source options
@@ -1381,9 +1321,6 @@ contains
     if (this%inewton > 0) then
       this%satomega = DEM6
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_options
 
   !> @ brief Read ghost nodes
@@ -1438,9 +1375,6 @@ contains
     !
     ! -- close the file
     close (this%ingnc)
-    !
-    ! -- Return
-    return
   end subroutine read_gnc
 
   !> @ brief Read mover
@@ -1472,9 +1406,6 @@ contains
     this%mvr%model1 => this%v_model1
     this%mvr%model2 => this%v_model2
     this%mvr%suppress_fileout = this%is_datacopy
-    !
-    ! -- Return
-    return
   end subroutine read_mvr
 
   !> @ brief Rewet
@@ -1526,9 +1457,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine rewet
 
   subroutine calc_cond_sat(this)
@@ -1616,9 +1544,6 @@ contains
       ! -- store csat in condsat
       this%condsat(iexg) = csat
     end do
-    !
-    ! -- Return
-    return
   end subroutine calc_cond_sat
 
   !> @ brief Calculate the conductance
@@ -1710,9 +1635,6 @@ contains
       this%cond(iexg) = cond
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine condcalc
 
   !> @ brief Allocate scalars
@@ -1744,9 +1666,6 @@ contains
     this%inmvr = 0
     this%inobs = 0
     this%satomega = DZERO
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Deallocate
@@ -1804,9 +1723,6 @@ contains
     !
     ! -- deallocate base
     call this%DisConnExchangeType%disconnex_da()
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_da
 
   !> @ brief Allocate arrays
@@ -1878,9 +1794,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Define observations
@@ -1897,9 +1810,6 @@ contains
     !    for gwf-gwf observation type.
     call this%obs%StoreObsType('flow-ja-face', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => gwf_gwf_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_df_obs
 
   !> @ brief Read and prepare observations
@@ -1971,9 +1881,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%obs%inputFilename)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_rp_obs
 
   !> @ brief Final processing
@@ -1983,9 +1890,6 @@ contains
   subroutine gwf_gwf_fp(this)
     ! -- dummy
     class(GwfExchangeType) :: this !<  GwfExchangeType
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_fp
 
   !> @ brief Calculate flow
@@ -2004,9 +1908,6 @@ contains
     !
     ! -- Calculate flow between nodes in the two models
     qcalc = this%cond(iexg) * (this%gwfmodel2%x(n2) - this%gwfmodel1%x(n1))
-    !
-    ! -- Return
-    return
   end function qcalc
 
   !> @ brief Set symmetric flag
@@ -2030,9 +1931,6 @@ contains
     if (this%ingnc > 0) then
       if (this%gnc%iasym /= 0) iasym = 1
     end if
-    !
-    ! -- Return
-    return
   end function gwf_gwf_get_iasym
 
   !> @brief Return true when this exchange provides matrix
@@ -2056,9 +1954,6 @@ contains
         is_connected = .true.
       end if
     end select
-    !
-    ! -- Return
-    return
   end function gwf_gwf_connects_model
 
   !> @brief Should interface model be used for this exchange
@@ -2081,9 +1976,6 @@ contains
       inbuy_m1 = m%inbuy%get()
     end select
     use_im = use_im .or. (inbuy_m1 > 0)
-    !
-    ! -- Return
-    return
   end function
 
   !> @ brief Save simulated flow observations
@@ -2129,9 +2021,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_save_simvals
 
   !> @ brief Obs ID processor
@@ -2171,9 +2060,6 @@ contains
       !    is for a named exchange boundary or group of exchange boundaries.
       obsrv%intPak1 = NAMEDBOUNDFLAG
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_gwf_process_obsID
 
   !> @ brief Cast polymorphic object as exchange
@@ -2194,9 +2080,6 @@ contains
     class is (GwfExchangeType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsGwfExchange
 
   !> @ brief Get exchange from list
@@ -2215,9 +2098,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsGwfExchange(obj)
-    !
-    ! -- Return
-    return
   end function GetGwfExchangeFromList
 
 end module GwfGwfExchangeModule

--- a/src/Exchange/exg-gwfgwt.f90
+++ b/src/Exchange/exg-gwfgwt.f90
@@ -79,9 +79,6 @@ contains
     !
     ! -- set model pointers
     call exchange%set_model_pointers()
-    !
-    ! -- Return
-    return
   end subroutine gwfgwt_cr
 
   !> @brief Allocate and read
@@ -130,9 +127,6 @@ contains
     ! -- Set a pointer to the GWF bndlist.  This will allow the transport model
     !    to look through the flow packages and establish a link to GWF flows
     gwtmodel%fmi%gwfbndlist => gwfmodel%bndlist
-    !
-    ! -- Return
-    return
   end subroutine set_model_pointers
 
   !> @brief Define the GwfGwt Exchange object
@@ -183,9 +177,6 @@ contains
     if (gwtmodel%indsp > 0) then
       gwfmodel%npf%icalcspdis = 1
     end if
-    !
-    ! -- Return
-    return
   end subroutine exg_df
 
   !> @brief Allocate and read
@@ -281,9 +272,6 @@ contains
     !
     ! -- connect Connections
     call this%gwfconn2gwtconn(gwfmodel, gwtmodel)
-    !
-    ! -- Return
-    return
   end subroutine exg_ar
 
   !> @brief Link GWT connections to GWF connections or exchanges
@@ -428,9 +416,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%filename)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwfconn2gwtconn
 
   !> @brief Links a GWT connection to its GWF counterpart
@@ -472,9 +457,6 @@ contains
     !   gwtConn%gwtModel%name, &
     !   gwtConn%conc, &
     !   gwtConn%icbound)
-    !
-    ! -- Return
-    return
   end subroutine link_connections
 
   !> @brief Deallocate memory
@@ -487,9 +469,6 @@ contains
     !
     call mem_deallocate(this%m1_idx)
     call mem_deallocate(this%m2_idx)
-    !
-    ! -- Return
-    return
   end subroutine exg_da
 
   !> @brief Allocate package scalars
@@ -504,9 +483,6 @@ contains
     call mem_allocate(this%m2_idx, 'M2ID', this%memoryPath)
     this%m1_idx = 0
     this%m2_idx = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Call routines in FMI that will set pointers to the necessary flow
@@ -558,9 +534,6 @@ contains
         iterm = iterm + 1
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwfbnd2gwtfmi
 
 end module GwfGwtExchangeModule

--- a/src/Exchange/exg-gwfprt.f90
+++ b/src/Exchange/exg-gwfprt.f90
@@ -69,9 +69,6 @@ contains
     !
     ! -- set model pointers
     call exchange%set_model_pointers()
-    !
-    ! -- return
-    return
   end subroutine gwfprt_cr
 
   subroutine set_model_pointers(this)
@@ -117,9 +114,6 @@ contains
     ! -- Set a pointer to the GWF bndlist.  This will allow the transport model
     !    to look through the flow packages and establish a link to GWF flows
     prtmodel%fmi%gwfbndlist => gwfmodel%bndlist
-    !
-    ! -- return
-    return
   end subroutine set_model_pointers
 
   subroutine exg_df(this)
@@ -178,9 +172,6 @@ contains
       call prtmodel%fmi%gwfpackages(ip)%set_auxname(packobj%naux, &
                                                     packobj%auxname)
     end do
-    !
-    ! -- return
-    return
   end subroutine exg_df
 
   subroutine exg_ar(this)
@@ -273,9 +264,6 @@ contains
     !
     call mem_deallocate(this%m1id)
     call mem_deallocate(this%m2id)
-    !
-    ! -- return
-    return
   end subroutine exg_da
 
   subroutine allocate_scalars(this)
@@ -289,9 +277,6 @@ contains
     call mem_allocate(this%m2id, 'M2ID', this%memoryPath)
     this%m1id = 0
     this%m2id = 0
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   subroutine gwfbnd2prtfmi(this)
@@ -343,9 +328,6 @@ contains
         iterm = iterm + 1
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine gwfbnd2prtfmi
 
 end module GwfPrtExchangeModule

--- a/src/Exchange/exg-gwtgwt.f90
+++ b/src/Exchange/exg-gwtgwt.f90
@@ -185,9 +185,6 @@ contains
     !
     ! -- Create the obs package
     call obs_cr(exchange%obs, exchange%inobs)
-    !
-    ! -- Return
-    return
   end subroutine gwtexchange_create
 
   !> @ brief Define GWT GWT exchange
@@ -242,9 +239,6 @@ contains
     !
     ! -- validate
     call this%validate_exchange()
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_df
 
   !> @brief validate exchange data after reading
@@ -302,9 +296,6 @@ contains
     if (count_errors() > 0) then
       call ustop()
     end if
-    !
-    ! -- Return
-    return
   end subroutine validate_exchange
 
   !> @ brief Allocate and read
@@ -320,9 +311,6 @@ contains
     !
     ! -- Observation AR
     call this%obs%obs_ar()
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_ar
 
   !> @ brief Read and prepare
@@ -343,9 +331,6 @@ contains
     !
     ! -- Read and prepare for observations
     call this%gwt_gwt_rp_obs()
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_rp
 
   !> @ brief Advance
@@ -361,9 +346,6 @@ contains
     !
     ! -- Push simulated values to preceding time step
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_ad
 
   !> @ brief Fill coefficients
@@ -380,9 +362,6 @@ contains
     !
     ! -- Call mvt fc routine
     if (this%inmvt > 0) call this%mvt%mvt_fc(this%gwtmodel1%x, this%gwtmodel2%x)
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_fc
 
   !> @ brief Budget
@@ -425,9 +404,6 @@ contains
     !
     ! -- Call mvt bd routine
     if (this%inmvt > 0) call this%mvt%mvt_bd(this%gwtmodel1%x, this%gwtmodel2%x)
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_bd
 
   !> @ brief Budget save
@@ -462,9 +438,6 @@ contains
     if (this%inobs /= 0) then
       call this%gwt_gwt_save_simvals()
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_bdsav
 
   !> @ brief Budget save
@@ -633,9 +606,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_bdsav_model
 
   !> @ brief Output
@@ -690,9 +660,6 @@ contains
     !
     ! -- OBS output
     call this%obs%obs_ot()
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_ot
 
   !> @ brief Source options
@@ -781,9 +748,6 @@ contains
     end if
     !
     write (iout, '(1x,a)') 'END OF GWT-GWT EXCHANGE OPTIONS'
-    !
-    ! -- return
-    return
   end subroutine source_options
 
   !> @ brief Read mover
@@ -805,9 +769,6 @@ contains
                 gwfmodelname1=this%gwfmodelname1, &
                 gwfmodelname2=this%gwfmodelname2, &
                 fmi2=this%gwtmodel2%fmi)
-    !
-    ! -- Return
-    return
   end subroutine read_mvt
 
   !> @ brief Allocate scalars
@@ -832,9 +793,6 @@ contains
     !
     call mem_allocate(this%inmvt, 'INMVT', this%memoryPath)
     this%inmvt = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Deallocate
@@ -881,9 +839,6 @@ contains
     !
     ! -- deallocate base
     call this%DisConnExchangeType%disconnex_da()
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_da
 
   !> @ brief Allocate arrays
@@ -952,9 +907,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Define observations
@@ -971,9 +923,6 @@ contains
     !    for gwt-gwt observation type.
     call this%obs%StoreObsType('flow-ja-face', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => gwt_gwt_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_df_obs
 
   !> @ brief Read and prepare observations
@@ -1045,9 +994,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%obs%inputFilename)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_rp_obs
 
   !> @ brief Final processing
@@ -1057,9 +1003,6 @@ contains
   subroutine gwt_gwt_fp(this)
     ! -- dummy
     class(GwtExchangeType) :: this !<  GwtExchangeType
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_fp
 
   !> @brief Return true when this exchange provides matrix coefficients for
@@ -1083,9 +1026,6 @@ contains
         is_connected = .true.
       end if
     end select
-    !
-    ! -- Return
-    return
   end function gwt_gwt_connects_model
 
   !> @brief Should interface model be used for this exchange
@@ -1105,9 +1045,6 @@ contains
     ! For now set use_im to .true. since the interface model approach
     ! must currently be used for any GWT-GWT exchange.
     use_im = .true.
-    !
-    ! -- Return
-    return
   end function
 
   !> @ brief Save simulated flow observations
@@ -1152,9 +1089,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_save_simvals
 
   !> @ brief Obs ID processor
@@ -1194,9 +1128,6 @@ contains
       !    is for a named exchange boundary or group of exchange boundaries.
       obsrv%intPak1 = NAMEDBOUNDFLAG
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwt_gwt_process_obsID
 
   !> @ brief Cast polymorphic object as exchange
@@ -1217,9 +1148,6 @@ contains
     class is (GwtExchangeType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsGwtExchange
 
   !> @ brief Get exchange from list
@@ -1238,9 +1166,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsGwtExchange(obj)
-    !
-    ! -- Return
-    return
   end function GetGwtExchangeFromList
 
 end module GwtGwtExchangeModule

--- a/src/Exchange/exg-swfgwf.f90
+++ b/src/Exchange/exg-swfgwf.f90
@@ -191,9 +191,6 @@ contains
       call sparse%addconnection(iglo, jglo, 1)
       call sparse%addconnection(jglo, iglo, 1)
     end do
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_ac
 
   !> @ brief Map connections
@@ -216,9 +213,6 @@ contains
       this%idxglo(n) = matrix_sln%get_position(iglo, jglo)
       this%idxsymglo(n) = matrix_sln%get_position(jglo, iglo)
     end do
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_mc
 
   !> @ brief Fill coefficients
@@ -328,9 +322,6 @@ contains
     !
     ! -- add exchange flows to model's flowja diagonal
     call this%swf_gwf_add_to_flowja()
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_cq
 
   !> @ brief Deallocate
@@ -364,9 +355,6 @@ contains
     call mem_deallocate(this%ifixedcond)
     call mem_deallocate(this%nexg)
     call mem_deallocate(this%inobs)
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_da
 
   !> @ brief Allocate scalars
@@ -394,9 +382,6 @@ contains
     this%ifixedcond = 0
     this%nexg = 0
     this%inobs = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate array data, using the number of
@@ -413,9 +398,6 @@ contains
     call mem_allocate(this%idxglo, this%nexg, 'IDXGLO', this%memoryPath)
     call mem_allocate(this%idxsymglo, this%nexg, 'IDXSYMGLO', this%memoryPath)
     call mem_allocate(this%simvals, this%nexg, 'SIMVALS', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief
@@ -443,9 +425,6 @@ contains
                       model%dis%mshape(3))
     end if
     noder = model%dis%get_nodenumber(node, 0)
-    !
-    ! -- return
-    return
   end function noder
 
   !> @brief
@@ -476,9 +455,6 @@ contains
       write (cellstr, fmtndim3) cellid(1), cellid(2), cellid(3)
     case default
     end select
-    !
-    ! -- return
-    return
   end function cellstr
 
   !> @brief Calculate flow rates for the exchanges and store them in a member
@@ -510,9 +486,6 @@ contains
       end if
       this%simvals(iexg) = rrate
     end do
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_calc_simvals
 
   !> @ brief Calculate flow
@@ -584,9 +557,6 @@ contains
 
     ! Calculate conductance
     get_cond = smooth_factor * this%bedleak(iexg) * area
-
-    ! -- Return
-    return
   end function get_cond
 
   !> @ brief Get wetted perimeter for swf channel model
@@ -642,9 +612,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_add_to_flowja
 
   !> @ brief Budget
@@ -688,9 +655,6 @@ contains
     ! -- Add any flows from one model into a constant head in another model
     !    as a separate budget term called FLOW-JA-FACE-CHD
     call this%swf_gwf_chd_bd()
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_bd
 
   !> @ brief swf-gwf-chd-bd
@@ -753,9 +717,6 @@ contains
       budterm(2, 1) = ratout
       call this%gwfmodel%model_bdentry(budterm, budtxt, this%name)
     end if
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_chd_bd
 
   !> @ brief Budget save
@@ -787,9 +748,6 @@ contains
     if (this%inobs /= 0) then
       call this%swf_gwf_save_simvals()
     end if
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_bdsav
 
   ! subroutine swf_gwf_bdsav_model(this, model, neighbor_name)
@@ -994,9 +952,6 @@ contains
     !
     ! -- OBS output
     call this%obs%obs_ot()
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_ot
 
   !> @ brief Save simulated flow observations
@@ -1043,9 +998,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine swf_gwf_save_simvals
 
   !> @brief Should return true when the exchange should be added to the
@@ -1069,9 +1021,6 @@ contains
         is_connected = .true.
       end if
     end select
-    !
-    ! -- Return
-    return
   end function
 
 end module SwfGwfExchangeModule

--- a/src/Model/Connection/DistributedVariable.f90
+++ b/src/Model/Connection/DistributedVariable.f90
@@ -37,8 +37,6 @@ contains
 
     obj => list%GetItem(idx)
     res => CastAsDistVar(obj)
-    return
-
   end function GetDistVarFromList
 
   function CastAsDistVar(obj) result(res)
@@ -53,7 +51,6 @@ contains
     class is (DistVarType)
       res => obj
     end select
-    return
   end function CastAsDistVar
 
 end module DistVariableModule

--- a/src/Model/Connection/GweInterfaceModel.f90
+++ b/src/Model/Connection/GweInterfaceModel.f90
@@ -100,9 +100,6 @@ contains
     call cnd_cr(this%cnd, this%name, '', -cnd_unit, this%iout, this%fmi, &
                 this%ieqnsclfac, this%gwecommon)
     call tsp_obs_cr(this%obs, inobs, this%depvartype)
-    !
-    ! -- Return
-    return
   end subroutine gweifmod_cr
 
   !> @brief Allocate scalars associated with the interface model object
@@ -117,9 +114,6 @@ contains
     call mem_allocate(this%iAdvScheme, 'ADVSCHEME', this%memoryPath)
     call mem_allocate(this%ixt3d, 'IXT3D', this%memoryPath)
     call mem_allocate(this%ieqnsclfac, 'IEQNSCLFAC', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate a Flow Model Interface (FMI) object for the interface model
@@ -136,9 +130,6 @@ contains
                       this%fmi%memoryPath)
     call mem_allocate(this%fmi%gwfspdis, 3, this%neq, 'GWFSPDIS', &
                       this%fmi%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine allocate_fmi
 
   !> @brief Define the GWE interface model
@@ -197,9 +188,6 @@ contains
     !
     ! -- Allocate model arrays, now that neq and nja are assigned
     call this%allocate_arrays()
-    !
-    ! -- Return
-    return
   end subroutine gweifmod_df
 
   !> @brief Override allocate and read the GWE interface model and its packages
@@ -216,9 +204,6 @@ contains
     if (this%incnd > 0) then
       call this%cnd%cnd_ar(this%ibound, this%est%porosity)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gweifmod_ar
 
   !> @brief Clean up resources
@@ -263,9 +248,6 @@ contains
     !
     ! -- base
     call this%NumericalModelType%model_da()
-    !
-    ! -- Return
-    return
   end subroutine gweifmod_da
 
 end module GweInterfaceModelModule

--- a/src/Model/Connection/GwfGwfConnection.f90
+++ b/src/Model/Connection/GwfGwfConnection.f90
@@ -298,8 +298,6 @@ contains
     if (this%owns_exchange) then
       call this%gwfExchange%exg_rp()
     end if
-
-    return
   end subroutine gwfgwfcon_rp
 
   !> @brief Advance this connection
@@ -722,7 +720,6 @@ contains
     class is (GwfGwfConnectionType)
       res => obj
     end select
-    return
   end function CastAsGwfGwfConnection
 
 end module GwfGwfConnectionModule

--- a/src/Model/Connection/GwtGwtConnection.f90
+++ b/src/Model/Connection/GwtGwtConnection.f90
@@ -500,7 +500,6 @@ contains
     class is (GwtGwtConnectionType)
       res => obj
     end select
-    return
   end function CastAsGwtGwtConnection
 
 end module

--- a/src/Model/Connection/GwtInterfaceModel.f90
+++ b/src/Model/Connection/GwtInterfaceModel.f90
@@ -90,9 +90,6 @@ contains
                 this%ieqnsclfac)
     call dsp_cr(this%dsp, this%name, '', -dsp_unit, this%iout, this%fmi)
     call tsp_obs_cr(this%obs, inobs, this%depvartype)
-    !
-    ! -- Return
-    return
   end subroutine gwtifmod_cr
 
   !> @brief Allocate scalars associated with the interface model object
@@ -107,9 +104,6 @@ contains
     call mem_allocate(this%iAdvScheme, 'ADVSCHEME', this%memoryPath)
     call mem_allocate(this%ixt3d, 'IXT3D', this%memoryPath)
     call mem_allocate(this%ieqnsclfac, 'IEQNSCLFAC', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate a Flow Model Interface (FMI) object for the interface model
@@ -126,9 +120,6 @@ contains
                       this%fmi%memoryPath)
     call mem_allocate(this%fmi%gwfspdis, 3, this%neq, 'GWFSPDIS', &
                       this%fmi%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine allocate_fmi
 
   !> @brief Define the GWT interface model
@@ -186,9 +177,6 @@ contains
     !
     ! allocate model arrays, now that neq and nja are assigned
     call this%allocate_arrays()
-    !
-    ! -- Return
-    return
   end subroutine gwtifmod_df
 
   !> @brief Override allocate and read the GWT interface model and its packages
@@ -205,9 +193,6 @@ contains
     if (this%indsp > 0) then
       call this%dsp%dsp_ar(this%ibound, this%mst%thetam)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwtifmod_ar
 
   !> @brief Clean up resources
@@ -252,9 +237,6 @@ contains
     !
     ! base
     call this%NumericalModelType%model_da()
-    !
-    ! -- Return
-    return
   end subroutine gwtifmod_da
 
 end module GwtInterfaceModelModule

--- a/src/Model/Connection/SpatialModelConnection.f90
+++ b/src/Model/Connection/SpatialModelConnection.f90
@@ -690,7 +690,6 @@ contains ! module procedures
     class is (SpatialModelConnectionType)
       res => obj
     end select
-    return
   end function cast_as_smc
 
   !> @brief Add connection to a list
@@ -705,8 +704,6 @@ contains ! module procedures
     !
     obj => conn
     call list%Add(obj)
-    !
-    return
   end subroutine add_smc_to_list
 
   !> @brief Get the connection from a list
@@ -720,8 +717,6 @@ contains ! module procedures
     class(*), pointer :: obj
     obj => list%GetItem(idx)
     res => cast_as_smc(obj)
-    !
-    return
   end function get_smc_from_list
 
 end module SpatialModelConnectionModule

--- a/src/Model/Discretization/Disv1d.f90
+++ b/src/Model/Discretization/Disv1d.f90
@@ -121,9 +121,6 @@ contains
       end if
 
     end if
-    !
-    ! -- Return
-    return
   end subroutine disv1d_cr
 
   !> @brief Define the discretization
@@ -249,9 +246,6 @@ contains
     ! -- Initialize
     this%nvert = 0
     this%ndim = 1
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   subroutine disv1d_load(this)
@@ -306,9 +300,6 @@ contains
     if (this%iout > 0) then
       call this%log_options(found)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_options
 
   !> @brief Write user options to list file
@@ -413,9 +404,6 @@ contains
       this%bottom(n) = DZERO
       this%idomain(n) = 1
     end do
-    !
-    ! -- Return
-    return
   end subroutine source_dimensions
 
   !> @brief Write dimensions to list file
@@ -542,9 +530,6 @@ contains
       write (this%iout, '(1x,a)') 'Setting Discretization Vertices'
       write (this%iout, '(1x,a,/)') 'End setting discretization vertices'
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_vertices
 
   !> @brief Copy cell1d information from input data context
@@ -608,9 +593,6 @@ contains
       write (this%iout, '(1x,a)') 'Setting Discretization CELL1D'
       write (this%iout, '(1x,a,/)') 'End Setting Discretization CELL1D'
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_cell1d
 
   !> @brief Construct the iavert and javert integer vectors which
@@ -651,9 +633,6 @@ contains
     call mem_allocate(this%javert, vert_spm%nnz, 'JAVERT', this%memoryPath)
     call vert_spm%filliaja(this%iavert, this%javert, ierr)
     call vert_spm%destroy()
-    !
-    ! -- Return
-    return
   end subroutine define_cellverts
 
   !> @brief Calculate x, y, coordinates of reach midpoint
@@ -816,9 +795,6 @@ contains
 
     ! create connectivity using vertices and cell1d
     call this%create_connections()
-
-    ! -- Return
-    return
   end subroutine grid_finalize
 
   subroutine allocate_arrays(this)
@@ -843,9 +819,6 @@ contains
     !
     ! -- Initialize
     this%mshape(1) = this%nodesuser
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   subroutine create_connections(this)
@@ -993,9 +966,6 @@ contains
     !
     ! -- Close the file
     close (iunit)
-    !
-    ! -- return
-    return
   end subroutine write_grb
 
   !>
@@ -1023,9 +993,6 @@ contains
     else
       nodenumber = this%nodereduced(nodeu)
     end if
-    !
-    ! -- return
-    return
   end function get_nodenumber_idx1
 
   subroutine nodeu_to_string(this, nodeu, str)
@@ -1038,9 +1005,6 @@ contains
     !
     write (nstr, '(i0)') nodeu
     str = '('//trim(adjustl(nstr))//')'
-    !
-    ! -- return
-    return
   end subroutine nodeu_to_string
 
   !>
@@ -1099,10 +1063,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- return
-    return
-
   end function nodeu_from_string
 
   subroutine disv1d_da(this)
@@ -1141,9 +1101,6 @@ contains
     !
     ! -- DisBaseType deallocate
     call this%DisBaseType%dis_da()
-    !
-    ! -- Return
-    return
   end subroutine disv1d_da
 
   !> @brief Record a double precision array
@@ -1238,9 +1195,6 @@ contains
       call ubdsv1(kstp, kper, aname, -idataun, dtemp, ncol, nrow, nlay, &
                   iout, delt, pertim, totim)
     end if
-    !
-    ! -- return
-    return
   end subroutine record_array
 
   !> @brief Record list header using ubdsv06
@@ -1274,9 +1228,6 @@ contains
     call ubdsv06(kstp, kper, text, textmodel, textpackage, dstmodel, dstpackage, &
                  ibdchn, naux, auxtxt, ncol, nrow, nlay, &
                  nlist, iout, delt, pertim, totim)
-    !
-    ! -- return
-    return
   end subroutine record_srcdst_list_header
 
   !> @ brief Calculate the flow width between two cells

--- a/src/Model/Discretization/Disv2d.f90
+++ b/src/Model/Discretization/Disv2d.f90
@@ -178,9 +178,6 @@ contains
     !
     ! -- DisBaseType deallocate
     call this%DisBaseType%dis_da()
-    !
-    ! -- Return
-    return
   end subroutine disv2d_da
 
   ! !> @brief Deallocate variables

--- a/src/Model/Geometry/BaseGeometry.f90
+++ b/src/Model/Geometry/BaseGeometry.f90
@@ -32,9 +32,6 @@ contains
     class(BaseGeometryType) :: this
     !
     area_sat = 0.d0
-    !
-    ! -- Return
-    return
   end function area_sat
 
   function perimeter_sat(this)
@@ -44,9 +41,6 @@ contains
     class(BaseGeometryType) :: this
     !
     perimeter_sat = 0.d0
-    !
-    ! -- Return
-    return
   end function perimeter_sat
 
   function area_wet(this, depth)
@@ -57,9 +51,6 @@ contains
     real(DP), intent(in) :: depth
     !
     area_wet = 0.d0
-    !
-    ! -- Return
-    return
   end function area_wet
 
   function perimeter_wet(this, depth)
@@ -70,18 +61,12 @@ contains
     real(DP), intent(in) :: depth
     !
     perimeter_wet = 0.d0
-    !
-    ! -- Return
-    return
   end function perimeter_wet
 
   subroutine set_attribute(this, line)
     ! -- dummy
     class(BaseGeometryType) :: this
     character(len=*), intent(inout) :: line
-    !
-    ! -- Return
-    return
   end subroutine set_attribute
 
   !> @brief Print the attributes for this object
@@ -98,9 +83,6 @@ contains
     write (iout, fmtid) 'ID = ', this%id
     write (iout, fmtnm) 'NAME = ', trim(adjustl(this%name))
     write (iout, fmtnm) 'GEOMETRY TYPE = ', trim(adjustl(this%geo_type))
-    !
-    ! -- Return
-    return
   end subroutine print_attributes
 
 end module BaseGeometryModule

--- a/src/Model/Geometry/CircularGeometry.f90
+++ b/src/Model/Geometry/CircularGeometry.f90
@@ -35,9 +35,6 @@ contains
     !
     ! -- Calculate area
     area_sat = DPI * this%radius**DTWO
-    !
-    ! -- Return
-    return
   end function area_sat
 
   !> @brief Return perimeter as if geometry is fully saturated
@@ -52,9 +49,6 @@ contains
     !
     ! -- Calculate area
     perimeter_sat = DTWO * DPI * this%radius
-    !
-    ! -- Return
-    return
   end function perimeter_sat
 
   !> @brief Return wetted area
@@ -84,9 +78,6 @@ contains
     else
       area_wet = DPI * this%radius * this%radius
     end if
-    !
-    ! -- Return
-    return
   end function area_wet
 
   !> @brief Return wetted perimeter
@@ -112,9 +103,6 @@ contains
     else
       perimeter_wet = DTWO * DPI * this%radius
     end if
-    !
-    ! -- Return
-    return
   end function perimeter_wet
 
   !> @brief Set a parameter for this circular object
@@ -151,9 +139,6 @@ contains
         'Unknown circular geometry attribute: ', line(istart:istop)
       call store_error(errmsg, terminate=.TRUE.)
     end select
-    !
-    ! -- Return
-    return
   end subroutine set_attribute
 
   !> @brief Print the attributes for this object
@@ -174,9 +159,6 @@ contains
     write (iout, fmttd) 'RADIUS = ', this%radius
     write (iout, fmttd) 'SATURATED AREA = ', this%area_sat()
     write (iout, fmttd) 'SATURATED WETTED PERIMETER = ', this%perimeter_sat()
-    !
-    ! -- Return
-    return
   end subroutine print_attributes
 
 end module CircularGeometryModule

--- a/src/Model/Geometry/RectangularGeometry.f90
+++ b/src/Model/Geometry/RectangularGeometry.f90
@@ -34,9 +34,6 @@ contains
     !
     ! -- Calculate area
     area_sat = this%height * this%width
-    !
-    ! -- Return
-    return
   end function area_sat
 
   !> @brief Return saturated perimeter
@@ -51,9 +48,6 @@ contains
     !
     ! -- Calculate area
     perimeter_sat = DTWO * (this%height + this%width)
-    !
-    ! -- Return
-    return
   end function perimeter_sat
 
   !> @brief Return wetted area
@@ -75,9 +69,6 @@ contains
     else
       area_wet = this%width * this%height
     end if
-    !
-    ! -- Return
-    return
   end function area_wet
 
   !> @brief Return wetted perimeter
@@ -99,9 +90,6 @@ contains
     else
       perimeter_wet = DTWO * (this%height + this%width)
     end if
-    !
-    ! -- Return
-    return
   end function perimeter_wet
 
   !> @brief Set a parameter for this rectangular object
@@ -141,9 +129,6 @@ contains
         'Unknown rectangular geometry attribute: ', line(istart:istop)
       call store_error(errmsg, terminate=.TRUE.)
     end select
-    !
-    ! -- Return
-    return
   end subroutine set_attribute
 
   !> @brief Print the attributes for this object
@@ -165,9 +150,6 @@ contains
     write (iout, fmttd) 'WIDTH = ', this%width
     write (iout, fmttd) 'SATURATED AREA = ', this%area_sat()
     write (iout, fmttd) 'SATURATED WETTED PERIMETER = ', this%perimeter_sat()
-    !
-    ! -- Return
-    return
   end subroutine print_attributes
 
 end module RectangularGeometryModule

--- a/src/Model/GroundWaterEnergy/gwe-cnd.f90
+++ b/src/Model/GroundWaterEnergy/gwe-cnd.f90
@@ -125,9 +125,6 @@ contains
         write (cndobj%iout, fmtcnd) input_mempath
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine cnd_cr
 
   !> @brief Define CND object
@@ -170,9 +167,6 @@ contains
       this%xt3d%ixt3d = this%ixt3d
       call this%xt3d%xt3d_df(dis)
     end if
-    !
-    ! -- Return
-    return
   end subroutine cnd_df
 
   !> @brief Add connections to CND
@@ -190,9 +184,6 @@ contains
     !
     ! -- Add extended neighbors (neighbors of neighbors)
     if (this%ixt3d > 0) call this%xt3d%xt3d_ac(moffset, sparse)
-    !
-    ! -- Return
-    return
   end subroutine cnd_ac
 
   !> @brief Map CND connections
@@ -209,9 +200,6 @@ contains
     !
     ! -- Call xt3d map connections
     if (this%ixt3d > 0) call this%xt3d%xt3d_mc(moffset, matrix_sln)
-    !
-    ! -- Return
-    return
   end subroutine cnd_mc
 
   !> @brief Allocate and read method for package
@@ -233,9 +221,6 @@ contains
     ! -- cnd pointers to arguments that were passed in
     this%ibound => ibound
     this%porosity => porosity
-    !
-    ! -- Return
-    return
   end subroutine cnd_ar
 
   !> @brief Advance method for the package
@@ -269,9 +254,6 @@ contains
         call this%xt3d%xt3d_fcpc(this%dis%nodes, .true.)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine cnd_ad
 
   !> @brief  Fill coefficient method for package
@@ -318,9 +300,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine cnd_fc
 
   !> @ brief Calculate flows for package
@@ -354,9 +333,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine cnd_cq
 
   !> @ brief Allocate scalar variables for package
@@ -408,9 +384,6 @@ contains
     this%iangle3 = 1
     this%iktw = 1
     this%ikts = 1
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate arrays for package
@@ -447,9 +420,6 @@ contains
     else
       call mem_allocate(this%dispcoef, 0, 'DISPCOEF', trim(this%memoryPath))
     end if
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Deallocate memory
@@ -511,9 +481,6 @@ contains
     !
     ! -- deallocate variables in NumericalPackageType
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine cnd_da
 
   !> @brief Write user options to list file
@@ -527,8 +494,6 @@ contains
     write (this%iout, '(4x,a,i0)') 'XT3D formulation [0=INACTIVE, 1=ACTIVE, &
                                    &3=ACTIVE RHS] set to: ', this%ixt3d
     write (this%iout, '(1x,a,/)') 'End Setting CND Options'
-    ! -- Return
-    return
   end subroutine log_options
 
   !> @brief Update simulation mempath options
@@ -556,9 +521,6 @@ contains
     if (this%iout > 0) then
       call this%log_options(found)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_options
 
   !> @brief Write dimensions to list file
@@ -599,9 +561,6 @@ contains
     end if
     !
     write (this%iout, '(1x,a,/)') 'End Setting CND Griddata'
-    !
-    ! -- Return
-    return
   end subroutine log_griddata
 
   !> @brief Update CND simulation data from input mempath
@@ -680,9 +639,6 @@ contains
     if (this%iout > 0) then
       call this%log_griddata(found)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_griddata
 
   !> @brief Calculate dispersion coefficients
@@ -800,9 +756,6 @@ contains
         !
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine calcdispellipse
 
   !> @brief Calculate dispersion coefficients
@@ -933,9 +886,6 @@ contains
         !
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine calcdispcoef
 
 end module GweCndModule

--- a/src/Model/GroundWaterEnergy/gwe-ctp.f90
+++ b/src/Model/GroundWaterEnergy/gwe-ctp.f90
@@ -91,9 +91,6 @@ contains
     !
     ! -- Store the appropriate label based on the dependent variable
     ctpobj%depvartype = depvartype
-    !
-    ! -- Return
-    return
   end subroutine ctp_create
 
   !> @brief Allocate arrays specific to the constant temperature package
@@ -126,9 +123,6 @@ contains
     call mem_checkin(this%tspvar, 'TSPVAR', this%memoryPath, &
                      'TSPVAR', this%input_mempath)
     !
-    !
-    ! -- Return
-    return
   end subroutine ctp_allocate_arrays
 
   !> @brief Constant temperature read and prepare (rp) routine
@@ -180,9 +174,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- Return
-    return
   end subroutine ctp_rp
 
   !> @brief Constant temperature package advance routine
@@ -212,9 +203,6 @@ contains
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine ctp_ad
 
   !> @brief Check constant temperature boundary condition data
@@ -246,9 +234,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine ctp_ck
 
   !> @brief Override bnd_fc and do nothing
@@ -263,9 +248,6 @@ contains
     integer(I4B), dimension(:), intent(in) :: ia
     integer(I4B), dimension(:), intent(in) :: idxglo
     class(MatrixBaseType), pointer :: matrix_sln
-    !
-    ! -- Return
-    return
   end subroutine ctp_fc
 
   !> @brief Calculate flow associated with constant temperature boundary
@@ -330,9 +312,6 @@ contains
       end do
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine ctp_cq
 
   !> @brief Add package ratin/ratout to model budget
@@ -355,9 +334,6 @@ contains
     call rate_accumulator(this%ratectpout(1:this%nbound), ratout, dum)
     call model_budget%addentry(ratin, ratout, delt, this%text, &
                                isuppress_output, this%packName)
-    !
-    ! -- Return
-    return
   end subroutine ctp_bd
 
   !> @brief Deallocate memory
@@ -377,9 +353,6 @@ contains
     call mem_deallocate(this%ratectpin)
     call mem_deallocate(this%ratectpout)
     call mem_deallocate(this%tspvar, 'TSPVAR', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine ctp_da
 
   !> @brief Define labels used in list file
@@ -408,9 +381,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   !> @brief Procedure related to observation processing
@@ -423,9 +393,6 @@ contains
     class(GweCtpType) :: this
     !
     ctp_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function ctp_obs_supported
 
   !> @brief Procedure related to observation processing
@@ -444,9 +411,6 @@ contains
     !
     call this%obs%StoreObsType(this%filtyp, .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- Return
-    return
   end subroutine ctp_df_obs
 
   ! -- Procedure related to time series
@@ -474,9 +438,6 @@ contains
         end select
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine ctp_rp_ts
 
   !> @brief Apply auxiliary multiplier to specified temperature if
@@ -495,9 +456,6 @@ contains
     else
       temp = this%tspvar(row)
     end if
-    !
-    ! -- Return
-    return
   end function temp_mult
 
   !> @ brief Return a bound value
@@ -524,9 +482,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- Return
-    return
   end function ctp_bound_value
 
 end module GweCtpModule

--- a/src/Model/GroundWaterEnergy/gwe-esl.f90
+++ b/src/Model/GroundWaterEnergy/gwe-esl.f90
@@ -82,9 +82,6 @@ contains
     !    for the budget calculations, and for accessing the latent heat of
     !    vaporization for evaporative cooling.
     eslobj%gwecommon => gwecommon
-    !
-    ! -- Return
-    return
   end subroutine esl_create
 
   !> @brief Deallocate memory
@@ -97,9 +94,6 @@ contains
     !
     ! -- Deallocate parent package
     call this%BndType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine esl_da
 
   !> @brief Allocate scalars
@@ -118,9 +112,6 @@ contains
     ! -- allocate the object and assign values to object variables
     !
     ! -- Set values
-    !
-    ! -- Return
-    return
   end subroutine esl_allocate_scalars
 
   !> @brief Formulate the HCOF and RHS terms
@@ -150,9 +141,6 @@ contains
       q = this%bound(1, i)
       this%rhs(i) = -q
     end do
-    !
-    ! -- Return
-    return
   end subroutine esl_cf
 
   !> @brief Add matrix terms related to specified energy source loading
@@ -187,9 +175,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(i, this%rhs(i))
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine esl_fc
 
   !> @brief Define list labels
@@ -217,9 +202,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   ! -- Procedures related to observations
@@ -236,9 +218,6 @@ contains
     class(GweEslType) :: this
     !
     esl_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function esl_obs_supported
 
   !> @brief Define observations
@@ -261,9 +240,6 @@ contains
     !    for to-mvr observation type.
     call this%obs%StoreObsType('to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- Return
-    return
   end subroutine esl_df_obs
 
   !> @brief Procedure related to time series
@@ -288,9 +264,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine esl_rp_ts
 
 end module GweEslModule

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -111,9 +111,6 @@ contains
     !
     ! -- Initialize block parser
     call estobj%parser%Initialize(estobj%inunit, estobj%iout)
-    !
-    ! -- Return
-    return
   end subroutine est_cr
 
   !> @ brief Allocate and read method for package
@@ -151,9 +148,6 @@ contains
     ! -- set data required by other packages
     call this%gwecommon%set_gwe_dat_ptrs(this%rhow, this%cpw, this%latheatvap, &
                                          this%rhos, this%cps)
-    !
-    ! -- Return
-    return
   end subroutine est_ar
 
   !> @ brief Fill coefficient method for package
@@ -183,9 +177,6 @@ contains
       call this%est_fc_dcy(nodes, cold, cnew, nja, matrix_sln, idxglo, &
                            rhs, kiter)
     end if
-    !
-    ! -- Return
-    return
   end subroutine est_fc
 
   !> @ brief Fill storage coefficient method for package
@@ -234,9 +225,6 @@ contains
       call matrix_sln%add_value_pos(idxglo(idiag), hhcof)
       rhs(n) = rhs(n) + rrhs
     end do
-    !
-    ! -- Return
-    return
   end subroutine est_fc_sto
 
   !> @ brief Fill decay coefficient method for package
@@ -297,9 +285,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine est_fc_dcy
 
   !> @ brief Calculate flows for package
@@ -323,9 +308,6 @@ contains
     if (this%idcy /= 0) then
       call this%est_cq_dcy(nodes, cnew, cold, flowja)
     end if
-    !
-    ! -- Return
-    return
   end subroutine est_cq
 
   !> @ brief Calculate storage terms for package
@@ -378,9 +360,6 @@ contains
       idiag = this%dis%con%ia(n)
       flowja(idiag) = flowja(idiag) + rate
     end do
-    !
-    ! -- Return
-    return
   end subroutine est_cq_sto
 
   !> @ brief Calculate decay terms for package
@@ -436,9 +415,6 @@ contains
       flowja(idiag) = flowja(idiag) + rate
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine est_cq_dcy
 
   !> @ brief Calculate budget terms for package
@@ -468,9 +444,6 @@ contains
       call model_budget%addentry(rin, rout, delt, budtxt(2), &
                                  isuppress_output, rowlabel=this%packName)
     end if
-    !
-    ! -- Return
-    return
   end subroutine est_bd
 
   !> @ brief Output flow terms for package
@@ -515,9 +488,6 @@ contains
                                    budtxt(2), cdatafmp, nvaluesp, &
                                    nwidthp, editdesc, dinact)
     end if
-    !
-    ! -- Return
-    return
   end subroutine est_ot_flow
 
   !> @brief Deallocate memory
@@ -551,9 +521,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine est_da
 
   !> @ brief Allocate scalar variables for package
@@ -581,9 +548,6 @@ contains
     this%rhow = DZERO
     this%latheatvap = DZERO
     this%idcy = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate arrays for package
@@ -630,9 +594,6 @@ contains
       this%ratedcy(n) = DZERO
       this%decaylast(n) = DZERO
     end do
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Read options for package
@@ -715,9 +676,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF ENERGY STORAGE AND TRANSFER OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @ brief Read data for package
@@ -831,9 +789,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_data
 
   !> @ brief Calculate zero-order decay rate and constrain if necessary
@@ -879,7 +834,6 @@ contains
       end if
       decay_rate = max(decay_rate, DZERO)
     end if
-    return
   end function get_zero_order_decay
 
 end module GweEstModule

--- a/src/Model/GroundWaterEnergy/gwe-lke.f90
+++ b/src/Model/GroundWaterEnergy/gwe-lke.f90
@@ -155,9 +155,6 @@ contains
     lkeobj%depvartype = dvt
     lkeobj%depvarunit = dvu
     lkeobj%depvarunitabbrev = dvua
-    !
-    ! -- Return
-    return
   end subroutine lke_create
 
   !> @brief Find corresponding lke package
@@ -278,9 +275,6 @@ contains
         '   MAX NO. OF ENTRIES = ', this%flowbudptr%budterm(ip)%maxlist
     end do
     write (this%iout, '(a, //)') 'DONE PROCESSING '//ftype//' INFORMATION'
-    !
-    ! -- Return
-    return
   end subroutine find_lke_package
 
   !> @brief Add matrix terms related to LKE
@@ -402,9 +396,6 @@ contains
         call matrix_sln%add_value_pos(ipossymoffd, ctherm)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine lke_fc_expanded
 
   !> @brief Add terms specific to lakes to the explicit lake solve
@@ -464,9 +455,6 @@ contains
         this%dbuff(n1) = this%dbuff(n1) + rrate
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lke_solve
 
   !> @brief Function to return the number of budget terms just for this package.
@@ -489,9 +477,6 @@ contains
     !    7) lakebed-cond
     !
     nbudterms = 7
-    !
-    ! -- Return
-    return
   end function lke_get_nbudterms
 
   !> @brief Set up the budget object that stores all the lake flows
@@ -606,9 +591,6 @@ contains
       n2 = this%flowbudptr%budterm(this%idxbudgwf)%id2(n)
       call this%budobj%budterm(idx)%update_term(n1, n2, q)
     end do
-    !
-    ! -- Return
-    return
   end subroutine lke_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -717,9 +699,6 @@ contains
         flowja(idiag) = flowja(idiag) - q
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine lke_fill_budobj
 
   !> @brief Allocate scalars specific to the lake energy transport (LKE)
@@ -751,9 +730,6 @@ contains
     this%idxbudwdrl = 0
     this%idxbudoutf = 0
     this%idxbudlbcd = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays specific to the lake energy transport (LKE)
@@ -784,9 +760,6 @@ contains
       this%tempiflw(n) = DZERO
     end do
     !
-    !
-    ! -- Return
-    return
   end subroutine lke_allocate_arrays
 
   !> @brief Deallocate memory
@@ -814,9 +787,6 @@ contains
     !
     ! -- Deallocate scalars in TspAptType
     call this%TspAptType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine lke_da
 
   !> @brief Rain term
@@ -842,9 +812,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine lke_rain_term
 
   !> @brief Evaporative term
@@ -871,9 +838,6 @@ contains
     if (present(rrate)) rrate = qbnd * heatlat
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine lke_evap_term
 
   !> @brief Runoff term
@@ -899,9 +863,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine lke_roff_term
 
   !> @brief Inflow Term
@@ -930,9 +891,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine lke_iflw_term
 
   !> @brief Specified withdrawal term
@@ -961,9 +919,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine lke_wdrl_term
 
   !> @brief Outflow term
@@ -992,9 +947,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine lke_outf_term
 
   !> @brief Defined observation types
@@ -1072,9 +1024,6 @@ contains
     !    for ext-outflow observation type.
     call this%obs%StoreObsType('ext-outflow', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => apt_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine lke_df_obs
 
   !> @brief Process package specific obs
@@ -1107,9 +1056,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine lke_rp_obs
 
   !> @brief Calculate observation value and pass it back to APT
@@ -1153,9 +1099,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine lke_bd_obs
 
   !> @brief Sets the stress period attributes for keyword use.
@@ -1233,9 +1176,6 @@ contains
     end select
     !
 999 continue
-    !
-    ! -- Return
-    return
   end subroutine lke_set_stressperiod
 
 end module GweLkeModule

--- a/src/Model/GroundWaterEnergy/gwe-mwe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-mwe.f90
@@ -148,9 +148,6 @@ contains
     mweobj%depvartype = dvt
     mweobj%depvarunit = dvu
     mweobj%depvarunitabbrev = dvua
-    !
-    ! -- Return
-    return
   end subroutine mwe_create
 
   !> @brief Find corresponding mwe package
@@ -267,9 +264,6 @@ contains
     !
     ! -- Streambed conduction term
     this%idxbudmwcd = this%idxbudgwf
-    !
-    ! -- Return
-    return
   end subroutine find_mwe_package
 
   !> @brief Add matrix terms related to MWE
@@ -369,9 +363,6 @@ contains
         call matrix_sln%add_value_pos(ipossymoffd, ctherm)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine mwe_fc_expanded
 
   !> @brief Add terms specific to multi-aquifer wells to the explicit multi-
@@ -416,9 +407,6 @@ contains
         this%dbuff(n1) = this%dbuff(n1) + rrate
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine mwe_solve
 
   !> @brief Function to return the number of budget terms just for this package
@@ -437,9 +425,6 @@ contains
     if (this%idxbudrtmv /= 0) nbudterms = nbudterms + 1
     if (this%idxbudfrtm /= 0) nbudterms = nbudterms + 1
     if (this%idxbudmwcd /= 0) nbudterms = nbudterms + 1
-    !
-    ! -- Return
-    return
   end function mwe_get_nbudterms
 
   !> @brief Set up the budget object that stores all the mwe flows
@@ -533,9 +518,6 @@ contains
       n2 = this%flowbudptr%budterm(this%idxbudgwf)%id2(n)
       call this%budobj%budterm(idx)%update_term(n1, n2, q)
     end do
-    !
-    ! -- Return
-    return
   end subroutine mwe_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -630,9 +612,6 @@ contains
         flowja(idiag) = flowja(idiag) - q
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine mwe_fill_budobj
 
   !> @brief Allocate scalars specific to the multi-aquifer well energy
@@ -660,9 +639,6 @@ contains
     this%idxbudrtmv = 0
     this%idxbudfrtm = 0
     this%idxbudmwcd = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays specific to the streamflow mass transport (SFT)
@@ -686,9 +662,6 @@ contains
     do n = 1, this%ncv
       this%temprate(n) = DZERO
     end do
-    !
-    ! -- Return
-    return
   end subroutine mwe_allocate_arrays
 
   !> @brief Deallocate memory associated with MWE package
@@ -711,9 +684,6 @@ contains
     !
     ! -- Deallocate scalars in TspAptType
     call this%TspAptType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine mwe_da
 
   !> @brief Thermal transport matrix term(s) associated with a user-specified
@@ -749,9 +719,6 @@ contains
     if (present(rrate)) rrate = qbnd * ctmp * this%eqnsclfac
     if (present(rhsval)) rhsval = r * this%eqnsclfac
     if (present(hcofval)) hcofval = h * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine mwe_rate_term
 
   !> @brief Thermal transport matrix term(s) associated with a flowing-
@@ -777,9 +744,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine mwe_fwrt_term
 
   !> @brief Thermal transport matrix term(s) associated with pumped-water-
@@ -805,9 +769,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine mwe_rtmv_term
 
   !> @brief Thermal transport matrix term(s) associated with the flowing-
@@ -833,9 +794,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine mwe_frtm_term
 
   !> @brief Observations
@@ -901,9 +859,6 @@ contains
     !    for observation type.
     call this%obs%StoreObsType('fw-rate-to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => apt_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine mwe_df_obs
 
   !> @brief Process package specific obs
@@ -929,9 +884,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine mwe_rp_obs
 
   !> @brief Calculate observation value and pass it back to APT
@@ -967,9 +919,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine mwe_bd_obs
 
   !> @brief Sets the stress period attributes for keyword use.
@@ -1010,9 +959,6 @@ contains
     end select
     !
 999 continue
-    !
-    ! -- Return
-    return
   end subroutine mwe_set_stressperiod
 
 end module GweMweModule

--- a/src/Model/GroundWaterEnergy/gwe-sfe.f90
+++ b/src/Model/GroundWaterEnergy/gwe-sfe.f90
@@ -154,9 +154,6 @@ contains
     sfeobj%depvartype = dvt
     sfeobj%depvarunit = dvu
     sfeobj%depvarunitabbrev = dvua
-    !
-    ! -- Return
-    return
   end subroutine sfe_create
 
   !> @brief Find corresponding sfe package
@@ -276,9 +273,6 @@ contains
     !
     ! -- Streambed conduction term
     this%idxbudsbcd = this%idxbudgwf
-    !
-    ! -- Return
-    return
   end subroutine find_sfe_package
 
   !> @brief Add matrix terms related to SFE
@@ -389,9 +383,6 @@ contains
         call matrix_sln%add_value_pos(ipossymoffd, ctherm)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine sfe_fc_expanded
 
   !> @ brief Add terms specific to sfr to the explicit sfe solve
@@ -445,9 +436,6 @@ contains
     end if
     !
     ! Note: explicit streambed conduction terms???
-    !
-    ! -- Return
-    return
   end subroutine sfe_solve
 
   !> @brief Function to return the number of budget terms just for this package.
@@ -468,9 +456,6 @@ contains
     !    5. ext-outflow
     !    6. streambed-cond
     nbudterms = 6
-    !
-    ! -- Return
-    return
   end function sfe_get_nbudterms
 
   !> @brief Set up the budget object that stores all the sfe flows
@@ -571,9 +556,6 @@ contains
       n2 = this%flowbudptr%budterm(this%idxbudgwf)%id2(n)
       call this%budobj%budterm(idx)%update_term(n1, n2, q)
     end do
-    !
-    ! -- Return
-    return
   end subroutine sfe_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -673,9 +655,6 @@ contains
         flowja(idiag) = flowja(idiag) - q
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine sfe_fill_budobj
 
   !> @brief Allocate scalars specific to the streamflow energy transport (SFE)
@@ -705,9 +684,6 @@ contains
     this%idxbudiflw = 0
     this%idxbudoutf = 0
     this%idxbudsbcd = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays specific to the streamflow energy transport (SFE)
@@ -737,9 +713,6 @@ contains
       this%temproff(n) = DZERO
       this%tempiflw(n) = DZERO
     end do
-    !
-    ! -- Return
-    return
   end subroutine sfe_allocate_arrays
 
   !> @brief Deallocate memory
@@ -766,9 +739,6 @@ contains
     !
     ! -- Deallocate scalars in TspAptType
     call this%TspAptType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine sfe_da
 
   !> @brief Rain term
@@ -793,9 +763,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac ! kluge note: think about budget / sensible heat issue
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine sfe_rain_term
 
   !> @brief Evaporative term
@@ -822,9 +789,6 @@ contains
     !!if (present(rhsval)) rhsval = -rrate / this%eqnsclfac  ! kluge note: divided by eqnsclfac for fc purposes because rrate is in terms of energy
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine sfe_evap_term
 
   !> @brief Runoff term
@@ -849,9 +813,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine sfe_roff_term
 
   !> @brief Inflow Term
@@ -880,9 +841,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine sfe_iflw_term
 
   !> @brief Outflow term
@@ -910,9 +868,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine sfe_outf_term
 
   !> @brief Observations
@@ -986,9 +941,6 @@ contains
     !    for ext-outflow observation type.
     call this%obs%StoreObsType('ext-outflow', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => apt_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine sfe_df_obs
 
   !> @brief Process package specific obs
@@ -1019,9 +971,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine sfe_rp_obs
 
   !> @brief Calculate observation value and pass it back to APT
@@ -1061,9 +1010,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine sfe_bd_obs
 
   !> @brief Sets the stress period attributes for keyword use.
@@ -1141,9 +1087,6 @@ contains
     end select
     !
 999 continue
-    !
-    ! -- Return
-    return
   end subroutine sfe_set_stressperiod
 
 end module GweSfeModule

--- a/src/Model/GroundWaterEnergy/gwe-uze.f90
+++ b/src/Model/GroundWaterEnergy/gwe-uze.f90
@@ -146,9 +146,6 @@ contains
     uzeobj%depvartype = dvt
     uzeobj%depvarunit = dvu
     uzeobj%depvarunitabbrev = dvua
-    !
-    ! -- Return
-    return
   end subroutine uze_create
 
   !> @brief Find corresponding uze package
@@ -266,9 +263,6 @@ contains
     !
     ! -- Thermal equilibration term
     this%idxbudtheq = this%flowbudptr%nbudterm + 1
-    !
-    ! -- Return
-    return
   end subroutine find_uze_package
 
   !> @brief Add package connection to matrix.
@@ -340,9 +334,6 @@ contains
         end do
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine uze_ac
 
   !> @brief Map package connection to matrix
@@ -430,9 +421,6 @@ contains
         end do
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine uze_mc
 
   !> @brief Add matrix terms related to UZE
@@ -573,9 +561,6 @@ contains
                                       (DONE - omega) * qbnd * this%eqnsclfac)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine uze_fc_expanded
 
   !> @brief Explicit solve
@@ -622,9 +607,6 @@ contains
         this%dbuff(n1) = this%dbuff(n1) + rrate
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine uze_solve
 
   !> @brief Return the number of UZE-specific budget terms
@@ -645,9 +627,6 @@ contains
     if (this%idxbuduzet /= 0) nbudterms = nbudterms + 1
     if (this%idxbudritm /= 0) nbudterms = nbudterms + 1
     if (this%idxbudtheq /= 0) nbudterms = nbudterms + 1
-    !
-    ! -- Return
-    return
   end function uze_get_nbudterms
 
   !> @brief Override similarly named function in APT
@@ -750,9 +729,6 @@ contains
                                              this%packName, &
                                              maxlist, .false., .false., &
                                              naux)
-    !
-    ! -- Return
-    return
   end subroutine uze_setup_budobj
 
   !> @brief Fill UZE budget object
@@ -926,9 +902,6 @@ contains
     end do
     !
     deallocate (budresid)
-    !
-    ! -- Return
-    return
   end subroutine uze_fill_budobj
 
   !> @brief Allocate scalars
@@ -958,9 +931,6 @@ contains
     this%idxbuduzet = 0
     this%idxbudritm = 0
     this%idxbudtheq = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays
@@ -987,9 +957,6 @@ contains
       this%tempinfl(n) = DZERO
       this%tempuzet(n) = DZERO
     end do
-    !
-    ! -- Return
-    return
   end subroutine uze_allocate_arrays
 
   !> @brief Deallocate memory
@@ -1013,9 +980,6 @@ contains
     !
     ! -- Deallocate scalars in TspAptType
     call this%TspAptType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine uze_da
 
   !> @brief Infiltration term
@@ -1055,9 +1019,6 @@ contains
     if (present(rrate)) rrate = qbnd * ctmp * this%eqnsclfac
     if (present(rhsval)) rhsval = r * this%eqnsclfac
     if (present(hcofval)) hcofval = h * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine uze_infl_term
 
   !> @brief Rejected infiltration term
@@ -1088,9 +1049,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine uze_rinf_term
 
   !> @brief Evapotranspiration from the unsaturated-zone term
@@ -1128,9 +1086,6 @@ contains
                (DONE - omega) * qbnd * ctmp) * this%eqnsclfac
     if (present(rhsval)) rhsval = -(DONE - omega) * qbnd * ctmp * this%eqnsclfac
     if (present(hcofval)) hcofval = omega * qbnd * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine uze_uzet_term
 
   !> @brief Rejected infiltration to MVR/MVT term
@@ -1161,9 +1116,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine uze_ritm_term
 
   !> @brief Heat transferred through thermal equilibrium with the solid phase
@@ -1201,9 +1153,6 @@ contains
       end do
     end if
     rrate = r
-    !
-    ! -- Return
-    return
   end subroutine uze_theq_term
 
   !> @brief Define UZE Observation
@@ -1276,9 +1225,6 @@ contains
     !    for observation type.
     call this%obs%StoreObsType('thermal-equil', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => apt_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine uze_df_obs
 
   !> @brief Process package specific obs
@@ -1306,8 +1252,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    return
   end subroutine uze_rp_obs
 
   !> @brief Calculate observation value and pass it back to APT
@@ -1347,9 +1291,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine uze_bd_obs
 
   !> @brief Sets the stress period attributes for keyword use.
@@ -1402,9 +1343,6 @@ contains
     end select
     !
 999 continue
-    !
-    ! -- Return
-    return
   end subroutine uze_set_stressperiod
 
 end module GweUzeModule

--- a/src/Model/GroundWaterEnergy/gwe.f90
+++ b/src/Model/GroundWaterEnergy/gwe.f90
@@ -134,9 +134,6 @@ contains
     !
     ! -- Create model packages
     call this%create_packages(indis)
-    !
-    ! -- Return
-    return
   end subroutine gwe_cr
 
   !> @brief Define packages of the GWE model
@@ -193,9 +190,6 @@ contains
     !
     ! -- Store information needed for observations
     call this%obs%obs_df(this%iout, this%name, 'GWE', this%dis)
-    !
-    ! -- Return
-    return
   end subroutine gwe_df
 
   !> @brief Add the internal connections of this model to the sparse matrix
@@ -220,9 +214,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_ac(this%moffset, sparse)
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwe_ac
 
   !> @brief Map the positions of the GWE model connections in the numerical
@@ -247,9 +238,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_mc(this%moffset, matrix_sln)
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwe_mc
 
   !> @brief GWE Model Allocate and Read
@@ -295,9 +283,6 @@ contains
       ! -- Read and allocate package
       call packobj%bnd_ar()
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwe_ar
 
   !> @brief GWE Model Read and Prepare
@@ -328,9 +313,6 @@ contains
       call packobj%bnd_rp()
       call packobj%bnd_rp_obs()
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwe_rp
 
   !> @brief GWE Model Time Step Advance
@@ -384,9 +366,6 @@ contains
     !
     ! -- Push simulated values to preceding time/subtime step
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine gwe_ad
 
   !> @brief GWE Model calculate coefficients
@@ -407,9 +386,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_cf()
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwe_cf
 
   !> @brief GWE Model fill coefficients
@@ -454,9 +430,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_fc(this%rhs, this%ia, this%idxglo, matrix_sln)
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwe_fc
 
   !> @brief GWE Model Final Convergence Check
@@ -477,9 +450,6 @@ contains
     !
     ! -- If mover is on, then at least 2 outers required
     if (this%inmvt > 0) call this%mvt%mvt_cc(kiter, iend, icnvgmod, cpak, dpak)
-    !
-    ! -- Return
-    return
   end subroutine gwe_cc
 
   !> @brief GWE Model calculate flow
@@ -526,9 +496,6 @@ contains
     !    This results in the flow residual being stored in the diagonal
     !    position for each cell.
     call csr_diagsum(this%dis%con%ia, this%flowja)
-    !
-    ! -- Return
-    return
   end subroutine gwe_cq
 
   !> @brief GWE Model Budget
@@ -563,9 +530,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_bd(this%budget)
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwe_bd
 
   !> @brief GWE model output routine
@@ -648,9 +612,6 @@ contains
     !
     ! -- NumericalModelType
     call this%NumericalModelType%model_da()
-    !
-    ! -- Return
-    return
   end subroutine gwe_da
 
   !> @brief GroundWater Energy Transport Model Budget Entry
@@ -670,9 +631,6 @@ contains
     character(len=*), intent(in) :: rowlabel
     !
     call this%budget%addentry(budterm, delt, budtxt, rowlabel=rowlabel)
-    !
-    ! -- Return
-    return
   end subroutine gwe_bdentry
 
   !> @brief return 1 if any package causes the matrix to be asymmetric.
@@ -703,9 +661,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       if (packobj%iasym /= 0) iasym = 1
     end do
-    !
-    ! -- Return
-    return
   end function gwe_get_iasym
 
   !> Allocate memory for non-allocatable members
@@ -730,9 +685,6 @@ contains
     !
     this%inest = 0
     this%incnd = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Create boundary condition packages for this model
@@ -811,9 +763,6 @@ contains
       end if
     end do
     call AddBndToList(this%bndlist, packobj)
-    !
-    ! -- Return
-    return
   end subroutine package_create
 
   !> @brief Cast to GweModelType
@@ -830,9 +779,6 @@ contains
     type is (GweModelType)
       gwemodel => model
     end select
-    !
-    ! -- Return
-    return
   end function CastAsGweModel
 
   !> @brief Source package info and begin to process
@@ -887,9 +833,6 @@ contains
       ! -- Cleanup
       deallocate (bndpkgs)
     end if
-    !
-    ! -- Return
-    return
   end subroutine create_bndpkgs
 
   !> @brief Source package info and begin to process
@@ -968,9 +911,6 @@ contains
     call this%ftype_check(indis, this%inest)
     !
     call this%create_bndpkgs(bndpkgs, pkgtypes, pkgnames, mempaths, inunits)
-    !
-    ! -- Return
-    return
   end subroutine create_gwe_packages
 
 end module GweModule

--- a/src/Model/GroundWaterFlow/TvBase.f90
+++ b/src/Model/GroundWaterFlow/TvBase.f90
@@ -163,8 +163,6 @@ contains
     this%inunit = inunit
     this%iout = iout
     call this%parser%Initialize(this%inunit, this%iout)
-    !
-    return
   end subroutine init
 
   !> @brief Allocate scalar variables
@@ -181,8 +179,6 @@ contains
     !
     ! -- Allocate time series manager
     allocate (this%tsmanager)
-    !
-    return
   end subroutine tvbase_allocate_scalars
 
   !> @brief Allocate and read method for package
@@ -217,8 +213,6 @@ contains
       call this%parser%StoreErrorUnit()
       call ustop()
     end if
-    !
-    return
   end subroutine ar
 
   !> @brief Read OPTIONS block of package input file
@@ -287,8 +281,6 @@ contains
       write (this%iout, '(1x,a)') &
         'END OF '//trim(adjustl(this%packName))//' OPTIONS'
     end if
-    !
-    return
   end subroutine read_options
 
   !> @brief Read and prepare method for package
@@ -410,8 +402,6 @@ contains
       call this%parser%StoreErrorUnit()
       call ustop()
     end if
-    !
-    return
   end subroutine rp
 
   !> @brief Advance the package
@@ -459,8 +449,6 @@ contains
       call this%parser%StoreErrorUnit()
       call ustop()
     end if
-    !
-    return
   end subroutine ad
 
   !> @brief Deallocate package memory
@@ -477,8 +465,6 @@ contains
     !
     ! -- Deallocate parent
     call this%NumericalPackageType%da()
-    !
-    return
   end subroutine tvbase_da
 
 end module TvBaseModule

--- a/src/Model/GroundWaterFlow/gwf-api.f90
+++ b/src/Model/GroundWaterFlow/gwf-api.f90
@@ -78,9 +78,6 @@ contains
     packobj%ncolbnd = 2
     packobj%iscloc = 2
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- return
-    return
   end subroutine api_create
 
   !> @ brief Read additional options for package
@@ -105,9 +102,6 @@ contains
       ! -- No options found
       found = .false.
     end select
-    !
-    ! -- return
-    return
   end subroutine api_options
 
   !> @ brief Read and prepare stress period data for package
@@ -120,9 +114,6 @@ contains
   subroutine api_rp(this)
     ! -- dummy variables
     class(ApiType), intent(inout) :: this
-    !
-    ! -- return
-    return
   end subroutine api_rp
 
   !> @ brief Fill A and r for the package
@@ -163,9 +154,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(i, qusr)
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine api_fc
 
   ! -- Procedures related to observations
@@ -182,9 +170,6 @@ contains
     !
     ! -- set variables
     api_obs_supported = .true.
-    !
-    ! -- return
-    return
   end function api_obs_supported
 
   !> @brief Define the observation types available in the package
@@ -206,9 +191,6 @@ contains
     !    for to-mvr observation type.
     call this%obs%StoreObsType('to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- return
-    return
   end subroutine api_df_obs
 
 end module apimodule

--- a/src/Model/GroundWaterFlow/gwf-buy.f90
+++ b/src/Model/GroundWaterFlow/gwf-buy.f90
@@ -95,9 +95,6 @@ contains
     do i = 1, nrhospec
       dense = dense + drhodc(i) * (conc(i) - crhoref(i))
     end do
-    !
-    ! -- Return
-    return
   end function calcdens
 
   !> @brief Create a new BUY object
@@ -124,9 +121,6 @@ contains
     !
     ! -- Initialize block parser
     call buyobj%parser%Initialize(buyobj%inunit, buyobj%iout)
-    !
-    ! -- Return
-    return
   end subroutine buy_cr
 
   !> @brief Read options and package data, or set from argument
@@ -174,9 +168,6 @@ contains
       ! set from input data instead
       call this%set_packagedata(buy_input)
     end if
-    !
-    ! -- Return
-    return
   end subroutine buy_df
 
   !> @brief Allocate and Read
@@ -200,9 +191,6 @@ contains
     !
     ! -- Calculate cell elevations
     call this%buy_calcelev()
-    !
-    ! -- Return
-    return
   end subroutine buy_ar
 
   !> @brief Buoyancy ar_bnd routine to activate density in packages
@@ -250,9 +238,6 @@ contains
       !
       ! -- nothing
     end select
-    !
-    ! -- Return
-    return
   end subroutine buy_ar_bnd
 
   !> @brief Check for new buy period data
@@ -284,9 +269,6 @@ contains
         call this%parser%StoreErrorUnit()
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine buy_rp
 
   !> @brief Advance
@@ -297,9 +279,6 @@ contains
     !
     ! -- update density using the last concentration
     call this%buy_calcdens()
-    !
-    ! -- Return
-    return
   end subroutine buy_ad
 
   !> @brief Fill coefficients
@@ -315,9 +294,6 @@ contains
         call this%buy_calcelev()
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine buy_cf
 
   !> @brief Fill coefficients
@@ -412,9 +388,6 @@ contains
     !
     ! -- deallocate
     deallocate (locconc)
-    !
-    ! -- Return
-    return
   end subroutine buy_cf_bnd
 
   !> @brief Return the density of the boundary package using one of several
@@ -456,9 +429,6 @@ contains
       ! -- neither of the above, so assign as denseref
       densebnd = denseref
     end if
-    !
-    ! -- Return
-    return
   end function get_bnd_density
 
   !> @brief Fill ghb coefficients
@@ -519,9 +489,6 @@ contains
         !
       end do
     end select
-    !
-    ! -- Return
-    return
   end subroutine buy_cf_ghb
 
   !> @brief Calculate density hcof and rhs terms for ghb conditions
@@ -568,9 +535,6 @@ contains
       ! -- this term goes on LHS for iform == 2
       rhsterm = rhsterm + DHALF * cond * t2 * hnode
     end if
-    !
-    ! -- Return
-    return
   end subroutine calc_ghb_hcof_rhs_terms
 
   !> @brief Fill riv coefficients
@@ -642,9 +606,6 @@ contains
         packobj%rhs(n) = packobj%rhs(n) - rhsterm
       end do
     end select
-    !
-    ! -- Return
-    return
   end subroutine buy_cf_riv
 
   !> @brief Fill drn coefficients
@@ -684,9 +645,6 @@ contains
         end if
       end do
     end select
-    !
-    ! -- Return
-    return
   end subroutine buy_cf_drn
 
   !> @brief Pass density information into lak package; density terms are
@@ -740,9 +698,6 @@ contains
         !
       end do
     end select
-    !
-    ! -- Return
-    return
   end subroutine buy_cf_lak
 
   !> @brief Pass density information into sfr package; density terms are
@@ -796,9 +751,6 @@ contains
         !
       end do
     end select
-    !
-    ! -- Return
-    return
   end subroutine buy_cf_sfr
 
   !> @brief Pass density information into maw package; density terms are
@@ -852,9 +804,6 @@ contains
         !
       end do
     end select
-    !
-    ! -- Return
-    return
   end subroutine buy_cf_maw
 
   !> @brief Fill coefficients
@@ -895,9 +844,6 @@ contains
         call matrix_sln%add_value_pos(idxglo(ipos), amatnm)
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine buy_fc
 
   !> @brief Save density array to binary file
@@ -935,9 +881,6 @@ contains
                                    nwidthp, editdesc, dinact)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine buy_ot_dv
 
   !> @brief Add buy term to flowja
@@ -970,9 +913,6 @@ contains
                                           deltaQ
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine buy_cq
 
   !> @brief Deallocate
@@ -1006,9 +946,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine buy_da
 
   !> @brief Read the dimensions for this package
@@ -1055,9 +992,6 @@ contains
       call store_error('NRHOSPECIES must be greater than zero.')
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_dimensions
 
   !> @brief Read PACKAGEDATA block
@@ -1144,9 +1078,6 @@ contains
     !
     ! -- deallocate
     deallocate (itemp)
-    !
-    ! -- Return
-    return
   end subroutine read_packagedata
 
   !> @brief Sets package data instead of reading from file
@@ -1164,9 +1095,6 @@ contains
       this%cmodelname(ispec) = input_data%cmodelname(ispec)
       this%cauxspeciesname(ispec) = input_data%cauxspeciesname(ispec)
     end do
-    !
-    ! -- Return
-    return
   end subroutine set_packagedata
 
   !> @brief Calculate buyancy term for this connection
@@ -1249,9 +1177,6 @@ contains
     !
     ! -- Calculate buoyancy term
     buy = cond * (avgdense - this%denseref) / this%denseref * (elevm - elevn)
-    !
-    ! -- Return
-    return
   end subroutine calcbuy
 
   !> @brief Calculate hydraulic head term for this connection
@@ -1345,9 +1270,6 @@ contains
       amatnn = amatnn - cond * (DONE - wt) * (rhonormm - rhonormn)
       amatnm = amatnm + cond * wt * (rhonormm - rhonormn)
     end if
-    !
-    ! -- Return
-    return
   end subroutine calchhterms
 
   !> @brief calculate fluid density from concentration
@@ -1372,9 +1294,6 @@ contains
       this%dense(n) = calcdens(this%denseref, this%drhodc, this%crhoref, &
                                this%ctemp)
     end do
-    !
-    ! -- Return
-    return
   end subroutine buy_calcdens
 
   !> @brief Calculate cell elevations to use in density flow equations
@@ -1393,9 +1312,6 @@ contains
       frac = this%npf%sat(n)
       this%elev(n) = bt + DHALF * frac * (tp - bt)
     end do
-    !
-    ! -- Return
-    return
   end subroutine buy_calcelev
 
   !> @brief Allocate scalars used by the package
@@ -1432,9 +1348,6 @@ contains
     ! -- Initialize default to LHS implementation of hydraulic head formulation
     this%iform = 2
     this%iasym = 1
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays used by the package
@@ -1471,9 +1384,6 @@ contains
       this%cmodelname(i) = ''
       this%cauxspeciesname(i) = ''
     end do
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief Read package options
@@ -1545,9 +1455,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'End of BUY OPTIONS block'
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @brief Sets options as opposed to reading them from a file
@@ -1565,9 +1472,6 @@ contains
     if (this%iform == 0 .or. this%iform == 1) then
       this%iasym = 0
     end if
-    !
-    ! -- Return
-    return
   end subroutine set_options
 
   !> @brief Pass in a gwt model name, concentration array and ibound, and store
@@ -1596,9 +1500,6 @@ contains
         exit
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine set_concentration_pointer
 
 end module GwfBuyModule

--- a/src/Model/GroundWaterFlow/gwf-chd.f90
+++ b/src/Model/GroundWaterFlow/gwf-chd.f90
@@ -85,9 +85,6 @@ contains
     packobj%id = id
     packobj%ibcnum = ibcnum
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- Return
-    return
   end subroutine chd_create
 
   !> @brief Allocate arrays specific to the constant head package
@@ -120,9 +117,6 @@ contains
     ! -- checkin constant head array input context pointer
     call mem_checkin(this%head, 'HEAD', this%memoryPath, &
                      'HEAD', this%input_mempath)
-    !
-    ! -- Return
-    return
   end subroutine chd_allocate_arrays
 
   !> @brief Constant concentration/temperature read and prepare (rp) routine
@@ -172,9 +166,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- Return
-    return
   end subroutine chd_rp
 
   !> @brief Constant head package advance routine
@@ -203,9 +194,6 @@ contains
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine chd_ad
 
   !> @brief Check constant concentration/temperature boundary condition data
@@ -240,9 +228,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine chd_ck
 
   !> @brief Override bnd_fc and do nothing
@@ -258,9 +243,6 @@ contains
     integer(I4B), dimension(:), intent(in) :: idxglo
     class(MatrixBaseType), pointer :: matrix_sln
     ! -- local
-    !
-    ! -- Return
-    return
   end subroutine chd_fc
 
   !> @brief Calculate flow associated with constant head boundary
@@ -335,9 +317,6 @@ contains
       end do
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine calc_chd_rate
 
   !> @brief Add package ratin/ratout to model budget
@@ -381,9 +360,6 @@ contains
     call mem_deallocate(this%ratechdin)
     call mem_deallocate(this%ratechdout)
     call mem_deallocate(this%head, 'HEAD', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine chd_da
 
   !> @brief Define the list heading that is written to iout when PRINT_INPUT
@@ -408,9 +384,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   ! -- Procedures related to observations
@@ -425,9 +398,6 @@ contains
     class(ChdType) :: this
     !
     chd_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function chd_obs_supported
 
   !> @brief Overrides bnd_df_obs from bndType class
@@ -444,9 +414,6 @@ contains
     !
     call this%obs%StoreObsType('chd', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- Return
-    return
   end subroutine chd_df_obs
 
   !> @brief Apply auxiliary multiplier to specified head if appropriate
@@ -465,9 +432,6 @@ contains
     else
       head = this%head(row)
     end if
-    !
-    ! -- Return
-    return
   end function head_mult
 
   !> @ brief Return a bound value
@@ -494,9 +458,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- Return
-    return
   end function chd_bound_value
 
 end module ChdModule

--- a/src/Model/GroundWaterFlow/gwf-csub.f90
+++ b/src/Model/GroundWaterFlow/gwf-csub.f90
@@ -350,9 +350,6 @@ contains
     !
     ! -- Initialize block parser
     call csubobj%parser%Initialize(csubobj%inunit, csubobj%iout)
-    !
-    ! -- return
-    return
   end subroutine csub_cr
 
   !> @ brief Allocate and read method for package
@@ -593,9 +590,6 @@ contains
         this%cg_theta(node) = this%cg_thetaini(node)
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_ar
 
   !> @ brief Read options for package
@@ -1034,9 +1028,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine read_options
 
   !> @ brief Read dimensions for package
@@ -1106,9 +1097,6 @@ contains
     ! -- Call define_listlabel to construct the list label that is written
     !    when PRINT_INPUT option is used.
     call this%define_listlabel()
-    !
-    ! -- return
-    return
   end subroutine csub_read_dimensions
 
   !> @ brief Allocate scalars
@@ -1223,9 +1211,6 @@ contains
     this%icellf = 0
     this%ninterbeds = 0
     this%gwfiss0 = 0
-    !
-    ! -- return
-    return
   end subroutine csub_allocate_scalars
 
   !> @ brief Allocate package arrays
@@ -1401,10 +1386,6 @@ contains
       this%nodelistsig0(n) = 0
       this%sig0(n) = DZERO
     end do
-    !
-    ! -- return
-    return
-
   end subroutine csub_allocate_arrays
 
   !> @ brief Read packagedata for package
@@ -1859,9 +1840,6 @@ contains
         call store_error(errmsg)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_read_packagedata
 
   !> @ brief Final processing for package
@@ -2273,9 +2251,6 @@ contains
     deallocate (imap_sel)
     deallocate (locs)
     deallocate (pctcomp_arr)
-    !
-    ! -- return
-    return
   end subroutine csub_fp
 
   !> @ brief Deallocate package memory
@@ -2496,9 +2471,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- return
-    return
   end subroutine csub_da
 
   !> @ brief Read and prepare stress period data for package
@@ -2659,9 +2631,6 @@ contains
     !
     ! -- read observations
     call this%csub_rp_obs()
-    !
-    ! -- return
-    return
   end subroutine csub_rp
 
   !> @ brief Advance the package
@@ -2782,9 +2751,6 @@ contains
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
     call this%obs%obs_ad()
-    !
-    ! -- return
-    return
   end subroutine csub_ad
 
   !> @ brief Fill A and r for the package
@@ -2898,9 +2864,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_fc
 
   !> @ brief Fill Newton-Raphson terms in A and r for the package
@@ -3002,9 +2965,6 @@ contains
         end do
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_fn
 
   !> @ brief Initialize optional tables
@@ -3249,9 +3209,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_cc
 
   !> @ brief Calculate flows for package
@@ -3551,10 +3508,6 @@ contains
         call this%parser%StoreErrorUnit()
       end if
     end if
-    !
-    ! -- return
-    return
-
   end subroutine csub_cq
 
   !> @ brief Model budget calculation for package
@@ -3689,9 +3642,6 @@ contains
                                  budtxt(4), cdatafmp, nvaluesp, &
                                  nwidthp, editdesc, dinact)
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_save_model_flows
 
 !> @ brief Save and print dependent values for package
@@ -3956,9 +3906,6 @@ contains
         write (this%iout, fmtnconv) this%idb_nconv_count(1)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_ot_dv
 
   !> @ brief Calculate the stress for model cells
@@ -4091,10 +4038,6 @@ contains
       es = this%cg_gs(node) - phead
       this%cg_es(node) = es
     end do
-    !
-    ! -- return
-    return
-
   end subroutine csub_cg_calc_stress
 
   !> @ brief Check effective stress values
@@ -4158,10 +4101,6 @@ contains
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
-
   end subroutine csub_cg_chk_stress
 
   !> @ brief Update no-delay material properties
@@ -4200,9 +4139,6 @@ contains
       this%thick(i) = thick
       this%theta(i) = theta
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_nodelay_update
 
   !> @ brief Calculate no-delay interbed storage coefficients
@@ -4313,10 +4249,6 @@ contains
     ! -- save ske and sk
     this%ske(ib) = rho1
     this%sk(ib) = rho2
-    !
-    ! -- return
-    return
-
   end subroutine csub_nodelay_fc
 
   !> @ brief Calculate no-delay interbed compaction
@@ -4362,10 +4294,6 @@ contains
     else
       comp = -pcs * (rho2 - rho1) - (rho1 * es0) + (rho2 * es)
     end if
-    !
-    ! -- return
-    return
-
   end subroutine csub_nodelay_calc_comp
 
   !> @ brief Set initial states for the package
@@ -4752,9 +4680,6 @@ contains
     if (this%lhead_based .EQV. .TRUE.) then
       this%iupdatestress = 0
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_set_initial_state
 
   !> @ brief Formulate the coefficients for coarse-grained materials
@@ -4820,9 +4745,6 @@ contains
       ! -- calculate and apply the flow correction term
       rhs = rhs - rho1 * snnew * (hcell - hbar)
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_cg_fc
 
   !> @ brief Formulate coarse-grained Newton-Raphson terms
@@ -4896,9 +4818,6 @@ contains
       ! -- calculate rhs term
       rhs = hcof * hcell
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_cg_fn
 
   !> @ brief Formulate the coefficients for a interbed
@@ -4985,9 +4904,6 @@ contains
       rhs = rhs * f
       hcof = -hcof * f
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_interbed_fc
 
   !> @ brief Formulate the coefficients for a interbed
@@ -5080,9 +4996,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_interbed_fn
 
   !> @ brief Calculate Sske for a cell
@@ -5139,9 +5052,6 @@ contains
       call this%csub_calc_sfacts(n, bot, znode, theta, es, es0, f)
     end if
     sske = f * this%cg_ske_cr(n)
-    !
-    ! -- return
-    return
   end subroutine csub_cg_calc_sske
 
   !> @ brief Calculate coarse-grained compaction in a cell
@@ -5173,9 +5083,6 @@ contains
     !
     ! - calculate compaction
     comp = hcof * hcell - rhs
-    !
-    ! -- return
-    return
   end subroutine csub_cg_calc_comp
 
   !> @ brief Update coarse-grained material properties
@@ -5215,9 +5122,6 @@ contains
       this%cg_thick(node) = thick
       this%cg_theta(node) = theta
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_cg_update
 
   !> @ brief Formulate coarse-grained water compressibility coefficients
@@ -5273,9 +5177,6 @@ contains
     !
     ! -- calculate rhs term
     rhs = -wc0 * snold * hcellold
-    !
-    ! -- return
-    return
   end subroutine csub_cg_wcomp_fc
 
   !> @ brief Formulate coarse-grained water compressibility coefficients
@@ -5338,9 +5239,6 @@ contains
     !
     ! -- calculate rhs term
     rhs = hcof * hcell
-    !
-    ! -- return
-    return
   end subroutine csub_cg_wcomp_fn
 
   !> @ brief Formulate no-delay interbed water compressibility coefficients
@@ -5391,9 +5289,6 @@ contains
     wc = f * this%theta(ib) * this%thick(ib)
     hcof = -wc * snnew
     rhs = -wc0 * snold * hcellold
-    !
-    ! -- return
-    return
   end subroutine csub_nodelay_wcomp_fc
 
   !> @ brief Formulate no-delay interbed water compressibility coefficients
@@ -5454,9 +5349,6 @@ contains
     !
     ! -- set rhs
     rhs = hcof * hcell
-    !
-    ! -- return
-    return
   end subroutine csub_nodelay_wcomp_fn
 
   !> @brief Calculate the void ratio
@@ -5473,9 +5365,6 @@ contains
     real(DP) :: void_ratio
     ! -- calculate void ratio
     void_ratio = theta / (DONE - theta)
-    !
-    ! -- return
-    return
   end function csub_calc_void_ratio
 
   !> @brief Calculate the porosity
@@ -5493,9 +5382,6 @@ contains
     !
     ! -- calculate theta
     theta = void_ratio / (DONE + void_ratio)
-    !
-    ! -- return
-    return
   end function csub_calc_theta
 
   !> @brief Calculate the interbed thickness
@@ -5518,9 +5404,6 @@ contains
     if (idelay /= 0) then
       thick = thick * this%rnb(ib)
     end if
-    !
-    ! -- return
-    return
   end function csub_calc_interbed_thickness
 
   !> @brief Calculate the cell node
@@ -5550,9 +5433,6 @@ contains
       v = zbar
     end if
     znode = DHALF * (v + bottom)
-    !
-    ! -- return
-    return
   end function csub_calc_znode
 
   !> @brief Calculate the effective stress at elevation z
@@ -5575,9 +5455,6 @@ contains
     !
     ! -- adjust effective stress to vertical node position
     es = es0 - (z - z0) * (this%sgs(node) - DONE)
-    !
-    ! -- return
-    return
   end function csub_calc_adjes
 
   !> @brief Check delay interbed head
@@ -5626,9 +5503,6 @@ contains
         exit idelaycells
       end if
     end do idelaycells
-    !
-    ! -- return
-    return
   end subroutine csub_delay_head_check
 
   !> @brief Calculate cell saturation
@@ -5665,9 +5539,6 @@ contains
     if (this%ieslag /= 0) then
       snold = snnew
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_calc_sat
 
   !> @brief Calculate the saturation derivative
@@ -5694,9 +5565,6 @@ contains
     else
       satderv = DZERO
     end if
-    !
-    ! -- return
-    return
   end function csub_calc_sat_derivative
 
   !> @brief Calculate specific storage coefficient factor
@@ -5738,9 +5606,6 @@ contains
     if (denom /= DZERO) then
       fact = DONE / denom
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_calc_sfacts
 
   !> @brief Calculate new material properties
@@ -5772,9 +5637,6 @@ contains
     void_ratio = void_ratio + strain * (DONE + void_ratio)
     theta = this%csub_calc_theta(void_ratio)
     thick = thick - comp
-    !
-    ! -- return
-    return
   end subroutine csub_adj_matprop
 
   !> @brief Solve delay interbed continuity equation
@@ -5865,9 +5727,6 @@ contains
         dhmax0 = dhmax
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_delay_sln
 
   !> @brief Calculate delay interbed znode and z relative to interbed center
@@ -5929,10 +5788,6 @@ contains
       this%dbrelz(n, idelay) = zr
       zr = zr - dz
     end do
-    !
-    ! -- return
-    return
-
   end subroutine csub_delay_init_zcell
 
   !> @brief Calculate delay interbed stress values
@@ -6009,9 +5864,6 @@ contains
       this%dbgeo(n, idelay) = sigma
       this%dbes(n, idelay) = sigma - phead
     end do
-    !
-    ! -- return
-    return
   end subroutine csub_delay_calc_stress
 
   !> @brief Calculate delay interbed cell storage coefficients
@@ -6117,9 +5969,6 @@ contains
         ssk = f * this%ci(ib)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_delay_calc_ssksske
 
   !> @brief Assemble delay interbed coefficients
@@ -6157,10 +6006,6 @@ contains
       this%dbad(n) = aii
       this%dbrhs(n) = r
     end do
-    !
-    ! -- return
-    return
-
   end subroutine csub_delay_assemble
 
   !> @brief Assemble delay interbed standard formulation coefficients
@@ -6292,10 +6137,6 @@ contains
     wc0 = dz0 * wcf * theta0
     aii = aii - dsn * wc
     r = r - dsn0 * wc0 * h0
-    !
-    ! -- return
-    return
-
   end subroutine csub_delay_assemble_fc
 
   !> @brief Assemble delay interbed Newton-Raphson formulation coefficients
@@ -6460,10 +6301,6 @@ contains
     ! -- add newton-raphson water compressibility terms
     aii = aii + wcderv
     r = r - qwc + wcderv * h
-    !
-    ! -- return
-    return
-
   end subroutine csub_delay_assemble_fn
 
   !> @brief Calculate delay interbed saturation
@@ -6504,9 +6341,6 @@ contains
     if (this%ieslag /= 0) then
       snold = snnew
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_delay_calc_sat
 
   !> @brief Calculate the delay interbed cell saturation derivative
@@ -6538,9 +6372,6 @@ contains
     else
       satderv = DZERO
     end if
-    !
-    ! -- return
-    return
   end function csub_delay_calc_sat_derivative
 
   !> @brief Calculate delay interbed storage change
@@ -6627,9 +6458,6 @@ contains
     ! -- save ske and sk
     this%ske(ib) = ske
     this%sk(ib) = sk
-    !
-    ! -- return
-    return
   end subroutine csub_delay_calc_dstor
 
   !> @brief Calculate delay interbed water compressibility
@@ -6681,9 +6509,6 @@ contains
         dwc = dwc + v * tled
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_delay_calc_wcomp
 
   !> @brief Calculate delay interbed compaction
@@ -6768,9 +6593,6 @@ contains
     comp = comp * this%rnb(ib)
     compi = compi * this%rnb(ib)
     compe = compe * this%rnb(ib)
-    !
-    ! -- return
-    return
   end subroutine csub_delay_calc_comp
 
   !> @brief Update delay interbed material properties
@@ -6846,9 +6668,6 @@ contains
     end if
     this%thick(ib) = tthick
     this%theta(ib) = wtheta
-    !
-    ! -- return
-    return
   end subroutine csub_delay_update
 
   !> @brief Calculate delay interbed contribution to the cell
@@ -6885,9 +6704,6 @@ contains
       rhs = rhs - c2 * this%dbh(this%ndelaycells, idelay)
       hcof = c1 + c2
     end if
-    !
-    ! -- return
-    return
   end subroutine csub_delay_fc
 
   !> @brief Calculate the flow from delay interbed top or bottom
@@ -6912,9 +6728,6 @@ contains
     idelay = this%idelay(ib)
     c = DTWO * this%kv(ib) / this%dbdzini(n, idelay)
     q = c * (hcell - this%dbh(n, idelay))
-    !
-    ! -- return
-    return
   end function csub_calc_delay_flow
 
   !
@@ -6932,9 +6745,6 @@ contains
     !
     ! -- initialize variables
     csub_obs_supported = .true.
-    !
-    ! -- return
-    return
   end function csub_obs_supported
 
   !> @brief Define the observation types available in the package
@@ -7122,8 +6932,6 @@ contains
     !    for delay-flowbot observation type.
     call this%obs%StoreObsType('delay-flowbot', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => csub_process_obsID
-    !
-    return
   end subroutine csub_df_obs
 
   !> @brief Set the observations for this time step
@@ -7342,8 +7150,6 @@ contains
         call this%parser%StoreErrorUnit()
       end if
     end if
-    !
-    return
   end subroutine csub_bd_obs
 
   !> @brief Read and prepare the observations
@@ -7510,10 +7316,8 @@ contains
         call store_error_unit(this%inunit)
       end if
     end if
-    !
-    !
-    return
   end subroutine csub_rp_obs
+
   !
   ! -- Procedures related to observations (NOT type-bound)
 
@@ -7595,9 +7399,6 @@ contains
     !
     ! -- store reach number (NodeNumber)
     obsrv%NodeNumber = nn1
-    !
-    ! -- return
-    return
   end subroutine csub_process_obsID
 
   !> @ brief Define the list label for the package
@@ -7626,9 +7427,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- return
-    return
   end subroutine define_listlabel
 
 end module GwfCsubModule

--- a/src/Model/GroundWaterFlow/gwf-drn.f90
+++ b/src/Model/GroundWaterFlow/gwf-drn.f90
@@ -89,9 +89,6 @@ contains
     packobj%id = id
     packobj%ibcnum = ibcnum
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- Return
-    return
   end subroutine drn_create
 
   !> @brief Deallocate memory
@@ -112,9 +109,6 @@ contains
     ! -- arrays
     call mem_deallocate(this%elev, 'ELEV', this%memoryPath)
     call mem_deallocate(this%cond, 'COND', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine drn_da
 
   !> @brief Allocate package scalar members
@@ -139,9 +133,6 @@ contains
     else
       this%icubic_scaling = 0
     end if
-    !
-    ! -- Return
-    return
   end subroutine drn_allocate_scalars
 
   !> @brief Allocate package arrays
@@ -166,9 +157,6 @@ contains
                      'ELEV', this%input_mempath)
     call mem_checkin(this%cond, 'COND', this%memoryPath, &
                      'COND', this%input_mempath)
-    !
-    ! -- Return
-    return
   end subroutine drn_allocate_arrays
 
   !> @brief Read and prepare
@@ -192,9 +180,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- Return
-    return
   end subroutine drn_rp
 
   !> @brief Source options specific to DrnType
@@ -253,9 +238,6 @@ contains
     !
     ! -- log DRN specific options
     call this%log_drn_options(found)
-    !
-    ! -- Return
-    return
   end subroutine drn_options
 
   !> @ brief Log DRN specific package options
@@ -286,9 +268,6 @@ contains
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
-    !
-    ! -- Return
-    return
   end subroutine log_drn_options
 
   !> @brief Check drain boundary condition data
@@ -352,9 +331,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine drn_ck
 
   !> @brief Formulate the HCOF and RHS terms
@@ -394,9 +370,6 @@ contains
       this%rhs(i) = -fact * cdrn * drnbot
       this%hcof(i) = -fact * cdrn
     end do
-    !
-    ! -- Return
-    return
   end subroutine drn_cf
 
   !> @brief Copy rhs and hcof into solution rhs and amat
@@ -440,9 +413,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(i, qdrn)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine drn_fc
 
   !> @brief Fill newton terms
@@ -497,9 +467,6 @@ contains
         end if
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine drn_fn
 
   !> @brief Define the list heading that is written to iout when PRINT_INPUT
@@ -526,9 +493,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   !> @brief Define drain depth and the top and bottom elevations used to scale
@@ -563,9 +527,6 @@ contains
       drntop = drnelev
       drnbot = drnelev
     end if
-    !
-    ! -- Return
-    return
   end subroutine get_drain_elevations
 
   !> @brief Get the drain conductance scale factor
@@ -610,9 +571,6 @@ contains
         factor = DONE
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine get_drain_factor
 
   ! -- Procedures related to observations
@@ -627,9 +585,6 @@ contains
     class(DrnType) :: this
     !
     drn_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function drn_obs_supported
 
   !> @brief Store observation type supported by DRN package
@@ -650,9 +605,6 @@ contains
     !    for to-mvr observation type.
     call this%obs%StoreObsType('to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- Return
-    return
   end subroutine drn_df_obs
 
   !> @brief Store user-specified drain conductance
@@ -667,9 +619,6 @@ contains
     do n = 1, this%nbound
       this%condinput(n) = this%cond_mult(n)
     end do
-    !
-    ! -- Return
-    return
   end subroutine drn_store_user_cond
 
   !> @brief Apply multiplier to conductance value depending on user-selected option
@@ -688,9 +637,6 @@ contains
     else
       cond = this%cond(row)
     end if
-    !
-    ! -- Return
-    return
   end function cond_mult
 
   !> @brief Return requested boundary value
@@ -716,9 +662,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- Return
-    return
   end function drn_bound_value
 
 end module DrnModule

--- a/src/Model/GroundWaterFlow/gwf-evt.f90
+++ b/src/Model/GroundWaterFlow/gwf-evt.f90
@@ -97,9 +97,6 @@ contains
     packobj%id = id
     packobj%ibcnum = ibcnum
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- Return
-    return
   end subroutine evt_create
 
   !> @brief Allocate package scalar members
@@ -128,9 +125,6 @@ contains
     this%fixed_cell = .false.
     this%read_as_arrays = .false.
     this%surfratespecified = .false.
-    !
-    ! -- Return
-    return
   end subroutine evt_allocate_scalars
 
   !> @brief Allocate package arrays
@@ -184,9 +178,6 @@ contains
                          'PETM0', this%input_mempath)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine evt_allocate_arrays
 
   !> @brief Source options specific to EvtType
@@ -235,9 +226,6 @@ contains
     ! -- log evt specific options
     call this%evt_log_options(found_fixed_cell, found_readasarrays, &
                               found_surfratespec)
-    !
-    ! -- Return
-    return
   end subroutine evt_source_options
 
   !> @brief Source options specific to EvtType
@@ -284,9 +272,6 @@ contains
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
-    !
-    ! -- Return
-    return
   end subroutine evt_log_options
 
   !> @brief Source the dimensions for this package
@@ -358,9 +343,6 @@ contains
     ! -- Call define_listlabel to construct the list label that is written
     !    when PRINT_INPUT option is used.
     call this%define_listlabel()
-    !
-    ! -- Return
-    return
   end subroutine evt_source_dimensions
 
   !> @brief Part of allocate and read
@@ -374,9 +356,6 @@ contains
     if (this%read_as_arrays) then
       call this%default_nodelist()
     end if
-    !
-    ! -- Return
-    return
   end subroutine evt_read_initial_attr
 
   !> @brief Read and Prepare
@@ -416,9 +395,6 @@ contains
     !
     ! -- copy nodelist to nodesontop if not fixed cell
     if (.not. this%fixed_cell) call this%set_nodesontop()
-    !
-    ! -- Return
-    return
   end subroutine evt_rp
 
   !> @brief Subroutine to check pxdp
@@ -482,9 +458,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine check_pxdp
 
   !> @brief Store nodelist in nodesontop
@@ -504,9 +477,6 @@ contains
     do n = 1, this%nbound
       this%nodesontop(n) = this%nodelist(n)
     end do
-    !
-    ! -- Return
-    return
   end subroutine set_nodesontop
 
   !> @brief Formulate the HCOF and RHS terms
@@ -646,9 +616,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine evt_cf
 
   !> @brief Copy rhs and hcof into solution rhs and amat
@@ -677,9 +644,6 @@ contains
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))
     end do
-    !
-    ! -- Return
-    return
   end subroutine evt_fc
 
   !> @brief Deallocate
@@ -716,9 +680,6 @@ contains
     !
     ! -- Deallocate parent package
     call this%BndExtType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine evt_da
 
   !> @brief Define the list heading that is written to iout when PRINT_INPUT
@@ -770,9 +731,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine evt_define_listlabel
 
   !> @brief Assign default nodelist when READASARRAYS is specified.
@@ -817,9 +775,6 @@ contains
     ! -- if fixed_cell option not set, then need to store nodelist
     !    in the nodesontop array
     if (.not. this%fixed_cell) call this%set_nodesontop()
-    !
-    ! -- Return
-    return
   end subroutine default_nodelist
 
   ! -- Procedures related to observations
@@ -833,9 +788,6 @@ contains
     class(EvtType) :: this
     !
     evt_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function evt_obs_supported
 
   !> @brief Store observation type supported by EVT package
@@ -850,9 +802,6 @@ contains
     !
     call this%obs%StoreObsType('evt', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- Return
-    return
   end subroutine evt_df_obs
 
   !> @brief Return requested boundary value
@@ -916,9 +865,6 @@ contains
       end if
       !
     end select
-    !
-    ! -- Return
-    return
   end function evt_bound_value
 
   !> @brief Update the nodelist based on IEVT input
@@ -960,9 +906,6 @@ contains
       call dis%nlarray_to_nodelist(ievt, nodelist, &
                                    maxbound, nbound, aname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine nodelist_update
 
 end module EvtModule

--- a/src/Model/GroundWaterFlow/gwf-ghb.f90
+++ b/src/Model/GroundWaterFlow/gwf-ghb.f90
@@ -76,9 +76,6 @@ contains
     packobj%id = id
     packobj%ibcnum = ibcnum
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- Return
-    return
   end subroutine ghb_create
 
   !> @brief Deallocate memory
@@ -95,9 +92,6 @@ contains
     ! -- arrays
     call mem_deallocate(this%bhead, 'BHEAD', this%memoryPath)
     call mem_deallocate(this%cond, 'COND', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine ghb_da
 
   !> @brief Set options specific to GhbType
@@ -120,9 +114,6 @@ contains
     !
     ! -- log ghb specific options
     call this%log_ghb_options(found)
-    !
-    ! -- Return
-    return
   end subroutine ghb_options
 
   !> @brief Log options specific to GhbType
@@ -145,9 +136,6 @@ contains
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
-    !
-    ! -- Return
-    return
   end subroutine log_ghb_options
 
   !> @brief Allocate arrays
@@ -172,9 +160,6 @@ contains
                      'BHEAD', this%input_mempath)
     call mem_checkin(this%cond, 'COND', this%memoryPath, &
                      'COND', this%input_mempath)
-    !
-    ! -- Return
-    return
   end subroutine ghb_allocate_arrays
 
   !> @brief Read and prepare
@@ -199,9 +184,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- Return
-    return
   end subroutine ghb_rp
 
   !> @brief Check ghb boundary condition data
@@ -254,9 +236,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(this%inunit)
     end if
-    !
-    ! -- Return
-    return
   end subroutine ghb_ck
 
   !> @brief Formulate the HCOF and RHS terms
@@ -283,9 +262,6 @@ contains
       this%hcof(i) = -this%cond_mult(i)
       this%rhs(i) = -this%cond_mult(i) * this%bhead(i)
     end do
-    !
-    ! -- Return
-    return
   end subroutine ghb_cf
 
   !> @brief Copy rhs and hcof into solution rhs and amat
@@ -322,9 +298,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(i, qghb)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine ghb_fc
 
   !> @brief Define the list heading that is written to iout when PRINT_INPUT
@@ -351,9 +324,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   ! -- Procedures related to observations
@@ -368,9 +338,6 @@ contains
     class(GhbType) :: this
     !
     ghb_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function ghb_obs_supported
 
   !> @brief Store observation type supported by GHB package
@@ -391,9 +358,6 @@ contains
     !    for to-mvr observation type.
     call this%obs%StoreObsType('to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- Return
-    return
   end subroutine ghb_df_obs
 
   !> @brief Store user-specified conductance for GHB boundary type
@@ -408,9 +372,6 @@ contains
     do n = 1, this%nbound
       this%condinput(n) = this%cond_mult(n)
     end do
-    !
-    ! -- Return
-    return
   end subroutine ghb_store_user_cond
 
   !> @brief Apply multiplier to GHB conductance if option AUXMULTCOL is used
@@ -429,9 +390,6 @@ contains
     else
       cond = this%cond(row)
     end if
-    !
-    ! -- Return
-    return
   end function cond_mult
 
   !> @brief Return requested boundary value
@@ -457,9 +415,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- Return
-    return
   end function ghb_bound_value
 
 end module ghbmodule

--- a/src/Model/GroundWaterFlow/gwf-hfb.f90
+++ b/src/Model/GroundWaterFlow/gwf-hfb.f90
@@ -88,9 +88,6 @@ contains
     !
     ! -- Initialize block parser
     call hfbobj%parser%Initialize(hfbobj%inunit, hfbobj%iout)
-    !
-    ! -- Return
-    return
   end subroutine hfb_cr
 
   !> @brief Allocate and read
@@ -145,9 +142,6 @@ contains
       write (this%iout, '(/1x,a,a)') 'Viscosity active in ', &
         trim(this%filtyp)//' Package calculations: '//trim(adjustl(this%packName))
     end if
-    !
-    ! -- Return
-    return
   end subroutine hfb_ar
 
   !> @brief Check for new HFB stress period data
@@ -204,9 +198,6 @@ contains
     else
       write (this%iout, fmtlsp) 'HFB'
     end if
-    !
-    ! -- Return
-    return
   end subroutine hfb_rp
 
   !> @brief Fill matrix terms
@@ -354,9 +345,6 @@ contains
       end if
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine hfb_fc
 
   !> @brief flowja will automatically include the effects of the hfb for
@@ -459,9 +447,6 @@ contains
       end if
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine hfb_cq
 
   !> @brief Deallocate memory
@@ -505,9 +490,6 @@ contains
     this%bot => null()
     this%hwva => null()
     this%vsc => null()
-    !
-    ! -- Return
-    return
   end subroutine hfb_da
 
   !> @brief Allocate package scalars
@@ -532,9 +514,6 @@ contains
     this%maxhfb = 0
     this%nhfb = 0
     this%ivsc = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate package arrays
@@ -558,9 +537,6 @@ contains
     do ihfb = 1, this%maxhfb
       this%idxloc(ihfb) = 0
     end do
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief Read a hfb options block
@@ -601,9 +577,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF HFB OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @brief Read the dimensions for this package
@@ -654,9 +627,6 @@ contains
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_dimensions
 
   !> @brief Read HFB period block
@@ -732,9 +702,6 @@ contains
       ' HFBs READ FOR STRESS PERIOD ', kper
     call this%check_data()
     write (this%iout, '(1x,a)') 'END READING HFB DATA'
-    !
-    ! -- Return
-    return
   end subroutine read_data
 
   !> @brief Check for hfb's between two unconnected cells and write a warning
@@ -796,9 +763,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(this%inunit)
     end if
-    !
-    ! -- Return
-    return
   end subroutine check_data
 
   !> @brief Reset condsat to its value prior to being modified by hfb's
@@ -814,9 +778,6 @@ contains
       ipos = this%idxloc(ihfb)
       this%condsat(this%jas(ipos)) = this%csatsav(ihfb)
     end do
-    !
-    ! -- Return
-    return
   end subroutine condsat_reset
 
   !> @brief Modify condsat
@@ -868,9 +829,6 @@ contains
         this%condsat(this%jas(ipos)) = cond
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine condsat_modify
 
 end module GwfHfbModule

--- a/src/Model/GroundWaterFlow/gwf-lak.f90
+++ b/src/Model/GroundWaterFlow/gwf-lak.f90
@@ -321,9 +321,6 @@ contains
     packobj%iscloc = 0 ! not supported
     packobj%isadvpak = 1
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- Return
-    return
   end subroutine lak_create
 
   !> @brief Allocate scalar members
@@ -384,9 +381,6 @@ contains
     this%cbcauxitems = 1
     this%idense = 0
     this%ivsc = 0
-    !
-    ! -- Return
-    return
   end subroutine lak_allocate_scalars
 
   !> @brief Allocate scalar members
@@ -451,9 +445,6 @@ contains
     !
     ! -- allocate viscratios to size 0
     call mem_allocate(this%viscratios, 2, 0, 'VISCRATIOS', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine lak_allocate_arrays
 
   !> @brief Read the dimensions for this package
@@ -685,9 +676,6 @@ contains
     !
     ! -- deallocate local storage for nboundchk
     deallocate (nboundchk)
-    !
-    ! -- Return
-    return
   end subroutine lak_read_lakes
 
   !> @brief Read the lake connections for this package
@@ -1001,9 +989,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_read_lake_connections
 
   !> @brief Read the lake tables for this package
@@ -1127,9 +1112,6 @@ contains
       end if
     end do
     deallocate (laketables)
-    !
-    ! -- Return
-    return
   end subroutine lak_read_tables
 
   !> @brief Copy the laketables structure data into flattened vectors that are
@@ -1179,9 +1161,6 @@ contains
         j = j + 1
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine laktables_to_vectors
 
   !> @brief Read the lake table for this package
@@ -1415,9 +1394,6 @@ contains
     !
     ! Close the table file and clear other parser members
     call parser%Clear()
-    !
-    ! -- Return
-    return
   end subroutine lak_read_table
 
   !> @brief Read the lake outlets for this package
@@ -1600,9 +1576,6 @@ contains
     if (ierr > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_read_outlets
 
   !> @brief Read the dimensions for this package
@@ -1687,9 +1660,6 @@ contains
     !
     ! -- setup the stage table object
     call this%lak_setup_tableobj()
-    !
-    ! -- Return
-    return
   end subroutine lak_read_dimensions
 
   !> @brief Read the initial parameters for this package
@@ -1958,9 +1928,6 @@ contains
     ! -- deallocate temporary storage
     deallocate (clb)
     deallocate (caq)
-    !
-    ! -- Return
-    return
   end subroutine lak_read_initial_attr
 
   !> @brief Perform linear interpolation of two vectors.
@@ -2008,9 +1975,6 @@ contains
         end if
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_linear_interpolation
 
   !> @brief Calculate the surface area of a lake at a given stage
@@ -2053,9 +2017,6 @@ contains
         sarea = sarea + sa
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_sarea
 
   !> @brief Calculate the wetted area of a lake at a given stage.
@@ -2084,9 +2045,6 @@ contains
       call this%lak_calculate_conn_warea(ilak, i, stage, head, wa)
       warea = warea + wa
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_warea
 
   !> @brief Calculate the wetted area of a lake connection at a given stage
@@ -2138,9 +2096,6 @@ contains
       end if
       wa = sat * this%warea(iconn)
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_conn_warea
 
   !> @brief Calculate the volume of a lake at a given stage
@@ -2194,9 +2149,6 @@ contains
         volume = volume + v
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_vol
 
   !> @brief Calculate the total conductance for a lake at a provided stage
@@ -2216,9 +2168,6 @@ contains
       call this%lak_calculate_conn_conductance(ilak, i, stage, stage, c)
       conductance = conductance + c
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_conductance
 
   !> @brief Calculate the controlling lake stage or groundwater head used to
@@ -2249,9 +2198,6 @@ contains
     else
       vv = DHALF * (ss + hh)
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_cond_head
 
   !> @brief Calculate the conductance for a lake connection at a provided stage
@@ -2319,9 +2265,6 @@ contains
       end if
     end if
     cond = sat * this%satcond(iconn) * vscratio
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_conn_conductance
 
   !> @brief Calculate the total groundwater-lake flow at a provided stage
@@ -2345,9 +2288,6 @@ contains
       call this%lak_calculate_conn_exchange(ilak, j, stage, hgwf, flow)
       totflow = totflow + flow
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_exchange
 
   !> @brief Calculate the groundwater-lake flow at a provided stage and
@@ -2411,9 +2351,6 @@ contains
     ! -- If present update gwfhcof and gwfrhs
     if (present(gwfhcof)) gwfhcof = gwfhcof0
     if (present(gwfrhs)) gwfrhs = gwfrhs0
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_conn_exchange
 
   !> @brief Calculate the groundwater-lake flow at a provided stage and
@@ -2457,9 +2394,6 @@ contains
     ! -- Set gwfhcof and gwfrhs if present
     if (present(gwfhcof)) gwfhcof = gwfhcof0
     if (present(gwfrhs)) gwfrhs = gwfrhs0
-    !
-    ! -- Return
-    return
   end subroutine lak_estimate_conn_exchange
 
   !> @brief Calculate the storage change in a lake based on provided stages
@@ -2483,9 +2417,6 @@ contains
       call this%lak_calculate_vol(ilak, stage0, v0)
       dvr = (v0 - v) / delt
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_storagechange
 
   !> @brief Calculate the rainfall for a lake
@@ -2508,9 +2439,6 @@ contains
       call this%lak_calculate_sarea(ilak, stage, sa)
     end if
     ra = this%rainfall(ilak) * sa
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_rainfall
 
   !> @brief Calculate runoff to a lake
@@ -2523,9 +2451,6 @@ contains
     !
     ! -- runoff
     ro = this%runoff(ilak)
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_runoff
 
   !> @brief Calculate specified inflow to a lake
@@ -2538,9 +2463,6 @@ contains
     !
     ! -- inflow to lake
     qin = this%inflow(ilak)
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_inflow
 
   !> @brief Calculate the external flow terms to a lake
@@ -2557,9 +2479,6 @@ contains
     if (this%imover == 1) then
       ex = this%pakmvrobj%get_qfrommvr(ilak)
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_external
 
   !> @brief Calculate the withdrawal from a lake subject to an available volume
@@ -2581,9 +2500,6 @@ contains
       end if
     end if
     avail = avail + wr
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_withdrawal
 
   !> @brief Calculate the evaporation from a lake at a provided stage subject
@@ -2612,9 +2528,6 @@ contains
       ev = -ev
     end if
     avail = avail + ev
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_evaporation
 
   !> @brief Calculate the outlet inflow to a lake
@@ -2636,9 +2549,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_outlet_inflow
 
   !> @brief Calculate the outlet outflow from a lake
@@ -2697,9 +2607,6 @@ contains
         outoutf = outoutf + rate
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_outlet_outflow
 
   !> @brief Get the outlet inflow to a lake from another lake
@@ -2721,9 +2628,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_get_internal_inlet
 
   !> @brief Get the outlet from a lake to another lake
@@ -2743,9 +2647,6 @@ contains
         outoutf = outoutf + this%simoutrate(n)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_get_internal_outlet
 
   !> @brief Get the outlet outflow from a lake to an external boundary
@@ -2765,9 +2666,6 @@ contains
         outoutf = outoutf + this%simoutrate(n)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_get_external_outlet
 
   !> @brief Get the mover outflow from a lake to an external boundary
@@ -2789,9 +2687,6 @@ contains
         end if
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_get_external_mover
 
   !> @brief Get the mover outflow from a lake to another lake
@@ -2813,9 +2708,6 @@ contains
         end if
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_get_internal_mover
 
   !> @brief Get the outlet to mover from a lake
@@ -2836,9 +2728,6 @@ contains
         end if
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_get_outlet_tomover
 
   !> @brief Determine the stage from a provided volume
@@ -2921,9 +2810,6 @@ contains
      &    'final change in stage =', ds
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_vol2stage
 
   !> @brief Determine if a valid lake or outlet number has been specified
@@ -2957,9 +2843,6 @@ contains
         ierr = 1
       end if
     end if
-    !
-    ! -- Return
-    return
   end function lak_check_valid
 
   !> @brief Set a stress period attribute for lakweslls(itemno) using keywords
@@ -3199,8 +3082,6 @@ contains
       write (errmsg, '(a,1x,a,1x,i0,1x,a)') keyword, ' for LAKE', ilak, msg
     end if
     call store_error(errmsg)
-    ! -- Return
-    return
   end subroutine lak_set_attribute_error
 
   !> @brief Set options specific to LakType
@@ -3357,9 +3238,6 @@ contains
       ! -- No options found
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine lak_options
 
   !> @brief Allocate and Read
@@ -3383,9 +3261,6 @@ contains
       allocate (this%pakmvrobj)
       call this%pakmvrobj%ar(this%noutlets, this%nlakes, this%memoryPath)
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_ar
 
   !> @brief Read and Prepare
@@ -3522,9 +3397,6 @@ contains
         this%pakmvrobj%iprmap(n) = this%lakein(n)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_rp
 
   !> @brief Add package connection to matrix
@@ -3592,9 +3464,6 @@ contains
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine lak_ad
 
   !> @brief Formulate the HCOF and RHS terms
@@ -3678,9 +3547,6 @@ contains
     ! -- Store the lake stage and cond in bound array for other
     !    packages, such as the BUY package
     call this%lak_bound_update()
-    !
-    ! -- Return
-    return
   end subroutine lak_cf
 
   !> @brief Copy rhs and hcof into solution rhs and amat
@@ -3716,9 +3582,6 @@ contains
         rhs(igwfnode) = rhs(igwfnode) + this%rhs(j)
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_fc
 
   !> @brief Fill newton terms
@@ -3778,9 +3641,6 @@ contains
         end if
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_fn
 
   !> @brief Final convergence check for package
@@ -4077,9 +3937,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_cc
 
   !> @brief Calculate flows
@@ -4182,9 +4039,6 @@ contains
     !
     ! -- fill the budget object
     call this%lak_fill_budobj()
-    !
-    ! -- Return
-    return
   end subroutine lak_cq
 
   !> @brief Output LAK package flow terms
@@ -4211,9 +4065,6 @@ contains
     if (ibudfl /= 0 .and. this%iprflow /= 0) then
       call this%budobj%write_flowtable(this%dis, kstp, kper)
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_ot_package_flows
 
   !> @brief Write flows to binary file and/or print flows to budget
@@ -4227,9 +4078,6 @@ contains
     !
     ! -- write the flows from the budobj
     call this%BndType%bnd_ot_model_flows(icbcfl, ibudfl, icbcun, this%imap)
-    !
-    ! -- Return
-    return
   end subroutine lak_ot_model_flows
 
   !> @brief Save LAK-calculated values to binary file
@@ -4301,9 +4149,6 @@ contains
         call this%stagetab%add_term(v)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_ot_dv
 
   !> @brief Write LAK budget to listing file
@@ -4319,9 +4164,6 @@ contains
     integer(I4B), intent(in) :: ibudfl !< flag indicating budget should be written
     !
     call this%budobj%write_budtable(kstp, kper, iout, ibudfl, totim, delt)
-    !
-    ! -- Return
-    return
   end subroutine lak_ot_bdsummary
 
   !> @brief Deallocate objects
@@ -4485,9 +4327,6 @@ contains
     !
     ! -- Parent object
     call this%BndType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine lak_da
 
   !> @brief Define the list heading that is written to iout when PRINT_INPUT
@@ -4513,9 +4352,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   !> @brief Set pointers to model arrays and variables so that a package has
@@ -4545,9 +4381,6 @@ contains
     !do n = 1, this%nlakes
     !  this%xnewpak(n) = DEP20
     !end do
-    !
-    ! -- Return
-    return
   end subroutine lak_set_pointers
 
   !> @brief Procedures related to observations (type-bound)
@@ -4560,9 +4393,6 @@ contains
     class(LakType) :: this
     !
     lak_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function lak_obs_supported
 
   !> @brief Store observation type supported by LAK package. Overrides
@@ -4668,9 +4498,6 @@ contains
     !    for conductance observation type.
     call this%obs%StoreObsType('conductance', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => lak_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine lak_df_obs
 
   !> @brief Calculate observations this time step and call ObsType%SaveOneSimval
@@ -4824,9 +4651,6 @@ contains
         call store_error_unit(this%inunit)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_bd_obs
 
   !> @brief Process each observation
@@ -4977,9 +4801,6 @@ contains
         call store_error_unit(this%inunit)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_rp_obs
 
   !
@@ -5033,9 +4854,6 @@ contains
     end if
     ! -- store lake number (NodeNumber)
     obsrv%NodeNumber = nn1
-    !
-    ! -- Return
-    return
   end subroutine lak_process_obsID
 
   !
@@ -5070,9 +4888,6 @@ contains
         chratin = chratin + q
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_accumulate_chterm
 
   !> @brief Store the lake head and connection conductance in the bound array
@@ -5098,9 +4913,6 @@ contains
         this%bound(2, j) = clak
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine lak_bound_update
 
   !> @brief Solve for lake stage
@@ -5477,9 +5289,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(n, -this%simoutrate(n))
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_solve
 
   !> @ brief Lake package bisection method
@@ -5529,9 +5338,6 @@ contains
       temporary_stage0 = temporary_stage
     end do
     dh = hlak - temporary_stage
-    !
-    ! -- Return
-    return
   end subroutine lak_bisection
 
   !> @brief Calculate the available volumetric rate for a lake given a passed
@@ -5598,9 +5404,6 @@ contains
     ! -- calculate volume available in storage
     call this%lak_calculate_vol(n, this%xoldpak(n), v0)
     avail = avail + v0 / delt
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_available
 
   !> @brief Calculate the residual for a lake given a passed stage
@@ -5683,9 +5486,6 @@ contains
       call this%lak_calculate_vol(n, hlak, v1)
       resid = resid + (v0 - v1) / delt
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_residual
 
   !> @brief Set up the budget object that stores all the lake flows
@@ -5938,9 +5738,6 @@ contains
     if (this%iprflow /= 0) then
       call this%budobj%flowtable_df(this%iout)
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -6126,9 +5923,6 @@ contains
     !
     ! --Terms are filled, now accumulate them for this time step
     call this%budobj%accumulate_terms()
-    !
-    ! -- Return
-    return
   end subroutine lak_fill_budobj
 
   !> @brief Set up the table object that is used to write the lak stage data
@@ -6193,9 +5987,6 @@ contains
       text = 'VOLUME'
       call this%stagetab%initialize_column(text, 12, alignment=TABCENTER)
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_setup_tableobj
 
   !> @brief Activate addition of density terms
@@ -6217,9 +6008,6 @@ contains
     end do
     write (this%iout, '(/1x,a)') 'DENSITY TERMS HAVE BEEN ACTIVATED FOR LAKE &
       &PACKAGE: '//trim(adjustl(this%packName))
-    !
-    ! -- Return
-    return
   end subroutine lak_activate_density
 
   !> @brief Activate viscosity terms
@@ -6246,9 +6034,6 @@ contains
     end do
     write (this%iout, '(/1x,a)') 'VISCOSITY HAS BEEN ACTIVATED FOR LAK &
       &PACKAGE: '//trim(adjustl(this%packName))
-    !
-    ! -- Return
-    return
   end subroutine lak_activate_viscosity
 
   !> @brief Calculate the groundwater-lake density exchange terms
@@ -6359,9 +6144,6 @@ contains
         flow = flow + d2
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine lak_calculate_density_exchange
 
 end module LakModule

--- a/src/Model/GroundWaterFlow/gwf-maw.f90
+++ b/src/Model/GroundWaterFlow/gwf-maw.f90
@@ -263,9 +263,6 @@ contains
     packobj%iscloc = 0 ! not supported
     packobj%isadvpak = 1
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- Return
-    return
   end subroutine maw_create
 
   !> @brief Allocate scalar members
@@ -319,9 +316,6 @@ contains
     this%cbcauxitems = 1
     this%idense = 0
     this%ivsc = 0
-    !
-    ! -- Return
-    return
   end subroutine maw_allocate_scalars
 
   !> @brief Allocate well arrays
@@ -519,9 +513,6 @@ contains
     !
     ! -- allocate viscratios to size 0
     call mem_allocate(this%viscratios, 2, 0, 'VISCRATIOS', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine maw_allocate_well_conn_arrays
 
   !> @brief Allocate arrays
@@ -535,9 +526,6 @@ contains
     !
     ! -- call standard BndType allocate scalars
     call this%BndType%allocate_arrays()
-    !
-    ! -- Return
-    return
   end subroutine maw_allocate_arrays
 
   !> @brief Read the packagedata for this package
@@ -790,9 +778,6 @@ contains
     deallocate (ngwfnodes)
     deallocate (radius)
     deallocate (bottom)
-    !
-    ! -- Return
-    return
   end subroutine maw_read_wells
 
   !> @brief Read the dimensions for this package
@@ -1038,9 +1023,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_read_well_connections
 
   !> @brief Read the dimensions for this package
@@ -1114,9 +1096,6 @@ contains
     !
     ! -- setup the head table object
     call this%maw_setup_tableobj()
-    !
-    ! -- Return
-    return
   end subroutine maw_read_dimensions
 
   !> @brief Read the initial parameters for this package
@@ -1344,9 +1323,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(this%inunit)
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_read_initial_attr
 
   !> @brief Set a stress period attribute for mawweslls(imaw) using keywords
@@ -1479,9 +1455,6 @@ contains
       call store_error(errmsg)
     end select
 
-    !
-    ! -- Return
-    return
   end subroutine maw_set_stressperiod
 
   !> @brief Issue a parameter error for mawweslls(imaw)
@@ -1504,9 +1477,6 @@ contains
         keyword, ' for MAW well', imaw, msg
     end if
     call store_error(errmsg)
-    !
-    ! -- Return
-    return
   end subroutine maw_set_attribute_error
 
   !> @brief Issue parameter errors for mawwells(imaw)
@@ -1578,8 +1548,6 @@ contains
     end do
     ! -- reset check_attr
     this%check_attr = 0
-    ! -- Return
-    return
   end subroutine maw_check_attributes
 
   !> @brief Add package connection to matrix
@@ -1610,9 +1578,6 @@ contains
       end do
 
     end do
-    !
-    ! -- Return
-    return
   end subroutine maw_ac
 
   !> @brief Map package connection to matrix
@@ -1671,9 +1636,6 @@ contains
         ipos = ipos + 1
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine maw_mc
 
   !> @brief Set options specific to MawType.
@@ -1792,9 +1754,6 @@ contains
       ! -- No options found
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine maw_read_options
 
   !> @brief Allocate and Read
@@ -1825,9 +1784,6 @@ contains
       allocate (this%pakmvrobj)
       call this%pakmvrobj%ar(this%nmawwells, this%nmawwells, this%memoryPath)
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_ar
 
   !> @brief Read and Prepare
@@ -2114,9 +2070,6 @@ contains
         ibnd = ibnd + 1
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine maw_rp
 
   !> @brief Add package connection to matrix
@@ -2183,9 +2136,6 @@ contains
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine maw_ad
 
   !> @brief Formulate the HCOF and RHS terms
@@ -2199,9 +2149,6 @@ contains
     !
     ! -- Calculate maw conductance and update package RHS and HCOF
     call this%maw_cfupdate()
-    !
-    ! -- Return
-    return
   end subroutine maw_cf
 
   !> @brief Copy rhs and hcof into solution rhs and amat
@@ -2354,9 +2301,6 @@ contains
         idx = idx + 1
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine maw_fc
 
   !> @brief Fill newton terms
@@ -2519,9 +2463,6 @@ contains
         idx = idx + 1
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine maw_fn
 
   !> @brief Calculate under-relaxation of groundwater flow model MAW Package heads
@@ -2562,9 +2503,6 @@ contains
         dx(n) = DZERO
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine maw_nur
 
   !> @brief Calculate flows
@@ -2682,9 +2620,6 @@ contains
     !
     ! -- fill the budget object
     call this%maw_fill_budobj()
-    !
-    ! -- Return
-    return
   end subroutine maw_cq
 
   !> @brief Write flows to binary file and/or print flows to budget
@@ -2725,9 +2660,6 @@ contains
     if (ibudfl /= 0 .and. this%iprflow /= 0) then
       call this%budobj%write_flowtable(this%dis, kstp, kper)
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_ot_package_flows
 
   !> @brief Save maw-calculated values to binary file
@@ -2783,9 +2715,6 @@ contains
         call this%headtab%add_term(this%xnewpak(n))
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_ot_dv
 
   !> @brief Write MAW budget to listing file
@@ -2801,9 +2730,6 @@ contains
     integer(I4B), intent(in) :: ibudfl !< flag indicating budget should be written
     !
     call this%budobj%write_budtable(kstp, kper, iout, ibudfl, totim, delt)
-    !
-    ! -- Return
-    return
   end subroutine maw_ot_bdsummary
 
   !> @brief Deallocate memory
@@ -2920,9 +2846,6 @@ contains
     !
     ! -- call standard BndType deallocate
     call this%BndType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine maw_da
 
   !> @brief Define the list heading that is written to iout when PRINT_INPUT
@@ -2947,9 +2870,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   !> @brief Set pointers to model arrays and variables so that a package has
@@ -2987,9 +2907,6 @@ contains
     do n = 1, this%nmawwells
       this%xnewpak(n) = DEP20
     end do
-    !
-    ! -- Return
-    return
   end subroutine maw_set_pointers
 
   ! -- Procedures related to observations (type-bound)
@@ -3002,9 +2919,6 @@ contains
     class(MawType) :: this
     !
     maw_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function maw_obs_supported
 
   !> @brief Store observation type supported by MAW package
@@ -3071,9 +2985,6 @@ contains
     !    for fw-conductance observation type.
     call this%obs%StoreObsType('fw-conductance', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => maw_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine maw_df_obs
 
   !> @brief Calculate observations this time step and call
@@ -3208,9 +3119,6 @@ contains
     if (this%ioutredflowcsv > 0) then
       call this%maw_redflow_csv_write()
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_bd_obs
 
   !> @brief Process each observation
@@ -3337,9 +3245,6 @@ contains
         call store_error_unit(this%inunit)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_rp_obs
 
   !
@@ -3394,9 +3299,6 @@ contains
     end if
     ! -- store multi-aquifer well number (NodeNumber)
     obsrv%NodeNumber = nn1
-    !
-    ! -- Return
-    return
   end subroutine maw_process_obsID
 
   !
@@ -3420,9 +3322,6 @@ contains
       this%ioutredflowcsv
     write (this%ioutredflowcsv, '(a)') &
       'time,period,step,MAWnumber,rate-requested,rate-actual,maw-reduction'
-    !
-    ! -- Return
-    return
   end subroutine maw_redflow_csv_init
 
   !> @brief MAW reduced flows only when & where they occur
@@ -3450,9 +3349,6 @@ contains
           totim, kper, kstp, n, this%rate(n), this%ratesim(n), v
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine maw_redflow_csv_write
 
   !> @brief Calculate the appropriate saturated conductance to use based on
@@ -3618,9 +3514,6 @@ contains
     !
     ! -- set saturated conductance
     this%satcond(jpos) = c
-    !
-    ! -- Return
-    return
   end subroutine maw_calculate_satcond
 
   !> @brief Calculate the saturation between the aquifer maw well_head
@@ -3680,9 +3573,6 @@ contains
     else
       sat = DONE
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_calculate_saturation
 
   !> @brief Calculate matrix terms for a multi-aquifer well connection. Terms
@@ -3837,9 +3727,6 @@ contains
       call this%maw_calculate_density_exchange(jpos, hmaw, hgwf, cmaw, &
                                                bmaw, flow, term, cterm)
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_calculate_conn_terms
 
   !> @brief Calculate well pumping rate based on constraints
@@ -4005,9 +3892,6 @@ contains
         q = scale * rate
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_calculate_wellq
 
   !> @brief Calculate groundwater inflow to a maw well
@@ -4094,9 +3978,6 @@ contains
       end if
       qnet = qnet + cmaw * (hgwf - hv)
     end do
-    !
-    ! -- Return
-    return
   end subroutine maw_calculate_qpot
 
   !> @brief Update MAW satcond and package rhs and hcof
@@ -4152,9 +4033,6 @@ contains
         ibnd = ibnd + 1
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine maw_cfupdate
 
   !> @brief Set up the budget object that stores all the maw flows
@@ -4356,9 +4234,6 @@ contains
     if (this%iprflow /= 0) then
       call this%budobj%flowtable_df(this%iout)
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -4570,9 +4445,6 @@ contains
     !
     ! --Terms are filled, now accumulate them for this time step
     call this%budobj%accumulate_terms()
-    !
-    ! -- Return
-    return
   end subroutine maw_fill_budobj
 
   !> @brief Set up the table object that is used to write the maw head data
@@ -4620,9 +4492,6 @@ contains
       text = 'HEAD'
       call this%headtab%initialize_column(text, 12, alignment=TABCENTER)
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_setup_tableobj
 
   !> @brief Get position of value in connection data
@@ -4638,9 +4507,6 @@ contains
     !
     ! -- set jpos
     jpos = this%iaconn(n) + j - 1
-    !
-    ! -- Return
-    return
   end function get_jpos
 
   !> @brief Get the gwfnode for connection
@@ -4658,9 +4524,6 @@ contains
     ! -- set jpos
     jpos = this%get_jpos(n, j)
     igwfnode = this%gwfnodes(jpos)
-    !
-    ! -- Return
-    return
   end function get_gwfnode
 
   !> @brief Activate density terms
@@ -4683,9 +4546,6 @@ contains
     end do
     write (this%iout, '(/1x,a)') 'DENSITY TERMS HAVE BEEN ACTIVATED FOR MAW &
       &PACKAGE: '//trim(adjustl(this%packName))
-    !
-    ! -- Return
-    return
   end subroutine maw_activate_density
 
   !> @brief Activate viscosity terms
@@ -4712,9 +4572,6 @@ contains
     end do
     write (this%iout, '(/1x,a)') 'VISCOSITY HAS BEEN ACTIVATED FOR MAW &
       &PACKAGE: '//trim(adjustl(this%packName))
-    !
-    ! -- Return
-    return
   end subroutine maw_activate_viscosity
 
   !> @brief Calculate the groundwater-maw density exchange terms
@@ -4798,9 +4655,6 @@ contains
       !
       ! -- Flow should be zero so do nothing
     end if
-    !
-    ! -- Return
-    return
   end subroutine maw_calculate_density_exchange
 
 end module MawModule

--- a/src/Model/GroundWaterFlow/gwf-mvr.f90
+++ b/src/Model/GroundWaterFlow/gwf-mvr.f90
@@ -196,9 +196,6 @@ contains
     !
     ! -- Init
     call mvrobj%mvr_init(name_parent, inunit, iout, dis, iexgmvr)
-    !
-    ! -- Return
-    return
   end subroutine mvr_cr
 
   subroutine mvr_init(this, name_parent, inunit, iout, dis, iexgmvr)
@@ -236,9 +233,6 @@ contains
     !
     ! -- instantiate the budget object
     call budgetobject_cr(this%budobj, 'WATER MOVER')
-    !
-    ! -- Return
-    return
   end subroutine mvr_init
 
   !> @brief Allocate and read water mover information
@@ -272,9 +266,6 @@ contains
     !
     ! -- setup the budget object
     call this%mvr_setup_budobj()
-    !
-    ! -- Return
-    return
   end subroutine mvr_ar
 
   !> @brief Read and Prepare
@@ -408,9 +399,6 @@ contains
       write (this%iout, fmtlsp) 'MVR'
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvr_rp
 
   subroutine initialize_movers(this, nr_active_movers)
@@ -441,9 +429,6 @@ contains
     do i = 1, this%nmvr
       call this%mvr(i)%advance()
     end do
-    !
-    ! -- Return
-    return
   end subroutine mvr_ad
 
   !> @brief Calculate qfrommvr as a function of qtomvr
@@ -485,9 +470,6 @@ contains
         write (this%iout, fmtmvrcnvg)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvr_cc
 
   !> @brief Fill the mover budget object
@@ -509,9 +491,6 @@ contains
     !
     ! -- fill the budget object
     call this%fill_budobj()
-    !
-    ! -- Return
-    return
   end subroutine mvr_bd
 
   !> @brief Write mover terms
@@ -546,9 +525,6 @@ contains
       call this%budobj%save_flows(this%dis, ibinun, kstp, kper, delt, &
                                   pertim, totim, this%iout)
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvr_bdsav
 
   !> @brief Write mover terms
@@ -573,9 +549,6 @@ contains
       call this%budobj%save_flows(this%dis, ibinun, kstp, kper, delt, &
                                   pertim, totim, this%iout)
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvr_ot_saveflow
 
   !> @brief Print mover flow table
@@ -590,9 +563,6 @@ contains
     if (ibudfl /= 0 .and. this%iprflow /= 0) then
       call this%mvr_print_outputtab()
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvr_ot_printflow
 
   !> @brief Write mover budget to listing file
@@ -655,9 +625,6 @@ contains
     !    in a table that has one entry.  A custom table looks
     !    better here with a row for each package.
     !call this%budobj%write_budtable(kstp, kper, this%iout)
-    !
-    ! -- Return
-    return
   end subroutine mvr_ot_bdsummary
 
   !> @brief Deallocate
@@ -712,9 +679,6 @@ contains
     !
     ! -- deallocate scalars in NumericalPackageType
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine mvr_da
 
   !> @brief Read options specified in the input options block
@@ -804,9 +768,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF MVR OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @brief Check MODELNAMES option set correctly
@@ -837,9 +798,6 @@ contains
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine check_options
 
   !> @brief Read the dimensions for this package
@@ -909,9 +867,6 @@ contains
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_dimensions
 
   !> @brief Read the packages that will be managed by this mover
@@ -973,9 +928,6 @@ contains
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_packages
 
   !> @brief Check to make sure packages have mover activated
@@ -1009,9 +961,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine check_packages
 
   !> @brief Assign pointer to each package's packagemover object
@@ -1031,9 +980,6 @@ contains
                                       trim(this%pckMemPaths(i)))
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine assign_packagemovers
 
   !> @brief Allocate package scalars
@@ -1072,9 +1018,6 @@ contains
     !
     ! -- allocate the period data input object
     allocate (this%gwfmvrperioddata)
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate package arrays
@@ -1114,9 +1057,6 @@ contains
     !
     ! -- setup the output table
     call this%mvr_setup_outputtab()
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief Set up the budget object that stores all the mvr flows
@@ -1178,9 +1118,6 @@ contains
                                                  naux)
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine mvr_setup_budobj
 
   !> @brief Fill budget object
@@ -1263,9 +1200,6 @@ contains
     !
     ! --Terms are filled, now accumulate them for this time step
     call this%budobj%accumulate_terms()
-    !
-    ! -- Return
-    return
   end subroutine fill_budobj
 
   !> @brief Set up output table
@@ -1309,9 +1243,6 @@ contains
       call this%outputtab%initialize_column(text, 10)
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvr_setup_outputtab
 
   !> @brief Set up output table
@@ -1342,9 +1273,6 @@ contains
       call this%outputtab%add_term(this%mvr(i)%mem_path_tgt)
       call this%outputtab%add_term(this%mvr(i)%iRchNrTgt)
     end do
-    !
-    ! -- Return
-    return
   end subroutine mvr_print_outputtab
 
   !> @brief Set mapped id
@@ -1379,9 +1307,6 @@ contains
       this%mvr(i)%iRchNrSrcMapped = mapped_id
     end do
     deallocate (pkg_mvr)
-    !
-    ! -- Return
-    return
   end subroutine set_mapped_id
 
 end module

--- a/src/Model/GroundWaterFlow/gwf-npf.f90
+++ b/src/Model/GroundWaterFlow/gwf-npf.f90
@@ -183,9 +183,6 @@ contains
       ! -- Print a message identifying the node property flow package.
       write (iout, fmtheader) input_mempath
     end if
-    !
-    ! -- Return
-    return
   end subroutine npf_cr
 
   !> @brief Define the NPF package instance
@@ -244,9 +241,6 @@ contains
                        '.  The XT3D option cannot be used with the GNC &
                        &Package.', terminate=.TRUE.)
     end if
-    !
-    ! -- Return
-    return
   end subroutine npf_df
 
   !> @brief Add connections for extended neighbors to the sparse matrix
@@ -261,9 +255,6 @@ contains
     !
     ! -- Add extended neighbors (neighbors of neighbors)
     if (this%ixt3d /= 0) call this%xt3d%xt3d_ac(moffset, sparse)
-    !
-    ! -- Return
-    return
   end subroutine npf_ac
 
   !> @brief Map connections and construct iax, jax, and idxglox
@@ -275,9 +266,6 @@ contains
     class(MatrixBaseType), pointer :: matrix_sln
     !
     if (this%ixt3d /= 0) call this%xt3d%xt3d_mc(moffset, matrix_sln)
-    !
-    ! -- Return
-    return
   end subroutine npf_mc
 
   !> @brief Allocate and read this NPF instance
@@ -350,9 +338,6 @@ contains
     if (this%intvk /= 0) then
       call this%tvk%ar(this%dis)
     end if
-    !
-    ! -- Return
-    return
   end subroutine npf_ar
 
   !> @brief Read and prepare method for package
@@ -368,9 +353,6 @@ contains
     if (this%intvk /= 0) then
       call this%tvk%rp()
     end if
-    !
-    ! -- Return
-    return
   end subroutine npf_rp
 
   !> @brief Advance
@@ -437,9 +419,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine npf_ad
 
   !> @brief Routines associated fill coefficients
@@ -470,9 +449,6 @@ contains
         this%sat(n) = satn
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine npf_cf
 
   !> @brief Formulate coefficients
@@ -577,9 +553,6 @@ contains
       end do
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine npf_fc
 
   !> @brief Fill newton terms
@@ -704,9 +677,6 @@ contains
       end do
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine npf_fn
 
   !> @brief Under-relaxation
@@ -750,9 +720,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine npf_nur
 
   !> @brief Calculate flowja
@@ -783,9 +750,6 @@ contains
       end do
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine npf_cq
 
   !> @brief Fractional cell saturation
@@ -809,9 +773,6 @@ contains
       thksat = sQuadraticSaturation(this%dis%top(n), this%dis%bot(n), hn, &
                                     this%satomega)
     end if
-    !
-    ! -- Return
-    return
   end subroutine sgwf_npf_thksat
 
   !> @brief Flow between two cells
@@ -883,9 +844,6 @@ contains
     !
     ! -- Calculate flow positive into cell n
     qnm = condnm * (hmtemp - hntemp)
-    !
-    ! -- Return
-    return
   end subroutine sgwf_npf_qcalc
 
   !> @brief Record flowja and calculate specific discharge if requested
@@ -923,9 +881,6 @@ contains
     if (this%isavsat /= 0) then
       if (ibinun /= 0) call this%sav_sat(ibinun)
     end if
-    !
-    ! -- Return
-    return
   end subroutine npf_save_model_flows
 
   !> @brief Print budget
@@ -965,9 +920,6 @@ contains
         write (this%iout, '(a)') trim(line)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine npf_print_model_flows
 
   !> @brief Deallocate variables
@@ -1151,9 +1103,6 @@ contains
     !
     ! -- If newton is on, then NPF creates asymmetric matrix
     this%iasym = this%inewton
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Store backup copy of hydraulic conductivity when the VSC
@@ -1182,9 +1131,6 @@ contains
       this%k22input(n) = this%k22(n)
       this%k33input(n) = this%k33(n)
     end do
-    !
-    ! -- Return
-    return
   end subroutine store_original_k_arrays
 
   !> @brief Allocate npf arrays
@@ -1244,9 +1190,6 @@ contains
                   '                     K33', '                     K22', &
                   '                  WETDRY', '                  ANGLE1', &
                   '                  ANGLE2', '                  ANGLE3']
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief Log npf options sourced from the input mempath
@@ -1316,9 +1259,6 @@ contains
       write (this%iout, '(4x,a,i5)') &
       'Head rewet equation (IHDWET) has been set to: ', this%ihdwet
     write (this%iout, '(1x,a,/)') 'End Setting NPF Options'
-    !
-    ! -- Return
-    return
   end subroutine log_options
 
   !> @brief Update simulation options from input mempath
@@ -1395,9 +1335,6 @@ contains
     if (this%iout > 0) then
       call this%log_options(found)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_options
 
   !> @brief Set options in the NPF object
@@ -1416,9 +1353,6 @@ contains
     this%wetfct = options%wetfct
     this%iwetit = options%iwetit
     this%ihdwet = options%ihdwet
-    !
-    ! -- Return
-    return
   end subroutine set_options
 
   !> @brief Check for conflicting NPF options
@@ -1481,9 +1415,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine check_options
 
   !> @brief Write dimensions to list file
@@ -1534,9 +1465,6 @@ contains
     end if
     !
     write (this%iout, '(1x,a,/)') 'End Setting NPF Griddata'
-    !
-    ! -- Return
-    return
   end subroutine log_griddata
 
   !> @brief Update simulation griddata from input mempath
@@ -1626,9 +1554,6 @@ contains
     if (this%iout > 0) then
       call this%log_griddata(found)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_griddata
 
   !> @brief Initialize and check NPF data
@@ -1782,9 +1707,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine prepcheck
 
   !> @brief preprocess the NPF input data
@@ -1992,9 +1914,6 @@ contains
     !
     ! -- nullify unneeded gwf pointers
     this%igwfnewtonur => null()
-    !
-    ! -- Return
-    return
   end subroutine preprocess_input
 
   !> @brief Calculate CONDSAT array entries for the given node
@@ -2089,9 +2008,6 @@ contains
       end if
       this%condsat(jj) = csat
     end do
-    !
-    ! -- Return
-    return
   end subroutine calc_condsat
 
   !> @brief Calculate initial saturation for the given node
@@ -2112,8 +2028,6 @@ contains
     if (this%ibound(n) /= 0 .and. this%ithickstartflag(n) /= 0) then
       call this%thksat(n, this%ic%strt(n), satn)
     end if
-    !
-    return
   end function calc_initial_sat
 
   !> @brief Perform wetting and drying
@@ -2215,9 +2129,6 @@ contains
     do n = 1, this%dis%nodes
       if (this%ibound(n) == 30000) this%ibound(n) = 1
     end do
-    !
-    ! -- Return
-    return
   end subroutine sgwf_npf_wetdry
 
   !> @brief Determine if a cell should rewet
@@ -2283,9 +2194,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine rewet_check
 
   !> @brief Print wet/dry message
@@ -2331,9 +2239,6 @@ contains
         (acnvrt(l), trim(adjustl(nodcnvrt(l))), l=1, ncnvrt)
       ncnvrt = 0
     end if
-    !
-    ! -- Return
-    return
   end subroutine sgwf_npf_wdmsg
 
   !> @brief Calculate the effective hydraulic conductivity for the n-m connection
@@ -2421,9 +2326,6 @@ contains
       end if
       !
     end if
-    !
-    ! -- Return
-    return
   end function hy_eff
 
   !> @brief Calculate the 3 components of specific discharge at the cell center
@@ -2718,9 +2620,6 @@ contains
     deallocate (wiz)
     deallocate (bix)
     deallocate (biy)
-    !
-    ! -- Return
-    return
   end subroutine calc_spdis
 
   !> @brief Save specific discharge in binary format to ibinun
@@ -2749,9 +2648,6 @@ contains
       call this%dis%record_mf6_list_entry(ibinun, n, n, DZERO, naux, &
                                           this%spdis(:, n))
     end do
-    !
-    ! -- Return
-    return
   end subroutine sav_spdis
 
   !> @brief Save saturation in binary format to ibinun
@@ -2781,9 +2677,6 @@ contains
       a(1) = this%sat(n)
       call this%dis%record_mf6_list_entry(ibinun, n, n, DZERO, naux, a)
     end do
-    !
-    ! -- Return
-    return
   end subroutine sav_sat
 
   !> @brief Reserve space for nedges cells that have an edge on them.
@@ -2797,9 +2690,6 @@ contains
     integer(I4B), intent(in) :: nedges
     !
     this%nedges = this%nedges + nedges
-    !
-    ! -- Return
-    return
   end subroutine increase_edge_count
 
   !> @brief Provide the npf package with edge properties
@@ -2831,9 +2721,6 @@ contains
     ! -- If this is the last edge, then the next call must be starting a new
     !    edge properties assignment loop, so need to reset lastedge to 0
     if (this%lastedge == this%nedges) this%lastedge = 0
-    !
-    ! -- Return
-    return
   end subroutine set_edge_properties
 
   !> Calculate saturated thickness between cell n and m
@@ -2861,9 +2748,6 @@ contains
                             this%dis%top(m), &
                             this%dis%bot(n), &
                             this%dis%bot(m))
-    !
-    ! -- Return
-    return
   end function calcSatThickness
 
 end module GwfNpfModule

--- a/src/Model/GroundWaterFlow/gwf-obs.f90
+++ b/src/Model/GroundWaterFlow/gwf-obs.f90
@@ -47,9 +47,6 @@ contains
     obs%active = .false.
     obs%inputFilename = ''
     obs%inUnitObs => inobs
-    !
-    ! -- Return
-    return
   end subroutine gwf_obs_cr
 
   !> @brief Allocate and read
@@ -66,9 +63,6 @@ contains
     !
     ! set pointers
     call this%set_pointers(ic, x, flowja)
-    !
-    ! -- Return
-    return
   end subroutine gwf_obs_ar
 
   !> @brief Define
@@ -100,9 +94,6 @@ contains
     ! -- Store obs type and assign procedure pointer for flow-ja-face observation type
     call this%StoreObsType('flow-ja-face', .true., indx)
     this%obsData(indx)%ProcessIdPtr => gwf_process_intercell_obs_id
-    !
-    ! -- Return
-    return
   end subroutine gwf_obs_df
 
   !> @brief Save obs
@@ -143,9 +134,6 @@ contains
         call store_error_unit(this%inUnitObs)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_obs_bd
 
   !> @brief Do GWF observations need any checking? If so, add checks here
@@ -155,9 +143,6 @@ contains
     class(GwfObsType), intent(inout) :: this
     !
     ! Do GWF observations need any checking? If so, add checks here
-    !
-    ! -- Return
-    return
   end subroutine gwf_obs_rp
 
   !> @brief Deallocate memory
@@ -170,9 +155,6 @@ contains
     nullify (this%x)
     nullify (this%flowja)
     call this%ObsType%obs_da()
-    !
-    ! -- Return
-    return
   end subroutine gwf_obs_da
 
   !> @brief Set pointers
@@ -187,9 +169,6 @@ contains
     this%ic => ic
     this%x => x
     this%flowja => flowja
-    !
-    ! -- Return
-    return
   end subroutine set_pointers
 
   ! -- Procedures related to GWF observations (NOT type-bound)
@@ -223,9 +202,6 @@ contains
       call store_error(ermsg)
       call store_error_unit(inunitobs)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_process_head_drawdown_obs_id
 
   !> @brief Process flow between two cells when requested
@@ -281,9 +257,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(inunitobs)
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_process_intercell_obs_id
 
 end module GwfObsModule

--- a/src/Model/GroundWaterFlow/gwf-oc.f90
+++ b/src/Model/GroundWaterFlow/gwf-oc.f90
@@ -47,9 +47,6 @@ contains
     !
     ! -- Initialize block parser
     call ocobj%parser%Initialize(inunit, iout)
-    !
-    ! -- Return
-    return
   end subroutine oc_cr
 
   !> @ brief Allocate and read GwfOcType
@@ -92,9 +89,6 @@ contains
     if (this%inunit > 0) then
       call this%read_options()
     end if
-    !
-    ! -- Return
-    return
   end subroutine oc_ar
 
 end module GwfOcModule

--- a/src/Model/GroundWaterFlow/gwf-rch.f90
+++ b/src/Model/GroundWaterFlow/gwf-rch.f90
@@ -91,9 +91,6 @@ contains
     packobj%id = id
     packobj%ibcnum = ibcnum
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- Return
-    return
   end subroutine rch_create
 
   !> @brief Allocate scalar members
@@ -112,9 +109,6 @@ contains
     ! -- Set values
     this%fixed_cell = .false.
     this%read_as_arrays = .false.
-    !
-    ! -- Return
-    return
   end subroutine rch_allocate_scalars
 
   !> @brief Allocate package arrays
@@ -136,9 +130,6 @@ contains
     ! -- checkin recharge input context pointer
     call mem_checkin(this%recharge, 'RECHARGE', this%memoryPath, &
                      'RECHARGE', this%input_mempath)
-    !
-    ! -- Return
-    return
   end subroutine rch_allocate_arrays
 
   !> @brief Source options specific to RchType
@@ -175,9 +166,6 @@ contains
     !
     ! -- log rch params
     call this%log_rch_options(found_fixed_cell, found_readasarrays)
-    !
-    ! -- Return
-    return
   end subroutine rch_source_options
 
   !> @brief Log options specific to RchType
@@ -209,9 +197,6 @@ contains
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
-    !
-    ! -- Return
-    return
   end subroutine log_rch_options
 
   !> @brief Source the dimensions for this package
@@ -244,9 +229,6 @@ contains
     ! -- Call define_listlabel to construct the list label that is written
     !    when PRINT_INPUT option is used.
     call this%define_listlabel()
-    !
-    ! -- Return
-    return
   end subroutine rch_source_dimensions
 
   !> @brief Part of allocate and read
@@ -258,9 +240,6 @@ contains
     if (this%read_as_arrays) then
       call this%default_nodelist()
     end if
-    !
-    ! -- Return
-    return
   end subroutine rch_read_initial_attr
 
   !> @brief Read and Prepare
@@ -295,9 +274,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- Return
-    return
   end subroutine rch_rp
 
   !> @brief Store nodelist in nodesontop
@@ -318,9 +294,6 @@ contains
     do n = 1, this%nbound
       this%nodesontop(n) = this%nodelist(n)
     end do
-    !
-    ! -- Return
-    return
   end subroutine set_nodesontop
 
   !> @brief Formulate the HCOF and RHS terms
@@ -377,9 +350,6 @@ contains
         cycle
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine rch_cf
 
   !> @brief Copy rhs and hcof into solution rhs and amat
@@ -408,9 +378,6 @@ contains
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))
     end do
-    !
-    ! -- Return
-    return
   end subroutine rch_fc
 
   !> @brief Deallocate memory
@@ -431,9 +398,6 @@ contains
     ! -- arrays
     if (associated(this%nodesontop)) deallocate (this%nodesontop)
     call mem_deallocate(this%recharge, 'RECHARGE', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine rch_da
 
   !> @brief Define the list heading that is written to iout when PRINT_INPUT
@@ -461,9 +425,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine rch_define_listlabel
 
   !> @brief Assign default nodelist when READASARRAYS is specified.
@@ -505,9 +466,6 @@ contains
     ! -- if fixed_cell option not set, then need to store nodelist
     !    in the nodesontop array
     if (.not. this%fixed_cell) call this%set_nodesontop()
-    !
-    ! -- Return
-    return
   end subroutine default_nodelist
 
   ! -- Procedures related to observations
@@ -522,9 +480,6 @@ contains
     class(RchType) :: this
     !
     rch_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function rch_obs_supported
 
   !> @brief Implements bnd_df_obs
@@ -541,9 +496,6 @@ contains
     !
     call this%obs%StoreObsType('rch', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- Return
-    return
   end subroutine rch_df_obs
 
   !> @brief Return requested boundary value
@@ -571,9 +523,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- Return
-    return
   end function rch_bound_value
 
   !> @brief Update the nodelist based on IRCH input
@@ -618,9 +567,6 @@ contains
       call dis%nlarray_to_nodelist(irch, nodelist, &
                                    maxbound, nbound, aname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine nodelist_update
 
 end module RchModule

--- a/src/Model/GroundWaterFlow/gwf-riv.f90
+++ b/src/Model/GroundWaterFlow/gwf-riv.f90
@@ -79,9 +79,6 @@ contains
     packobj%id = id
     packobj%ibcnum = ibcnum
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- Return
-    return
   end subroutine riv_create
 
   !> @brief Deallocate memory
@@ -99,9 +96,6 @@ contains
     call mem_deallocate(this%stage, 'STAGE', this%memoryPath)
     call mem_deallocate(this%cond, 'COND', this%memoryPath)
     call mem_deallocate(this%rbot, 'RBOT', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine riv_da
 
   !> @brief Set options specific to RivType
@@ -124,9 +118,6 @@ contains
     !
     ! -- log riv specific options
     call this%log_riv_options(found)
-    !
-    ! -- Return
-    return
   end subroutine riv_options
 
   !> @brief Log options specific to RivType
@@ -149,9 +140,6 @@ contains
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
-    !
-    ! -- Return
-    return
   end subroutine log_riv_options
 
   !> @brief Allocate package arrays
@@ -179,9 +167,6 @@ contains
                      'COND', this%input_mempath)
     call mem_checkin(this%rbot, 'RBOT', this%memoryPath, &
                      'RBOT', this%input_mempath)
-    !
-    ! -- Return
-    return
   end subroutine riv_allocate_arrays
 
   !> @brief Read and prepare
@@ -206,9 +191,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- Return
-    return
   end subroutine riv_rp
 
   !> @brief Check river boundary condition data
@@ -279,9 +261,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(this%inunit)
     end if
-    !
-    ! -- Return
-    return
   end subroutine riv_ck
 
   !> @brief Formulate the HCOF and RHS terms
@@ -317,9 +296,6 @@ contains
         this%hcof(i) = -criv
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine riv_cf
 
   !> @brief Copy rhs and hcof into solution rhs and amat
@@ -356,9 +332,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(i, qriv)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine riv_fc
 
   !> @brief Define the list heading that is written to iout when PRINT_INPUT
@@ -386,9 +359,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   ! -- Procedures related to observations
@@ -403,9 +373,6 @@ contains
     class(RivType) :: this
     !
     riv_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function riv_obs_supported
 
   !> @brief Store observation type supported by RIV package
@@ -426,9 +393,6 @@ contains
     !    for to-mvr observation type.
     call this%obs%StoreObsType('to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- Return
-    return
   end subroutine riv_df_obs
 
   !> @brief Store user-specified conductance value
@@ -443,9 +407,6 @@ contains
     do n = 1, this%nbound
       this%condinput(n) = this%cond_mult(n)
     end do
-    !
-    ! -- Return
-    return
   end subroutine riv_store_user_cond
 
   !> @brief Apply multiplier to conductance if auxmultcol option is in use
@@ -464,9 +425,6 @@ contains
     else
       cond = this%cond(row)
     end if
-    !
-    ! -- Return
-    return
   end function cond_mult
 
   !> @brief Return requested boundary value
@@ -494,9 +452,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- Return
-    return
   end function riv_bound_value
 
 end module rivmodule

--- a/src/Model/GroundWaterFlow/gwf-sfr.f90
+++ b/src/Model/GroundWaterFlow/gwf-sfr.f90
@@ -328,9 +328,6 @@ contains
     packobj%iscloc = 0 ! not supported
     packobj%isadvpak = 1
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- return
-    return
   end subroutine sfr_create
 
   !> @ brief Allocate scalars
@@ -402,9 +399,6 @@ contains
     this%ivsc = 0
     this%ianynone = 0
     this%ncrossptstot = 0
-    !
-    ! -- return
-    return
   end subroutine sfr_allocate_scalars
 
   !> @ brief Allocate arrays
@@ -614,9 +608,6 @@ contains
     !
     ! -- allocate viscratios to size 0
     call mem_allocate(this%viscratios, 2, 0, 'VISCRATIOS', this%memoryPath)
-    !
-    ! -- return
-    return
   end subroutine sfr_allocate_arrays
 
   !> @ brief Read dimensions for package
@@ -706,9 +697,6 @@ contains
     !
     ! -- setup the stage table object
     call this%sfr_setup_tableobj()
-    !
-    ! -- return
-    return
   end subroutine sfr_read_dimensions
 
   !> @ brief Read additional options for package
@@ -874,9 +862,6 @@ contains
       ! -- No options found
       found = .false.
     end select
-    !
-    ! -- return
-    return
   end subroutine sfr_options
 
   !> @ brief Allocate and read method for package
@@ -945,9 +930,6 @@ contains
       allocate (this%pakmvrobj)
       call this%pakmvrobj%ar(this%maxbound, this%maxbound, this%memoryPath)
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_ar
 
   !> @ brief Read packagedata for the package
@@ -1199,9 +1181,6 @@ contains
     if (this%naux > 0) then
       deallocate (caux)
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_read_packagedata
 
   !> @ brief Read crosssection block for the package
@@ -1341,9 +1320,6 @@ contains
       deallocate (cross_data)
       nullify (cross_data)
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_read_crossection
 
   !> @ brief Read connectiondata for the package
@@ -1622,9 +1598,6 @@ contains
     if (istat == 0) then
       deallocate (order)
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_read_connectiondata
 
   !> @ brief Read diversions for the package
@@ -1825,9 +1798,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_read_diversions
 
   !> @ brief Read initialstages data for the package
@@ -2109,9 +2079,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_rp
 
   !> @ brief Advance the package
@@ -2181,9 +2148,6 @@ contains
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
     call this%obs%obs_ad()
-    !
-    ! -- return
-    return
   end subroutine sfr_ad
 
   !> @ brief Formulate the package hcof and rhs terms.
@@ -2213,9 +2177,6 @@ contains
       this%igwfnode(n) = igwfnode
       this%nodelist(n) = igwfnode
     end do
-    !
-    ! -- return
-    return
   end subroutine sfr_cf
 
   !> @ brief Copy hcof and rhs terms into solution.
@@ -2317,9 +2278,6 @@ contains
       ipos = ia(node)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(n))
     end do
-    !
-    ! -- return
-    return
   end subroutine sfr_fc
 
   !> @ brief Add Newton-Raphson terms for package into solution.
@@ -2371,9 +2329,6 @@ contains
       call matrix_sln%add_value_pos(idxglo(ipos), drterm - this%hcof(i))
       rhs(n) = rhs(n) - rterm + drterm * this%xnew(n)
     end do
-    !
-    ! -- return
-    return
   end subroutine sfr_fn
 
   !> @ brief Convergence check for package.
@@ -2577,9 +2532,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_cc
 
   !> @ brief Calculate package flows.
@@ -2658,9 +2610,6 @@ contains
     !
     ! -- fill the budget object
     call this%sfr_fill_budobj()
-    !
-    ! -- return
-    return
   end subroutine sfr_cq
 
   !> @ brief Output package flow terms.
@@ -2715,9 +2664,6 @@ contains
         call this%budobj%write_flowtable(this%dis, kstp, kper)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_ot_package_flows
 
   !> @ brief Output package dependent-variable terms.
@@ -2831,9 +2777,6 @@ contains
         end if
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_ot_dv
 
   !> @ brief Output advanced package budget summary.
@@ -2852,9 +2795,6 @@ contains
     integer(I4B), intent(in) :: ibudfl !< flag indicating budget should be written
     !
     call this%budobj%write_budtable(kstp, kper, iout, ibudfl, totim, delt)
-    !
-    ! -- return
-    return
   end subroutine sfr_ot_bdsummary
 
   !> @ brief Deallocate package memory
@@ -2994,9 +2934,6 @@ contains
     !
     ! -- call base BndType deallocate
     call this%BndType%bnd_da()
-    !
-    ! -- return
-    return
   end subroutine sfr_da
 
   !> @ brief Define the list label for the package
@@ -3025,9 +2962,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- return
-    return
   end subroutine define_listlabel
 
   !
@@ -3047,9 +2981,6 @@ contains
     !
     ! -- set boolean
     sfr_obs_supported = .true.
-    !
-    ! -- return
-    return
   end function sfr_obs_supported
 
   !> @brief Define the observation types available in the package
@@ -3147,9 +3078,6 @@ contains
     !    for wetted-width observation type.
     call this%obs%StoreObsType('wet-width', .false., indx)
     this%obs%obsData(indx)%ProcessIdPtr => sfr_process_obsID
-    !
-    ! -- return
-    return
   end subroutine sfr_df_obs
 
   !> @brief Save observations for the package
@@ -3243,9 +3171,6 @@ contains
         call this%parser%StoreErrorUnit()
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_bd_obs
 
   !> @brief Read and prepare observations for a package
@@ -3354,9 +3279,6 @@ contains
         call this%parser%StoreErrorUnit()
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_rp_obs
 
   !
@@ -3397,9 +3319,6 @@ contains
     !
     ! -- store reach number (NodeNumber)
     obsrv%NodeNumber = nn1
-    !
-    ! -- return
-    return
   end subroutine sfr_process_obsID
 
   !
@@ -3600,9 +3519,6 @@ contains
         trim(keyword)//'.'
       call store_error(errmsg)
     end select
-    !
-    ! -- return
-    return
   end subroutine sfr_set_stressperiod
 
   !> @brief Solve reach continuity equation
@@ -3852,9 +3768,6 @@ contains
         this%divq(jpos) = DZERO
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_update_flows
 
   !> @brief Adjust runoff and evaporation
@@ -3930,9 +3843,6 @@ contains
     !
     ! -- limit downstream flow to a positive value
     if (qd < DEM30) qd = DZERO
-    !
-    ! -- return
-    return
   end subroutine sfr_calc_qd
 
   !> @brief Calculate sum of sources
@@ -3982,9 +3892,6 @@ contains
     !
     ! -- adjust runoff or evaporation if sum of sources is negative
     call this%sfr_adjust_ro_ev(qsrc, qu, qi, qr, qro, qe, qfrommvr)
-    !
-    ! -- return
-    return
   end subroutine sfr_calc_qsource
 
   !> @brief Calculate streamflow
@@ -4055,9 +3962,6 @@ contains
       ! -- calculate stream flow
       qman = sat * qman
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_calc_qman
 
   !> @brief Calculate reach-aquifer exchange
@@ -4127,9 +4031,6 @@ contains
     ! -- Set gwfhcof and gwfrhs if present
     if (present(gwfhcof)) gwfhcof = gwfhcof0
     if (present(gwfrhs)) gwfrhs = gwfrhs0
-    !
-    ! -- return
-    return
   end subroutine sfr_calc_qgwf
 
   !> @brief Determine if a reach is connected to a gwf cell
@@ -4197,9 +4098,6 @@ contains
         cond = this%hk(n) * vscratio * this%length(n) * wp / this%bthick(n)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_calc_cond
 
   !> @brief Calculate diversion flow
@@ -4258,9 +4156,6 @@ contains
     ! -- update upstream from for downstream reaches
     qd = qd - v
     qdiv = v
-    !
-    ! -- return
-    return
   end subroutine sfr_calc_div
 
   !> @brief Calculate the depth at the midpoint
@@ -4296,9 +4191,6 @@ contains
     else
       d1 = DZERO
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_calc_reach_depth
 
   !> @brief Calculate the depth at the midpoint of a irregular cross-section
@@ -4348,9 +4240,6 @@ contains
         exit nriter
       end if
     end do nriter
-    !
-    ! -- return
-    return
   end subroutine sfr_calc_xs_depth
 
   !> @brief Check unit conversion data
@@ -4388,9 +4277,6 @@ contains
           trim(adjustl(this%packName)), this%unitconv
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_check_conversion
 
   !> @brief Check storage weight
@@ -4535,9 +4421,6 @@ contains
         call this%inputtab%add_term(this%ustrf(n))
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine sfr_check_reaches
 
   !> @brief Check connection data
@@ -4816,9 +4699,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_check_connections
 
   !> @brief Check diversions data
@@ -4926,9 +4806,6 @@ contains
         end if
       end do
     end do
-    !
-    ! -- return
-    return
   end subroutine sfr_check_diversions
 
   !> @brief Check initial stage data
@@ -5190,9 +5067,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine sfr_check_ustrf
 
   !> @brief Setup budget object for package
@@ -5409,9 +5283,6 @@ contains
     if (this%iprflow /= 0) then
       call this%budobj%flowtable_df(this%iout, cellids='GWF')
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_setup_budobj
 
   !> @brief Copy flow terms into budget object for package
@@ -5645,9 +5516,6 @@ contains
     !
     ! --Terms are filled, now accumulate them for this time step
     call this%budobj%accumulate_terms()
-    !
-    ! -- return
-    return
   end subroutine sfr_fill_budobj
 
   !> @brief Setup stage table object for package
@@ -5725,9 +5593,6 @@ contains
       text = 'STREAMBED GRADIENT'
       call this%stagetab%initialize_column(text, 12, alignment=TABCENTER)
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_setup_tableobj
 
   ! -- reach geometry functions
@@ -5759,9 +5624,6 @@ contains
     else
       calc_area_wet = this%station(i0) * depth
     end if
-    !
-    ! -- return
-    return
   end function calc_area_wet
 
   !> @brief Calculate wetted perimeter
@@ -5791,9 +5653,6 @@ contains
     else
       calc_perimeter_wet = this%station(i0) ! no depth dependence in original implementation
     end if
-    !
-    ! -- return
-    return
   end function calc_perimeter_wet
 
   !> @brief Calculate maximum surface area
@@ -5823,9 +5682,6 @@ contains
       top_width = this%station(i0)
     end if
     calc_surface_area = top_width * this%length(n)
-    !
-    ! -- return
-    return
   end function calc_surface_area
 
   !> @brief Calculate wetted surface area
@@ -5846,9 +5702,6 @@ contains
     ! -- Calculate wetted surface area
     top_width = this%calc_top_width_wet(n, depth)
     calc_surface_area_wet = top_width * this%length(n)
-    !
-    ! -- return
-    return
   end function calc_surface_area_wet
 
   !> @brief Calculate wetted top width
@@ -5882,9 +5735,6 @@ contains
     else
       calc_top_width_wet = sat * this%station(i0)
     end if
-    !
-    ! -- return
-    return
   end function calc_top_width_wet
 
   !> @brief Activate density terms
@@ -5912,9 +5762,6 @@ contains
     end do
     write (this%iout, '(/1x,a)') 'DENSITY TERMS HAVE BEEN ACTIVATED FOR SFR &
       &PACKAGE: '//trim(adjustl(this%packName))
-    !
-    ! -- return
-    return
   end subroutine sfr_activate_density
 
   !> @brief Activate viscosity terms
@@ -5943,9 +5790,6 @@ contains
     end do
     write (this%iout, '(/1x,a)') 'VISCOSITY HAS BEEN ACTIVATED FOR SFR &
       &PACKAGE: '//trim(adjustl(this%packName))
-    !
-    ! -- return
-    return
   end subroutine sfr_activate_viscosity
 
   !> @brief Calculate density terms
@@ -6044,9 +5888,6 @@ contains
         flow = flow + d2
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine sfr_calculate_density_exchange
 
 end module SfrModule

--- a/src/Model/GroundWaterFlow/gwf-sto.f90
+++ b/src/Model/GroundWaterFlow/gwf-sto.f90
@@ -94,9 +94,6 @@ contains
     ! -- Set variables
     stoobj%inunit = inunit
     stoobj%iout = iout
-    !
-    ! -- return
-    return
   end subroutine sto_cr
 
   !> @ brief Allocate and read method for package
@@ -144,9 +141,6 @@ contains
     if (this%intvs /= 0) then
       call this%tvs%ar(this%dis)
     end if
-    !
-    ! -- return
-    return
   end subroutine sto_ar
 
   !> @ brief Read and prepare method for package
@@ -200,9 +194,6 @@ contains
     if (this%intvs /= 0) then
       call this%tvs%rp()
     end if
-    !
-    ! -- return
-    return
   end subroutine sto_rp
 
   !> @ brief Advance the package
@@ -225,9 +216,6 @@ contains
     if (this%intvs /= 0) then
       call this%tvs%ad()
     end if
-    !
-    ! -- return
-    return
   end subroutine sto_ad
 
   !> @ brief Fill A and right-hand side for the package
@@ -354,9 +342,6 @@ contains
         rhs(n) = rhs(n) + rhsterm
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine sto_fc
 
   !> @ brief Fill Newton-Raphson terms in A and right-hand side for the package
@@ -451,9 +436,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine sto_fn
 
   !> @ brief Calculate flows for package
@@ -579,9 +561,6 @@ contains
         flowja(idiag) = flowja(idiag) + rate
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine sto_cq
 
   !> @ brief Model budget calculation for package
@@ -613,9 +592,6 @@ contains
       call model_budget%addentry(rin, rout, delt, budtxt(2), &
                                  isuppress_output, '         STORAGE')
     end if
-    !
-    ! -- return
-    return
   end subroutine sto_bd
 
   !> @ brief Save model flows for package
@@ -661,9 +637,6 @@ contains
                                    nwidthp, editdesc, dinact)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine sto_save_model_flows
 
   !> @ brief Deallocate package memory
@@ -715,9 +688,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- return
-    return
   end subroutine sto_da
 
   !> @ brief Allocate scalars
@@ -753,9 +723,6 @@ contains
     this%satomega = DZERO
     this%integratechanges = 0
     this%intvs = 0
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate package arrays
@@ -800,9 +767,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Source input options for package
@@ -863,9 +827,6 @@ contains
     if (this%inewton > 0) then
       this%satomega = DEM6
     end if
-    !
-    ! -- return
-    return
   end subroutine source_options
 
   !> @ brief Log found options for package
@@ -920,9 +881,6 @@ contains
     end if
     !
     write (this%iout, '(1x,a)') 'END OF STORAGE OPTIONS'
-    !
-    ! -- return
-    return
   end subroutine log_options
 
   !> @ brief Source input data for package
@@ -1018,9 +976,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine source_data
 
   !> @ brief Save old storage property values
@@ -1056,9 +1011,6 @@ contains
         this%oldsy(n) = this%sy(n)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine save_old_ss_sy
 
 end module GwfStoModule

--- a/src/Model/GroundWaterFlow/gwf-tvk.f90
+++ b/src/Model/GroundWaterFlow/gwf-tvk.f90
@@ -58,9 +58,6 @@ contains
     !
     allocate (tvk)
     call tvk%init(name_model, 'TVK', 'TVK', inunit, iout)
-    !
-    ! -- Return
-    return
   end subroutine tvk_cr
 
   !> @brief Announce package and set pointers to variables
@@ -92,9 +89,6 @@ contains
     call mem_setptr(this%kchangeper, 'KCHANGEPER', npfMemoryPath)
     call mem_setptr(this%kchangestp, 'KCHANGESTP', npfMemoryPath)
     call mem_setptr(this%nodekchange, 'NODEKCHANGE', npfMemoryPath)
-    !
-    ! -- Return
-    return
   end subroutine tvk_ar_set_pointers
 
   !> @brief Read a TVK-specific option from the OPTIONS block
@@ -111,9 +105,6 @@ contains
     !
     ! -- There are no TVK-specific options, so just return false
     success = .false.
-    !
-    ! -- Return
-    return
   end function tvk_read_option
 
   !> @brief Get an array value pointer given a variable name and node index
@@ -139,9 +130,6 @@ contains
     case default
       bndElem => null()
     end select
-    !
-    ! -- Return
-    return
   end function tvk_get_pointer_to_value
 
   !> @brief Mark property changes as having occurred at (kper, kstp)
@@ -157,9 +145,6 @@ contains
     !
     this%kchangeper = kper
     this%kchangestp = kstp
-    !
-    ! -- Return
-    return
   end subroutine tvk_set_changed_at
 
   !> @brief Clear all per-node change flags
@@ -178,9 +163,6 @@ contains
     do i = 1, this%dis%nodes
       this%nodekchange(i) = 0
     end do
-    !
-    ! -- Return
-    return
   end subroutine tvk_reset_change_flags
 
   !> @brief Check that a given property value is valid
@@ -234,9 +216,6 @@ contains
         call store_error(errmsg)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine tvk_validate_change
 
   !> @brief Deallocate package memory
@@ -259,9 +238,6 @@ contains
     !
     ! -- Deallocate parent
     call tvbase_da(this)
-    !
-    ! -- Return
-    return
   end subroutine tvk_da
 
 end module TvkModule

--- a/src/Model/GroundWaterFlow/gwf-tvs.f90
+++ b/src/Model/GroundWaterFlow/gwf-tvs.f90
@@ -54,9 +54,6 @@ contains
     !
     allocate (tvs)
     call tvs%init(name_model, 'TVS', 'TVS', inunit, iout)
-    !
-    ! -- Return
-    return
   end subroutine tvs_cr
 
   !> @brief Announce package and set pointers to variables
@@ -87,9 +84,6 @@ contains
     !
     ! -- Instruct STO to integrate storage changes, since TVS is active
     this%integratechanges = 1
-    !
-    ! -- Return
-    return
   end subroutine tvs_ar_set_pointers
 
   !> @brief Read a TVS-specific option from the OPTIONS block
@@ -116,9 +110,6 @@ contains
     case default
       success = .false.
     end select
-    !
-    ! -- Return
-    return
   end function tvs_read_option
 
   !> @brief Get an array value pointer given a variable name and node index
@@ -142,9 +133,6 @@ contains
     case default
       bndElem => null()
     end select
-    !
-    ! -- Return
-    return
   end function tvs_get_pointer_to_value
 
   !> @brief Mark property changes as having occurred at (kper, kstp)
@@ -160,9 +148,6 @@ contains
     !
     ! -- No need to record TVS/STO changes, as no other packages cache
     ! -- Ss or Sy values
-    !
-    ! -- Return
-    return
   end subroutine tvs_set_changed_at
 
   !> @brief Clear all per-node change flags
@@ -177,9 +162,6 @@ contains
     !
     ! -- No need to record TVS/STO changes, as no other packages cache
     ! -- Ss or Sy values
-    !
-    ! -- Return
-    return
   end subroutine tvs_reset_change_flags
 
   !> @brief Check that a given property value is valid
@@ -224,9 +206,6 @@ contains
         call store_error(errmsg)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine tvs_validate_change
 
   !> @brief Deallocate package memory
@@ -245,9 +224,6 @@ contains
     !
     ! -- Deallocate parent
     call tvbase_da(this)
-    !
-    ! -- Return
-    return
   end subroutine tvs_da
 
 end module TvsModule

--- a/src/Model/GroundWaterFlow/gwf-uzf.f90
+++ b/src/Model/GroundWaterFlow/gwf-uzf.f90
@@ -208,9 +208,6 @@ contains
     packobj%iscloc = 0 ! not supported
     packobj%isadvpak = 1
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- Return
-    return
   end subroutine uzf_create
 
   !> @brief Allocate and Read
@@ -257,9 +254,6 @@ contains
       allocate (this%pakmvrobj)
       call this%pakmvrobj%ar(this%maxbound, this%maxbound, this%memoryPath)
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzf_ar
 
   !> @brief Allocate arrays used for uzf
@@ -371,9 +365,6 @@ contains
     do i = 1, this%cbcauxitems
       this%qauxcbc(i) = DZERO
     end do
-    !
-    ! -- Return
-    return
   end subroutine uzf_allocate_arrays
 
   !> @brief Set options specific to UzfType
@@ -528,10 +519,8 @@ contains
       ! -- No options found
       found = .false.
     end select
-    ! -- Return
-    return
   end subroutine uzf_options
-!
+
   !> @brief Set dimensions specific to UzfType
   !<
   subroutine uzf_readdimensions(this)
@@ -634,9 +623,6 @@ contains
     !
     ! -- setup the budget object
     call this%uzf_setup_budobj()
-    !
-    ! -- Return
-    return
   end subroutine uzf_readdimensions
 
   !> @brief Read stress data
@@ -929,9 +915,6 @@ contains
     !
     ! -- Save old ss flag
     this%issflagold = this%issflag
-    !
-    ! -- Return
-    return
   end subroutine uzf_rp
 
   !> @brief Advance UZF Package
@@ -1031,9 +1014,6 @@ contains
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine uzf_ad
 
   !> @brief Formulate the HCOF and RHS terms
@@ -1058,9 +1038,6 @@ contains
       this%rch0(n) = this%rch(n)
       this%gwd0(n) = this%gwd(n)
     end do
-    !
-    ! -- Return
-    return
   end subroutine uzf_cf
 
   !> @brief Copy rhs and hcof into solution rhs and amat
@@ -1091,9 +1068,6 @@ contains
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))
     end do
-    !
-    ! -- Return
-    return
   end subroutine uzf_fc
 
   !> @brief Fill newton terms
@@ -1116,9 +1090,6 @@ contains
       call matrix_sln%add_value_pos(idxglo(ipos), this%deriv(i))
       rhs(n) = rhs(n) + this%deriv(i) * this%xnew(n)
     end do
-    !
-    ! -- Return
-    return
   end subroutine uzf_fn
 
   !> @brief Final convergence check for package
@@ -1347,9 +1318,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzf_cc
 
   !> @brief Calculate flows
@@ -1451,9 +1419,6 @@ contains
     !
     ! -- fill the budget object
     call this%uzf_fill_budobj()
-    !
-    ! -- Return
-    return
   end subroutine uzf_cq
 
   function get_storage_change(top, bot, carea, hold, hnew, wcold, wcnew, &
@@ -1488,9 +1453,6 @@ contains
     else
       qsto = DZERO
     end if
-    !
-    ! -- Return
-    return
   end function get_storage_change
 
   !> @brief Add package ratin/ratout to model budget
@@ -1529,9 +1491,6 @@ contains
       call model_budget%addentry(ratin, ratout, delt, this%bdtxt(4), &
                                  isuppress_output, this%packName)
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzf_bd
 
   !> @brief Write flows to binary file and/or print flows to budget
@@ -1607,9 +1566,6 @@ contains
                                   this%auxvar, this%iout, this%inamedbound, &
                                   this%boundname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzf_ot_model_flows
 
   !> @brief Output UZF package flow terms
@@ -1638,9 +1594,6 @@ contains
     if (ibudfl /= 0 .and. this%iprflow /= 0) then
       call this%budobj%write_flowtable(this%dis, kstp, kper)
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzf_ot_package_flows
 
   !> @brief Save UZF-calculated values to binary file
@@ -1668,9 +1621,6 @@ contains
       call ulasav(this%wcnew, '   WATER-CONTENT', kstp, kper, pertim, &
                   totim, this%nodes, 1, 1, ibinun)
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzf_ot_dv
 
   !> @brief Write UZF budget to listing file
@@ -1686,9 +1636,6 @@ contains
     integer(I4B), intent(in) :: ibudfl !< flag indicating budget should be written
     !
     call this%budobj%write_budtable(kstp, kper, iout, ibudfl, totim, delt)
-    !
-    ! -- Return
-    return
   end subroutine uzf_ot_bdsummary
 
   !> @brief Formulate the HCOF and RHS terms
@@ -1808,9 +1755,6 @@ contains
         !
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine uzf_solve
 
   !> @brief Define the list heading that is written to iout when PRINT_INPUT
@@ -1836,9 +1780,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   !> @brief Identify overlying cell ID based on user-specified mapping
@@ -1864,9 +1805,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine findcellabove
 
   !> @brief Read UZF cell properties and set them for UzfCellGroup type
@@ -2104,9 +2042,6 @@ contains
     ! -- deallocate local variables
     deallocate (rowmaxnnz)
     deallocate (nboundchk)
-    !
-    ! -- Return
-    return
   end subroutine read_cell_properties
 
   !> @brief Read UZF cell properties and set them for UZFCellGroup type
@@ -2188,9 +2123,6 @@ contains
         call this%inputtab%add_term(this%uzfname(i))
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine print_cell_properties
 
   !> @brief Check UZF cell areas
@@ -2270,8 +2202,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    ! -- Return
-    return
   end subroutine check_cell_area
 
   ! -- Procedures related to observations (type-bound)
@@ -2285,9 +2215,6 @@ contains
     class(UzfType) :: this
     !
     uzf_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function uzf_obs_supported
 
   !> @brief Implements bnd_df_obs
@@ -2350,9 +2277,6 @@ contains
     !    for water-content observation type.
     call this%obs%StoreObsType('water-content', .false., indx)
     this%obs%obsData(indx)%ProcessIdPtr => uzf_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine uzf_df_obs
 
   !> @brief Calculate observations this time step and call ObsType%SaveOneSimval
@@ -2447,9 +2371,6 @@ contains
         call this%parser%StoreErrorUnit()
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzf_bd_obs
 
   !> @brief Process each observation
@@ -2572,9 +2493,6 @@ contains
         call store_error_unit(this%inunit)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzf_rp_obs
 
   ! -- Procedures related to observations (NOT type-bound)
@@ -2629,9 +2547,6 @@ contains
       ! -- store observations depth
       obsrv%Obsdepth = obsdepth
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzf_process_obsID
 
   !> @brief Allocate scalar members
@@ -2692,9 +2607,6 @@ contains
     !
     ! -- convergence check
     this%iconvchk = 1
-    !
-    ! -- Return
-    return
   end subroutine uzf_allocate_scalars
 
   !> @brief Deallocate objects
@@ -2792,9 +2704,6 @@ contains
     !
     ! -- Parent object
     call this%BndType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine uzf_da
 
   !> @brief Set up the budget object that stores all the uzf flows
@@ -2998,9 +2907,6 @@ contains
     if (this%iprflow /= 0) then
       call this%budobj%flowtable_df(this%iout, cellids='GWF')
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzf_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -3151,9 +3057,6 @@ contains
     !
     ! --Terms are filled, now accumulate them for this time step
     call this%budobj%accumulate_terms()
-    !
-    ! -- Return
-    return
   end subroutine uzf_fill_budobj
 
 end module UzfModule

--- a/src/Model/GroundWaterFlow/gwf-vsc.f90
+++ b/src/Model/GroundWaterFlow/gwf-vsc.f90
@@ -130,9 +130,6 @@ contains
       end if
       ! end if
     end do
-    !
-    ! -- Return
-    return
   end function calc_visc
 
   !> @ brief Create a new package object
@@ -161,9 +158,6 @@ contains
     !
     ! -- Initialize block parser
     call vscobj%parser%Initialize(vscobj%inunit, vscobj%iout)
-    !
-    ! -- Return
-    return
   end subroutine vsc_cr
 
   !> @ brief Define viscosity package options and dimensions
@@ -210,9 +204,6 @@ contains
       ! set from input data instead
       call this%set_packagedata(vsc_input)
     end if
-    !
-    ! -- Return
-    return
   end subroutine vsc_df
 
   !> @ brief Allocate and read method for viscosity package
@@ -230,9 +221,6 @@ contains
     !
     ! -- Set pointers to npf variables
     call this%set_npf_pointers()
-    !
-    ! -- Return
-    return
   end subroutine vsc_ar
 
   !> @brief Activate viscosity in advanced packages
@@ -302,9 +290,6 @@ contains
       !
       ! -- nothing
     end select
-    !
-    ! -- Return
-    return
   end subroutine vsc_ar_bnd
 
   !> @brief Set pointers to NPF variables
@@ -330,9 +315,6 @@ contains
     call mem_setptr(this%kchangeper, 'KCHANGEPER', npfMemoryPath)
     call mem_setptr(this%kchangestp, 'KCHANGESTP', npfMemoryPath)
     call mem_setptr(this%nodekchange, 'NODEKCHANGE', npfMemoryPath)
-    !
-    ! -- Return
-    return
   end subroutine set_npf_pointers
 
   !> @ brief Read new period data in viscosity package
@@ -366,9 +348,6 @@ contains
         call this%parser%StoreErrorUnit()
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine vsc_rp
 
   !> @ brief Advance the viscosity package
@@ -382,9 +361,6 @@ contains
     !
     ! -- update viscosity using the latest concentration/temperature
     call this%vsc_calcvisc()
-    !
-    ! -- Return
-    return
   end subroutine vsc_ad
 
   !> @brief Advance the boundary packages when viscosity is active
@@ -476,9 +452,6 @@ contains
     !
     ! -- deallocate
     deallocate (locconc)
-    !
-    ! -- Return
-    return
   end subroutine vsc_ad_bnd
 
   !> @brief advance ghb while accounting for viscosity
@@ -550,9 +523,6 @@ contains
       end select
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine vsc_ad_standard_bnd
 
   !> @brief Update sfr-related viscosity ratios
@@ -607,9 +577,6 @@ contains
         packobj%viscratios(2, n) = calc_vsc_ratio(viscref, visc(node))
       end do
     end select
-    !
-    ! -- Return
-    return
   end subroutine vsc_ad_sfr
 
   !> @brief Update lak-related viscosity ratios
@@ -664,9 +631,6 @@ contains
         packobj%viscratios(2, n) = calc_vsc_ratio(viscref, visc(node))
       end do
     end select
-    !
-    ! -- Return
-    return
   end subroutine vsc_ad_lak
 
   !> @brief Update maw-related viscosity ratios
@@ -721,9 +685,6 @@ contains
         packobj%viscratios(2, n) = calc_vsc_ratio(viscref, visc(node))
       end do
     end select
-    !
-    ! -- Return
-    return
   end subroutine vsc_ad_maw
 
   !> @brief Apply viscosity to the conductance term
@@ -744,9 +705,6 @@ contains
     !
     ! -- calculate new conductance here
     updatedcond = vscratio * spcfdcond
-    !
-    ! -- Return
-    return
   end function update_bnd_cond
 
   !> @brief calculate and return the viscosity ratio
@@ -759,9 +717,6 @@ contains
     real(DP) :: viscratio
     !
     viscratio = viscref / bndvisc
-    !
-    ! -- Return
-    return
   end function calc_vsc_ratio
 
   !> @ brief Calculate the boundary viscosity
@@ -808,9 +763,6 @@ contains
       ! -- neither of the above, so assign as viscref
       viscbnd = viscref
     end if
-    !
-    ! -- Return
-    return
   end function calc_bnd_viscosity
 
   !> @brief Calculate the viscosity ratio
@@ -838,9 +790,6 @@ contains
       cellid = n
     end if
     call this%calc_q_visc(cellid, viscratio)
-    !
-    ! -- Return
-    return
   end subroutine get_visc_ratio
 
   !> @brief Account for viscosity in the aquiferhorizontal flow barriers
@@ -863,9 +812,6 @@ contains
     !
     ! -- Calculate the viscosity ratio for the
     viscratio = calc_vsc_ratio(this%viscref, visc)
-    !
-    ! -- Return
-    return
   end subroutine calc_q_visc
 
   !> @brief Appled the viscosity ratio (mu_o/mu) to the hydraulic conductivity
@@ -895,9 +841,6 @@ contains
     !
     ! -- Flag kchange
     call this%vsc_set_changed_at(kper, kstp)
-    !
-    ! -- Return
-    return
   end subroutine update_k_with_vsc
 
   !> @brief Mark K changes as having occurred at (kper, kstp)
@@ -913,9 +856,6 @@ contains
     !
     this%kchangeper = kper
     this%kchangestp = kstp
-    !
-    ! -- Return
-    return
   end subroutine vsc_set_changed_at
 
   !> @ brief Output viscosity package dependent-variable terms.
@@ -955,9 +895,6 @@ contains
                                    nwidthp, editdesc, dinact)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine vsc_ot_dv
 
   !> @ brief Deallocate viscosity package memory
@@ -1005,9 +942,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine vsc_da
 
   !> @ brief Read dimensions
@@ -1056,9 +990,6 @@ contains
       call store_error('NVISCSPECIES must be greater than zero.')
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_dimensions
 
   !> @ brief Read data for package
@@ -1163,9 +1094,6 @@ contains
     deallocate (itemp)
     !
     write (this%iout, '(/,1x,a)') 'End of VSC PACKAGEDATA block'
-    !
-    ! -- Return
-    return
   end subroutine read_packagedata
 
   !> @brief Sets package data instead of reading from file
@@ -1183,9 +1111,6 @@ contains
       this%cmodelname(ispec) = input_data%cmodelname(ispec)
       this%cauxspeciesname(ispec) = input_data%cauxspeciesname(ispec)
     end do
-    !
-    ! -- Return
-    return
   end subroutine set_packagedata
 
   !> @brief Calculate fluid viscosity
@@ -1215,9 +1140,6 @@ contains
                                this%cviscref, this%ctemp, this%a2, &
                                this%a3, this%a4)
     end do
-    !
-    ! -- Return
-    return
   end subroutine vsc_calcvisc
 
   !> @ brief Allocate scalars
@@ -1259,9 +1181,6 @@ contains
     this%A4 = 133.15_DP
     !
     this%nviscspecies = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate arrays
@@ -1301,9 +1220,6 @@ contains
       this%cmodelname(i) = ''
       this%cauxspeciesname(i) = ''
     end do
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Read Options block
@@ -1449,9 +1365,6 @@ contains
     end if
     !
     write (this%iout, '(/,1x,a)') 'end of VSC options block'
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @brief Sets options as opposed to reading them from a file
@@ -1462,9 +1375,6 @@ contains
     type(GwfVscInputDataType), intent(in) :: input_data !< the input data to be set
     !
     this%viscref = input_data%viscref
-    !
-    ! -- Return
-    return
   end subroutine set_options
 
   !> @ brief Set pointers to concentration(s)
@@ -1495,9 +1405,6 @@ contains
         exit
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine set_concentration_pointer
 
 end module GwfVscModule

--- a/src/Model/GroundWaterFlow/gwf-wel.f90
+++ b/src/Model/GroundWaterFlow/gwf-wel.f90
@@ -103,9 +103,6 @@ contains
     packobj%id = id
     packobj%ibcnum = ibcnum
     packobj%ictMemPath = create_mem_path(namemodel, 'NPF')
-    !
-    ! -- return
-    return
   end subroutine wel_create
 
   !> @ brief Deallocate package memory
@@ -127,9 +124,6 @@ contains
     call mem_deallocate(this%flowred)
     call mem_deallocate(this%ioutafrcsv)
     call mem_deallocate(this%q, 'Q', this%memoryPath)
-    !
-    ! -- return
-    return
   end subroutine wel_da
 
   !> @ brief Allocate scalars
@@ -156,9 +150,6 @@ contains
     this%iflowred = 0
     this%ioutafrcsv = 0
     this%flowred = DZERO
-    !
-    ! -- return
-    return
   end subroutine wel_allocate_scalars
 
   !> @ brief Allocate arrays
@@ -184,9 +175,6 @@ contains
     ! -- checkin constant head array input context pointer
     call mem_checkin(this%q, 'Q', this%memoryPath, &
                      'Q', this%input_mempath)
-    !
-    ! -- return
-    return
   end subroutine wel_allocate_arrays
 
   !> @ brief Source additional options for package
@@ -239,9 +227,6 @@ contains
     !
     ! -- log WEL specific options
     call this%log_wel_options(found)
-    !
-    ! -- return
-    return
   end subroutine wel_options
 
   !> @ brief Log WEL specific package options
@@ -280,9 +265,6 @@ contains
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
-    !
-    ! -- return
-    return
   end subroutine log_wel_options
 
   !> @ brief WEL read and prepare
@@ -303,9 +285,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- return
-    return
   end subroutine wel_rp
 
   !> @ brief Formulate the package hcof and rhs terms.
@@ -350,8 +329,6 @@ contains
       end if
       this%rhs(i) = -q
     end do
-    !
-    return
   end subroutine wel_cf
 
   !> @ brief Copy hcof and rhs terms into solution.
@@ -390,9 +367,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(i, this%rhs(i))
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine wel_fc
 
   !> @ brief Add Newton-Raphson terms for package into solution.
@@ -447,9 +421,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine wel_fn
 
   !> @brief Initialize the auto flow reduce csv output file
@@ -470,7 +441,6 @@ contains
     write (this%ioutafrcsv, '(a)') &
       'time,period,step,boundnumber,cellnumber,rate-requested,&
       &rate-actual,wel-reduction'
-    return
   end subroutine wel_afr_csv_init
 
   !> @brief Write out auto flow reductions only when & where they occur
@@ -527,9 +497,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- return
-    return
   end subroutine define_listlabel
 
   ! -- Procedures related to observations
@@ -548,9 +515,6 @@ contains
     !
     ! -- set boolean
     wel_obs_supported = .true.
-    !
-    ! -- return
-    return
   end function wel_obs_supported
 
   !> @brief Define the observation types available in the package
@@ -577,9 +541,6 @@ contains
     !    for wel-reduction observation type.
     call this%obs%StoreObsType('wel-reduction', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- return
-    return
   end subroutine wel_df_obs
 
   !> @brief Save observations for the package
@@ -636,9 +597,6 @@ contains
     if (this%ioutafrcsv > 0) then
       call this%wel_afr_csv_write()
     end if
-    !
-    ! -- return
-    return
   end subroutine wel_bd_obs
 
   function q_mult(this, row) result(q)
@@ -655,9 +613,6 @@ contains
     else
       q = this%q(row)
     end if
-    !
-    ! -- return
-    return
   end function q_mult
 
   !> @ brief Return a bound value
@@ -685,9 +640,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- return
-    return
   end function wel_bound_value
 
 end module WelModule

--- a/src/Model/GroundWaterFlow/gwf.f90
+++ b/src/Model/GroundWaterFlow/gwf.f90
@@ -205,9 +205,6 @@ contains
     !
     ! -- create model packages
     call this%create_packages()
-    !
-    ! -- return
-    return
   end subroutine gwf_cr
 
   !> @brief Define packages of the model
@@ -251,9 +248,6 @@ contains
     !
     ! -- Store information needed for observations
     call this%obs%obs_df(this%iout, this%name, 'GWF', this%dis)
-    !
-    ! -- return
-    return
   end subroutine gwf_df
 
   !> @brief Add the internal connections of this model to the sparse matrix
@@ -282,9 +276,6 @@ contains
     !
     ! -- If GNC is active, then add the gnc connections to sparse
     if (this%ingnc > 0) call this%gnc%gnc_ac(sparse)
-    !
-    ! -- return
-    return
   end subroutine gwf_ac
 
   !> @brief Map the positions of this models connections in the
@@ -314,9 +305,6 @@ contains
     ! -- For implicit gnc, need to store positions of gnc connections
     !    in solution matrix connection
     if (this%ingnc > 0) call this%gnc%gnc_mc(matrix_sln)
-    !
-    ! -- return
-    return
   end subroutine gwf_mc
 
   !> @brief GroundWater Flow Model Allocate and Read
@@ -362,9 +350,6 @@ contains
       if (this%inbuy > 0) call this%buy%buy_ar_bnd(packobj, this%x)
       if (this%invsc > 0) call this%vsc%vsc_ar_bnd(packobj)
     end do
-    !
-    ! -- return
-    return
   end subroutine gwf_ar
 
   !> @brief GroundWater Flow Model Read and Prepare
@@ -401,9 +386,6 @@ contains
     !
     ! -- Check for steady state period
     call this%steady_period_check()
-    !
-    ! -- Return
-    return
   end subroutine gwf_rp
 
   !> @brief GroundWater Flow Model Time Step Advance
@@ -457,9 +439,6 @@ contains
     !
     ! -- Push simulated values to preceding time/subtime step
     call this%obs%obs_ad()
-    !
-    ! -- return
-    return
   end subroutine gwf_ad
 
   !> @brief GroundWater Flow Model calculate coefficients
@@ -480,9 +459,6 @@ contains
       call packobj%bnd_cf()
       if (this%inbuy > 0) call this%buy%buy_cf_bnd(packobj, this%x)
     end do
-    !
-    ! -- return
-    return
   end subroutine gwf_cf
 
   !> @brief GroundWater Flow Model fill coefficients
@@ -576,9 +552,6 @@ contains
         call packobj%bnd_fn(this%rhs, this%ia, this%idxglo, matrix_sln)
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine gwf_fc
 
   !> @brief GroundWater Flow Model Final Convergence Check for Boundary Packages
@@ -618,9 +591,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_cc(innertot, kiter, iend, icnvgmod, cpak, ipak, dpak)
     end do
-    !
-    ! -- return
-    return
   end subroutine gwf_cc
 
   !> @brief check if pseudo-transient continuation factor should be used
@@ -644,9 +614,6 @@ contains
         iptc = this%npf%inewton
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine gwf_ptcchk
 
   !> @brief calculate maximum pseudo-transient continuation factor
@@ -717,9 +684,6 @@ contains
     if (iptc == 0) then
       if (iptct > 0) iptc = 1
     end if
-    !
-    ! -- return
-    return
   end subroutine gwf_ptc
 
   !> @brief under-relaxation
@@ -767,9 +731,6 @@ contains
         end if
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine gwf_nur
 
   !> @brief Groundwater flow model calculate flow
@@ -814,9 +775,6 @@ contains
       if (this%inbuy > 0) call this%buy%buy_cf_bnd(packobj, this%x)
       call packobj%bnd_cq(this%x, this%flowja)
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwf_cq
 
   !> @brief GroundWater Flow Model Budget
@@ -863,9 +821,6 @@ contains
         call this%npf%calc_spdis(this%flowja)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_bd
 
   !> @brief GroundWater Flow Model Output
@@ -923,9 +878,6 @@ contains
     if (this%icnvg == 0) then
       write (this%iout, fmtnocnvg) kstp, kper
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwf_ot
 
   !> @brief GroundWater Flow Model output observations
@@ -1036,9 +988,6 @@ contains
     !
     ! -- save head and print head
     call this%oc%oc_ot(ipflag)
-    !
-    ! -- Return
-    return
   end subroutine gwf_ot_dv
 
   !> @brief Groundwater Flow Model output budget summary
@@ -1086,8 +1035,6 @@ contains
     if (this%incsub > 0) then
       call this%csub%csub_fp()
     end if
-    !
-    return
   end subroutine gwf_fp
 
   !> @brief Deallocate
@@ -1163,9 +1110,6 @@ contains
     !
     ! -- NumericalModelType
     call this%NumericalModelType%model_da()
-    !
-    ! -- return
-    return
   end subroutine gwf_da
 
   !> @brief GroundWater Flow Model Budget Entry
@@ -1184,9 +1128,6 @@ contains
     character(len=*), intent(in) :: rowlabel
     !
     call this%budget%addentry(budterm, delt, budtxt, rowlabel=rowlabel)
-    !
-    ! -- return
-    return
   end subroutine gwf_bdentry
 
   !> @brief return 1 if any package causes the matrix to be asymmetric.
@@ -1218,9 +1159,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       if (packobj%iasym /= 0) iasym = 1
     end do
-    !
-    ! -- return
-    return
   end function gwf_get_iasym
 
   !> @brief Allocate memory for non-allocatable members
@@ -1263,9 +1201,6 @@ contains
     this%inobs = 0
     this%iss = 1 !default is steady-state (i.e., no STO package)
     this%inewtonur = 0 !default is to not use newton bottom head dampening
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   !> @brief Create boundary condition packages for this model
@@ -1354,9 +1289,6 @@ contains
       end if
     end do
     call AddBndToList(this%bndlist, packobj)
-    !
-    ! -- return
-    return
   end subroutine package_create
 
   !> @brief Check to make sure required input files have been specified
@@ -1392,9 +1324,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%filename)
     end if
-    !
-    ! -- return
-    return
   end subroutine ftype_check
 
   !> @brief Cast to GWF model
@@ -1410,8 +1339,6 @@ contains
     class is (GwfModelType)
       gwfModel => model
     end select
-    return
-
   end function CastAsGwfModel
 
   !> @brief Source package info and begin to process
@@ -1466,9 +1393,6 @@ contains
       ! -- cleanup
       deallocate (bndpkgs)
     end if
-    !
-    ! -- return
-    return
   end subroutine create_bndpkgs
 
   !> @brief Source package info and begin to process
@@ -1599,9 +1523,6 @@ contains
     call this%ftype_check(indis)
     !
     call this%create_bndpkgs(bndpkgs, pkgtypes, pkgnames, mempaths, inunits)
-    !
-    ! -- return
-    return
   end subroutine create_packages
 
   !> @brief Write model namfile options to list file
@@ -1665,7 +1586,6 @@ contains
         call store_warning(warnmsg)
       end if
     end if
-    return
   end subroutine steady_period_check
 
 end module GwfModule

--- a/src/Model/GroundWaterTransport/gwt-cnc.f90
+++ b/src/Model/GroundWaterTransport/gwt-cnc.f90
@@ -89,9 +89,6 @@ contains
     !
     ! -- Store the appropriate label based on the dependent variable
     cncobj%depvartype = depvartype
-    !
-    ! -- Return
-    return
   end subroutine cnc_create
 
   !> @brief Allocate arrays specific to the constant concentration/tempeature
@@ -125,9 +122,6 @@ contains
     call mem_checkin(this%tspvar, 'TSPVAR', this%memoryPath, &
                      'TSPVAR', this%input_mempath)
     !
-    !
-    ! -- Return
-    return
   end subroutine cnc_allocate_arrays
 
   !> @brief Constant concentration/temperature read and prepare (rp) routine
@@ -179,9 +173,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- Return
-    return
   end subroutine cnc_rp
 
   !> @brief Constant concentration/temperature package advance routine
@@ -213,9 +204,6 @@ contains
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine cnc_ad
 
   !> @brief Check constant concentration/temperature boundary condition data
@@ -248,9 +236,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine cnc_ck
 
   !> @brief Override bnd_fc and do nothing
@@ -266,9 +251,6 @@ contains
     integer(I4B), dimension(:), intent(in) :: idxglo
     class(MatrixBaseType), pointer :: matrix_sln
     ! -- local
-    !
-    ! -- Return
-    return
   end subroutine cnc_fc
 
   !> @brief Calculate flow associated with constant concentration/temperature
@@ -335,9 +317,6 @@ contains
       end do
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine cnc_cq
 
   !> @brief Add package ratin/ratout to model budget
@@ -360,9 +339,6 @@ contains
     call rate_accumulator(this%ratecncout(1:this%nbound), ratout, dum)
     call model_budget%addentry(ratin, ratout, delt, this%text, &
                                isuppress_output, this%packName)
-    !
-    ! -- Return
-    return
   end subroutine cnc_bd
 
   !> @brief Deallocate memory
@@ -382,9 +358,6 @@ contains
     call mem_deallocate(this%ratecncin)
     call mem_deallocate(this%ratecncout)
     call mem_deallocate(this%tspvar, 'TSPVAR', this%memoryPath)
-    !
-    ! -- Return
-    return
   end subroutine cnc_da
 
   !> @brief Define labels used in list file
@@ -413,9 +386,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   !> @brief Procedure related to observation processing
@@ -428,9 +398,6 @@ contains
     class(GwtCncType) :: this
     !
     cnc_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function cnc_obs_supported
 
   !> @brief Procedure related to observation processing
@@ -449,9 +416,6 @@ contains
     !
     call this%obs%StoreObsType(this%filtyp, .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- Return
-    return
   end subroutine cnc_df_obs
 
   ! -- Procedure related to time series
@@ -480,9 +444,6 @@ contains
         end select
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine cnc_rp_ts
 
   !> @brief Apply auxiliary multiplier to specified concentration if
@@ -501,9 +462,6 @@ contains
     else
       conc = this%tspvar(row)
     end if
-    !
-    ! -- Return
-    return
   end function conc_mult
 
   !> @ brief Return a bound value
@@ -530,9 +488,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- Return
-    return
   end function cnc_bound_value
 
 end module GwtCncModule

--- a/src/Model/GroundWaterTransport/gwt-dsp.f90
+++ b/src/Model/GroundWaterTransport/gwt-dsp.f90
@@ -112,9 +112,6 @@ contains
         write (dspobj%iout, fmtdsp) input_mempath
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine dsp_cr
 
   !> @brief Define DSP object
@@ -158,9 +155,6 @@ contains
       this%xt3d%ixt3d = this%ixt3d
       call this%xt3d%xt3d_df(dis)
     end if
-    !
-    ! -- Return
-    return
   end subroutine dsp_df
 
   !> @brief Add connections to DSP
@@ -179,9 +173,6 @@ contains
     !
     ! -- Add extended neighbors (neighbors of neighbors)
     if (this%ixt3d > 0) call this%xt3d%xt3d_ac(moffset, sparse)
-    !
-    ! -- Return
-    return
   end subroutine dsp_ac
 
   !> @brief Map DSP connections
@@ -199,9 +190,6 @@ contains
     !
     ! -- Call xt3d map connections
     if (this%ixt3d > 0) call this%xt3d%xt3d_mc(moffset, matrix_sln)
-    !
-    ! -- Return
-    return
   end subroutine dsp_mc
 
   !> @brief Allocate and read method for package
@@ -223,9 +211,6 @@ contains
     ! -- dsp pointers to arguments that were passed in
     this%ibound => ibound
     this%thetam => thetam
-    !
-    ! -- Return
-    return
   end subroutine dsp_ar
 
   !> @brief Advance method for the package
@@ -260,9 +245,6 @@ contains
         call this%xt3d%xt3d_fcpc(this%dis%nodes, .false.)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine dsp_ad
 
   !> @brief  Fill coefficient method for package
@@ -310,9 +292,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine dsp_fc
 
   !> @ brief Calculate flows for package
@@ -344,9 +323,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine dsp_cq
 
   !> @ brief Allocate scalar variables for package
@@ -397,9 +373,6 @@ contains
     this%iangle1 = 1
     this%iangle2 = 1
     this%iangle3 = 1
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate arrays for package
@@ -436,9 +409,6 @@ contains
     else
       call mem_allocate(this%dispcoef, 0, 'DISPCOEF', trim(this%memoryPath))
     end if
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Deallocate memory
@@ -500,9 +470,6 @@ contains
     !
     ! -- nullify pointers
     this%thetam => null()
-    !
-    ! -- Return
-    return
   end subroutine dsp_da
 
   !> @brief Write user options to list file
@@ -516,8 +483,6 @@ contains
     write (this%iout, '(4x,a,i0)') 'XT3D formulation [0=INACTIVE, 1=ACTIVE, &
                                    &3=ACTIVE RHS] set to: ', this%ixt3d
     write (this%iout, '(1x,a,/)') 'End Setting DSP Options'
-    ! -- Return
-    return
   end subroutine log_options
 
   !> @brief Update simulation mempath options
@@ -546,9 +511,6 @@ contains
     if (this%iout > 0) then
       call this%log_options(found)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_options
 
   !> @brief Write dimensions to list file
@@ -667,9 +629,6 @@ contains
     if (this%iout > 0) then
       call this%log_griddata(found)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_griddata
 
   !> @brief Calculate dispersion coefficients
@@ -781,9 +740,6 @@ contains
         !
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine calcdispellipse
 
   !> @brief Calculate dispersion coefficients
@@ -914,9 +870,6 @@ contains
         !
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine calcdispcoef
 
 end module GwtDspModule

--- a/src/Model/GroundWaterTransport/gwt-ist.f90
+++ b/src/Model/GroundWaterTransport/gwt-ist.f90
@@ -152,9 +152,6 @@ contains
     ! -- Point IST specific variables
     istobj%fmi => fmi
     istobj%mst => mst
-    !
-    ! -- return
-    return
   end subroutine ist_create
 
   !> @ brief Allocate and read method for package
@@ -213,9 +210,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine ist_ar
 
   !> @ brief Read and prepare method for package
@@ -228,9 +222,6 @@ contains
     class(GwtIstType), intent(inout) :: this !< GwtIstType object
     ! -- local
     ! -- format
-    !
-    ! -- return
-    return
   end subroutine ist_rp
 
   !> @ brief Advance the ist package
@@ -264,8 +255,6 @@ contains
         this%cimnew(n) = this%cimold(n)
       end do
     end if
-    !
-    return
   end subroutine ist_ad
 
   !> @ brief Fill coefficient method for package
@@ -613,7 +602,6 @@ contains
     call rate_accumulator(this%strg(:), ratin, ratout)
     call model_budget%addentry(ratin, ratout, delt, this%text, &
                                isuppress_output, this%packName)
-    return
   end subroutine ist_bd
 
   !> @ brief Output model flow terms.
@@ -681,9 +669,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine ist_ot_model_flows
 
   !> @ brief Output dependent variables.
@@ -799,7 +784,6 @@ contains
     !
     ! -- Write budget csv
     call this%budget%writecsv(totim)
-    return
   end subroutine ist_ot_bdsummary
 
   !> @ brief Deallocate package memory
@@ -851,9 +835,6 @@ contains
     !
     ! -- deallocate parent
     call this%BndType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine ist_da
 
   !> @ brief Allocate package scalars
@@ -893,9 +874,6 @@ contains
     ! -- Create the ocd object, which is used to manage printing and saving
     !    of the immobile domain concentrations
     call ocd_cr(this%ocd)
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate package arrays
@@ -985,9 +963,6 @@ contains
     !
     ! -- Set pointers
     this%ocd%dis => this%dis
-    !
-    ! -- return
-    return
   end subroutine ist_allocate_arrays
 
   !> @ brief Read options for package
@@ -1128,9 +1103,6 @@ contains
       write (this%iout, '(1x,a)') 'END OF IMMOBILE STORAGE AND TRANSFER &
                                 &OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @ brief Read dimensions for package
@@ -1143,9 +1115,6 @@ contains
     class(GwtIstType), intent(inout) :: this !< GwtIstType object
     ! -- local
     ! -- format
-    !
-    ! -- return
-    return
   end subroutine ist_read_dimensions
 
   !> @ brief Read data for package
@@ -1374,9 +1343,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_data
 
   !> @ brief Return thetaim
@@ -1393,9 +1359,6 @@ contains
     real(DP) :: thetaim
     !
     thetaim = this%volfrac(node) * this%porosity(node)
-    !
-    ! -- Return
-    return
   end function get_thetaim
 
   !> @ brief Calculate immobile domain equation terms
@@ -1448,9 +1411,6 @@ contains
     !
     ! -- calculate denominator term, f
     f = ddterm(1) + ddterm(3) + ddterm(5) + ddterm(6) + ddterm(9)
-    !
-    ! -- Return
-    return
   end subroutine get_ddterm
 
   !> @ brief Calculate the hcof and rhs terms for immobile domain
@@ -1475,9 +1435,6 @@ contains
     rhs = (ddterm(2) + ddterm(4)) * cimold - ddterm(7) - ddterm(8)
     rhs = rhs * ddterm(9) / f
     rhs = -rhs
-    !
-    ! -- Return
-    return
   end subroutine get_hcofrhs
 
   !> @ brief Calculate the immobile domain concentration
@@ -1499,9 +1456,6 @@ contains
     cimnew = (ddterm(2) + ddterm(4)) * cimold + ddterm(9) * cnew - ddterm(7) &
              - ddterm(8)
     cimnew = cimnew / f
-    !
-    ! -- Return
-    return
   end function get_ddconc
 
   !> @ brief Calculate the immobile domain budget terms
@@ -1581,9 +1535,6 @@ contains
       budterm(2, i) = budterm(2, i) - rate
     end if
     !
-    !
-    ! -- Return
-    return
   end subroutine accumulate_budterm
 
 end module GwtIstModule

--- a/src/Model/GroundWaterTransport/gwt-lkt.f90
+++ b/src/Model/GroundWaterTransport/gwt-lkt.f90
@@ -145,9 +145,6 @@ contains
     lktobj%depvartype = dvt
     lktobj%depvarunit = dvu
     lktobj%depvarunitabbrev = dvua
-    !
-    ! -- Return
-    return
   end subroutine lkt_create
 
   !> @brief Find corresponding lkt package
@@ -267,9 +264,6 @@ contains
         '   MAX NO. OF ENTRIES = ', this%flowbudptr%budterm(ip)%maxlist
     end do
     write (this%iout, '(a, //)') 'DONE PROCESSING '//ftype//' INFORMATION'
-    !
-    ! -- Return
-    return
   end subroutine find_lkt_package
 
   !> @brief Add matrix terms related to LKT
@@ -358,9 +352,6 @@ contains
         rhs(iloc) = rhs(iloc) + rhsval
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lkt_fc_expanded
 
   !> @brief Add terms specific to lakes to the explicit lake solve
@@ -420,9 +411,6 @@ contains
         this%dbuff(n1) = this%dbuff(n1) + rrate
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine lkt_solve
 
   !> @brief Function to return the number of budget terms just for this package.
@@ -439,9 +427,6 @@ contains
     !
     ! -- Number of budget terms is 6
     nbudterms = 6
-    !
-    ! -- Return
-    return
   end function lkt_get_nbudterms
 
   !> @brief Set up the budget object that stores all the lake flows
@@ -535,9 +520,6 @@ contains
                                              this%packName, &
                                              maxlist, .false., .false., &
                                              naux)
-    !
-    ! -- Return
-    return
   end subroutine lkt_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -616,9 +598,6 @@ contains
       call this%budobj%budterm(idx)%update_term(n1, n2, q)
       call this%apt_accumulate_ccterm(n1, q, ccratin, ccratout)
     end do
-    !
-    ! -- Return
-    return
   end subroutine lkt_fill_budobj
 
   !> @brief Allocate scalars specific to the lake mass transport (LKT)
@@ -649,9 +628,6 @@ contains
     this%idxbudiflw = 0
     this%idxbudwdrl = 0
     this%idxbudoutf = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays specific to the lake mass transport (LKT)
@@ -682,9 +658,6 @@ contains
       this%conciflw(n) = DZERO
     end do
     !
-    !
-    ! -- Return
-    return
   end subroutine lkt_allocate_arrays
 
   !> @brief Deallocate memory
@@ -712,9 +685,6 @@ contains
     !
     ! -- deallocate scalars in TspAptType
     call this%TspAptType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine lkt_da
 
   !> @brief Rain term
@@ -740,9 +710,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine lkt_rain_term
 
   !> @brief Evaporative term
@@ -777,9 +744,6 @@ contains
               (DONE - omega) * qbnd * ctmp
     if (present(rhsval)) rhsval = -(DONE - omega) * qbnd * ctmp
     if (present(hcofval)) hcofval = omega * qbnd
-    !
-    ! -- Return
-    return
   end subroutine lkt_evap_term
 
   !> @brief Runoff term
@@ -805,9 +769,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine lkt_roff_term
 
   !> @brief Inflow Term
@@ -836,9 +797,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine lkt_iflw_term
 
   !> @brief Specified withdrawal term
@@ -867,9 +825,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd
-    !
-    ! -- Return
-    return
   end subroutine lkt_wdrl_term
 
   !> @brief Outflow term
@@ -898,9 +853,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd
-    !
-    ! -- Return
-    return
   end subroutine lkt_outf_term
 
   !> @brief Defined observation types
@@ -979,9 +931,6 @@ contains
     !    for ext-outflow observation type.
     call this%obs%StoreObsType('ext-outflow', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => apt_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine lkt_df_obs
 
   !> @brief Process package specific obs
@@ -1015,9 +964,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine lkt_rp_obs
 
   !> @brief Calculate observation value and pass it back to APT
@@ -1061,9 +1007,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine lkt_bd_obs
 
   !> @brief Sets the stress period attributes for keyword use.
@@ -1141,9 +1084,6 @@ contains
     end select
     !
 999 continue
-    !
-    ! -- Return
-    return
   end subroutine lkt_set_stressperiod
 
 end module GwtLktModule

--- a/src/Model/GroundWaterTransport/gwt-mst.f90
+++ b/src/Model/GroundWaterTransport/gwt-mst.f90
@@ -123,9 +123,6 @@ contains
     !
     ! -- Initialize block parser
     call mstobj%parser%Initialize(mstobj%inunit, mstobj%iout)
-    !
-    ! -- Return
-    return
   end subroutine mst_cr
 
   !> @ brief Allocate and read method for package
@@ -160,9 +157,6 @@ contains
     !
     ! -- read the data block
     call this%read_data()
-    !
-    ! -- Return
-    return
   end subroutine mst_ar
 
   !> @ brief Fill coefficient method for package
@@ -204,9 +198,6 @@ contains
       call this%mst_fc_dcy_srb(nodes, cold, nja, matrix_sln, idxglo, rhs, &
                                cnew, kiter)
     end if
-    !
-    ! -- Return
-    return
   end subroutine mst_fc
 
   !> @ brief Fill storage coefficient method for package
@@ -254,9 +245,6 @@ contains
       call matrix_sln%add_value_pos(idxglo(idiag), hhcof)
       rhs(n) = rhs(n) + rrhs
     end do
-    !
-    ! -- Return
-    return
   end subroutine mst_fc_sto
 
   !> @ brief Fill decay coefficient method for package
@@ -315,9 +303,6 @@ contains
       end if
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine mst_fc_dcy
 
   !> @ brief Fill sorption coefficient method for package
@@ -377,9 +362,6 @@ contains
       rhs(n) = rhs(n) + rrhs
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine mst_fc_srb
 
   !> @ brief Calculate sorption terms
@@ -454,7 +436,6 @@ contains
                + term * cbaravg * (swnew - swold)
       end if
     end if
-    return
   end subroutine mst_srb_term
 
   !> @ brief Fill sorption-decay coefficient method for package
@@ -557,9 +538,6 @@ contains
       rhs(n) = rhs(n) + rrhs
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine mst_fc_dcy_srb
 
   !> @ brief Calculate flows for package
@@ -599,9 +577,6 @@ contains
     if (this%isrb /= 0) then
       call this%mst_calc_csrb(cnew)
     end if
-    !
-    ! -- Return
-    return
   end subroutine mst_cq
 
   !> @ brief Calculate storage terms for package
@@ -651,9 +626,6 @@ contains
       idiag = this%dis%con%ia(n)
       flowja(idiag) = flowja(idiag) + rate
     end do
-    !
-    ! -- Return
-    return
   end subroutine mst_cq_sto
 
   !> @ brief Calculate decay terms for package
@@ -709,9 +681,6 @@ contains
       flowja(idiag) = flowja(idiag) + rate
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine mst_cq_dcy
 
   !> @ brief Calculate sorption terms for package
@@ -769,9 +738,6 @@ contains
       flowja(idiag) = flowja(idiag) + rate
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine mst_cq_srb
 
   !> @ brief Calculate decay-sorption terms for package
@@ -872,9 +838,6 @@ contains
       flowja(idiag) = flowja(idiag) + rate
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine mst_cq_dcy_srb
 
   !> @ brief Calculate sorbed concentration
@@ -945,9 +908,6 @@ contains
       call model_budget%addentry(rin, rout, delt, budtxt(4), &
                                  isuppress_output, rowlabel=this%packName)
     end if
-    !
-    ! -- Return
-    return
   end subroutine mst_bd
 
   !> @ brief Output flow terms for package
@@ -1004,9 +964,6 @@ contains
                                    budtxt(4), cdatafmp, nvaluesp, &
                                    nwidthp, editdesc, dinact)
     end if
-    !
-    ! -- Return
-    return
   end subroutine mst_ot_flow
 
   !> @brief Save sorbate concentration array to binary file
@@ -1084,9 +1041,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine mst_da
 
   !> @ brief Allocate scalar variables for package
@@ -1113,9 +1067,6 @@ contains
     this%isrb = 0
     this%ioutsorbate = 0
     this%idcy = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate arrays for package
@@ -1206,9 +1157,6 @@ contains
       this%ratedcys(n) = DZERO
       this%decayslast(n) = DZERO
     end do
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Read options for package
@@ -1312,9 +1260,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF MOBILE STORAGE AND TRANSFER OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @ brief Read data for package
@@ -1512,9 +1457,6 @@ contains
     do n = 1, size(this%porosity)
       this%thetam(n) = this%porosity(n)
     end do
-    !
-    ! -- Return
-    return
   end subroutine read_data
 
   !> @ brief Add volfrac values to volfracim
@@ -1541,9 +1483,6 @@ contains
     do n = 1, this%dis%nodes
       this%thetam(n) = this%get_volfracm(n) * this%porosity(n)
     end do
-    !
-    ! -- Return
-    return
   end subroutine addto_volfracim
 
   !> @ brief Return mobile domain volume fraction
@@ -1560,9 +1499,6 @@ contains
     real(DP) :: volfracm
     !
     volfracm = DONE - this%volfracim(node)
-    !
-    ! -- Return
-    return
   end function get_volfracm
 
   !> @ brief Calculate sorption concentration using Freundlich
@@ -1583,7 +1519,6 @@ contains
     else
       cbar = DZERO
     end if
-    return
   end function
 
   !> @ brief Calculate sorption concentration using Langmuir
@@ -1604,7 +1539,6 @@ contains
     else
       cbar = DZERO
     end if
-    return
   end function
 
   !> @ brief Calculate sorption derivative using Freundlich
@@ -1625,7 +1559,6 @@ contains
     else
       derv = DZERO
     end if
-    return
   end function
 
   !> @ brief Calculate sorption derivative using Langmuir
@@ -1646,7 +1579,6 @@ contains
     else
       derv = DZERO
     end if
-    return
   end function
 
   !> @ brief Get effective Freundlich distribution coefficient
@@ -1664,7 +1596,6 @@ contains
     else
       kd = DZERO
     end if
-    return
   end function get_freundlich_kd
 
   !> @ brief Get effective Langmuir distribution coefficient
@@ -1682,7 +1613,6 @@ contains
     else
       kd = DZERO
     end if
-    return
   end function get_langmuir_kd
 
   !> @ brief Calculate zero-order decay rate and constrain if necessary
@@ -1728,7 +1658,6 @@ contains
       end if
       decay_rate = max(decay_rate, DZERO)
     end if
-    return
   end function get_zero_order_decay
 
 end module GwtMstModule

--- a/src/Model/GroundWaterTransport/gwt-mwt.f90
+++ b/src/Model/GroundWaterTransport/gwt-mwt.f90
@@ -138,9 +138,6 @@ contains
     mwtobj%depvartype = dvt
     mwtobj%depvarunit = dvu
     mwtobj%depvarunitabbrev = dvua
-    !
-    ! -- Return
-    return
   end subroutine mwt_create
 
   !> @brief find corresponding mwt package
@@ -254,9 +251,6 @@ contains
         '   MAX NO. OF ENTRIES = ', this%flowbudptr%budterm(ip)%maxlist
     end do
     write (this%iout, '(a, //)') 'DONE PROCESSING '//ftype//' INFORMATION'
-    !
-    ! -- Return
-    return
   end subroutine find_mwt_package
 
   !> @brief Add matrix terms related to MWT
@@ -323,9 +317,6 @@ contains
         rhs(iloc) = rhs(iloc) + rhsval
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine mwt_fc_expanded
 
   !> @ brief Add terms specific to multi-aquifer wells to the explicit multi-
@@ -370,9 +361,6 @@ contains
         this%dbuff(n1) = this%dbuff(n1) + rrate
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine mwt_solve
 
   !> @brief Function to return the number of budget terms just for this package
@@ -392,9 +380,6 @@ contains
     if (this%idxbudfwrt /= 0) nbudterms = nbudterms + 1
     if (this%idxbudrtmv /= 0) nbudterms = nbudterms + 1
     if (this%idxbudfrtm /= 0) nbudterms = nbudterms + 1
-    !
-    ! -- Return
-    return
   end function mwt_get_nbudterms
 
   !> @brief Set up the budget object that stores all the mwt flows
@@ -466,9 +451,6 @@ contains
                                                maxlist, .false., .false., &
                                                naux)
     end if
-    !
-    ! -- Return
-    return
   end subroutine mwt_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -533,9 +515,6 @@ contains
         call this%apt_accumulate_ccterm(n1, q, ccratin, ccratout)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine mwt_fill_budobj
 
   !> @brief Allocate scalars specific to the streamflow mass transport (SFT)
@@ -562,9 +541,6 @@ contains
     this%idxbudfwrt = 0
     this%idxbudrtmv = 0
     this%idxbudfrtm = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays specific to the streamflow mass transport (SFT)
@@ -589,9 +565,6 @@ contains
       this%concrate(n) = DZERO
     end do
     !
-    !
-    ! -- Return
-    return
   end subroutine mwt_allocate_arrays
 
   !> @brief Deallocate memory
@@ -614,9 +587,6 @@ contains
     !
     ! -- deallocate scalars in TspAptType
     call this%TspAptType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine mwt_da
 
   !> @brief Rate term associated with pumping (or injection)
@@ -652,9 +622,6 @@ contains
     if (present(rrate)) rrate = qbnd * ctmp
     if (present(rhsval)) rhsval = r
     if (present(hcofval)) hcofval = h
-    !
-    ! -- Return
-    return
   end subroutine mwt_rate_term
 
   !> @brief Transport matrix term(s) associated with a flowing-
@@ -681,9 +648,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd
-    !
-    ! -- Return
-    return
   end subroutine mwt_fwrt_term
 
   !> @brief Rate-to-mvr term associated with pumping (or injection)
@@ -712,9 +676,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd
-    !
-    ! -- Return
-    return
   end subroutine mwt_rtmv_term
 
   !> @brief Flowing well rate-to-mvr term (or injection)
@@ -743,9 +704,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd
-    !
-    ! -- Return
-    return
   end subroutine mwt_frtm_term
 
   !> @brief Observations
@@ -812,9 +770,6 @@ contains
     !    for observation type.
     call this%obs%StoreObsType('fw-rate-to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => apt_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine mwt_df_obs
 
   !> @brief Process package specific obs
@@ -841,9 +796,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine mwt_rp_obs
 
   !> @brief Calculate observation value and pass it back to APT
@@ -879,9 +831,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine mwt_bd_obs
 
   !> @brief Sets the stress period attributes for keyword use.
@@ -923,9 +872,6 @@ contains
     end select
     !
 999 continue
-    !
-    ! -- Return
-    return
   end subroutine mwt_set_stressperiod
 
 end module GwtMwtModule

--- a/src/Model/GroundWaterTransport/gwt-sft.f90
+++ b/src/Model/GroundWaterTransport/gwt-sft.f90
@@ -142,9 +142,6 @@ contains
     sftobj%depvartype = dvt
     sftobj%depvarunit = dvu
     sftobj%depvarunitabbrev = dvua
-    !
-    ! -- Return
-    return
   end subroutine sft_create
 
   !> @brief Find corresponding sft package
@@ -261,9 +258,6 @@ contains
         '   MAX NO. OF ENTRIES = ', this%flowbudptr%budterm(ip)%maxlist
     end do
     write (this%iout, '(a, //)') 'DONE PROCESSING '//ftype//' INFORMATION'
-    !
-    ! -- Return
-    return
   end subroutine find_sft_package
 
   !> @brief Add matrix terms related to SFT
@@ -341,9 +335,6 @@ contains
         rhs(iloc) = rhs(iloc) + rhsval
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine sft_fc_expanded
 
   !> @brief Add terms specific to sft to the explicit sft solve
@@ -395,9 +386,6 @@ contains
         this%dbuff(n1) = this%dbuff(n1) + rrate
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine sft_solve
 
   !> @brief Function to return the number of budget terms just for this package.
@@ -414,9 +402,6 @@ contains
     !
     ! -- Number of budget terms is 5
     nbudterms = 5
-    !
-    ! -- Return
-    return
   end function sft_get_nbudterms
 
   !> @brief Set up the budget object that stores all the sft flows
@@ -495,9 +480,6 @@ contains
                                              this%packName, &
                                              maxlist, .false., .false., &
                                              naux)
-    !
-    ! -- return
-    return
   end subroutine sft_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -566,9 +548,6 @@ contains
       call this%budobj%budterm(idx)%update_term(n1, n2, q)
       call this%apt_accumulate_ccterm(n1, q, ccratin, ccratout)
     end do
-    !
-    ! -- Return
-    return
   end subroutine sft_fill_budobj
 
   !> @brief Allocate scalars specific to the streamflow energy transport (SFE)
@@ -597,9 +576,6 @@ contains
     this%idxbudroff = 0
     this%idxbudiflw = 0
     this%idxbudoutf = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays specific to the streamflow energy transport (SFE)
@@ -629,9 +605,6 @@ contains
       this%concroff(n) = DZERO
       this%conciflw(n) = DZERO
     end do
-    !
-    ! -- Return
-    return
   end subroutine sft_allocate_arrays
 
   !> @brief Deallocate memory
@@ -658,9 +631,6 @@ contains
     !
     ! -- deallocate scalars in TspAptType
     call this%TspAptType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine sft_da
 
   !> @brief Rain term
@@ -686,9 +656,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine sft_rain_term
 
   !> @brief Evaporative term
@@ -723,9 +690,6 @@ contains
               (DONE - omega) * qbnd * ctmp
     if (present(rhsval)) rhsval = -(DONE - omega) * qbnd * ctmp
     if (present(hcofval)) hcofval = omega * qbnd
-    !
-    ! -- Return
-    return
   end subroutine sft_evap_term
 
   !> @brief Runoff term
@@ -751,9 +715,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine sft_roff_term
 
   !> @brief Inflow Term
@@ -783,9 +744,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = -rrate
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine sft_iflw_term
 
   !> @brief Outflow term
@@ -814,9 +772,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd
-    !
-    ! -- Return
-    return
   end subroutine sft_outf_term
 
   !> @brief Observations
@@ -890,9 +845,6 @@ contains
     !    for ext-outflow observation type.
     call this%obs%StoreObsType('ext-outflow', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => apt_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine sft_df_obs
 
   !> @brief Process package specific obs
@@ -923,9 +875,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine sft_rp_obs
 
   !> @brief Calculate observation value and pass it back to APT
@@ -965,9 +914,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine sft_bd_obs
 
   !> @brief Sets the stress period attributes for keyword use.
@@ -1045,9 +991,6 @@ contains
     end select
     !
 999 continue
-    !
-    ! -- Return
-    return
   end subroutine sft_set_stressperiod
 
 end module GwtSftModule

--- a/src/Model/GroundWaterTransport/gwt-src.f90
+++ b/src/Model/GroundWaterTransport/gwt-src.f90
@@ -79,9 +79,6 @@ contains
     !
     ! -- Store the appropriate label based on the dependent variable
     srcobj%depvartype = depvartype
-    !
-    ! -- return
-    return
   end subroutine src_create
 
   !> @brief Deallocate memory
@@ -96,9 +93,6 @@ contains
     call this%BndType%bnd_da()
     !
     ! -- scalars
-    !
-    ! -- Return
-    return
   end subroutine src_da
 
   !> @brief Allocate scalars
@@ -116,9 +110,6 @@ contains
     ! -- allocate the object and assign values to object variables
     !
     ! -- Set values
-    !
-    ! -- Return
-    return
   end subroutine src_allocate_scalars
 
   !> @brief Formulate the HCOF and RHS terms
@@ -148,9 +139,6 @@ contains
       q = this%bound(1, i)
       this%rhs(i) = -q
     end do
-    !
-    ! -- Return
-    return
   end subroutine src_cf
 
   !> @brief Add matrix terms related to specified mass source loading
@@ -185,9 +173,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(i, this%rhs(i))
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine src_fc
 
   !> @brief Define list labels
@@ -216,9 +201,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   ! -- Procedures related to observations
@@ -234,9 +216,6 @@ contains
     class(GwtSrcType) :: this
     !
     src_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function src_obs_supported
 
   !> @brief Define observations
@@ -259,9 +238,6 @@ contains
     !    for to-mvr observation type.
     call this%obs%StoreObsType('to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- Return
-    return
   end subroutine src_df_obs
 
   !> @brief Procedure related to time series
@@ -286,9 +262,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine src_rp_ts
 
 end module GwtSrcModule

--- a/src/Model/GroundWaterTransport/gwt-uzt.f90
+++ b/src/Model/GroundWaterTransport/gwt-uzt.f90
@@ -131,9 +131,6 @@ contains
     uztobj%depvartype = dvt
     uztobj%depvarunit = dvu
     uztobj%depvarunitabbrev = dvua
-    !
-    ! -- Return
-    return
   end subroutine uzt_create
 
   !> @brief Find corresponding uzt package
@@ -247,9 +244,6 @@ contains
         '   MAX NO. OF ENTRIES = ', this%flowbudptr%budterm(ip)%maxlist
     end do
     write (this%iout, '(a, //)') 'DONE PROCESSING '//ftype//' INFORMATION'
-    !
-    ! -- Return
-    return
   end subroutine find_uzt_package
 
   !> @brief Add matrix terms related to UZT
@@ -316,9 +310,6 @@ contains
         rhs(iloc) = rhs(iloc) + rhsval
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzt_fc_expanded
 
   !> @brief Explicit solve
@@ -364,9 +355,6 @@ contains
         this%dbuff(n1) = this%dbuff(n1) + rrate
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzt_solve
 
   !> @brief Function that returns the number of budget terms for this package
@@ -387,9 +375,6 @@ contains
     if (this%idxbudrinf /= 0) nbudterms = nbudterms + 1
     if (this%idxbuduzet /= 0) nbudterms = nbudterms + 1
     if (this%idxbudritm /= 0) nbudterms = nbudterms + 1
-    !
-    ! -- Return
-    return
   end function uzt_get_nbudterms
 
   !> @brief Override similarly named function in APT
@@ -475,9 +460,6 @@ contains
                                                maxlist, .false., .false., &
                                                naux)
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzt_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -541,9 +523,6 @@ contains
         call this%apt_accumulate_ccterm(n1, q, ccratin, ccratout)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine uzt_fill_budobj
 
   !> @brief Allocate scalar variables for package
@@ -571,9 +550,6 @@ contains
     this%idxbudrinf = 0
     this%idxbuduzet = 0
     this%idxbudritm = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays for package
@@ -600,9 +576,6 @@ contains
       this%concinfl(n) = DZERO
       this%concuzet(n) = DZERO
     end do
-    !
-    ! -- Return
-    return
   end subroutine uzt_allocate_arrays
 
   !> @brief Deallocate memory
@@ -628,9 +601,6 @@ contains
     !
     ! -- deallocate scalars in TspAptType
     call this%TspAptType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine uzt_da
 
   !> @brief Infiltration term
@@ -669,9 +639,6 @@ contains
     if (present(rrate)) rrate = qbnd * ctmp
     if (present(rhsval)) rhsval = r
     if (present(hcofval)) hcofval = h
-    !
-    ! -- Return
-    return
   end subroutine uzt_infl_term
 
   !> @brief Rejected infiltration term
@@ -702,9 +669,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd
-    !
-    ! -- Return
-    return
   end subroutine uzt_rinf_term
 
   !> @brief Evapotranspiration from the unsaturated-zone term
@@ -742,9 +706,6 @@ contains
               (DONE - omega) * qbnd * ctmp
     if (present(rhsval)) rhsval = -(DONE - omega) * qbnd * ctmp
     if (present(hcofval)) hcofval = omega * qbnd
-    !
-    ! -- Return
-    return
   end subroutine uzt_uzet_term
 
   !> @brief Rejected infiltration to MVR/MVT term
@@ -775,9 +736,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd
-    !
-    ! -- Return
-    return
   end subroutine uzt_ritm_term
 
   !> @brief Define UZT Observation
@@ -846,9 +804,6 @@ contains
     !    for observation type.
     call this%obs%StoreObsType('rej-inf-to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => apt_process_obsID
-    !
-    ! -- Return
-    return
   end subroutine uzt_df_obs
 
   !> @brief Process package specific obs
@@ -875,8 +830,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    return
   end subroutine uzt_rp_obs
 
   !> @brief Calculate observation value and pass it back to APT
@@ -912,9 +865,6 @@ contains
     case default
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine uzt_bd_obs
 
   !> @brief Sets the stress period attributes for keyword use.
@@ -967,9 +917,6 @@ contains
     end select
     !
 999 continue
-    !
-    ! -- Return
-    return
   end subroutine uzt_set_stressperiod
 
 end module GwtUztModule

--- a/src/Model/GroundWaterTransport/gwt.f90
+++ b/src/Model/GroundWaterTransport/gwt.f90
@@ -135,9 +135,6 @@ contains
     !
     ! -- create model packages
     call this%create_packages(indis)
-    !
-    ! -- Return
-    return
   end subroutine gwt_cr
 
   !> @brief Define packages of the GWT model
@@ -194,9 +191,6 @@ contains
     !
     ! -- Store information needed for observations
     call this%obs%obs_df(this%iout, this%name, 'GWT', this%dis)
-    !
-    ! -- Return
-    return
   end subroutine gwt_df
 
   !> @brief Add the internal connections of this model to the sparse matrix
@@ -221,9 +215,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_ac(this%moffset, sparse)
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwt_ac
 
   !> @brief Map the positions of the GWT model connections in the numerical
@@ -248,9 +239,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_mc(this%moffset, matrix_sln)
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwt_mc
 
   !> @brief GWT Model Allocate and Read
@@ -302,9 +290,6 @@ contains
       ! -- Read and allocate package
       call packobj%bnd_ar()
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwt_ar
 
   !> @brief GWT Model Read and Prepare
@@ -335,9 +320,6 @@ contains
       call packobj%bnd_rp()
       call packobj%bnd_rp_obs()
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwt_rp
 
   !> @brief GWT Model time step size
@@ -414,9 +396,6 @@ contains
     !
     ! -- Push simulated values to preceding time/subtime step
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine gwt_ad
 
   !> @brief GWT Model calculate coefficients
@@ -437,9 +416,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_cf()
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwt_cf
 
   !> @brief GWT Model fill coefficients
@@ -484,9 +460,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_fc(this%rhs, this%ia, this%idxglo, matrix_sln)
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwt_fc
 
   !> @brief GWT Model Final Convergence Check
@@ -513,9 +486,6 @@ contains
     !
     ! -- If mover is on, then at least 2 outers required
     if (this%inmvt > 0) call this%mvt%mvt_cc(kiter, iend, icnvgmod, cpak, dpak)
-    !
-    ! -- Return
-    return
   end subroutine gwt_cc
 
   !> @brief GWT Model calculate flow
@@ -562,9 +532,6 @@ contains
     !    This results in the flow residual being stored in the diagonal
     !    position for each cell.
     call csr_diagsum(this%dis%con%ia, this%flowja)
-    !
-    ! -- Return
-    return
   end subroutine gwt_cq
 
   !> @brief GWT Model Budget
@@ -599,9 +566,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       call packobj%bnd_bd(this%budget)
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwt_bd
 
   !> @brief GWT model output routine
@@ -700,9 +664,6 @@ contains
     !
     ! -- NumericalModelType
     call this%NumericalModelType%model_da()
-    !
-    ! -- Return
-    return
   end subroutine gwt_da
 
   !> @brief GroundWater Transport Model Budget Entry
@@ -722,9 +683,6 @@ contains
     character(len=*), intent(in) :: rowlabel
     !
     call this%budget%addentry(budterm, delt, budtxt, rowlabel=rowlabel)
-    !
-    ! -- Return
-    return
   end subroutine gwt_bdentry
 
   !> @brief return 1 if any package causes the matrix to be asymmetric.
@@ -755,9 +713,6 @@ contains
       packobj => GetBndFromList(this%bndlist, ip)
       if (packobj%iasym /= 0) iasym = 1
     end do
-    !
-    ! -- Return
-    return
   end function gwt_get_iasym
 
   !> Allocate memory for non-allocatable members
@@ -782,9 +737,6 @@ contains
     !
     this%inmst = 0
     this%indsp = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Create boundary condition packages for this model
@@ -864,9 +816,6 @@ contains
       end if
     end do
     call AddBndToList(this%bndlist, packobj)
-    !
-    ! -- Return
-    return
   end subroutine package_create
 
   !> @brief Cast to GwtModelType
@@ -881,9 +830,6 @@ contains
     type is (GwtModelType)
       gwtmodel => model
     end select
-    !
-    ! -- Return
-    return
   end function CastAsGwtModel
 
   !> @brief Source package info and begin to process
@@ -938,9 +884,6 @@ contains
       ! -- cleanup
       deallocate (bndpkgs)
     end if
-    !
-    ! -- Return
-    return
   end subroutine create_bndpkgs
 
   !> @brief Source package info and begin to process
@@ -1018,9 +961,6 @@ contains
     call this%ftype_check(indis, this%inmst)
     !
     call this%create_bndpkgs(bndpkgs, pkgtypes, pkgnames, mempaths, inunits)
-    !
-    ! -- Return
-    return
   end subroutine create_gwt_packages
 
 end module GwtModule

--- a/src/Model/ModelUtilities/BoundaryPackage.f90
+++ b/src/Model/ModelUtilities/BoundaryPackage.f90
@@ -225,9 +225,6 @@ contains
       call this%obs%obs_df(this%iout, this%packName, this%filtyp, this%dis)
       call this%bnd_df_obs()
     end if
-    !
-    ! -- return
-    return
   end subroutine bnd_df
 
   !> @ brief Add boundary package connection to matrix
@@ -245,9 +242,6 @@ contains
     class(BndType), intent(inout) :: this !< BndType object
     integer(I4B), intent(in) :: moffset !< solution matrix model offset
     type(sparsematrix), intent(inout) :: sparse !< sparse object
-    !
-    ! -- return
-    return
   end subroutine bnd_ac
 
   !> @ brief Map boundary package connection to matrix
@@ -262,9 +256,6 @@ contains
     class(BndType), intent(inout) :: this !< BndType object
     integer(I4B), intent(in) :: moffset !< solution matrix model offset
     class(MatrixBaseType), pointer :: matrix_sln !< global system matrix
-    !
-    ! -- return
-    return
   end subroutine bnd_mc
 
   !> @ brief Allocate and read method for boundary package
@@ -294,9 +285,6 @@ contains
       allocate (this%pakmvrobj)
       call this%pakmvrobj%ar(this%maxbound, 0, this%memoryPath)
     end if
-    !
-    ! -- return
-    return
   end subroutine bnd_ar
 
   !> @ brief Allocate and read method for package
@@ -394,9 +382,6 @@ contains
     else
       write (this%iout, fmtlsp) trim(this%filtyp)
     end if
-    !
-    ! -- return
-    return
   end subroutine bnd_rp
 
   !> @ brief Advance the boundary package
@@ -425,8 +410,6 @@ contains
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
     call this%obs%obs_ad()
-    !
-    return
   end subroutine bnd_ad
 
   !> @ brief Check boundary package period data
@@ -441,9 +424,6 @@ contains
     !
     ! -- check stress period data
     ! -- each package must override generic functionality
-    !
-    ! -- return
-    return
   end subroutine bnd_ck
 
   !> @ brief Reset bnd package before formulating
@@ -470,9 +450,6 @@ contains
     class(BndType) :: this !< BndType object
     !
     ! -- bnd has no cf routine
-    !
-    ! -- return
-    return
   end subroutine bnd_cf
 
   !> @ brief Copy hcof and rhs terms into solution.
@@ -502,9 +479,6 @@ contains
       ipos = ia(n)
       call matrix_sln%add_value_pos(idxglo(ipos), this%hcof(i))
     end do
-    !
-    ! -- return
-    return
   end subroutine bnd_fc
 
   !> @ brief Add Newton-Raphson terms for package into solution.
@@ -525,9 +499,6 @@ contains
     !
     ! -- No addition terms for Newton-Raphson with constant conductance
     !    boundary conditions
-    !
-    ! -- return
-    return
   end subroutine bnd_fn
 
   !> @ brief Apply Newton-Raphson under-relaxation for package.
@@ -552,9 +523,6 @@ contains
     ! -- local variables
     !
     ! -- Newton-Raphson under-relaxation
-    !
-    ! -- return
-    return
   end subroutine bnd_nur
 
   !> @ brief Convergence check for package.
@@ -580,9 +548,6 @@ contains
     real(DP), intent(inout) :: dpak !< maximum dependent variable change
     !
     ! -- No addition convergence check for boundary conditions
-    !
-    ! -- return
-    return
   end subroutine bnd_cc
 
   !> @ brief Calculate advanced package flows.
@@ -621,9 +586,6 @@ contains
     if (imover == 1) then
       call this%bnd_cq_simtomvr(flowja)
     end if
-    !
-    ! -- return
-    return
   end subroutine bnd_cq
 
   !> @ brief Calculate simrate.
@@ -669,9 +631,6 @@ contains
         !
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine bnd_cq_simrate
 
   !> @ brief Calculate flow to the mover.
@@ -739,9 +698,6 @@ contains
         !
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine bnd_cq_simtomvr
 
   !> @ brief Add package flows to model budget.
@@ -778,9 +734,6 @@ contains
       call model_budget%addentry(ratin, ratout, delt, text, &
                                  isuppress_output, this%packName)
     end if
-    !
-    ! -- return
-    return
   end subroutine bnd_bd
 
   !> @ brief Output advanced package flow terms.
@@ -797,9 +750,6 @@ contains
     integer(I4B), intent(in) :: ibudfl !< flag indication if cell-by-cell data should be saved
     !
     ! -- override for advanced packages
-    !
-    ! -- return
-    return
   end subroutine bnd_ot_package_flows
 
   !> @ brief Output advanced package dependent-variable terms.
@@ -816,9 +766,6 @@ contains
     integer(I4B), intent(in) :: idvprint !< flag indicating if dependent-variable should be written to the model listing file
     !
     ! -- override for advanced packages
-    !
-    ! -- return
-    return
   end subroutine bnd_ot_dv
 
   !> @ brief Output advanced package budget summary.
@@ -837,9 +784,6 @@ contains
     integer(I4B), intent(in) :: ibudfl !< flag indicating budget should be written
     !
     ! -- override for advanced packages
-    !
-    ! -- return
-    return
   end subroutine bnd_ot_bdsummary
 
   !> @ brief Output package flow terms.
@@ -904,9 +848,6 @@ contains
                                   this%auxname, this%auxvar, this%iout, &
                                   this%inamedbound, this%boundname)
     end if
-    !
-    ! -- return
-    return
   end subroutine bnd_ot_model_flows
 
   !> @ brief Deallocate package memory
@@ -999,9 +940,6 @@ contains
     !
     ! -- Deallocate parent object
     call this%NumericalPackageType%da()
-    !
-    ! -- return
-    return
   end subroutine bnd_da
 
   !> @ brief Allocate package scalars
@@ -1078,9 +1016,6 @@ contains
     call mem_setptr(imodelnewton, 'INEWTON', create_mem_path(this%name_model))
     this%inewton = imodelnewton
     imodelnewton => null()
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate package arrays
@@ -1188,9 +1123,6 @@ contains
     !
     ! -- setup the output table
     call this%pak_setup_outputtab()
-    !
-    ! -- return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Allocate and initialize select package members
@@ -1203,9 +1135,6 @@ contains
   subroutine pack_initialize(this)
     ! -- dummy variables
     class(BndType) :: this !< BndType object
-    !
-    ! -- return
-    return
   end subroutine pack_initialize
 
   !> @ brief Set pointers to model variables
@@ -1229,8 +1158,6 @@ contains
     this%xnew => xnew
     this%xold => xold
     this%flowja => flowja
-    !
-    ! -- return
   end subroutine set_pointers
 
   !> @ brief Read additional options for package
@@ -1436,9 +1363,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine bnd_read_options
 
   !> @ brief Read dimensions for package
@@ -1501,9 +1425,6 @@ contains
     ! -- Call define_listlabel to construct the list label that is written
     !    when PRINT_INPUT option is used.
     call this%define_listlabel()
-    !
-    ! -- return
-    return
   end subroutine bnd_read_dimensions
 
   !> @ brief Store user-specified conductances when vsc is active
@@ -1530,9 +1451,6 @@ contains
     do l = 1, nlist
       condinput(l) = rlist(2, l)
     end do
-    !
-    ! -- return
-    return
   end subroutine bnd_store_user_cond
 
   !> @ brief Read initial parameters for package
@@ -1545,9 +1463,6 @@ contains
   subroutine bnd_read_initial_attr(this)
     ! -- dummy
     class(BndType), intent(inout) :: this !< BndType object
-    !
-    ! -- return
-    return
   end subroutine bnd_read_initial_attr
 
   !> @ brief Read additional options for package
@@ -1565,9 +1480,6 @@ contains
     !
     ! Return with found = .false.
     found = .false.
-    !
-    ! -- return
-    return
   end subroutine bnd_options
 
   !> @ brief Copy boundnames into boundnames_cst
@@ -1589,9 +1501,6 @@ contains
         this%boundname_cst(i) = this%boundname(i)
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine copy_boundname
 
   !> @ brief Setup output table for package
@@ -1635,9 +1544,6 @@ contains
                                               alignment=TABLEFT)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine pak_setup_outputtab
 
   !> @ brief Define the list label for the package
@@ -1649,9 +1555,6 @@ contains
   subroutine define_listlabel(this)
     ! -- dummy variables
     class(BndType), intent(inout) :: this !< BndType object
-    !
-    ! -- return
-    return
   end subroutine define_listlabel
 
   ! -- Procedures related to observations
@@ -1673,9 +1576,6 @@ contains
     !
     ! -- initialize return variables
     supported = .false.
-    !
-    ! -- return
-    return
   end function bnd_obs_supported
 
   !> @brief Define the observation types available in the package
@@ -1691,9 +1591,6 @@ contains
     class(BndType) :: this !< BndType object
     !
     ! -- do nothing here. Override as needed.
-    !
-    ! -- return
-    return
   end subroutine bnd_df_obs
 
   !> @brief Read and prepare observations for a package
@@ -1756,8 +1653,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(this%inunit)
     end if
-    !
-    return
   end subroutine bnd_rp_obs
 
   !> @brief Save observations for the package
@@ -1803,9 +1698,6 @@ contains
         call this%obs%SaveOneSimval(obsrv, DNODATA)
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine bnd_bd_obs
 
   !> @brief Output observations for the package
@@ -1820,9 +1712,6 @@ contains
     !
     ! -- call the observation output method
     call this%obs%obs_ot()
-    !
-    ! -- return
-    return
   end subroutine bnd_ot_obs
 
   ! -- Procedures related to time series
@@ -1837,9 +1726,6 @@ contains
   subroutine bnd_rp_ts(this)
     ! -- dummy variables
     class(BndType), intent(inout) :: this
-    !
-    ! -- return
-    return
   end subroutine bnd_rp_ts
 
   ! -- Procedures related to casting
@@ -1864,9 +1750,6 @@ contains
     class is (BndType)
       res => obj
     end select
-    !
-    ! -- return
-    return
   end function CastAsBndClass
 
   !> @brief Add boundary to package list
@@ -1883,9 +1766,6 @@ contains
     !
     obj => bnd
     call list%Add(obj)
-    !
-    ! -- return
-    return
   end subroutine AddBndToList
 
   !> @brief Get boundary from package list
@@ -1906,9 +1786,6 @@ contains
     ! -- get the package from the list
     obj => list%GetItem(idx)
     res => CastAsBndClass(obj)
-    !
-    ! -- return
-    return
   end function GetBndFromList
 
   !> @brief Save and/or print flows for a package
@@ -2066,9 +1943,6 @@ contains
       end if
 
     end if
-    !
-    ! -- return
-    return
   end subroutine save_print_model_flows
 
   !> @brief Activate viscosity terms
@@ -2100,9 +1974,6 @@ contains
     !    boundary package.
     write (this%iout, '(/1x,a,a)') 'VISCOSITY ACTIVE IN ', &
       trim(this%filtyp)//' PACKAGE CALCULATIONS: '//trim(adjustl(this%packName))
-    !
-    ! -- return
-    return
   end subroutine bnd_activate_viscosity
 
 end module BndModule

--- a/src/Model/ModelUtilities/BoundaryPackageExt.f90
+++ b/src/Model/ModelUtilities/BoundaryPackageExt.f90
@@ -123,9 +123,6 @@ contains
       call this%obs%obs_df(this%iout, this%packName, this%filtyp, this%dis)
       call this%bnd_df_obs()
     end if
-    !
-    ! -- return
-    return
   end subroutine bndext_df
 
   subroutine bndext_rp(this)
@@ -154,9 +151,6 @@ contains
         this%boundname(n) = this%boundname_cst(n)
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine bndext_rp
 
   !> @ brief Deallocate package memory
@@ -181,9 +175,6 @@ contains
     !
     ! -- deallocate
     call this%BndType%bnd_da()
-    !
-    ! -- return
-    return
   end subroutine bndext_da
 
   !> @ brief Allocate package scalars
@@ -212,9 +203,6 @@ contains
     !
     ! -- set pointers to period input data scalars
     call mem_setptr(this%iper, 'IPER', input_mempath)
-    !
-    ! -- return
-    return
   end subroutine bndext_allocate_scalars
 
   !> @ brief Allocate package arrays
@@ -256,9 +244,6 @@ contains
       call mem_checkin(this%auxvar, 'AUXVAR_IDM', this%memoryPath, &
                        'AUXVAR', this%input_mempath)
     end if
-    !
-    ! -- return
-    return
   end subroutine bndext_allocate_arrays
 
   !> @ brief Source package options from input context
@@ -356,9 +341,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- return
-    return
   end subroutine source_options
 
   !> @ brief Log package options
@@ -416,9 +398,6 @@ contains
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' BASE OPTIONS'
-    !
-    ! -- return
-    return
   end subroutine log_options
 
   !> @ brief Source package dimensions from input context
@@ -454,9 +433,6 @@ contains
     ! -- Call define_listlabel to construct the list label that is written
     !    when PRINT_INPUT option is used.
     call this%define_listlabel()
-    !
-    ! -- return
-    return
   end subroutine source_dimensions
 
   !> @ brief Update package nodelist
@@ -520,9 +496,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end if
-    !
-    ! -- return
-    return
   end subroutine nodelist_update
 
   !> @ brief Check for valid cellid
@@ -580,9 +553,6 @@ contains
       !
     case default
     end select
-    !
-    ! -- return
-    return
   end subroutine check_cellid
 
   !> @ brief Log package list input
@@ -745,9 +715,6 @@ contains
     deallocate (inputtab)
     nullify (inputtab)
     deallocate (words)
-    !
-    ! -- return
-    return
   end subroutine write_list
 
   !> @ brief Return a bound value
@@ -770,9 +737,6 @@ contains
     ! -- override this return value by redefining this
     !    routine in the derived package.
     bndval = DNODATA
-    !
-    ! -- return
-    return
   end function bound_value
 
 end module BndExtModule

--- a/src/Model/ModelUtilities/Connections.f90
+++ b/src/Model/ModelUtilities/Connections.f90
@@ -101,9 +101,6 @@ contains
     call mem_deallocate(this%ihc)
     call mem_deallocate(this%cl1)
     call mem_deallocate(this%cl2)
-    !
-    ! -- Return
-    return
   end subroutine con_da
 
   !> @brief Allocate scalars for ConnectionsType
@@ -129,9 +126,6 @@ contains
     this%nja = 0
     this%njas = 0
     this%ianglex = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays for ConnectionsType
@@ -157,9 +151,6 @@ contains
     ! -- let mask point to ja, which is always nonzero,
     !    until someone decides to do a 'set_mask'
     this%mask => this%ja
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief Finalize connection data
@@ -320,9 +311,6 @@ contains
         this%anglex(n) = DNODATA
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine con_finalize
 
   !> @brief Read and process IAC and JA from an an input block called
@@ -444,9 +432,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_connectivity_from_block
 
   !> @brief Using a vector of cell lengths, calculate the cl1 and cl2 arrays.
@@ -468,9 +453,6 @@ contains
         this%cl2(this%jas(ii)) = fleng(m) * DHALF
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine set_cl1_cl2_from_fleng
 
   !> @brief Construct the connectivity arrays for a structured
@@ -711,9 +693,6 @@ contains
     !    them to ia and ja.
     nodesuser = nlay * nrow * ncol
     call this%iajausr(nrsize, nodesuser, nodereduced, nodeuser)
-    !
-    ! -- Return
-    return
   end subroutine disconnections
 
   !> @brief Construct the connectivity arrays using cell disv information
@@ -812,9 +791,6 @@ contains
     !    them to ia and ja.
     nodesuser = nlay * ncpl
     call this%iajausr(nrsize, nodesuser, nodereduced, nodeuser)
-    !
-    ! -- Return
-    return
   end subroutine disvconnections
 
   !> @brief Construct the connectivity arrays using disu information.  Grid
@@ -947,9 +923,6 @@ contains
     ! -- If reduced system, then need to build iausr and jausr, otherwise point
     !    them to ia and ja.
     call this%iajausr(nrsize, nodesuser, nodereduced, nodeuser)
-    !
-    ! -- Return
-    return
   end subroutine disuconnections
 
   !> @brief Fill the connections object for a disv1d package from vertices
@@ -1178,9 +1151,6 @@ contains
       call mem_setptr(this%iausr, 'IA', this%memoryPath)
       call mem_setptr(this%jausr, 'JA', this%memoryPath)
     end if
-    !
-    ! -- Return
-    return
   end subroutine iajausr
 
   !> @brief Get the index in the JA array corresponding to the connection
@@ -1226,7 +1196,6 @@ contains
     ! -- If execution reaches here, no connection exists
     !    between nodes of interest.
     getjaindex = 0 ! indicates no connection exists
-    return
   end function getjaindex
 
   !> @brief Function to fill the isym array
@@ -1257,9 +1226,6 @@ contains
         end if
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine fillisym
 
   !> @brief Function to fill the jas array
@@ -1297,9 +1263,6 @@ contains
         end if
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine filljas
 
   !> @brief Routine to make cell connections from vertices
@@ -1393,9 +1356,6 @@ contains
         end do
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine vertexconnect
 
   !> @brief Routine to make cell connections from vertices
@@ -1483,9 +1443,6 @@ contains
     !
     ! -- set the mask value
     this%mask(ipos) = maskVal
-    !
-    ! -- Return
-    return
   end subroutine set_mask
 
   !> @brief Convert an iac array into an ia array
@@ -1511,9 +1468,6 @@ contains
       ia(n) = ia(n - 1) + 1
     end do
     ia(1) = 1
-    !
-    ! -- Return
-    return
   end subroutine iac_to_ia
 
   !> @brief Is cell m is connected to the downstream end of cell n

--- a/src/Model/ModelUtilities/Disv1dGeom.f90
+++ b/src/Model/ModelUtilities/Disv1dGeom.f90
@@ -21,9 +21,6 @@ contains
     xdist = abs(vertices(1, ivert1) - vertices(1, ivert2))
     ydist = abs(vertices(2, ivert1) - vertices(2, ivert2))
     dist = sqrt(xdist * xdist + ydist * ydist)
-
-    ! -- return
-    return
   end function calcdist
 
   !> @brief Calculate distance between two vertices
@@ -48,7 +45,6 @@ contains
     vmag = sqrt(dx**2 + dy**2)
     xcomp = dx / vmag
     ycomp = dy / vmag
-    return
   end subroutine line_unit_vector
 
 end module Disv1dGeom

--- a/src/Model/ModelUtilities/DisvGeom.f90
+++ b/src/Model/ModelUtilities/DisvGeom.f90
@@ -102,9 +102,6 @@ contains
       this%nodered = this%nodeusr
     end if
     call this%cell_setup()
-    !
-    ! -- Return
-    return
   end subroutine set_kj
 
   !> @brief Set reduced node number
@@ -124,9 +121,6 @@ contains
     !
     call get_jk(this%nodeusr, this%ncpl, this%nlay, this%j, this%k)
     call this%cell_setup()
-    !
-    ! -- Return
-    return
   end subroutine set_nodered
 
   !> @brief Set top and bottom elevations of grid cell
@@ -205,9 +199,6 @@ contains
         ax = anglex(x1, y1, x2, y2)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine cprops
 
   !> @brief Return the x and y components of an outward normal facing vector
@@ -238,9 +229,6 @@ contains
     y2 = this%vertex_grid(2, ivert2)
     !
     call line_unit_normal(x1, y1, x2, y2, xcomp, ycomp)
-    !
-    ! -- Return
-    return
   end subroutine edge_normal
 
   !> @brief Return the x y and z components of a unit vector that points from
@@ -278,9 +266,6 @@ contains
     !
     call line_unit_vector(x1, y1, z1, x2, y2, z2, xcomp, ycomp, zcomp, &
                           conlen)
-    !
-    ! -- Return
-    return
   end subroutine connection_vector
 
   !> @brief Return true if this shares a horizontal edge with cell2
@@ -306,9 +291,6 @@ contains
     if (ivert1 == 0 .or. ivert2 == 0) then
       l = .false.
     end if
-    !
-    ! -- Return
-    return
   end function shares_edge
 
   !> @brief Find two common vertices shared by cell1 and cell2.
@@ -401,9 +383,6 @@ contains
     end do
     !
     area = abs(area) * DHALF
-    !
-    ! -- Return
-    return
   end function get_area
 
   !> @brief Calculate the angle that the x-axis makes with a line that is
@@ -430,9 +409,6 @@ contains
     dy = y2 - y1
     ax = atan2(dx, -dy)
     if (ax < DZERO) ax = DTWO * DPI + ax
-    !
-    ! -- Return
-    return
   end function anglex
 
   !> @brief Calculate distance between two points
@@ -448,9 +424,6 @@ contains
     !
     d = (x1 - x2)**2 + (y1 - y2)**2
     d = sqrt(d)
-    !
-    ! -- Return
-    return
   end function distance
 
   !> @brief Calculate normal distance from point (x0, y0) to line defined by
@@ -469,9 +442,6 @@ contains
     !
     d = abs((x2 - x1) * (y1 - y0) - (x1 - x0) * (y2 - y1))
     d = d / distance(x1, y1, x2, y2)
-    !
-    ! -- Return
-    return
   end function distance_normal
 
   !> @brief Calculate the normal vector components (xcomp and ycomp) for a line
@@ -493,9 +463,6 @@ contains
     vmag = sqrt(dx**2 + dy**2)
     xcomp = -dy / vmag
     ycomp = dx / vmag
-    !
-    ! -- Return
-    return
   end subroutine line_unit_normal
 
   !> @brief Calculate the vector components (xcomp, ycomp, and zcomp) for a
@@ -526,9 +493,6 @@ contains
     xcomp = dx / vmag
     ycomp = dy / vmag
     zcomp = dz / vmag
-    !
-    ! -- Return
-    return
   end subroutine line_unit_vector
 
 end module DisvGeom

--- a/src/Model/ModelUtilities/FlowModelInterface.f90
+++ b/src/Model/ModelUtilities/FlowModelInterface.f90
@@ -126,9 +126,6 @@ contains
     !    transport model since conduction will still be simulated.
     !    0: GWE (skip deactivation step); 1: GWT (default: use existing code)
     this%idryinactive = idryinactive
-    !
-    ! -- Return
-    return
   end subroutine fmi_df
 
   !> @brief Allocate the package
@@ -145,9 +142,6 @@ contains
     !
     ! -- Allocate arrays
     call this%allocate_arrays(this%dis%nodes)
-    !
-    ! -- Return
-    return
   end subroutine fmi_ar
 
   !> @brief Deallocate variables
@@ -192,9 +186,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine fmi_da
 
   !> @brief Allocate scalars
@@ -231,9 +222,6 @@ contains
     this%iumvr = 0
     this%nflowpack = 0
     this%idryinactive = 1
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate arrays
@@ -294,9 +282,6 @@ contains
       !    connected GWF model, so allocate gwfpackages to zero
       if (this%inunit == 0) call this%allocate_gwfpackages(this%nflowpack)
     end if
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief Read options from input file
@@ -336,9 +321,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF FMI OPTIONS'
     end if
-    !
-    ! -- return
-    return
   end subroutine read_options
 
   !> @brief Read packagedata block from input file
@@ -436,9 +418,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF FMI PACKAGEDATA'
     end if
-    !
-    ! -- return
-    return
   end subroutine read_packagedata
 
   !> @brief Initialize the budget file reader
@@ -836,9 +815,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine initialize_gwfterms_from_bfr
 
   !> @brief Initialize gwf terms from a GWF exchange
@@ -902,7 +878,6 @@ contains
         iterm = iterm + 1
       end if
     end do
-    return
   end subroutine initialize_gwfterms_from_gwfbndlist
 
   !> @brief Allocate budget packages
@@ -940,9 +915,6 @@ contains
       write (memPath, '(a, i0)') trim(this%memoryPath)//'-FT', n
       call this%gwfpackages(n)%initialize(memPath)
     end do
-    !
-    ! -- return
-    return
   end subroutine allocate_gwfpackages
 
   !> @brief Deallocate memory in the gwfpackages array
@@ -958,9 +930,6 @@ contains
     do n = 1, this%nflowpack
       call this%gwfpackages(n)%da()
     end do
-    !
-    ! -- return
-    return
   end subroutine deallocate_gwfpackages
 
   !> @brief Find the package index for the package with the given name
@@ -985,9 +954,6 @@ contains
       call store_error('Error in get_package_index.  Could not find '//name, &
                        terminate=.TRUE.)
     end if
-    !
-    ! -- return
-    return
   end subroutine get_package_index
 
 end module FlowModelInterfaceModule

--- a/src/Model/ModelUtilities/GwfConductanceUtils.f90
+++ b/src/Model/ModelUtilities/GwfConductanceUtils.f90
@@ -368,7 +368,6 @@ contains
       end if
       res = DHALF * (thksatn + thksatm)
     end if
-    return
   end function thksatnm
 
   !> @brief Calculate the thickness fraction for staggered grids

--- a/src/Model/ModelUtilities/GwfMvrPeriodData.f90
+++ b/src/Model/ModelUtilities/GwfMvrPeriodData.f90
@@ -67,8 +67,6 @@ contains
     call mem_allocate(this%id2, maxsize, 'ID2', memoryPath)
     call mem_allocate(this%imvrtype, maxsize, 'IMVRTYPE', memoryPath)
     call mem_allocate(this%value, maxsize, 'VALUE', memoryPath)
-
-    return
   end subroutine construct
 
   !> @ brief Fill the arrays from parser
@@ -144,7 +142,6 @@ contains
       i = i + 1
     end do
     nmvr = i - 1
-    return
   end subroutine read_from_parser
 
   !> @ brief Destroy memory
@@ -169,8 +166,6 @@ contains
     call mem_deallocate(this%id2)
     call mem_deallocate(this%imvrtype)
     call mem_deallocate(this%value)
-
-    return
   end subroutine destroy
 
 end module GwfMvrPeriodDataModule

--- a/src/Model/ModelUtilities/GwfStorageUtils.f90
+++ b/src/Model/ModelUtilities/GwfStorageUtils.f90
@@ -85,9 +85,6 @@ contains
     if (present(rate)) then
       rate = aterm * hnew - rhsterm
     end if
-    !
-    ! -- return
-    return
   end subroutine SsTerms
 
   !> @brief Calculate the specific yield storage terms
@@ -134,9 +131,6 @@ contains
     if (present(rate)) then
       rate = rho2old * tthk * snold - rho2 * tthk * snnew
     end if
-    !
-    ! -- return
-    return
   end subroutine SyTerms
 
   !> @brief Calculate the specific storage capacity
@@ -163,9 +157,6 @@ contains
       thick = DONE
     end if
     sc1 = ss * thick * area
-    !
-    ! -- return
-    return
   end function SsCapacity
 
   !> @brief Calculate the specific yield capacity
@@ -183,9 +174,6 @@ contains
     real(DP) :: sc2
     ! -- calculate specific yield capacity
     sc2 = sy * area
-    !
-    ! -- return
-    return
   end function SyCapacity
 
 end module GwfStorageUtilsModule

--- a/src/Model/ModelUtilities/ModelPackageInput.f90
+++ b/src/Model/ModelUtilities/ModelPackageInput.f90
@@ -74,9 +74,6 @@ contains
       pkgtypes = [PRT_BASEPKG, PRT_MULTIPKG]
     case default
     end select
-    !
-    ! -- return
-    return
   end subroutine supported_model_packages
 
   !> @brief Is the package multi-instance
@@ -146,9 +143,6 @@ contains
       !
     case default
     end select
-    !
-    ! -- return
-    return
   end function multi_package_type
 
 end module ModelPackageInputModule

--- a/src/Model/ModelUtilities/Mover.f90
+++ b/src/Model/ModelUtilities/Mover.f90
@@ -82,8 +82,6 @@ contains
 
     ! to be set later
     this%iRchNrSrcMapped = -1
-
-    return
   end subroutine set_values
 
   !> @ brief Prepare object
@@ -183,9 +181,6 @@ contains
       end if
       this%qfrommvr_ptr => temp_ptr(this%iRchNrTgt)
     end if
-    !
-    ! -- return
-    return
   end subroutine prepare
 
   !> @ brief Echo data to list file
@@ -206,9 +201,6 @@ contains
       ' TO ID: ', this%iRchNrTgt
     write (iout, '(4x, a, a, a, 1pg15.6,/)') 'MOVER TYPE: ', &
       trim(mvrtypes(this%imvrtype)), ' ', this%value
-    !
-    ! -- return
-    return
   end subroutine echo
 
   !> @ brief Advance
@@ -221,9 +213,6 @@ contains
     ! -- dummy
     class(MvrType) :: this
     ! -- local
-    !
-    ! -- return
-    return
   end subroutine advance
 
   !> @ brief Formulate coefficients
@@ -257,9 +246,6 @@ contains
     ! -- Reduce the amount of water that is available in the provider package
     !    qformvr array.
     this%qformvr_ptr = this%qformvr_ptr - qpactual
-    !
-    ! -- return
-    return
   end subroutine update_provider
 
   !> @ brief Formulate coefficients
@@ -272,9 +258,6 @@ contains
     ! -- Add the calculated qpactual term directly into the receiver package
     !    qfrommvr array.
     this%qfrommvr_ptr = this%qfrommvr_ptr + this%qpactual
-    !
-    ! -- return
-    return
   end subroutine update_receiver
 
   !> @ brief Flow to receiver
@@ -323,9 +306,6 @@ contains
         qr = qa
       end if
     end select
-    !
-    ! -- return
-    return
   end function qrcalc
 
   !> @ brief Write flow
@@ -345,9 +325,6 @@ contains
     !
     write (iout, fmt) trim(this%mem_path_src), this%iRchNrSrc, this%qavailable, &
       this%qpactual, trim(this%mem_path_tgt), this%iRchNrTgt
-    !
-    ! -- return
-    return
   end subroutine writeflow
 
 end module MvrModule

--- a/src/Model/ModelUtilities/PackageMover.f90
+++ b/src/Model/ModelUtilities/PackageMover.f90
@@ -81,9 +81,6 @@ contains
     this%nreceivers = nreceivers
     !
     call this%allocate_arrays()
-    !
-    ! -- return
-    return
   end subroutine ar
 
   subroutine ad(this)
@@ -95,9 +92,6 @@ contains
       this%qtomvr(i) = DZERO
       this%qformvr(i) = DZERO
     end do
-    !
-    ! -- return
-    return
   end subroutine ad
 
   subroutine reset(this)
@@ -113,9 +107,6 @@ contains
       this%qtomvr(i) = DZERO
       this%qtformvr(i) = this%qformvr(i)
     end do
-    !
-    ! -- return
-    return
   end subroutine reset
 
   subroutine fc(this)
@@ -126,9 +117,6 @@ contains
     do i = 1, this%nproviders
       this%qformvr(i) = DZERO
     end do
-    !
-    ! -- return
-    return
   end subroutine fc
 
   subroutine da(this)
@@ -148,9 +136,6 @@ contains
     !
     ! -- pointers
     nullify (this%iprmap)
-    !
-    ! -- return
-    return
   end subroutine da
 
   subroutine allocate_scalars(this)
@@ -161,9 +146,6 @@ contains
     !
     this%nproviders = 0
     this%nreceivers = 0
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   subroutine allocate_arrays(this)
@@ -189,9 +171,6 @@ contains
       this%qfrommvr(i) = DZERO
       this%qfrommvr0(i) = DZERO
     end do
-    !
-    ! -- return
-    return
   end subroutine allocate_arrays
 
   function get_qfrommvr(this, ireceiver) result(qfrommvr)

--- a/src/Model/ModelUtilities/SfrCrossSectionManager.f90
+++ b/src/Model/ModelUtilities/SfrCrossSectionManager.f90
@@ -75,9 +75,6 @@ contains
     this%iout => iout
     this%iprpak => iprpak
     this%nreaches => nreaches
-    !
-    ! -- Return
-    return
   end subroutine cross_section_cr
 
   !> @brief Initialize a cross-section object
@@ -139,9 +136,6 @@ contains
         ipos = ipos + 1
       end do
     end do
-    !
-    ! -- return
-    return
   end subroutine initialize
 
   !> @brief Read a cross-section table
@@ -319,9 +313,6 @@ contains
     !
     ! -- validate the table
     call this%validate(irch)
-    !
-    ! -- return
-    return
   end subroutine read_table
 
   !> @brief Validate cross-section tables
@@ -461,9 +452,6 @@ contains
     ! -- deallocate local storage
     deallocate (heights)
     deallocate (unique_heights)
-    !
-    ! -- return
-    return
   end subroutine validate
 
   !> @brief Write cross-section tables
@@ -626,9 +614,6 @@ contains
         'listing file for more information.'
       call store_warning(warnmsg)
     end if
-    !
-    ! -- return
-    return
   end subroutine output
 
   !> @brief Get the total number of cross-section points
@@ -649,9 +634,6 @@ contains
     do n = 1, this%nreaches
       nptstot = nptstot + this%npoints(n)
     end do
-    !
-    ! -- return
-    return
   end function get_ncrossptstot
 
   !> @brief Pack the cross-section object
@@ -689,9 +671,6 @@ contains
       end do
       iacross(n + 1) = ipos
     end do
-    !
-    ! -- return
-    return
   end subroutine pack
 
   !> @brief Deallocate the cross-section object
@@ -738,9 +717,6 @@ contains
     nullify (this%iout)
     nullify (this%iprpak)
     nullify (this%nreaches)
-    !
-    ! -- return
-    return
   end subroutine destroy
 
 end module sfrCrossSectionManager

--- a/src/Model/ModelUtilities/SfrCrossSectionUtils.f90
+++ b/src/Model/ModelUtilities/SfrCrossSectionUtils.f90
@@ -44,9 +44,6 @@ contains
     else
       w = stations(1)
     end if
-    !
-    ! -- return
-    return
   end function get_saturated_topwidth
 
   !> @brief Calculate the wetted top width for a reach
@@ -77,9 +74,6 @@ contains
     do n = 1, npts - 1
       w = w + widths(n)
     end do
-    !
-    ! -- return
-    return
   end function get_wetted_topwidth
 
   !> @brief Calculate wetted vertical height
@@ -112,9 +106,6 @@ contains
         vwf = heights(n + 2) - heights(n + 1)
       end if
     end if
-    !
-    ! -- return
-    return
   end function get_wet_vert_face
 
   !> @brief Calculate the wetted perimeter for a reach
@@ -145,9 +136,6 @@ contains
     do n = 1, npts - 1
       p = p + perimeters(n)
     end do
-    !
-    ! -- return
-    return
   end function get_wetted_perimeter
 
   !> @brief Calculate the cross-sectional area for a reach
@@ -178,9 +166,6 @@ contains
     do n = 1, npts - 1
       a = a + areas(n)
     end do
-    !
-    ! -- return
-    return
   end function get_cross_section_area
 
   !> @brief Calculate the hydraulic radius for a reach
@@ -231,9 +216,6 @@ contains
       ! -- calculate the hydraulic radius
       r = a / p
     end if
-    !
-    ! -- return
-    return
   end function get_hydraulic_radius
 
   !> @brief Calculate the manning's discharge for a reach
@@ -300,9 +282,6 @@ contains
       end do
       q = conv_fact * conveyance * sqrt(slope)
     end if
-    !
-    ! -- return
-    return
   end function get_mannings_section
 
   ! -- private functions and subroutines
@@ -343,9 +322,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine determine_vert_neighbors
 
   !> @brief Calculate the wetted perimeters for each line segment
@@ -427,9 +403,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine get_wetted_perimeters
 
   !> @brief Calculate the cross-sectional areas for each line segment
@@ -490,9 +463,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine get_cross_section_areas
 
   !> @brief Calculate the wetted top widths for each line segment
@@ -533,9 +503,6 @@ contains
       ! -- calculate the wetted top width for the segment
       w(n) = x1 - x0
     end do
-    !
-    ! -- return
-    return
   end subroutine get_wetted_topwidths
 
   !> @brief Calculate the station values for the wetted portion of the cross-section
@@ -599,9 +566,6 @@ contains
       x0 = xt0
       x1 = xt1
     end if
-    !
-    ! -- return
-    return
   end subroutine get_wetted_station
 
 end module GwfSfrCrossSectionUtilsModule

--- a/src/Model/ModelUtilities/SwfCxsUtils.f90
+++ b/src/Model/ModelUtilities/SwfCxsUtils.f90
@@ -62,9 +62,6 @@ contains
                                    cxs_xf, cxs_h, cxs_rf, unitconv, &
                                    icalcmeth)
     end if
-    !
-    ! -- return
-    return
   end function calc_depth_from_q
 
   !> @brief Calculate the depth at the midpoint of a irregular cross-section
@@ -129,9 +126,6 @@ contains
     !
     ! TODO: raise an error
     print *, "bisection routine failed"
-    !
-    ! -- return
-    return
   end function calc_depth_from_q_bisect
 
   !> @brief Calculate the depth at the midpoint of a irregular cross-section
@@ -204,9 +198,6 @@ contains
 
     end do nriter
     depth = d
-    !
-    ! -- return
-    return
   end function calc_depth_from_q_nr
 
   !> @brief Calculate streamflow using Manning's equation
@@ -250,9 +241,6 @@ contains
                                  cxs_xf, cxs_h, cxs_rf, unitconv, &
                                  linmeth)
     end select
-    !
-    ! -- return
-    return
   end function calc_qman
 
   function calc_qman_composite(depth, width, rough, slope, &
@@ -304,9 +292,6 @@ contains
       call sChSmooth(depth, sat, derv)
       qman = sat * qman
     end if
-    !
-    ! -- return
-    return
   end function calc_qman_composite
 
   function calc_composite_roughness(npts, depth, width, rough, slope, &
@@ -371,9 +356,6 @@ contains
       end if
 
     end if
-    !
-    ! -- return
-    return
   end function calc_composite_roughness
 
   function calc_qman_by_section(depth, width, rough, slope, &
@@ -441,9 +423,6 @@ contains
       ! -- calculate stream flow
       qman = sat * qman
     end if
-    !
-    ! -- return
-    return
   end function calc_qman_by_section
 
   !> @brief Calculate the saturated top width for a reach
@@ -466,9 +445,6 @@ contains
     else
       w = stations(1)
     end if
-    !
-    ! -- return
-    return
   end function get_saturated_topwidth
 
   !> @brief Calculate the wetted top width for a reach
@@ -506,9 +482,6 @@ contains
     do n = 1, npts - 1
       w = w + widths(n)
     end do
-    !
-    ! -- return
-    return
   end function get_wetted_topwidth
 
   !> @brief Calculate the wetted perimeter for a reach
@@ -546,9 +519,6 @@ contains
     do n = 1, npts - 1
       p = p + perimeters(n)
     end do
-    !
-    ! -- return
-    return
   end function get_wetted_perimeter
 
   !> @brief Calculate the cross-sectional area for a reach
@@ -586,9 +556,6 @@ contains
     do n = 1, npts - 1
       a = a + areas(n)
     end do
-    !
-    ! -- return
-    return
   end function get_cross_section_area
 
   !> @brief Calculate conveyance
@@ -738,9 +705,6 @@ contains
       end if
       c = c + cn
     end do
-    !
-    ! -- return
-    return
   end function get_composite_conveyance
 
   !> @brief Calculate the hydraulic radius for a reach
@@ -791,9 +755,6 @@ contains
       ! -- calculate the hydraulic radius
       r = a / p
     end if
-    !
-    ! -- return
-    return
   end function get_hydraulic_radius
 
   !> @brief Calculate the hydraulic radius for a reach
@@ -824,9 +785,6 @@ contains
     !
     ! -- calculate hydraulic radius
     r = get_hydraulic_radius(npts, stations, heights, d)
-    !
-    ! -- return
-    return
   end function get_hydraulic_radius_xf
 
   !> @brief Calculate the manning's discharge for a reach
@@ -897,9 +855,6 @@ contains
         end if
       end do
     end if
-    !
-    ! -- return
-    return
   end function get_mannings_section
 
   ! -- private functions and subroutines
@@ -962,9 +917,6 @@ contains
       end if
       p(n) = sqrt(xlen**DTWO + dlen**DTWO)
     end do
-    !
-    ! -- return
-    return
   end subroutine get_wetted_perimeters
 
   !> @brief Calculate the cross-sectional areas for each line segment
@@ -1025,9 +977,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine get_cross_section_areas
 
   !> @brief Calculate the wetted top widths for each line segment
@@ -1068,9 +1017,6 @@ contains
       ! -- calculate the wetted top width for the segment
       w(n) = x1 - x0
     end do
-    !
-    ! -- return
-    return
   end subroutine get_wetted_topwidths
 
   !> @brief Calculate the station values for the wetted portion of the cross-section
@@ -1134,9 +1080,6 @@ contains
       x0 = xt0
       x1 = xt1
     end if
-    !
-    ! -- return
-    return
   end subroutine get_wetted_station
 
 end module SwfCxsUtilsModule

--- a/src/Model/ModelUtilities/TspSpc.f90
+++ b/src/Model/ModelUtilities/TspSpc.f90
@@ -140,9 +140,6 @@ contains
     ! -- Now that time series are read, call define
     call this%tsmanager%tsmanager_df()
     call this%tasmanager%tasmanager_df()
-    !
-    ! -- return
-    return
   end subroutine initialize
 
   !> @ brief Allocate package scalars
@@ -179,9 +176,6 @@ contains
     this%lastonper = 0
     this%iprpak = 0
     this%readasarrays = .false.
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Read options for package
@@ -255,9 +249,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF SPC OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @ brief Read dimensions for package
@@ -313,9 +304,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine read_dimensions
 
   !> @ brief Allocate package arrays
@@ -338,9 +326,6 @@ contains
     do i = 1, this%maxbound
       this%dblvec(i) = DZERO
     end do
-    !
-    ! -- return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Get the data value from this package
@@ -462,9 +447,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine spc_rp
 
   !> @ brief spc_rp_list
@@ -530,9 +512,6 @@ contains
     if (this%iprpak /= 0) then
       call this%inputtab%finalize_table()
     end if
-    !
-    ! -- return
-    return
   end subroutine spc_rp_list
 
   !> @ brief spc_rp_array
@@ -637,9 +616,6 @@ contains
     !
     ! -- Check flow package consistency
     call this%check_flow_package(nbound_flowpack, budtxt)
-    !
-    ! -- return
-    return
   end subroutine spc_ad
 
   !> @ brief Deallocate variables
@@ -670,9 +646,6 @@ contains
     call this%TsManager%da()
     deallocate (this%TsManager)
     nullify (this%TsManager)
-    !
-    ! -- return
-    return
   end subroutine spc_da
 
   !> @ brief Check ionper
@@ -702,9 +675,6 @@ contains
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine read_check_ionper
 
   !> @ brief Set the data value from the input file
@@ -801,9 +771,6 @@ contains
         call this%parser%StoreErrorUnit()
       end if
     end select
-    !
-    ! -- return
-    return
   end subroutine check_flow_package
 
 end module TspSpcModule

--- a/src/Model/ModelUtilities/TspSpc.f90
+++ b/src/Model/ModelUtilities/TspSpc.f90
@@ -369,7 +369,6 @@ contains
     else
       value = this%dblvec(ientry)
     end if
-    return
   end function get_value
 
   !> @ brief Read and prepare
@@ -592,8 +591,6 @@ contains
       end select
 
     end do
-    !
-    return
   end subroutine spc_rp_array
 
   !> @ brief Advance
@@ -706,7 +703,6 @@ contains
                                          this%depvarname)
 
     end select
-    return
   end subroutine set_value
 
   !> @ brief check_flow_package

--- a/src/Model/ModelUtilities/UzfCellGroup.f90
+++ b/src/Model/ModelUtilities/UzfCellGroup.f90
@@ -234,9 +234,6 @@ contains
       this%landflag(icell) = 0
       this%ivertcon(icell) = 0
     end do
-    !
-    ! -- Return
-    return
   end subroutine init
 
   !> @brief Deallocate uzf object variables
@@ -331,9 +328,6 @@ contains
       call mem_deallocate(this%landflag)
       call mem_deallocate(this%ivertcon)
     end if
-    !
-    ! -- Return
-    return
   end subroutine dealloc
 
   !> @brief Set uzf object material properties
@@ -395,9 +389,6 @@ contains
     if (this%watab(icell) > this%celtop(icell)) &
       this%watab(icell) = this%celtop(icell)
     this%watabold(icell) = this%watab(icell)
-    !
-    ! -- Return
-    return
   end subroutine sethead
 
   !> @brief Set infiltration
@@ -418,9 +409,6 @@ contains
     this%finf_rej(icell) = DZERO
     this%surflux(icell) = DZERO
     this%surfluxbelow(icell) = DZERO
-    !
-    ! -- Return
-    return
   end subroutine setdatafinf
 
   !> @brief Set uzfarea using cellarea and areamult
@@ -433,9 +421,6 @@ contains
     !
     ! -- set uzf area
     this%uzfarea(icell) = this%cellarea(icell) * areamult
-    !
-    ! -- Return
-    return
   end subroutine setdatauzfarea
 
   !> @brief Set unsaturated ET-related variables
@@ -480,9 +465,6 @@ contains
       this%landtop(jbelow) = this%landtop(icell)
       this%petmax(jbelow) = this%petmax(icell)
     end if
-    !
-    ! -- Return
-    return
   end subroutine setdataet
 
   !> @brief Subtract aet from pet to calculate residual et for gw
@@ -502,9 +484,6 @@ contains
     pet = this%pet(icell) - this%etact(icell) / delt
     if (pet < DZERO) pet = DZERO
     this%gwpet(icell) = pet
-    !
-    ! -- Return
-    return
   end subroutine setgwpet
 
   !> @brief Subtract aet from pet to calculate residual et for deeper cells
@@ -529,9 +508,6 @@ contains
       if (pet < DZERO) pet = DZERO
     end if
     this%pet(jbelow) = pet
-    !
-    ! -- Return
-    return
   end subroutine setbelowpet
 
   !> @brief Set extinction water content
@@ -546,9 +522,6 @@ contains
     ! -- set extinction water content
     this%extwc(icell) = extwc
     if (jbelow > 0) this%extwc(jbelow) = extwc
-    !
-    ! -- Return
-    return
   end subroutine setdataetwc
 
   !> @brief Set variables for head-based unsaturated flow
@@ -571,9 +544,6 @@ contains
       this%hroot(jbelow) = hroot
       this%rootact(jbelow) = rootact
     end if
-    !
-    ! -- Return
-    return
   end subroutine setdataetha
 
   !> @brief Set variables to advance to new time step. nothing yet.
@@ -585,9 +555,6 @@ contains
     !
     ! -- set variables
     this%surfseep(icell) = DZERO
-    !
-    ! -- Return
-    return
   end subroutine advance
 
   !> @brief Formulate the unsaturated flow object, calculate terms for gwf
@@ -726,9 +693,6 @@ contains
     if (reset_state) then
       call this%wave_shift(thiswork, icell, 1, 0, 1, thiswork%nwavst(1), 1)
     end if
-    !
-    ! -- Return
-    return
   end subroutine solve
 
   !> @brief Add recharge or infiltration to cells
@@ -768,9 +732,6 @@ contains
     this%surfluxbelow(icell) = this%finf(jbelow)
     this%totflux(icell) = scale * this%totflux(icell) + fcheck * delt
     trhs = this%uzfarea(icell) * this%totflux(icell) / delt
-    !
-    ! -- Return
-    return
   end subroutine addrech
 
   !> @brief Reject applied infiltration due to low vks
@@ -799,9 +760,6 @@ contains
       trhs = finfact * this%uzfarea(icell) * this%celtop(icell) / range
       thcof = finfact * this%uzfarea(icell) / range
     end if
-    !
-    ! -- Return
-    return
   end subroutine rejfinf
 
   !> @brief Calculate groudwater discharge to land surface
@@ -842,9 +800,6 @@ contains
       trhs = DZERO
       thcof = DZERO
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwseep
 
   !> @brief Calculate gwf et using residual uzf pet
@@ -882,9 +837,6 @@ contains
     thcof = thcof * this%uzfarea(icell)
     this%gwet(icell) = trhs - (thcof * hgwf)
     ! write(99,*)'in group', icell, this%gwet(icell)
-    !
-    ! -- Return
-    return
   end subroutine simgwet
 
   !> @brief Square-wave ET function with smoothing at extinction depth
@@ -914,9 +866,6 @@ contains
     trhs = -etgw
     det = -det * etgw
     etfunc_nlin = etgw
-    !
-    ! -- Return
-    return
   end function etfunc_nlin
 
   !> @brief Calculate recharge due to a rise in the gwf head
@@ -937,9 +886,6 @@ contains
       fm2 = this%unsat_stor(icell, d1)
       totfluxtot = totfluxtot + (fm1 - fm2)
     end if
-    !
-    ! -- Return
-    return
   end subroutine uz_rise
 
   !> @brief Reset waves to default values at start of simulation
@@ -989,9 +935,6 @@ contains
       this%uzspst(1, icell) = DZERO
       this%uzthst(1, icell) = this%thtr(icell)
     end if
-    !
-    ! -- Return
-    return
   end subroutine
 
   !> @brief Prepare and route waves over time step
@@ -1030,9 +973,6 @@ contains
       if (ierr > 0) return
       totfluxtot = totfluxtot + this%totflux(icell)
     end do
-    !
-    ! -- Return
-    return
   end subroutine routewaves
 
   !> @brief Copy waves or shift waves in arrays
@@ -1058,9 +998,6 @@ contains
       this%uzspst(j, icell) = this2%uzspst(j + shft, icell2)
     end do
     this%nwavst(icell) = this2%nwavst(icell2)
-    !
-    ! -- Return
-    return
   end subroutine
 
   !> @brief Method of Characteristics solution for kinematic wave equation
@@ -1150,9 +1087,6 @@ contains
     ! -- simulate et
     if (ietflag > 0) call this%uzet(icell, delt, ietflag, ierr)
     if (ierr > 0) return
-    !
-    ! -- Return
-    return
   end subroutine uzflow
 
   !> @brief Calculate unit specific tolerances
@@ -1181,9 +1115,6 @@ contains
     factor2 = DONE / 0.3048
     feps1 = feps1 * factor1 * factor2
     feps2 = feps2 * factor1 * factor2
-    !
-    ! -- Return
-    return
   end subroutine factors
 
   !> @brief Create and set trail waves
@@ -1270,9 +1201,6 @@ contains
         leadspeed(theta1, theta2, flux1, flux2, this%thts(icell), &
                   this%thtr(icell), this%eps(icell), this%vks(icell))
     end if
-    !
-    ! -- Return
-    return
   end subroutine trailwav
 
   !> @brief Create a lead wave and route over time step
@@ -1474,9 +1402,6 @@ contains
     end if
     deallocate (checktime)
     deallocate (more)
-    !
-    ! -- Return
-    return
   end subroutine leadwav
 
   !> @brief Calculates waves speed from dflux/dtheta
@@ -1512,9 +1437,6 @@ contains
       leadspeed = (flux2 - flux1) / (theta2 - theta1)
     end if
     if (leadspeed < DEM30) leadspeed = DEM30
-    !
-    ! -- Return
-    return
   end function leadspeed
 
   !> @brief Sums up mobile water over depth interval
@@ -1559,9 +1481,6 @@ contains
       fm = fm + (this%uzthst(1, icell) - this%thtr(icell)) * d1
     end if
     unsat_stor = fm
-    !
-    ! -- Return
-    return
   end function unsat_stor
 
   !> @brief Update to new state of uz at end of time step
@@ -1638,9 +1557,6 @@ contains
       end if
       this%watabold(icell) = this%watab(icell)
     end if
-    !
-    ! -- Return
-    return
   end subroutine update_wav
 
   !> @brief Remove water from uz due to et
@@ -1975,9 +1891,6 @@ contains
     !
     ! -- deallocate temporary worker
     call uzfktemp%dealloc()
-    !
-    ! -- Return
-    return
   end subroutine uzet
 
   !> @brief Calculate capillary pressure head from B-C equation
@@ -2001,9 +1914,6 @@ contains
         caph = DZERO
       end if
     end if
-    !
-    ! -- Return
-    return
   end function caph
 
   !> @brief Calculate capillary pressure-based uz et
@@ -2017,9 +1927,6 @@ contains
     !
     rate_et_z = factor * fktho * (h - this%hroot(icell))
     if (rate_et_z < DZERO) rate_et_z = DZERO
-    !
-    ! -- Return
-    return
   end function rate_et_z
 
   !> @brief Determine the water content at a specific depth
@@ -2053,9 +1960,6 @@ contains
     else
       theta_at_depth = this%thts(icell)
     end if
-    !
-    ! -- Return
-    return
   end function get_water_content_at_depth
 
   !> @brief Calculate and return the cell-based water content value
@@ -2088,9 +1992,6 @@ contains
     else
       watercontent = DZERO
     end if
-    !
-    ! -- Return
-    return
   end function get_wcnew
 
 end module UzfCellGroupModule

--- a/src/Model/ModelUtilities/Xt3dAlgorithm.f90
+++ b/src/Model/ModelUtilities/Xt3dAlgorithm.f90
@@ -120,9 +120,6 @@ contains
         chat1j(i) = wght1 * bhat1(i)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine qconds
 
   !> @brief Compute "ahat" and "bhat" coefficients for one side of an interface
@@ -265,9 +262,6 @@ contains
     ! -- Multiply by area.
     ahat = ahat * ar01
     bhat = bhat * ar01
-    !
-    ! -- Return
-    return
   end subroutine abhats
 
   !> @brief Compute the matrix that rotates the model-coordinate axes to the
@@ -379,9 +373,6 @@ contains
     do il = 1, nnbrs
       vccde(il, :) = matmul(transpose(rmat), vc(il, :))
     end do
-    !
-    ! -- Return
-    return
   end subroutine tranvc
 
   !> @brief Compute "a" and "b" weights for the local connections with respect

--- a/src/Model/ModelUtilities/Xt3dInterface.f90
+++ b/src/Model/ModelUtilities/Xt3dInterface.f90
@@ -107,9 +107,6 @@ contains
     xt3dobj%inunit = inunit
     xt3dobj%iout = iout
     if (present(ldispopt)) xt3dobj%ldispersion = ldispopt
-    !
-    ! -- Return
-    return
   end subroutine xt3d_cr
 
   !> @brief Define the xt3d object
@@ -120,9 +117,6 @@ contains
     class(DisBaseType), pointer, intent(inout) :: dis
     !
     this%dis => dis
-    !
-    ! -- Return
-    return
   end subroutine xt3d_df
 
   !> @brief Add connections for extended neighbors to the sparse matrix
@@ -190,9 +184,6 @@ contains
       call mem_allocate(this%ia_xt3d, 0, 'IA_XT3D', trim(this%memoryPath))
       call mem_allocate(this%ja_xt3d, 0, 'JA_XT3D', trim(this%memoryPath))
     end if
-    !
-    ! -- Return
-    return
   end subroutine xt3d_ac
 
   !> @brief Map connections and construct iax, jax, and idxglox
@@ -277,9 +268,6 @@ contains
       call mem_allocate(this%idxglox, 0, 'IDXGLOX', trim(this%memoryPath))
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine xt3d_mc
 
   !> @brief Allocate and Read
@@ -377,9 +365,6 @@ contains
     ! -- permanently confined connections
     if (this%lamatsaved .and. .not. this%ldispersion) &
       call this%xt3d_fcpc(this%dis%nodes, .true.)
-    !
-    ! -- Return
-    return
   end subroutine xt3d_ar
 
   !> @brief Formulate
@@ -506,9 +491,6 @@ contains
         !
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_fc
 
   !> @brief Formulate for permanently confined connections and save in amatpc
@@ -587,9 +569,6 @@ contains
         call this%xt3d_amatpcx_nbrnbrs(nodes, m, n, ii10, nnbr0, inbr0, chati0)
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_fcpc
 
   !> @brief Formulate HFB correction
@@ -708,9 +687,6 @@ contains
       call this%xt3d_rhs(nodes, n, m, nnbr0, inbr0, chati0, hnew, rhs)
       call this%xt3d_rhs(nodes, m, n, nnbr1, inbr1, chat1j, hnew, rhs)
     end if
-    !
-    ! -- Return
-    return
   end subroutine xt3d_fhfb
 
   !> @brief Fill Newton terms for xt3d
@@ -814,9 +790,6 @@ contains
         end if
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_fn
 
   !> @brief Budget
@@ -897,9 +870,6 @@ contains
         flowja(this%dis%con%isym(ipos)) = flowja(this%dis%con%isym(ipos)) - qnm
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_flowja
 
   !> @brief hfb contribution to flowja when xt3d is used
@@ -1004,9 +974,6 @@ contains
     ipos = ii01
     flowja(ipos) = flowja(ipos) + qnm
     flowja(this%dis%con%isym(ipos)) = flowja(this%dis%con%isym(ipos)) - qnm
-    !
-    ! -- Return
-    return
   end subroutine xt3d_flowjahfb
 
   !> @brief Deallocate variables
@@ -1042,9 +1009,6 @@ contains
     call mem_deallocate(this%lamatsaved)
     call mem_deallocate(this%nbrmax)
     call mem_deallocate(this%ldispersion)
-    !
-    ! -- Return
-    return
   end subroutine xt3d_da
 
   !> @brief Allocate scalar pointer variables
@@ -1078,9 +1042,6 @@ contains
     this%vcthresh = 1.d-10
     this%lamatsaved = .false.
     this%ldispersion = .false.
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Allocate xt3d arrays
@@ -1142,9 +1103,6 @@ contains
       this%amatpc = DZERO
       this%amatpcx = DZERO
     end if
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief Allocate and populate iallpc array. Set lamatsaved.
@@ -1216,9 +1174,6 @@ contains
       ! in order to save memory
       call mem_reallocate(this%iallpc, 0, 'IALLPC', this%memoryPath)
     end if
-    !
-    ! -- Return
-    return
   end subroutine xt3d_iallpc
 
   !> @brief Set various indices for XT3D.
@@ -1248,9 +1203,6 @@ contains
     ii11 = this%dis%con%ia(m)
     ! -- Set index of node 1-0 connection in the ja array.
     ii10 = ii11 + il10
-    !
-    ! -- Return
-    return
   end subroutine xt3d_indices
 
   !> @brief Load conductivity and connection info for a cell into arrays used
@@ -1318,9 +1270,6 @@ contains
         inbr(il) = 0
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_load
 
   !> @brief Load neighbor list for a cell.
@@ -1344,9 +1293,6 @@ contains
         inbr(il) = 0
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_load_inbr
 
   !> @brief Compute interfacial areas.
@@ -1429,9 +1375,6 @@ contains
       ar01 = this%dis%con%hwva(jjs01) * thksatn
       ar10 = this%dis%con%hwva(jjs01) * thksatm
     end if
-    !
-    ! -- Return
-    return
   end subroutine xt3d_areas
 
   !> @brief Add contributions from neighbors to amat.
@@ -1456,9 +1399,6 @@ contains
         call matrix_sln%add_value_pos(idxglo(iii), chat(iil))
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_amat_nbrs
 
   !> @brief Add contributions from neighbors of neighbor to amat.
@@ -1490,9 +1430,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_amat_nbrnbrs
 
   !> @brief Add contributions from neighbors to amatpc.
@@ -1512,9 +1449,6 @@ contains
       this%amatpc(idiag) = this%amatpc(idiag) - chat(iil)
       this%amatpc(iii) = this%amatpc(iii) + chat(iil)
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_amatpc_nbrs
 
   !> @brief Add contributions from neighbors of neighbor to amatpc and amatpcx
@@ -1541,9 +1475,6 @@ contains
         this%amatpc(iijjj) = this%amatpc(iijjj) - chat(iil)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_amatpcx_nbrnbrs
 
   !> @brief Get position of n-m connection in ja array (return 0 if not
@@ -1564,9 +1495,6 @@ contains
         exit
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_get_iinm
 
   !> @brief Get position of n-m "extended connection" in jax array (return 0 if
@@ -1587,9 +1515,6 @@ contains
         exit
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_get_iinmx
 
   !> @brief Add contributions to rhs.
@@ -1616,9 +1541,6 @@ contains
         rhs(m) = rhs(m) + term
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_rhs
 
   !> @brief Add contributions to flow from neighbors
@@ -1646,9 +1568,6 @@ contains
         qnbrs = qnbrs + term
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine xt3d_qnbrs
 
   !> @brief Fill rmat array for cell n.
@@ -1689,9 +1608,6 @@ contains
     this%rmatck(3, 1) = s2
     this%rmatck(3, 2) = -c2 * s3
     this%rmatck(3, 3) = c2 * c3
-    !
-    ! -- Return
-    return
   end subroutine xt3d_fillrmatck
 
 end module Xt3dModule

--- a/src/Model/NumericalModel.f90
+++ b/src/Model/NumericalModel.f90
@@ -248,9 +248,6 @@ contains
     ! -- BaseModelType
     call this%BaseModelType%model_da()
     !
-    !
-    ! -- Return
-    return
   end subroutine model_da
 
   subroutine set_moffset(this, moffset)
@@ -294,9 +291,6 @@ contains
     this%nja = 0
     this%icnvg = 0
     this%moffset = 0
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   subroutine allocate_arrays(this)
@@ -313,9 +307,6 @@ contains
     do i = 1, size(this%flowja)
       this%flowja(i) = DZERO
     end do
-    !
-    ! -- return
-    return
   end subroutine allocate_arrays
 
   subroutine set_xptr(this, xsln, sln_offset, varNameTgt, memPathTgt)
@@ -400,7 +391,6 @@ contains
     end if
     write (mcellid, '(i0, a, a, a, a)') this%id, '_', this%macronym, '-', &
       trim(adjustl(cellid))
-    return
   end subroutine get_mcellid
 
   subroutine get_mnodeu(this, node, nodeu)
@@ -414,7 +404,6 @@ contains
     else
       nodeu = -(node - this%dis%nodes)
     end if
-    return
   end subroutine get_mnodeu
 
   function get_iasym(this) result(iasym)
@@ -435,7 +424,6 @@ contains
     class is (NumericalModelType)
       res => obj
     end select
-    return
   end function CastAsNumericalModelClass
 
   subroutine AddNumericalModelToList(list, model)
@@ -448,8 +436,6 @@ contains
     !
     obj => model
     call list%Add(obj)
-    !
-    return
   end subroutine AddNumericalModelToList
 
   function GetNumericalModelFromList(list, idx) result(res)
@@ -463,8 +449,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsNumericalModelClass(obj)
-    !
-    return
   end function GetNumericalModelFromList
 
   subroutine create_lstfile(this, lst_fname, model_fname, defined, headertxt)
@@ -511,9 +495,6 @@ contains
     !
     ! -- write list file header
     call write_listfile_header(this%iout, headertxt)
-    !
-    ! -- return
-    return
   end subroutine create_lstfile
 
 end module NumericalModelModule

--- a/src/Model/SurfaceWaterFlow/swf-cdb.f90
+++ b/src/Model/SurfaceWaterFlow/swf-cdb.f90
@@ -118,9 +118,6 @@ contains
     !
     ! -- store unit conversion
     cdbobj%gravconv = DGRAVITY * lengthconv * timeconv**2
-    !
-    ! -- return
-    return
   end subroutine cdb_create
 
   !> @ brief Allocate scalars
@@ -143,9 +140,6 @@ contains
     !
     ! -- Set values
     this%gravconv = DZERO
-    !
-    ! -- return
-    return
   end subroutine cdb_allocate_scalars
 
   !> @ brief Allocate arrays
@@ -174,9 +168,6 @@ contains
                      'IDCXS', this%input_mempath)
     call mem_checkin(this%width, 'WIDTH', this%memoryPath, &
                      'WIDTH', this%input_mempath)
-    !
-    ! -- return
-    return
   end subroutine cdb_allocate_arrays
 
   !> @ brief Deallocate package memory
@@ -199,9 +190,6 @@ contains
     !
     ! -- scalars
     call mem_deallocate(this%gravconv)
-    !
-    ! -- return
-    return
   end subroutine cdb_da
 
   !> @ brief Source additional options for package
@@ -228,9 +216,6 @@ contains
     !
     ! -- log SWF specific options
     call this%log_cdb_options(found)
-    !
-    ! -- return
-    return
   end subroutine cdb_options
 
   !> @ brief Log SWF specific package options
@@ -255,9 +240,6 @@ contains
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
-    !
-    ! -- return
-    return
   end subroutine log_cdb_options
 
   !> @ brief SWF read and prepare
@@ -278,9 +260,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- return
-    return
   end subroutine cdb_rp
 
   !> @ brief Formulate the package hcof and rhs terms.
@@ -333,8 +312,6 @@ contains
       this%rhs(i) = -q + derv * this%xnew(node)
 
     end do
-    !
-    return
   end subroutine cdb_cf
 
   !> @brief Calculate critical depth boundary flow
@@ -404,9 +381,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(i, this%rhs(i))
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine cdb_fc
 
   !> @ brief Define the list label for the package
@@ -435,9 +409,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- return
-    return
   end subroutine define_listlabel
 
   ! -- Procedures related to observations
@@ -456,9 +427,6 @@ contains
     !
     ! -- set boolean
     cdb_obs_supported = .true.
-    !
-    ! -- return
-    return
   end function cdb_obs_supported
 
   !> @brief Define the observation types available in the package
@@ -480,9 +448,6 @@ contains
     !    for to-mvr observation type.
     call this%obs%StoreObsType('to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- return
-    return
   end subroutine cdb_df_obs
 
   !> @brief Save observations for the package
@@ -530,9 +495,6 @@ contains
         call this%obs%SaveOneSimval(obsrv, DNODATA)
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine cdb_bd_obs
 
   ! -- Procedure related to time series
@@ -560,9 +522,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine cdb_rp_ts
 
   !> @ brief Return a bound value
@@ -592,9 +551,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- return
-    return
   end function cdb_bound_value
 
 end module SwfCdbModule

--- a/src/Model/SurfaceWaterFlow/swf-cxs.f90
+++ b/src/Model/SurfaceWaterFlow/swf-cxs.f90
@@ -116,9 +116,6 @@ contains
       call pobj%source_crosssectiondata()
 
     end if
-
-    ! -- Return
-    return
   end subroutine cxs_cr
 
   !> @ brief Allocate scalars
@@ -142,8 +139,6 @@ contains
     ! -- initialize
     this%nsections = 0
     this%npoints = 0
-
-    return
   end subroutine allocate_scalars
 
   !> @brief Copy options from IDM into package
@@ -171,9 +166,6 @@ contains
     if (this%iout > 0) then
       call this%log_options(found)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_options
 
   !> @brief Write user options to list file
@@ -232,9 +224,6 @@ contains
     if (this%iout > 0) then
       call this%log_dimensions(found)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_dimensions
 
   !> @brief Write user options to list file
@@ -293,9 +282,6 @@ contains
     do n = 1, this%nsections + 1
       this%iacross(n) = 0
     end do
-
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @brief Copy options from IDM into package
@@ -340,9 +326,6 @@ contains
     !
     ! -- Calculate the iacross index array using nxspoints
     call calc_iacross(this%nxspoints, this%iacross)
-    !
-    ! -- Return
-    return
   end subroutine source_packagedata
 
   !> @brief Calculate index pointer array iacross from nxspoints
@@ -428,9 +411,6 @@ contains
     if (this%iout > 0) then
       call this%log_crosssectiondata(found)
     end if
-    !
-    ! -- Return
-    return
   end subroutine source_crosssectiondata
 
   !> @brief Write user packagedata to list file
@@ -519,8 +499,6 @@ contains
       write (this%iout, *) 'Done processing information for cross section ', idcxs
 
     end if
-
-    return
   end subroutine write_cxs_table
 
   !> @brief deallocate memory
@@ -553,9 +531,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine cxs_da
 
   subroutine get_cross_section_info(this, idcxs, i0, i1, npts, icalcmeth)
@@ -592,7 +567,6 @@ contains
         icalcmeth = 0 ! sum q by cross section segments
       end if
     end if
-    return
   end subroutine get_cross_section_info
 
   function get_area(this, idcxs, width, depth) result(area)

--- a/src/Model/SurfaceWaterFlow/swf-flw.f90
+++ b/src/Model/SurfaceWaterFlow/swf-flw.f90
@@ -95,9 +95,6 @@ contains
     packobj%ncolbnd = 1
     packobj%iscloc = 1
     packobj%ictMemPath = ''
-    !
-    ! -- return
-    return
   end subroutine flw_create
 
   !> @ brief Allocate scalars
@@ -120,9 +117,6 @@ contains
     !
     ! -- Set values
     ! none for this package
-    !
-    ! -- return
-    return
   end subroutine flw_allocate_scalars
 
   !> @ brief Allocate arrays
@@ -148,9 +142,6 @@ contains
     ! -- checkin q array input context pointer
     call mem_checkin(this%q, 'Q', this%memoryPath, &
                      'Q', this%input_mempath)
-    !
-    ! -- return
-    return
   end subroutine flw_allocate_arrays
 
   !> @ brief Deallocate package memory
@@ -169,9 +160,6 @@ contains
     !
     ! -- scalars
     call mem_deallocate(this%q, 'Q', this%memoryPath)
-    !
-    ! -- return
-    return
   end subroutine flw_da
 
   !> @ brief Source additional options for package
@@ -198,9 +186,6 @@ contains
     !
     ! -- log SWF specific options
     call this%log_flw_options(found)
-    !
-    ! -- return
-    return
   end subroutine flw_options
 
   !> @ brief Log SWF specific package options
@@ -225,9 +210,6 @@ contains
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
-    !
-    ! -- return
-    return
   end subroutine log_flw_options
 
   !> @ brief SWF read and prepare
@@ -248,9 +230,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- return
-    return
   end subroutine flw_rp
 
   !> @ brief Formulate the package hcof and rhs terms.
@@ -280,8 +259,6 @@ contains
       q = this%q_mult(i)
       this%rhs(i) = -q
     end do
-    !
-    return
   end subroutine flw_cf
 
   !> @ brief Copy hcof and rhs terms into solution.
@@ -320,9 +297,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(i, this%rhs(i))
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine flw_fc
 
   !> @ brief Define the list label for the package
@@ -351,9 +325,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- return
-    return
   end subroutine define_listlabel
 
   ! -- Procedures related to observations
@@ -372,9 +343,6 @@ contains
     !
     ! -- set boolean
     flw_obs_supported = .true.
-    !
-    ! -- return
-    return
   end function flw_obs_supported
 
   !> @brief Define the observation types available in the package
@@ -396,9 +364,6 @@ contains
     !    for to-mvr observation type.
     call this%obs%StoreObsType('to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- return
-    return
   end subroutine flw_df_obs
 
   !> @brief Save observations for the package
@@ -446,9 +411,6 @@ contains
         call this%obs%SaveOneSimval(obsrv, DNODATA)
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine flw_bd_obs
 
   ! -- Procedure related to time series
@@ -476,9 +438,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine flw_rp_ts
 
   function q_mult(this, row) result(q)
@@ -495,9 +454,6 @@ contains
     else
       q = this%q(row)
     end if
-    !
-    ! -- return
-    return
   end function q_mult
 
   !> @ brief Return a bound value
@@ -525,9 +481,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- return
-    return
   end function flw_bound_value
 
 end module SwfFlwModule

--- a/src/Model/SurfaceWaterFlow/swf-obs.f90
+++ b/src/Model/SurfaceWaterFlow/swf-obs.f90
@@ -45,8 +45,6 @@ contains
     obs%active = .false.
     obs%inputFilename = ''
     obs%inUnitObs => inobs
-    !
-    return
   end subroutine swf_obs_cr
 
   !> @brief Allocate and read
@@ -63,8 +61,6 @@ contains
     !
     ! set pointers
     call this%set_pointers(ic, x, flowja)
-    !
-    return
   end subroutine swf_obs_ar
 
   !> @brief Define
@@ -92,8 +88,6 @@ contains
     ! -- Store obs type and assign procedure pointer for flow-ja-face observation type
     call this%StoreObsType('flow-ja-face', .true., indx)
     this%obsData(indx)%ProcessIdPtr => swf_process_intercell_obs_id
-    !
-    return
   end subroutine swf_obs_df
 
   !> @brief Save obs
@@ -126,8 +120,6 @@ contains
         end select
       end do
     end if
-    !
-    return
   end subroutine swf_obs_bd
 
   !> @brief Do observations need any checking? If so, add checks here
@@ -148,8 +140,6 @@ contains
     nullify (this%x)
     nullify (this%flowja)
     call this%ObsType%obs_da()
-    !
-    return
   end subroutine swf_obs_da
 
   !> @brief Set pointers
@@ -164,8 +154,6 @@ contains
     this%ic => ic
     this%x => x
     this%flowja => flowja
-    !
-    return
   end subroutine set_pointers
 
   ! -- Procedures related to SWF observations (NOT type-bound)
@@ -199,8 +187,6 @@ contains
       call store_error(ermsg)
       call store_error_unit(inunitobs)
     end if
-    !
-    return
   end subroutine swf_process_stage_obs_id
 
   !> @brief Process flow between two cells when requested
@@ -256,8 +242,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(inunitobs)
     end if
-    !
-    return
   end subroutine swf_process_intercell_obs_id
 
 end module SwfObsModule

--- a/src/Model/SurfaceWaterFlow/swf-oc.f90
+++ b/src/Model/SurfaceWaterFlow/swf-oc.f90
@@ -46,9 +46,6 @@ contains
     !
     ! -- Initialize block parser
     call ocobj%parser%Initialize(inunit, iout)
-    !
-    ! -- Return
-    return
   end subroutine oc_cr
 
   !> @ brief Allocate and read SwfOcType
@@ -92,9 +89,6 @@ contains
     if (this%inunit > 0) then
       call this%read_options()
     end if
-    !
-    ! -- Return
-    return
   end subroutine oc_ar
 
 end module SwfOcModule

--- a/src/Model/SurfaceWaterFlow/swf-sto.f90
+++ b/src/Model/SurfaceWaterFlow/swf-sto.f90
@@ -138,9 +138,6 @@ contains
     ! -- read the data block
     ! no griddata at the moment for SWF Storage Package
     ! call this%source_data()
-    !
-    ! -- return
-    return
   end subroutine sto_ar
 
   !> @ brief Read and prepare method for package
@@ -184,9 +181,6 @@ contains
     !
     write (this%iout, '(//1X,A,I0,A,A,/)') &
       'STRESS PERIOD ', kper, ' IS ', trim(adjustl(css(this%iss)))
-    !
-    ! -- return
-    return
   end subroutine sto_rp
 
   !> @ brief Advance the package
@@ -198,9 +192,6 @@ contains
     ! -- modules
     ! -- dummy variables
     class(SwfStoType) :: this !< SwfStoType object
-    !
-    ! -- return
-    return
   end subroutine sto_ad
 
   !> @ brief Fill A and right-hand side for the package
@@ -284,9 +275,6 @@ contains
       rhs(n) = rhs(n) + qsto - derv * stage_new(n)
 
     end do
-    !
-    ! -- Return
-    return
   end subroutine sto_fc_dis1d
 
   !> @ brief Fill A and right-hand side for the package
@@ -369,9 +357,6 @@ contains
       flowja(idiag) = flowja(idiag) + this%qsto(n)
 
     end do
-    !
-    ! -- Return
-    return
   end subroutine sto_cq
 
   subroutine calc_storage_dis1d(this, n, stage_new, stage_old, dx, qsto, derv)
@@ -467,9 +452,6 @@ contains
     call rate_accumulator(this%qsto, rin, rout)
     call model_budget%addentry(rin, rout, delt, '             STO', &
                                isuppress_output, '         STORAGE')
-    !
-    ! -- return
-    return
   end subroutine sto_bd
 
   !> @ brief Save model flows for package
@@ -508,9 +490,6 @@ contains
                                  budtxt(1), cdatafmp, nvaluesp, &
                                  nwidthp, editdesc, dinact)
     end if
-    !
-    ! -- return
-    return
   end subroutine sto_save_model_flows
 
   !> @ brief Deallocate package memory
@@ -536,9 +515,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- return
-    return
   end subroutine sto_da
 
   !> @ brief Allocate scalars
@@ -561,9 +537,6 @@ contains
     !
     ! -- initialize scalars
     !this%xxx = 0
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate package arrays
@@ -594,9 +567,6 @@ contains
     do n = 1, nodes
       this%qsto(n) = DZERO
     end do
-    !
-    ! -- return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Source input options for package
@@ -624,9 +594,6 @@ contains
     !
     ! -- log found options
     call this%log_options(found)
-    !
-    ! -- return
-    return
   end subroutine source_options
 
   !> @ brief Log found options for package
@@ -654,9 +621,6 @@ contains
     end if
     !
     write (this%iout, '(1x,a)') 'END OF STORAGE OPTIONS'
-    !
-    ! -- return
-    return
   end subroutine log_options
 
   !> @ brief Source input data for package
@@ -685,9 +649,6 @@ contains
     ! -- log griddata
     write (this%iout, '(1x,a)') 'PROCESSING GRIDDATA'
     write (this%iout, '(1x,a)') 'END PROCESSING GRIDDATA'
-    !
-    ! -- return
-    return
   end subroutine source_data
 
   !> @brief Set pointers to channel properties in DFW Package

--- a/src/Model/SurfaceWaterFlow/swf-zdg.f90
+++ b/src/Model/SurfaceWaterFlow/swf-zdg.f90
@@ -124,9 +124,6 @@ contains
     !
     ! -- store unit conversion
     zdgobj%unitconv = unitconv
-    !
-    ! -- return
-    return
   end subroutine zdg_create
 
   !> @ brief Allocate scalars
@@ -149,9 +146,6 @@ contains
     !
     ! -- Set values
     this%unitconv = DZERO
-    !
-    ! -- return
-    return
   end subroutine zdg_allocate_scalars
 
   !> @ brief Allocate arrays
@@ -186,9 +180,6 @@ contains
                      'SLOPE', this%input_mempath)
     call mem_checkin(this%rough, 'ROUGH', this%memoryPath, &
                      'ROUGH', this%input_mempath)
-    !
-    ! -- return
-    return
   end subroutine zdg_allocate_arrays
 
   !> @ brief Deallocate package memory
@@ -213,9 +204,6 @@ contains
     !
     ! -- scalars
     call mem_deallocate(this%unitconv)
-    !
-    ! -- return
-    return
   end subroutine zdg_da
 
   !> @ brief Source additional options for package
@@ -242,9 +230,6 @@ contains
     !
     ! -- log SWF specific options
     call this%log_zdg_options(found)
-    !
-    ! -- return
-    return
   end subroutine zdg_options
 
   !> @ brief Log SWF specific package options
@@ -269,9 +254,6 @@ contains
     ! -- close logging block
     write (this%iout, '(1x,a)') &
       'END OF '//trim(adjustl(this%text))//' OPTIONS'
-    !
-    ! -- return
-    return
   end subroutine log_zdg_options
 
   !> @ brief SWF read and prepare
@@ -292,9 +274,6 @@ contains
     if (this%iprpak /= 0) then
       call this%write_list()
     end if
-    !
-    ! -- return
-    return
   end subroutine zdg_rp
 
   !> @ brief Formulate the package hcof and rhs terms.
@@ -357,8 +336,6 @@ contains
       this%rhs(i) = -q + derv * this%xnew(node)
 
     end do
-    !
-    return
   end subroutine zdg_cf
 
   ! !> @brief Calculate flow
@@ -426,9 +403,6 @@ contains
         call this%pakmvrobj%accumulate_qformvr(i, this%rhs(i))
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine zdg_fc
 
   !> @ brief Define the list label for the package
@@ -457,9 +431,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- return
-    return
   end subroutine define_listlabel
 
   ! -- Procedures related to observations
@@ -478,9 +449,6 @@ contains
     !
     ! -- set boolean
     zdg_obs_supported = .true.
-    !
-    ! -- return
-    return
   end function zdg_obs_supported
 
   !> @brief Define the observation types available in the package
@@ -502,9 +470,6 @@ contains
     !    for to-mvr observation type.
     call this%obs%StoreObsType('to-mvr', .true., indx)
     this%obs%obsData(indx)%ProcessIdPtr => DefaultObsIdProcessor
-    !
-    ! -- return
-    return
   end subroutine zdg_df_obs
 
   !> @brief Save observations for the package
@@ -552,9 +517,6 @@ contains
         call this%obs%SaveOneSimval(obsrv, DNODATA)
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine zdg_bd_obs
 
   ! -- Procedure related to time series
@@ -582,9 +544,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine zdg_rp_ts
 
   !> @ brief Return a bound value
@@ -618,9 +577,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%input_fname)
     end select
-    !
-    ! -- return
-    return
   end function zdg_bound_value
 
 end module SwfZdgModule

--- a/src/Model/TransportModel/tsp-adv.f90
+++ b/src/Model/TransportModel/tsp-adv.f90
@@ -69,9 +69,6 @@ contains
     advobj%iout = iout
     advobj%fmi => fmi
     advobj%eqnsclfac => eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine adv_cr
 
   !> @brief Define ADV object
@@ -104,9 +101,6 @@ contains
       ! --set options from input arg
       this%iadvwt = adv_options%iAdvScheme
     end if
-    !
-    ! -- Return
-    return
   end subroutine adv_df
 
   !> @brief Allocate and read method for package
@@ -125,9 +119,6 @@ contains
     ! -- adv pointers to arguments that were passed in
     this%dis => dis
     this%ibound => ibound
-    !
-    ! -- Return
-    return
   end subroutine adv_ar
 
   !> @brief  Calculate maximum time step length
@@ -235,9 +226,6 @@ contains
         call this%advtvd(n, cnew, rhs)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine adv_fc
 
   !> @brief  Calculate TVD
@@ -266,9 +254,6 @@ contains
         rhs(m) = rhs(m) + qtvd
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine advtvd
 
   !> @brief  Calculate TVD
@@ -337,9 +322,6 @@ contains
         qtvd = qtvd * this%eqnsclfac
       end if
     end if
-    !
-    ! -- Return
-    return
   end function advqtvd
 
   !> @brief Calculate advection contribution to flowja
@@ -373,9 +355,6 @@ contains
     !
     ! -- TVD
     if (this%iadvwt == 2) call this%advtvd_bd(cnew, flowja)
-    !
-    ! -- Return
-    return
   end subroutine adv_cq
 
   !> @brief Add TVD contribution to flowja
@@ -401,9 +380,6 @@ contains
         end if
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine advtvd_bd
 
   !> @brief Deallocate memory
@@ -427,9 +403,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine adv_da
 
   !> @brief Allocate scalars specific to the streamflow energy transport (SFE)
@@ -455,9 +428,6 @@ contains
     !
     ! -- Advection creates an asymmetric coefficient matrix
     this%iasym = 1
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Read options
@@ -525,9 +495,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF ADVECTION OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @ brief Advection weight
@@ -569,9 +536,6 @@ contains
         omega = DONE
       end if
     end select
-    !
-    ! -- return
-    return
   end function adv_weight
 
 end module TspAdvModule

--- a/src/Model/TransportModel/tsp-apt.f90
+++ b/src/Model/TransportModel/tsp-apt.f90
@@ -233,9 +233,6 @@ contains
         end do
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_ac
 
   !> @brief Advanced package transport map package connections to matrix
@@ -297,9 +294,6 @@ contains
         end do
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_mc
 
   !> @brief Advanced package transport allocate and read (ar) routine
@@ -365,9 +359,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_ar
 
   !> @brief Advanced package transport read and prepare (rp) routine
@@ -486,9 +477,6 @@ contains
       igwfnode = this%flowbudptr%budterm(this%idxbudgwf)%id2(n)
       this%nodelist(n) = igwfnode
     end do
-    !
-    ! -- Return
-    return
   end subroutine apt_rp
 
   !> @brief Advanced package transport set stress period routine.
@@ -586,9 +574,6 @@ contains
 999 if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_set_stressperiod
 
   !> @brief Advanced package transport set stress period routine.
@@ -610,9 +595,6 @@ contains
     found = .false.
     call store_error('Program error: pak_set_stressperiod not implemented.', &
                      terminate=.TRUE.)
-    !
-    ! -- Return
-    return
   end subroutine pak_set_stressperiod
 
   !> @brief Advanced package transport routine
@@ -703,9 +685,6 @@ contains
     !    simulation time from "current" to "preceding" and reset
     !    "current" value.
     call this%obs%obs_ad()
-    !
-    ! -- Return
-    return
   end subroutine apt_ad
 
   !> @brief Override bnd reset for custom mover logic
@@ -717,9 +696,6 @@ contains
     do i = 1, size(this%qmfrommvr)
       this%qmfrommvr(i) = DZERO
     end do
-    !
-    ! -- Return
-    return
   end subroutine apt_reset
 
   subroutine apt_fc(this, rhs, ia, idxglo, matrix_sln)
@@ -738,9 +714,6 @@ contains
     else
       call this%apt_fc_expanded(rhs, ia, idxglo, matrix_sln)
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_fc
 
   !> @brief Advanced package transport fill coefficient (fc) method
@@ -770,9 +743,6 @@ contains
       call matrix_sln%add_value_pos(idiag, this%hcof(j))
       rhs(igwfnode) = rhs(igwfnode) + this%rhs(j)
     end do
-    !
-    ! -- Return
-    return
   end subroutine apt_fc_nonexpanded
 
   !> @brief Advanced package transport fill coefficient (fc) method
@@ -882,9 +852,6 @@ contains
         call matrix_sln%add_value_pos(iposoffd, (DONE - omega) * qbnd_scaled)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_fc_expanded
 
   !> @brief Advanced package transport fill coefficient (fc) method
@@ -905,9 +872,6 @@ contains
     ! -- this routine should never be called
     call store_error('Program error: pak_fc_expanded not implemented.', &
                      terminate=.TRUE.)
-    !
-    ! -- Return
-    return
   end subroutine pak_fc_expanded
 
   !> @brief Advanced package transport routine
@@ -939,9 +903,6 @@ contains
         this%rhs(j) = omega * qbnd * this%xnewpak(n) * this%eqnsclfac
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine apt_cfupdate
 
   !> @brief Advanced package transport calculate flows (cq) routine
@@ -984,9 +945,6 @@ contains
     !
     ! -- fill the budget object
     call this%apt_fill_budobj(x, flowja)
-    !
-    ! -- Return
-    return
   end subroutine apt_cq
 
   !> @brief Save advanced package flows routine
@@ -1013,9 +971,6 @@ contains
     if (ibudfl /= 0 .and. this%iprflow /= 0) then
       call this%budobj%write_flowtable(this%dis, kstp, kper)
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_ot_package_flows
 
   subroutine apt_ot_dv(this, idvsave, idvprint)
@@ -1070,9 +1025,6 @@ contains
         call this%dvtab%add_term(this%xnewpak(n))
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_ot_dv
 
   !> @brief Print advanced package transport dependent variables
@@ -1088,9 +1040,6 @@ contains
     integer(I4B), intent(in) :: ibudfl !< flag indicating budget should be written
     !
     call this%budobj%write_budtable(kstp, kper, iout, ibudfl, totim, delt)
-    !
-    ! -- Return
-    return
   end subroutine apt_ot_bdsummary
 
   !> @ brief Allocate scalars
@@ -1147,9 +1096,6 @@ contains
     !
     ! -- set this package as causing asymmetric matrix terms
     this%iasym = 1
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate index arrays
@@ -1207,9 +1153,6 @@ contains
       call mem_allocate(this%idxfjfoffdglo, 0, 'IDXFJFOFFDGLO', &
                         this%memoryPath)
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_allocate_index_arrays
 
   !> @ brief Allocate arrays
@@ -1265,9 +1208,6 @@ contains
       this%concbudssm(:, n) = DZERO
       this%concfeat(n) = DZERO
     end do
-    !
-    ! -- Return
-    return
   end subroutine apt_allocate_arrays
 
   !> @ brief Deallocate memory
@@ -1344,9 +1284,6 @@ contains
     !
     ! -- deallocate scalars in NumericalPackageType
     call this%BndType%bnd_da()
-    !
-    ! -- Return
-    return
   end subroutine apt_da
 
   !> @brief Find corresponding advanced package transport package
@@ -1361,9 +1298,6 @@ contains
     ! -- this routine should never be called
     call store_error('Program error: pak_solve not implemented.', &
                      terminate=.TRUE.)
-    !
-    ! -- Return
-    return
   end subroutine find_apt_package
 
   !> @brief Set options specific to the TspAptType
@@ -1457,9 +1391,6 @@ contains
       ! -- No options found
       found = .false.
     end select
-    !
-    ! -- Return
-    return
   end subroutine apt_options
 
   !> @brief Determine dimensions for this advanced package
@@ -1526,9 +1457,6 @@ contains
     !
     ! -- setup the conc table object
     call this%apt_setup_tableobj()
-    !
-    ! -- Return
-    return
   end subroutine apt_read_dimensions
 
   !> @brief Read feature information for this advanced package
@@ -1706,9 +1634,6 @@ contains
     !
     ! -- deallocate local storage for nboundchk
     deallocate (nboundchk)
-    !
-    ! -- Return
-    return
   end subroutine apt_read_cvs
 
   !> @brief Read the initial parameters for an advanced package
@@ -1754,9 +1679,6 @@ contains
     !
     ! -- copy boundname into boundname_cst
     call this%copy_boundname()
-    !
-    ! -- Return
-    return
   end subroutine apt_read_initial_attr
 
   !> @brief Add terms specific to advanced package transport to the explicit
@@ -1845,9 +1767,6 @@ contains
         this%xnewpak(n) = c1
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine apt_solve
 
   !> @brief Add terms specific to advanced package transport features to the
@@ -1863,9 +1782,6 @@ contains
     ! -- this routine should never be called
     call store_error('Program error: pak_solve not implemented.', &
                      terminate=.TRUE.)
-    !
-    ! -- Return
-    return
   end subroutine pak_solve
 
   !> @brief Accumulate constant concentration (or temperature) terms for budget
@@ -1897,9 +1813,6 @@ contains
         ccratin = ccratin + q
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_accumulate_ccterm
 
   !> @brief Define the list heading that is written to iout when PRINT_INPUT
@@ -1924,9 +1837,6 @@ contains
     if (this%inamedbound == 1) then
       write (this%listlabel, '(a, a16)') trim(this%listlabel), 'BOUNDARY NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine define_listlabel
 
   !> @brief Set pointers to model arrays and variables so that a package has
@@ -1954,9 +1864,6 @@ contains
       this%iboundpak => this%ibound(istart:iend)
       this%xnewpak => this%xnew(istart:iend)
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_set_pointers
 
   !> @brief Return the feature new volume and old volume
@@ -1979,9 +1886,6 @@ contains
       vnew = this%flowbudptr%budterm(this%idxbudsto)%auxvar(1, icv)
       vold = vnew + qss * delt
     end if
-    !
-    ! -- Return
-    return
   end subroutine get_volumes
 
   !> @brief Function to return the number of budget terms just for this package
@@ -2000,9 +1904,6 @@ contains
     call store_error('Program error: pak_get_nbudterms not implemented.', &
                      terminate=.TRUE.)
     nbudterms = 0
-    !
-    ! -- Return
-    return
   end function pak_get_nbudterms
 
   !> @brief Set up the budget object that stores advanced package flow terms
@@ -2189,9 +2090,6 @@ contains
     if (this%iprflow /= 0) then
       call this%budobj%flowtable_df(this%iout)
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_setup_budobj
 
   !> @brief Set up a budget object that stores an advanced package flows
@@ -2208,9 +2106,6 @@ contains
     ! -- this routine should never be called
     call store_error('Program error: pak_setup_budobj not implemented.', &
                      terminate=.TRUE.)
-    !
-    ! -- Return
-    return
   end subroutine pak_setup_budobj
 
   !> @brief Copy flow terms into this%budobj
@@ -2349,9 +2244,6 @@ contains
     !
     ! --Terms are filled, now accumulate them for this time step
     call this%budobj%accumulate_terms()
-    !
-    ! -- Return
-    return
   end subroutine apt_fill_budobj
 
   !> @brief Copy flow terms into this%budobj, must be overridden
@@ -2371,9 +2263,6 @@ contains
     ! -- this routine should never be called
     call store_error('Program error: pak_fill_budobj not implemented.', &
                      terminate=.TRUE.)
-    !
-    ! -- Return
-    return
   end subroutine pak_fill_budobj
 
   !> @brief Account for mass or energy storage in advanced package features
@@ -2401,9 +2290,6 @@ contains
     end if
     if (present(rhsval)) rhsval = -c0 * v0 * this%eqnsclfac / delt
     if (present(hcofval)) hcofval = -v1 * this%eqnsclfac / delt
-    !
-    ! -- Return
-    return
   end subroutine apt_stor_term
 
   !> @brief Account for mass or energy transferred to the MVR package
@@ -2431,9 +2317,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = DZERO
     if (present(hcofval)) hcofval = qbnd * this%eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine apt_tmvr_term
 
   !> @brief Account for mass or energy transferred to this package from the
@@ -2457,9 +2340,6 @@ contains
     if (present(rrate)) rrate = this%qmfrommvr(n1) ! NOTE: When bringing in GWE, ensure this is in terms of energy. Might need to apply eqnsclfac here.
     if (present(rhsval)) rhsval = this%qmfrommvr(n1)
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine apt_fmvr_term
 
   !> @brief Go through each "within apt-apt" connection (e.g., lkt-lkt, or
@@ -2491,9 +2371,6 @@ contains
     if (present(rrate)) rrate = ctmp * qbnd * this%eqnsclfac
     if (present(rhsval)) rhsval = -rrate * this%eqnsclfac
     if (present(hcofval)) hcofval = DZERO
-    !
-    ! -- Return
-    return
   end subroutine apt_fjf_term
 
   !> @brief Copy concentrations (or temperatures) into flow package aux
@@ -2517,9 +2394,6 @@ contains
         this%flowpackagebnd%auxvar(this%iauxfpconc, j) = this%xnewpak(n)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_copy2flowp
 
   !> @brief Determine whether an obs type is supported
@@ -2535,9 +2409,6 @@ contains
     !
     ! -- Set to true
     apt_obs_supported = .true.
-    !
-    ! -- Return
-    return
   end function apt_obs_supported
 
   !> @brief Define observation type
@@ -2554,9 +2425,6 @@ contains
     !
     ! -- call additional specific observations for lkt, sft, mwt, and uzt
     call this%pak_df_obs()
-    !
-    ! -- Return
-    return
   end subroutine apt_df_obs
 
   !> @brief Define apt observation type
@@ -2573,9 +2441,6 @@ contains
     ! -- this routine should never be called
     call store_error('Program error: pak_df_obs not implemented.', &
                      terminate=.TRUE.)
-    !
-    ! -- Return
-    return
   end subroutine pak_df_obs
 
   !> @brief Process package specific obs
@@ -2592,9 +2457,6 @@ contains
     ! -- this routine should never be called
     call store_error('Program error: pak_rp_obs not implemented.', &
                      terminate=.TRUE.)
-    !
-    ! -- Return
-    return
   end subroutine pak_rp_obs
 
   !> @brief Prepare observation
@@ -2638,9 +2500,6 @@ contains
       end if
       call obsrv%AddObsIndex(nn1)
     end if
-    !
-    ! -- Return
-    return
   end subroutine rp_obs_byfeature
 
   !> @brief Prepare observation
@@ -2713,9 +2572,6 @@ contains
         call store_error(errmsg)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine rp_obs_budterm
 
   !> @brief Prepare observation
@@ -2790,9 +2646,6 @@ contains
         call store_error(errmsg)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine rp_obs_flowjaface
 
   !> @brief Read and prepare apt-related observations
@@ -2869,9 +2722,6 @@ contains
         call store_error_unit(this%obs%inunitobs)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_rp_obs
 
   !> @brief Calculate observation values
@@ -2964,9 +2814,6 @@ contains
         call store_error_unit(this%obs%inunitobs)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine apt_bd_obs
 
   !> @brief Check if observation exists in an advanced package
@@ -2982,9 +2829,6 @@ contains
     !
     ! -- set found = .false. because obstypeid is not known
     found = .false.
-    !
-    ! -- Return
-    return
   end subroutine pak_bd_obs
 
   !> @brief Process observation IDs for an advanced package
@@ -3028,9 +2872,6 @@ contains
     !    as the iconn value for SFT.  This works for SFT
     !    because there is only one reach per GWT connection.
     obsrv%NodeNumber2 = 1
-    !
-    ! -- return
-    return
   end subroutine apt_process_obsID
 
   !> @brief Process observation IDs for a package
@@ -3081,9 +2922,6 @@ contains
     !
     ! -- store reach number (NodeNumber)
     obsrv%NodeNumber = nn1
-    !
-    ! -- Return
-    return
   end subroutine apt_process_obsID12
 
   !> @brief Setup a table object an advanced package
@@ -3134,9 +2972,6 @@ contains
       text_temp = this%depvartype(1:4)
       call this%dvtab%initialize_column(text_temp, 12, alignment=TABCENTER)
     end if
-    !
-    ! -- return
-    return
   end subroutine apt_setup_tableobj
 
 end module TspAptModule

--- a/src/Model/TransportModel/tsp-fmi.f90
+++ b/src/Model/TransportModel/tsp-fmi.f90
@@ -102,9 +102,6 @@ contains
     !
     ! -- Store pointer to governing equation scale factor
     fmiobj%eqnsclfac => eqnsclfac
-    !
-    ! -- Return
-    return
   end subroutine fmi_cr
 
   !> @brief Read and prepare
@@ -134,9 +131,6 @@ contains
         call store_error(errmsg, terminate=.TRUE.)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine fmi_rp
 
   !> @brief Advance routine for FMI object
@@ -187,9 +181,6 @@ contains
     if (this%idryinactive /= 0) then
       call this%set_active_status(cnew)
     end if
-    !
-    ! -- Return
-    return
   end subroutine fmi_ad
 
   !> @brief Calculate coefficients and fill matrix and rhs terms associated
@@ -221,9 +212,6 @@ contains
         call matrix_sln%add_value_pos(idiag_sln, qcorr)
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine fmi_fc
 
   !> @brief Calculate flow correction
@@ -256,9 +244,6 @@ contains
         flowja(idiag) = flowja(idiag) + rate
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine fmi_cq
 
   !> @brief Calculate budget terms associated with FMI object
@@ -280,9 +265,6 @@ contains
       call rate_accumulator(this%flowcorrect, rin, rout)
       call model_budget%addentry(rin, rout, delt, budtxt(2), isuppress_output)
     end if
-    !
-    ! -- Return
-    return
   end subroutine fmi_bd
 
   !> @brief Save budget terms associated with FMI object
@@ -321,9 +303,6 @@ contains
                                  budtxt(2), cdatafmp, nvaluesp, &
                                  nwidthp, editdesc, dinact)
     end if
-    !
-    ! -- Return
-    return
   end subroutine fmi_ot_flow
 
   !> @brief Deallocate variables
@@ -377,9 +356,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine gwtfmi_da
 
   !> @ brief Allocate scalars
@@ -405,9 +381,6 @@ contains
     !
     ! -- Initialize
     this%iflowerr = 0
-    !
-    ! -- Return
-    return
   end subroutine gwtfmi_allocate_scalars
 
   !> @ brief Allocate arrays for FMI object
@@ -436,9 +409,6 @@ contains
     do n = 1, size(this%flowcorrect)
       this%flowcorrect(n) = DZERO
     end do
-    !
-    ! -- return
-    return
   end subroutine gwtfmi_allocate_arrays
 
   !> @brief Set gwt transport cell status
@@ -523,9 +493,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine set_active_status
 
   !> @brief Calculate the previous saturation level
@@ -553,9 +520,6 @@ contains
     if (this%igwfstrgss /= 0) vold = vold + this%gwfstrgss(n) * delt
     if (this%igwfstrgsy /= 0) vold = vold + this%gwfstrgsy(n) * delt
     satold = vold / vcell
-    !
-    ! -- Return
-    return
   end function gwfsatold
 
   !> @brief Read options from input file
@@ -604,9 +568,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF FMI OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwtfmi_read_options
 
   !> @brief Read PACKAGEDATA block
@@ -737,9 +698,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF FMI PACKAGEDATA'
     end if
-    !
-    ! -- Return
-    return
   end subroutine gwtfmi_read_packagedata
 
   !> @brief Set the pointer to a budget object
@@ -765,9 +723,6 @@ contains
         exit
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine set_aptbudobj_pointer
 
   !> @brief Initialize the groundwater flow terms based on the budget file
@@ -870,9 +825,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine initialize_gwfterms_from_bfr
 
   !> @brief Initialize groundwater flow terms from the groundwater budget
@@ -942,9 +894,6 @@ contains
         iterm = iterm + 1
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine initialize_gwfterms_from_gwfbndlist
 
   !> @brief Initialize an array for storing PackageBudget objects.
@@ -984,9 +933,6 @@ contains
       write (memPath, '(a, i0)') trim(this%memoryPath)//'-FT', n
       call this%gwfpackages(n)%initialize(memPath)
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwtfmi_allocate_gwfpackages
 
   !> @brief Deallocate memory
@@ -1004,9 +950,6 @@ contains
     do n = 1, this%nflowpack
       call this%gwfpackages(n)%da()
     end do
-    !
-    ! -- Return
-    return
   end subroutine gwtfmi_deallocate_gwfpackages
 
 end module TspFmiModule

--- a/src/Model/TransportModel/tsp-ic.f90
+++ b/src/Model/TransportModel/tsp-ic.f90
@@ -48,9 +48,6 @@ contains
     !
     ! -- Give package access to the assigned labelsd based on dependent variable
     ic%depvartype = depvartype
-    !
-    ! -- Return
-    return
   end subroutine ic_cr
 
 end module TspIcModule

--- a/src/Model/TransportModel/tsp-mvt.f90
+++ b/src/Model/TransportModel/tsp-mvt.f90
@@ -122,9 +122,6 @@ contains
     ! -- Store pointer to labels associated with the current model so that the
     !    package has access to the corresponding dependent variable type
     mvt%depvartype = depvartype
-    !
-    ! -- Return
-    return
   end subroutine mvt_cr
 
   !> @brief Define mover transport object
@@ -152,9 +149,6 @@ contains
     !
     ! -- Read mvt options
     call this%read_options()
-    !
-    ! -- Return
-    return
   end subroutine mvt_df
 
   !> @ brief Set pointer to mvrbudobj
@@ -177,9 +171,6 @@ contains
     !
     ! -- Setup the output table
     call this%mvt_setup_outputtab()
-    !
-    ! -- Return
-    return
   end subroutine mvt_ar
 
   !> @brief Read and prepare mover transport object
@@ -207,9 +198,6 @@ contains
       call this%budget%budget_df(this%maxpackages, 'TRANSPORT MOVER', bddim='M')
       call this%budget%set_ibudcsv(this%ibudcsv)
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvt_rp
 
   !> @brief Calculate coefficients and fill amat and rhs
@@ -302,9 +290,6 @@ contains
         end do
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine mvt_fc
 
   !> @ brief Set the fmi_pr and fmi_rc pointers
@@ -372,9 +357,6 @@ contains
       print *, 'Could not find FMI Package...'
       stop "error in set_fmi_pr_rc"
     end if
-    !
-    ! -- Return
-    return
   end subroutine set_fmi_pr_rc
 
   !> @brief Extra convergence check for mover
@@ -400,9 +382,6 @@ contains
         write (this%iout, fmtmvrcnvg)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvt_cc
 
   !> @brief Write mover terms to listing file
@@ -415,9 +394,6 @@ contains
     !
     ! -- Fill the budget object
     call this%mvt_fill_budobj(cnew1, cnew2)
-    !
-    ! -- Return
-    return
   end subroutine mvt_bd
 
   !> @brief Write mover budget terms
@@ -442,9 +418,6 @@ contains
       call this%budobj%save_flows(this%dis, ibinun, kstp, kper, delt, &
                                   pertim, totim, this%iout)
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvt_ot_saveflow
 
   !> @brief Print mover flow table
@@ -459,9 +432,6 @@ contains
     if (ibudfl /= 0 .and. this%iprflow /= 0) then
       call this%mvt_print_outputtab()
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvt_ot_printflow
 
   !> @brief Write mover budget to listing file
@@ -524,9 +494,6 @@ contains
     !    in a table that has one entry.  A custom table looks
     !    better here with a row for each package.
     !call this%budobj%write_budtable(kstp, kper, this%iout)
-    !
-    ! -- Return
-    return
   end subroutine mvt_ot_bdsummary
 
   !> @ brief Deallocate memory
@@ -572,9 +539,6 @@ contains
     !
     ! -- Deallocate scalars in NumericalPackageType
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine mvt_da
 
   !> @ brief Allocate scalar variables for package
@@ -599,9 +563,6 @@ contains
     this%maxpackages = 0
     this%ibudgetout = 0
     this%ibudcsv = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @brief Read mover-for-transport options block
@@ -681,9 +642,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF MVT OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @brief Set up the budget object that stores all the mvr flows
@@ -732,9 +690,6 @@ contains
                                              maxlist, .false., .false., &
                                              naux)
     end do
-    !
-    ! -- Return
-    return
   end subroutine mvt_setup_budobj
 
   !> @brief Copy mover-for-transport flow terms into this%budobj
@@ -800,9 +755,6 @@ contains
     !
     ! --Terms are filled, now accumulate them for this time step
     call this%budobj%accumulate_terms()
-    !
-    ! -- Return
-    return
   end subroutine mvt_fill_budobj
 
   !> @brief Determine max number of packages in use
@@ -849,9 +801,6 @@ contains
         ipos = ipos + 1
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine mvt_scan_mvrbudobj
 
   !> @brief Set up the mover-for-transport output table
@@ -897,9 +846,6 @@ contains
       call this%outputtab%initialize_column(text, 10)
       !
     end if
-    !
-    ! -- Return
-    return
   end subroutine mvt_setup_outputtab
 
   !> @brief Set up mover-for-transport output table
@@ -953,9 +899,6 @@ contains
         inum = inum + 1
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine mvt_print_outputtab
 
 end module TspMvtModule

--- a/src/Model/TransportModel/tsp-obs.f90
+++ b/src/Model/TransportModel/tsp-obs.f90
@@ -52,9 +52,6 @@ contains
     obs%inputFilename = ''
     obs%inUnitObs => inobs
     obs%depvartype = dvt
-    !
-    ! -- Return
-    return
   end subroutine tsp_obs_cr
 
   !> @brief Allocate and read method for package
@@ -73,9 +70,6 @@ contains
     !
     ! -- set pointers
     call this%set_pointers(ic, x, flowja)
-    !
-    ! -- Return
-    return
   end subroutine tsp_obs_ar
 
   !> @brief Define observation object
@@ -103,9 +97,6 @@ contains
     ! -- Store obs type and assign procedure pointer for flow-ja-face observation type
     call this%StoreObsType('flow-ja-face', .true., indx)
     this%obsData(indx)%ProcessIdPtr => tsp_process_intercell_obs_id
-    !
-    ! -- Return
-    return
   end subroutine tsp_obs_df
 
   !> @brief Save observations
@@ -138,9 +129,6 @@ contains
         end select
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine tsp_obs_bd
 
   !> @brief If transport model observations need checks, add them here
@@ -150,9 +138,6 @@ contains
     class(TspObsType), intent(inout) :: this
     !
     ! Do GWT (or GWE) observations need any checking? If so, add checks here
-    !
-    ! -- Return
-    return
   end subroutine tsp_obs_rp
 
   !> Deallocate memory
@@ -167,9 +152,6 @@ contains
     nullify (this%x)
     nullify (this%flowja)
     call this%ObsType%obs_da()
-    !
-    ! -- Return
-    return
   end subroutine tsp_obs_da
 
   !> @brief Set pointers needed by the transport OBS package
@@ -184,9 +166,6 @@ contains
     this%ic => ic
     this%x => x
     this%flowja => flowja
-    !
-    ! -- Return
-    return
   end subroutine set_pointers
 
   !> @brief Procedure related to Tsp observations (NOT type-bound)
@@ -220,9 +199,6 @@ contains
       call store_error(ermsg)
       call store_error_unit(inunitobs)
     end if
-    !
-    ! -- Return
-    return
   end subroutine tsp_process_obs_id
 
   !> @brief Procedure related to Tsp observations (NOT type-bound)
@@ -280,9 +256,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(inunitobs)
     end if
-    !
-    ! -- Return
-    return
   end subroutine tsp_process_intercell_obs_id
 
 end module TspObsModule

--- a/src/Model/TransportModel/tsp-oc.f90
+++ b/src/Model/TransportModel/tsp-oc.f90
@@ -46,9 +46,6 @@ contains
     !
     ! -- Initialize block parser
     call ocobj%parser%Initialize(inunit, iout)
-    !
-    ! -- Return
-    return
   end subroutine oc_cr
 
   !> @ brief Allocate and read TspOcType
@@ -93,9 +90,6 @@ contains
     if (this%inunit > 0) then
       call this%read_options()
     end if
-    !
-    ! -- Return
-    return
   end subroutine oc_ar
 
 end module TspOcModule

--- a/src/Model/TransportModel/tsp-ssm.f90
+++ b/src/Model/TransportModel/tsp-ssm.f90
@@ -111,9 +111,6 @@ contains
     ! -- Store pointer to labels associated with the current model so that the
     !    package has access to the corresponding dependent variable type
     ssmobj%depvartype = depvartype
-    !
-    ! -- Return
-    return
   end subroutine ssm_cr
 
   !> @ brief Define SSM Package
@@ -127,9 +124,6 @@ contains
     use MemoryManagerModule, only: mem_setptr
     ! -- dummy
     class(TspSsmType) :: this !< TspSsmType object
-    !
-    ! -- Return
-    return
   end subroutine ssm_df
 
   !> @ brief Allocate and read SSM Package
@@ -181,9 +175,6 @@ contains
     !
     ! -- setup the output table
     call this%pak_setup_outputtab()
-    !
-    ! -- Return
-    return
   end subroutine ssm_ar
 
   !> @ brief Read and prepare this SSM Package
@@ -209,9 +200,6 @@ contains
         call ssmiptr%spc_rp()
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine ssm_rp
 
   !> @ brief Advance the SSM Package
@@ -256,9 +244,6 @@ contains
                             this%fmi%gwfpackages(ip)%budtxt)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine ssm_ad
 
   !> @ brief Calculate the SSM mass flow rate and hcof and rhs values
@@ -357,9 +342,6 @@ contains
     if (present(rrate)) rrate = hcoftmp * ctmp - rhstmp
     if (present(cssm)) cssm = ctmp
     if (present(qssm)) qssm = qbnd
-    !
-    ! -- Return
-    return
   end subroutine ssm_term
 
   !> @ brief Provide bound concentration (or temperature) and mixed flag
@@ -397,9 +379,6 @@ contains
       conc = this%ssmivec(ipackage)%get_value(ientry, nbound_flow)
       if (isrctype == 4) lauxmixed = .true.
     end select
-    !
-    ! -- Return
-    return
   end subroutine get_ssm_conc
 
   !> @ brief Fill coefficients
@@ -441,9 +420,6 @@ contains
       end do
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine ssm_fc
 
   !> @ brief Calculate flow
@@ -480,9 +456,6 @@ contains
       end do
       !
     end do
-    !
-    ! -- Return
-    return
   end subroutine ssm_cq
 
   !> @ brief Calculate the global SSM budget terms
@@ -536,9 +509,6 @@ contains
                                  this%fmi%gwfpackages(ip)%budtxt, &
                                  isuppress_output, rowlabel=rowlabel)
     end do
-    !
-    ! -- Return
-    return
   end subroutine ssm_bd
 
   !> @ brief Output flows
@@ -667,9 +637,6 @@ contains
         write (this%iout, '(1x)')
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine ssm_ot_flow
 
   !> @ brief Deallocate
@@ -716,9 +683,6 @@ contains
     !
     ! -- deallocate parent
     call this%NumericalPackageType%da()
-    !
-    ! -- Return
-    return
   end subroutine ssm_da
 
   !> @ brief Allocate scalars
@@ -739,9 +703,6 @@ contains
     !
     ! -- Initialize
     this%nbound = 0
-    !
-    ! -- Return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate arrays
@@ -770,9 +731,6 @@ contains
     !
     ! -- Allocate the ssmivec array
     allocate (this%ssmivec(nflowpack))
-    !
-    ! -- Return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Read package options
@@ -820,9 +778,6 @@ contains
       end do
       write (this%iout, '(1x,a)') 'END OF SSM OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_options
 
   !> @ brief Read package data
@@ -838,9 +793,6 @@ contains
     !
     ! -- read and process optional FILEINPUT block
     call this%read_sources_fileinput()
-    !
-    ! -- Return
-    return
   end subroutine read_data
 
   !> @ brief Read SOURCES block
@@ -938,9 +890,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_sources_aux
 
   !> @ brief Read FILEINPUT block
@@ -1053,9 +1002,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_sources_fileinput
 
   !> @ brief Set iauxpak array value for package ip
@@ -1097,9 +1043,6 @@ contains
     this%iauxpak(ip) = iaux
     write (this%iout, '(4x, a, i0, a, a)') 'USING AUX COLUMN ', &
       iaux, ' IN PACKAGE ', trim(packname)
-    !
-    ! -- Return
-    return
   end subroutine set_iauxpak
 
   !> @ brief Set ssmivec array value for package ip
@@ -1133,9 +1076,6 @@ contains
     write (this%iout, '(4x, a, a, a, a, a)') 'USING SPC INPUT FILE ', &
       trim(filename), ' TO SET ', trim(this%depvartype), &
       'S FOR PACKAGE ', trim(packname)
-    !
-    ! -- Return
-    return
   end subroutine set_ssmivec
 
   !> @ brief Setup the output table
@@ -1181,9 +1121,6 @@ contains
       !  call this%outputtab%initialize_column(text, 20, alignment=TABLEFT)
       !end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine pak_setup_outputtab
 
 end module TspSsmModule

--- a/src/Model/TransportModel/tsp.f90
+++ b/src/Model/TransportModel/tsp.f90
@@ -144,9 +144,6 @@ contains
     !
     ! -- create model packages
     call this%create_tsp_packages(indis)
-    !
-    ! -- Return
-    return
   end subroutine tsp_cr
 
   !> @brief Generalized transport model define model
@@ -158,9 +155,6 @@ contains
   subroutine tsp_df(this)
     ! -- dummy
     class(TransportModelType) :: this
-    !
-    ! -- Return
-    return
   end subroutine tsp_df
 
   !> @brief Generalized transport model add connections
@@ -174,9 +168,6 @@ contains
     ! -- dummy
     class(TransportModelType) :: this
     type(sparsematrix), intent(inout) :: sparse
-    !
-    ! -- Return
-    return
   end subroutine tsp_ac
 
   !> @brief Generalized transport model map coefficients
@@ -189,9 +180,6 @@ contains
     ! -- dummy
     class(TransportModelType) :: this
     class(MatrixBaseType), pointer :: matrix_sln !< global system matrix
-    !
-    ! -- Return
-    return
   end subroutine tsp_mc
 
   !> @brief Generalized transport model allocate and read
@@ -203,9 +191,6 @@ contains
   subroutine tsp_ar(this)
     ! -- dummy
     class(TransportModelType) :: this
-    !
-    ! -- Return
-    return
   end subroutine tsp_ar
 
   !> @brief Generalized transport model read and prepare
@@ -216,9 +201,6 @@ contains
   subroutine tsp_rp(this)
     ! -- dummy
     class(TransportModelType) :: this
-    !
-    ! -- Return
-    return
   end subroutine tsp_rp
 
   !> @brief Generalized transport model time step advance
@@ -229,9 +211,6 @@ contains
   subroutine tsp_ad(this)
     ! -- dummy
     class(TransportModelType) :: this
-    !
-    ! -- Return
-    return
   end subroutine tsp_ad
 
   !> @brief Generalized transport model fill coefficients
@@ -245,9 +224,6 @@ contains
     integer(I4B), intent(in) :: kiter
     class(MatrixBaseType), pointer :: matrix_sln
     integer(I4B), intent(in) :: inwtflag
-    !
-    ! -- Return
-    return
   end subroutine tsp_fc
 
   !> @brief Generalized transport model final convergence check
@@ -265,9 +241,6 @@ contains
     character(len=LENPAKLOC), intent(inout) :: cpak
     integer(I4B), intent(inout) :: ipak
     real(DP), intent(inout) :: dpak
-    !
-    ! -- Return
-    return
   end subroutine tsp_cc
 
   !> @brief Generalized transport model calculate flows
@@ -280,9 +253,6 @@ contains
     class(TransportModelType) :: this
     integer(I4B), intent(in) :: icnvg
     integer(I4B), intent(in) :: isuppress_output
-    !
-    ! -- Return
-    return
   end subroutine tsp_cq
 
   !> @brief Generalized transport model budget
@@ -295,9 +265,6 @@ contains
     class(TransportModelType) :: this
     integer(I4B), intent(in) :: icnvg
     integer(I4B), intent(in) :: isuppress_output
-    !
-    ! -- Return
-    return
   end subroutine tsp_bd
 
   !> @brief Generalized transport model output routine
@@ -358,9 +325,6 @@ contains
     if (this%icnvg == 0) then
       write (this%iout, fmtnocnvg) kstp, kper
     end if
-    !
-    ! -- Return
-    return
   end subroutine tsp_ot
 
   !> @brief Generalized transport model output routine
@@ -472,9 +436,6 @@ contains
     if (ibinun /= 0) then
       call this%dis%record_connection_array(flowja, ibinun, this%iout)
     end if
-    !
-    ! -- Return
-    return
   end subroutine tsp_ot_flowja
 
   !> @brief Generalized transport model output routine
@@ -497,9 +458,6 @@ contains
     !
     ! -- Save head and print head
     call this%oc%oc_ot(ipflag)
-    !
-    ! -- Return
-    return
   end subroutine tsp_ot_dv
 
   !> @brief Generalized tranpsort model output budget summary
@@ -534,9 +492,6 @@ contains
     !
     ! -- Write to budget csv
     call this%budget%writecsv(totim)
-    !
-    ! -- Return
-    return
   end subroutine tsp_ot_bdsummary
 
   !> @brief Allocate scalar variables for transport model
@@ -571,9 +526,6 @@ contains
     this%inoc = 0
     this%inobs = 0
     this%eqnsclfac = DZERO
-    !
-    ! -- Return
-    return
   end subroutine allocate_tsp_scalars
 
   !> @brief Define the labels corresponding to the flavor of
@@ -600,9 +552,6 @@ contains
     !
     ! -- Set the units abbreviation
     this%depvarunitabbrev = depvarunitabbrev
-    !
-    ! -- Return
-    return
   end subroutine set_tsp_labels
 
   !> @brief Deallocate memory
@@ -625,9 +574,6 @@ contains
     call mem_deallocate(this%inoc)
     call mem_deallocate(this%inobs)
     call mem_deallocate(this%eqnsclfac)
-    !
-    ! -- Return
-    return
   end subroutine tsp_da
 
   !> @brief Generalized tranpsort model routine
@@ -667,9 +613,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(this%filename)
     end if
-    !
-    ! -- Return
-    return
   end subroutine ftype_check
 
   !> @brief Write model name file options to list file
@@ -709,9 +652,6 @@ contains
     end if
     !
     write (this%iout, '(1x,a)') 'END NAMEFILE OPTIONS:'
-    !
-    ! -- Return
-    return
   end subroutine log_namfile_options
 
   !> @brief Source package info and begin to process
@@ -817,9 +757,6 @@ contains
                 this%eqnsclfac, this%depvartype)
     call oc_cr(this%oc, this%name, this%inoc, this%iout)
     call tsp_obs_cr(this%obs, this%inobs, this%depvartype)
-    !
-    ! -- Return
-    return
   end subroutine create_tsp_packages
 
 end module TransportModelModule

--- a/src/SimulationCreate.f90
+++ b/src/SimulationCreate.f90
@@ -37,9 +37,6 @@ contains
     !
     ! -- Source simulation nam input context and create objects
     call source_simulation_nam()
-    !
-    ! -- Return
-    return
   end subroutine simulation_cr
 
   !> @brief Deallocate simulation variables
@@ -57,9 +54,6 @@ contains
     !
     deallocate (model_names)
     deallocate (model_loc_idx)
-    !
-    ! -- Return
-    return
   end subroutine simulation_da
 
   !> @brief Source the simulation name file
@@ -94,9 +88,6 @@ contains
     !
     ! -- Go through each solution and assign exchanges accordingly
     call assign_exchanges()
-    !
-    ! -- Return
-    return
   end subroutine source_simulation_nam
 
   !> @brief Set the simulation options
@@ -161,9 +152,6 @@ contains
       !
       write (iout, '(1x,a)') 'END OF SIMULATION OPTIONS'
     end if
-    !
-    ! -- return
-    return
   end subroutine options_create
 
   !> @brief Set the timing module to be used for the simulation
@@ -199,9 +187,6 @@ contains
     end if
     !
     write (iout, '(1x,a)') 'END OF SIMULATION TIMING'
-    !
-    ! -- return
-    return
   end subroutine timing_create
 
   !> @brief Set the models to be used for the simulation
@@ -355,9 +340,6 @@ contains
         'No MODELS assigned to process ', proc_id
       call store_error(errmsg, terminate)
     end if
-    !
-    ! -- return
-    return
   end subroutine models_create
 
   !> @brief Set the exchanges to be used for the simulation
@@ -508,9 +490,6 @@ contains
     !
     ! -- close exchange logging block
     write (iout, '(1x,a)') 'END OF SIMULATION EXCHANGES'
-    !
-    ! -- return
-    return
   end subroutine exchanges_create
 
   !> @brief Check a solution_group to be used for the simulation
@@ -546,9 +525,6 @@ contains
         call store_error(errmsg, terminate)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine solution_group_check
 
   !> @brief Set the solution_groups to be used for the simulation
@@ -744,9 +720,6 @@ contains
     if (solutiongrouplist%Count() == 0) then
       call store_error('There are no solution groups.', terminate)
     end if
-    !
-    ! -- return
-    return
   end subroutine solution_groups_create
 
   !> @brief Check for dangling models, and break with
@@ -838,9 +811,6 @@ contains
         call store_error(errmsg, terminate)
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine check_model_name
 
 end module SimulationCreateModule

--- a/src/Solution/BaseSolution.f90
+++ b/src/Solution/BaseSolution.f90
@@ -161,7 +161,6 @@ contains
     class is (BaseSolutionType)
       res => obj
     end select
-    return
   end function CastAsBaseSolutionClass
 
   subroutine AddBaseSolutionToList(list, solution)
@@ -174,8 +173,6 @@ contains
     !
     obj => solution
     call list%Add(obj)
-    !
-    return
   end subroutine AddBaseSolutionToList
 
   function GetBaseSolutionFromList(list, idx) result(res)
@@ -189,8 +186,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsBaseSolutionClass(obj)
-    !
-    return
   end function GetBaseSolutionFromList
 
 end module BaseSolutionModule

--- a/src/Solution/LinearMethods/ImsLinear.f90
+++ b/src/Solution/LinearMethods/ImsLinear.f90
@@ -336,10 +336,7 @@ CONTAINS
     END IF
     !
     ! -- ALLOCATE MEMORY FOR STORING ITERATION CONVERGENCE DATA
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE imslinear_ar
+  end SUBROUTINE imslinear_ar
 
   !> @ brief Write summary of settings
     !!
@@ -448,9 +445,6 @@ CONTAINS
         END DO
       END IF
     end if
-    !
-    ! -- return
-    return
   end subroutine imslinear_summary
 
   !> @ brief Allocate and initialize scalars
@@ -491,9 +485,6 @@ CONTAINS
     this%njlu = 0
     this%njw = 0
     this%nwlu = 0
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Deallocate memory
@@ -558,9 +549,6 @@ CONTAINS
     nullify (this%amat)
     nullify (this%rhs)
     nullify (this%x)
-    !
-    ! -- return
-    return
   end subroutine imslinear_da
 
   !> @ brief Set default settings
@@ -617,10 +605,7 @@ CONTAINS
       this%DROPTOL = DEM4
       this%NORTH = 2
     END SELECT
-    !
-    ! -- return
-    RETURN
-  END SUBROUTINE imslinear_set_input
+  end SUBROUTINE imslinear_set_input
 
   !> @ brief Base linear accelerator subroutine
     !!
@@ -762,9 +747,6 @@ CONTAINS
     ! -- SET IMS INNER ITERATION NUMBER (IN_ITER) TO NUMBER OF
     !       IMSLINEAR INNER ITERATIONS (innerit)
     IN_ITER = innerit
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE imslinear_ap
+  end SUBROUTINE imslinear_ap
 
 END MODULE IMSLinearModule

--- a/src/Solution/LinearMethods/ImsLinearBase.f90
+++ b/src/Solution/LinearMethods/ImsLinearBase.f90
@@ -237,10 +237,7 @@ contains
     !
     ! -- RESET ICNVG
     IF (ICNVG < 0) ICNVG = 0
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_cg
+  end SUBROUTINE ims_base_cg
 
   !> @ brief Preconditioned BiConjugate Gradient Stabilized linear accelerator
   !!
@@ -549,10 +546,7 @@ contains
     !
     ! -- RESET ICNVG
     IF (ICNVG < 0) ICNVG = 0
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_bcgs
+  end SUBROUTINE ims_base_bcgs
 
   !> @ brief Calculate LORDER AND IORDER
   !!
@@ -613,10 +607,7 @@ contains
     if (count_errors() > 0) then
       call parser%StoreErrorUnit()
     end if
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_calc_order
+  end SUBROUTINE ims_base_calc_order
 
   !
   !> @ brief Scale the coefficient matrix
@@ -760,10 +751,7 @@ contains
         B(n) = B(n) / c1
       END DO
     END IF
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_scale
+  end SUBROUTINE ims_base_scale
 
   !> @ brief Update the preconditioner
   !!
@@ -873,10 +861,7 @@ contains
     if (icount > 0) then
       write (IOUT, 2000) icount
     end if
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_pcu
+  end SUBROUTINE ims_base_pcu
 
   !> @ brief Jacobi preconditioner
   !!
@@ -912,10 +897,7 @@ contains
       IF (ABS(tv) > DZERO) tv = DONE / tv
       APC(n) = tv
     END DO
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_pcjac
+  end SUBROUTINE ims_base_pcjac
 
   !> @ brief Apply the Jacobi preconditioner
   !!
@@ -936,10 +918,7 @@ contains
       tv = A(n) * D1(n)
       D2(n) = tv
     END DO
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_jaca
+  end SUBROUTINE ims_base_jaca
 
   !> @ brief Update the ILU0 preconditioner
   !!
@@ -1060,10 +1039,7 @@ contains
     !
     ! -- RESET IPCFLAG IF SUCCESSFUL COMPLETION OF MAIN
     IPCFLAG = 0
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_pcilu0
+  end SUBROUTINE ims_base_pcilu0
 
   !> @ brief Apply the ILU0 and MILU0 preconditioners
   !!
@@ -1113,10 +1089,7 @@ contains
       ! -- COMPUTE D FOR DIAGONAL - D = D / U
       D(n) = tv * APC(n)
     END DO BACKWARD
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_ilu0a
+  end SUBROUTINE ims_base_ilu0a
 
   !> @ brief Test for solver convergence
   !!
@@ -1170,10 +1143,7 @@ contains
         Icnvg = -1
       END IF
     END IF
-    !
-    ! -- return
-    RETURN
-  END SUBROUTINE ims_base_testcnvg
+  end SUBROUTINE ims_base_testcnvg
 
   subroutine ims_calc_pcdims(neq, nja, ia, level, ipc, &
                              niapc, njapc, njlu, njw, nwlu)
@@ -1288,10 +1258,7 @@ contains
         END IF
       END DO
     END DO
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_pccrs
+  end SUBROUTINE ims_base_pccrs
 
   !> @brief In-place sorting for an integer array
   !!
@@ -1314,10 +1281,7 @@ contains
         END IF
       END DO
     END DO
-    !
-    ! -- RETURN
-    RETURN
-  END SUBROUTINE ims_base_isort
+  end SUBROUTINE ims_base_isort
 
   !> @brief Calculate residual
   !!
@@ -1345,10 +1309,7 @@ contains
     DO n = 1, NEQ
       D(n) = B(n) - D(n)
     END DO
-    !
-    ! -- return
-    RETURN
-  END SUBROUTINE ims_base_residual
+  end SUBROUTINE ims_base_residual
 
   !> @brief Function returning EPFACT
   !<

--- a/src/Solution/LinearMethods/ImsLinearMisc.f90
+++ b/src/Solution/LinearMethods/ImsLinearMisc.f90
@@ -47,8 +47,6 @@ CONTAINS
     do j = n - 1, 1, -1
       x(j) = x(j) - w(j + 1) * x(j + 1)
     end do
-    ! -- return
-    return
   end subroutine ims_misc_thomas
 
 END MODULE IMSLinearMisc

--- a/src/Solution/NumericalSolution.f90
+++ b/src/Solution/NumericalSolution.f90
@@ -258,9 +258,6 @@ contains
     !
     ! -- Initialize block parser
     call num_sol%parser%Initialize(num_sol%iu, iout)
-    !
-    ! -- return
-    return
   end subroutine create_numerical_solution
 
   !> @ brief Allocate scalars
@@ -359,9 +356,6 @@ contains
     this%ptcdel0 = DZERO
     this%ptcexp = done
     this%atsfrac = DONETHIRD
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Allocate arrays
@@ -409,9 +403,6 @@ contains
       ieq = ieq + mp%neq
       this%convmodstart(i + 1) = ieq
     end do
-    !
-    ! -- return
-    return
   end subroutine allocate_arrays
 
   !> @ brief Define the solution
@@ -502,9 +493,6 @@ contains
     !
     ! -- Assign connections, fill ia/ja, map connections
     call this%sln_connect()
-    !
-    ! -- return
-    return
   end subroutine sln_df
 
   !> @ brief Allocate and read data
@@ -1050,9 +1038,6 @@ contains
     !
     ! -- close ims input file
     call this%parser%Clear()
-    !
-    ! -- return
-    return
   end subroutine sln_ar
 
   !> @ brief Calculate delt
@@ -1095,8 +1080,6 @@ contains
       ! -- submit stable dt for upcoming step
       call ats_submit_delt(kstp, kper, delt_temp, this%memory_path, idir=idir)
     end if
-    !
-    return
   end subroutine sln_dt
 
   !> @ brief Advance solution
@@ -1122,8 +1105,6 @@ contains
     this%icnvg = 0
     this%itertot_timestep = 0
     this%iouttot_timestep = 0
-
-    return
   end subroutine sln_ad
 
   !> @ brief Output solution
@@ -1136,9 +1117,6 @@ contains
     class(NumericalSolutionType) :: this !< NumericalSolutionType instance
     !
     ! -- Nothing to do here
-    !
-    ! -- return
-    return
   end subroutine sln_ot
 
   !> @ brief Finalize solution
@@ -1161,9 +1139,6 @@ contains
       write (iout, '(1x,a,1x,g0,1x,a,/)') &
         'Total solution time:  ', this%ttsoln, 'seconds'
     end if
-    !
-    ! -- return
-    return
   end subroutine sln_fp
 
   !> @ brief Deallocate solution
@@ -1280,9 +1255,6 @@ contains
     call mem_deallocate(this%ptcdel0)
     call mem_deallocate(this%ptcexp)
     call mem_deallocate(this%atsfrac)
-    !
-    ! -- return
-    return
   end subroutine sln_da
 
   !> @ brief Solve solution
@@ -1330,10 +1302,6 @@ contains
       ! finish up, write convergence info, CSV file, budgets and flows, ...
       call this%finalizeSolve(kiter, isgcnvg, isuppress_output)
     end select
-    !
-    ! -- return
-    return
-
   end subroutine sln_ca
 
   !> @ brief CSV header
@@ -1387,9 +1355,6 @@ contains
       end if
       write (this%icsvinnerout, '(a)') ''
     end if
-    !
-    ! -- return
-    return
   end subroutine writeCSVHeader
 
   !> @ brief PTC header
@@ -2082,9 +2047,6 @@ contains
       ! -- update i0
       i0 = iinner
     end do
-    !
-    ! -- return
-    return
   end subroutine convergence_summary
 
   !> @ brief Solution convergence CSV summary
@@ -2207,9 +2169,6 @@ contains
     !
     ! -- flush file
     flush (iu)
-    !
-    ! -- return
-    return
   end subroutine csv_convergence_summary
 
   !> @ brief Save solution data to a file
@@ -2244,9 +2203,6 @@ contains
       write (inunit, *) this%x
       close (inunit)
     end select
-    !
-    ! -- return
-    return
   end subroutine save
 
   !> @ brief Add a model
@@ -2267,9 +2223,6 @@ contains
       m => mp
       call AddNumericalModelToList(this%modellist, m)
     end select
-    !
-    ! -- return
-    return
   end subroutine add_model
 
   !> @brief Get a list of models
@@ -2305,9 +2258,6 @@ contains
       num_ex => exchange
       call AddNumericalExchangeToList(this%exchangelist, num_ex)
     end select
-    !
-    ! -- return
-    return
   end subroutine add_exchange
 
   !> @brief Returns a pointer to the list of exchanges in this solution
@@ -2374,9 +2324,6 @@ contains
       cp => GetNumericalExchangeFromList(this%exchangelist, ic)
       call cp%exg_mc(this%system_matrix)
     end do
-    !
-    ! -- return
-    return
   end subroutine sln_connect
 
   !> @ brief Reset the solution
@@ -2392,9 +2339,6 @@ contains
     ! -- reset the solution
     call this%system_matrix%zero_entries()
     call this%vec_rhs%zero_entries()
-    !
-    ! -- return
-    return
   end subroutine sln_reset
 
   !> @ brief Solve the linear system of equations
@@ -2614,9 +2558,6 @@ contains
       in_iter = this%linear_solver%iteration_number
       this%icnvg = this%linear_solver%is_converged
     end if
-    !
-    ! -- return
-    return
   end subroutine sln_ls
 
   !
@@ -2673,9 +2614,6 @@ contains
       this%breduc = 0.1d0
       this%res_lim = 0.002d0
     end select
-    !
-    ! -- return
-    return
   end subroutine sln_setouter
 
   !> @ brief Perform backtracking
@@ -2781,9 +2719,6 @@ contains
       call this%outertab%add_term(cmsg)
       call this%outertab%add_term(' ')
     end if
-    !
-    ! -- return
-    return
   end subroutine sln_backtracking
 
   !> @ brief Backtracking update of the dependent variable
@@ -2879,8 +2814,6 @@ contains
     ! clean up temp. vector
     call vec_resid%destroy()
     deallocate (vec_resid)
-
-    return
   end subroutine sln_l2norm
 
   !> @ brief Get the maximum value from a vector
@@ -2915,9 +2848,6 @@ contains
         vmax = d
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine sln_maxval
 
   !> @ brief Calculate dependent-variable change
@@ -2945,9 +2875,6 @@ contains
         dx(n) = x(n) - xtemp(n)
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine sln_calcdx
 
   !> @brief Calculate pseudo-transient continuation factor
@@ -3130,9 +3057,6 @@ contains
       end do
       !
     end if
-    !
-    ! -- return
-    return
   end subroutine sln_underrelax
 
   !> @ brief Determine maximum dependent-variable change
@@ -3172,9 +3096,6 @@ contains
     !-----store maximum change value and location
     hncg = bigch
     lrch = nb
-    !
-    ! -- return
-    return
   end subroutine sln_get_dxmax
 
   function sln_has_converged(this, max_dvc) result(has_converged)
@@ -3280,9 +3201,6 @@ contains
         exit
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine sln_get_loc
 
   !> @ brief Get user node number
@@ -3322,9 +3240,6 @@ contains
         exit
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine sln_get_nodeu
 
   !> @ brief Cast a object as a Numerical Solution
@@ -3349,9 +3264,6 @@ contains
     class is (NumericalSolutionType)
       res => obj
     end select
-    !
-    ! -- return
-    return
   end function CastAsNumericalSolutionClass
 
   !> @ brief Get a numerical solution
@@ -3370,7 +3282,5 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsNumericalSolutionClass(obj)
-    !
-    return
   end function GetNumericalSolutionFromList
 end module NumericalSolutionModule

--- a/src/Solution/SolutionGroup.f90
+++ b/src/Solution/SolutionGroup.f90
@@ -37,9 +37,6 @@ contains
     allocate (sgp)
     call sgp%allocate_scalars()
     sgp%id = id
-    !
-    ! -- return
-    return
   end subroutine solutiongroup_create
 
   !> @brief Calculate the solution group
@@ -106,9 +103,6 @@ contains
       lastStepFailed = 1
       write (iout, fmtnocnvg) this%id, kper, kstp
     end if
-    !
-    ! -- return
-    return
   end subroutine sgp_ca
 
   !> @brief Deallocate
@@ -121,9 +115,6 @@ contains
     deallocate (this%mxiter)
     deallocate (this%nsolutions)
     deallocate (this%idsolutions)
-    !
-    ! -- return
-    return
   end subroutine sgp_da
 
   !> @brief Allocate scalars
@@ -138,9 +129,6 @@ contains
     this%id = 0
     this%mxiter = 1
     this%nsolutions = 0
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   !> @brief Add solution
@@ -159,9 +147,6 @@ contains
     ipos = size(this%idsolutions)
     this%idsolutions(ipos) = isoln
     this%nsolutions = this%nsolutions + 1
-    !
-    ! -- return
-    return
   end subroutine add_solution
 
   function CastAsSolutionGroupClass(obj) result(res)
@@ -178,7 +163,6 @@ contains
     class is (SolutionGroupType)
       res => obj
     end select
-    return
   end function CastAsSolutionGroupClass
 
   subroutine AddSolutionGroupToList(list, solutiongroup)
@@ -191,8 +175,6 @@ contains
     !
     obj => solutiongroup
     call list%Add(obj)
-    !
-    return
   end subroutine AddSolutionGroupToList
 
   function GetSolutionGroupFromList(list, idx) result(res)
@@ -206,8 +188,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsSolutionGroupClass(obj)
-    !
-    return
   end function GetSolutionGroupFromList
 
 end module SolutionGroupModule

--- a/src/Timing/ats.f90
+++ b/src/Timing/ats.f90
@@ -50,7 +50,6 @@ contains
         lv = .true.
       end if
     end if
-    return
   end function isAdaptivePeriod
 
   !> @ brief Create ATS object
@@ -102,9 +101,6 @@ contains
     !
     ! -- Close the file
     call parser%Clear()
-    !
-    ! -- return
-    return
   end subroutine ats_cr
 
   !> @ brief Allocate scalars
@@ -125,9 +121,6 @@ contains
     nper = 0
     maxats = 0
     dtstable = DNODATA
-    !
-    ! -- return
-    return
   end subroutine ats_allocate_scalars
 
   !> @ brief Allocate arrays
@@ -163,9 +156,6 @@ contains
       dtadj(n) = DZERO
       dtfailadj(n) = DZERO
     end do
-    !
-    ! -- return
-    return
   end subroutine ats_allocate_arrays
 
   !> @ brief Deallocate variables
@@ -189,9 +179,6 @@ contains
     call mem_deallocate(dtmax)
     call mem_deallocate(dtadj)
     call mem_deallocate(dtfailadj)
-    !
-    ! -- Return
-    return
   end subroutine ats_da
 
   !> @ brief Read options
@@ -228,9 +215,6 @@ contains
       end do
       write (iout, '(1x,a)') 'END OF ATS OPTIONS'
     end if
-    !
-    ! -- Return
-    return
   end subroutine ats_read_options
 
   !> @ brief Read dimensions
@@ -276,9 +260,6 @@ contains
       call store_error(errmsg)
       call parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine ats_read_dimensions
 
   !> @ brief Read timing
@@ -328,9 +309,6 @@ contains
       call store_error(errmsg)
       call parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine ats_read_timing
 
   !> @ brief Process input
@@ -397,7 +375,6 @@ contains
     call inputtab%table_da()
     deallocate (inputtab)
     nullify (inputtab)
-    return
   end subroutine ats_input_table
 
   !> @ brief Check timing
@@ -503,7 +480,6 @@ contains
       &)"
     n = kperats(kper)
     write (iout, fmtspts) dt0(n), dtmin(n), dtmax(n), dtadj(n), dtfailadj(n)
-    return
   end subroutine ats_period_message
 
   !> @ brief Allow and external caller to submit preferred time step
@@ -553,7 +529,6 @@ contains
         end if
       end if
     end if
-    return
   end subroutine ats_submit_delt
 
   !> @ brief Set time step
@@ -619,8 +594,6 @@ contains
     !
     ! -- Write time step size information
     write (iout, fmtdt) delt, kstp, kper
-    !
-    return
   end subroutine ats_set_delt
 
   !> @ brief Reset time step because failure has occurred
@@ -661,7 +634,6 @@ contains
 
       end if
     end if
-    return
   end subroutine ats_reset_delt
 
   !> @ brief Set end of period indicator
@@ -683,7 +655,6 @@ contains
     if (abs(pertim - perlencurrent) < dtmin(n)) then
       endofperiod = .true.
     end if
-    return
   end subroutine ats_set_endofperiod
 
 end module AdaptiveTimeStepModule

--- a/src/Timing/tdis.f90
+++ b/src/Timing/tdis.f90
@@ -83,9 +83,6 @@ contains
     if (inats > 0) then
       call ats_cr(inats, nper)
     end if
-    !
-    ! -- Return
-    return
   end subroutine tdis_cr
 
   !> @brief Set kstp and kper
@@ -148,9 +145,6 @@ contains
         write (iout, fmtspits) nstp(kper), tsmult(kper)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine tdis_set_counters
 
   !> @brief Set time step length
@@ -208,9 +202,6 @@ contains
     if (endofperiod .and. kper == nper) then
       endofsimulation = .true.
     end if
-    !
-    ! -- Return
-    return
   end subroutine tdis_set_timestep
 
   !> @brief Reset delt and update timing variables and indicators
@@ -250,9 +241,6 @@ contains
       endofsimulation = .true.
       totim = totalsimtime
     end if
-    !
-    ! -- Return
-    return
   end subroutine tdis_delt_reset
 
   !> @brief Set time step length
@@ -278,9 +266,6 @@ contains
     else
       delt = tsmult(kper) * delt
     end if
-    !
-    ! -- Return
-    return
   end subroutine tdis_set_delt
 
   !> @brief Print simulation time
@@ -352,9 +337,6 @@ contains
       write (iout, fmtpertm) persec, permn, perhr, perdy, peryr
       write (iout, fmttottm) totsec, totmn, tothr, totdy, totyr
     end if
-    !
-    ! -- Return
-    return
   end subroutine tdis_ot
 
   !> @brief Deallocate memory
@@ -395,9 +377,6 @@ contains
     call mem_deallocate(perlen)
     call mem_deallocate(nstp)
     call mem_deallocate(tsmult)
-    !
-    ! -- Return
-    return
   end subroutine tdis_da
 
   !> @brief Source the timing discretization options
@@ -471,9 +450,6 @@ contains
     end if
     !
     write (iout, '(1x,a)') 'END OF TDIS OPTIONS'
-    !
-    ! -- Return
-    return
   end subroutine tdis_source_options
 
   !> @brief Allocate tdis scalars
@@ -526,9 +502,6 @@ contains
     pertimsav = DZERO
     totalsimtime = DZERO
     datetime0 = ''
-    !
-    ! -- Return
-    return
   end subroutine tdis_allocate_scalars
 
   !> @brief Allocate tdis arrays
@@ -540,9 +513,6 @@ contains
     call mem_allocate(perlen, nper, 'PERLEN', 'TDIS')
     call mem_allocate(nstp, nper, 'NSTP', 'TDIS')
     call mem_allocate(tsmult, nper, 'TSMULT', 'TDIS')
-    !
-    ! -- Return
-    return
   end subroutine tdis_allocate_arrays
 
   !> @brief Source dimension NPER
@@ -570,9 +540,6 @@ contains
     end if
     !
     write (iout, '(1x,a)') 'END OF TDIS DIMENSIONS'
-    !
-    ! -- Return
-    return
   end subroutine tdis_source_dimensions
 
   !> @brief Source timing information
@@ -617,9 +584,6 @@ contains
     end do
     !
     write (iout, '(1x,a)') 'END OF TDIS PERIODDATA'
-    !
-    ! -- Return
-    return
   end subroutine tdis_source_timing
 
   !> @brief Check the tdis timing information
@@ -708,8 +672,6 @@ contains
       tstart = tend
       !
     end do
-    ! -- Return
-    return
   end subroutine check_tdis_timing
 
 end module TdisModule

--- a/src/Utilities/ArrayReaders.f90
+++ b/src/Utilities/ArrayReaders.f90
@@ -141,8 +141,6 @@ contains
       call print_array_int(iarr, aname, iout, jj, 1, k, prfmt, ncpl, ndig, &
                            prowcolnum)
     end if
-    !
-    return
   end subroutine read_array_int1d
 
   subroutine read_array_int2d(iu, iarr, aname, ndim, jj, ii, iout, k)
@@ -234,8 +232,6 @@ contains
       call print_array_int(iarr, aname, iout, jj, ii, k, prfmt, ncpl, &
                            ndig, prowcolnum)
     end if
-    !
-    return
   end subroutine read_array_int2d
 
   subroutine read_array_int3d(iu, iarr, aname, ndim, ncol, nrow, nlay, iout, &
@@ -259,7 +255,6 @@ contains
       end if
       call read_array_int2d(iu, iarr(:, :, kk), aname, ndim, ncol, nrow, iout, k)
     end do
-    return
   end subroutine read_array_int3d
 
   subroutine read_array_int3d_all(iu, iarr, aname, ndim, nvals, iout)
@@ -272,8 +267,6 @@ contains
     ! -- local
     !
     call read_array_int1d(iu, iarr, aname, ndim, nvals, iout, 0)
-    !
-    return
   end subroutine read_array_int3d_all
 
   subroutine read_array_int1d_layered(iu, iarr, aname, ndim, ncol, nrow, &
@@ -288,8 +281,6 @@ contains
     ! -- local
     !
     call read_array_int3d(iu, iarr, aname, ndim, ncol, nrow, nlay, iout, k1, k2)
-    !
-    return
   end subroutine read_array_int1d_layered
 
   ! -- Procedures that are part of ReadArray interface (floating-point data)
@@ -387,8 +378,6 @@ contains
       call print_array_dbl(darr, aname, iout, jj, 1, k, prfmt, ncpl, ndig, &
                            prowcolnum)
     end if
-    !
-    return
   end subroutine read_array_dbl1d
 
   subroutine read_array_dbl2d(iu, darr, aname, ndim, jj, ii, iout, k)
@@ -481,8 +470,6 @@ contains
       call print_array_dbl(darr, aname, iout, jj, ii, k, prfmt, ncpl, &
                            ndig, prowcolnum)
     end if
-    !
-    return
   end subroutine read_array_dbl2d
 
   subroutine read_array_dbl3d(iu, darr, aname, ndim, ncol, nrow, nlay, iout, &
@@ -507,8 +494,6 @@ contains
       end if
       call read_array_dbl2d(iu, darr(:, :, kk), aname, ndim, ncol, nrow, iout, k)
     end do
-    !
-    return
   end subroutine read_array_dbl3d
 
   subroutine read_array_dbl3d_all(iu, darr, aname, ndim, nvals, iout)
@@ -521,8 +506,6 @@ contains
     ! -- local
     !
     call read_array_dbl1d(iu, darr, aname, ndim, nvals, iout, 0)
-    !
-    return
   end subroutine read_array_dbl3d_all
 
   subroutine read_array_dbl1d_layered(iu, darr, aname, ndim, ncol, nrow, &
@@ -537,8 +520,6 @@ contains
     ! -- local
     !
     call read_array_dbl3d(iu, darr, aname, ndim, ncol, nrow, nlay, iout, k1, k2)
-    !
-    return
   end subroutine read_array_dbl1d_layered
 
   ! -- Utility procedures
@@ -588,8 +569,6 @@ contains
     ! -- Read (BINARY) and IPRN options from array control record,
     !    and open an OPEN/CLOSE file if specified.
     call read_control_2(iu, iout, fname, line, icol, locat, iclose, iprn)
-    !
-    return
   end subroutine read_control_int
 
   subroutine read_control_dbl(iu, iout, aname, locat, cnstnt, &
@@ -638,8 +617,6 @@ contains
     ! -- Read (BINARY) and IPRN options from array control record,
     !    and open an OPEN/CLOSE file if specified.
     call read_control_2(iu, iout, fname, line, icol, locat, iclose, iprn)
-    !
-    return
   end subroutine read_control_dbl
 
   subroutine read_control_1(iu, iout, aname, locat, iclose, line, icol, fname)
@@ -684,8 +661,6 @@ contains
       call store_error(errmsg)
       call store_error_unit(iu)
     end if
-    !
-    return
   end subroutine read_control_1
 
   subroutine read_control_2(iu, iout, fname, line, icol, &
@@ -750,8 +725,6 @@ contains
         end if
       end if
     end if
-    !
-    return
   end subroutine read_control_2
 
   subroutine build_format_int(iprn, prfmt, prowcolnum, ncpl, ndig)
@@ -806,8 +779,6 @@ contains
     !
     call BuildIntFormat(ncpl, nwidp, prfmt, prowcolnum)
     ndig = nwidp + 1
-    !
-    return
   end subroutine build_format_int
 
   subroutine build_format_dbl(iprn, prfmt, prowcolnum, ncpl, ndig)
@@ -948,8 +919,6 @@ contains
     end if
     !
     ndig = nwidp + 1
-    !
-    return
   end subroutine build_format_dbl
 
   subroutine print_array_int(iarr, aname, iout, jj, ii, k, prfmt, &
@@ -996,8 +965,6 @@ contains
       ! -- Write array values, without row numbers
       write (iout, prfmt) (iarr(j, 1), j=1, jj)
     end if
-    !
-    return
   end subroutine print_array_int
 
   subroutine print_array_dbl(darr, aname, iout, jj, ii, k, prfmt, &
@@ -1044,8 +1011,6 @@ contains
       ! -- Write array values, without row numbers
       write (iout, prfmt) (darr(j, 1), j=1, jj)
     end if
-    !
-    return
   end subroutine print_array_dbl
 
   subroutine read_binary_header(locat, iout, arrname, nval)
@@ -1086,9 +1051,6 @@ contains
     !
     ! -- Assign the number of values that follow the header
     nval = m1 * m2
-    !
-    ! -- return
-    return
   end subroutine read_binary_header
 
   !> @ brief Check the binary data size
@@ -1123,9 +1085,6 @@ contains
       call store_error_unit(locat)
       isok = .FALSE.
     end if
-    !
-    ! -- return
-    return
   end function check_binary_size
 
 end module ArrayReadersModule

--- a/src/Utilities/BlockParser.f90
+++ b/src/Utilities/BlockParser.f90
@@ -73,9 +73,6 @@ contains
     this%iout = iout
     this%blockName = ''
     this%linesRead = 0
-    !
-    ! -- return
-    return
   end subroutine Initialize
 
   !> @ brief Close the block parser
@@ -115,9 +112,6 @@ contains
     this%blockName = ''
     this%line = ''
     deallocate (this%line)
-    !
-    ! -- return
-    return
   end subroutine Clear
 
   !> @ brief Get block
@@ -176,9 +170,6 @@ contains
     end if
     this%iuactive = this%iuext
     this%linesRead = 0
-    !
-    ! -- return
-    return
   end subroutine GetBlock
 
   !> @ brief Get the next line
@@ -239,9 +230,6 @@ contains
         lineread = .true.
       end if
     end do loop1
-    !
-    ! -- return
-    return
   end subroutine GetNextLine
 
   !> @ brief Get a integer
@@ -267,9 +255,6 @@ contains
     if (istart == istop .and. istop == len(this%line)) then
       call this%ReadScalarError('INTEGER')
     end if
-    !
-    ! -- return
-    return
   end function GetInteger
 
   !> @ brief Get the number of lines read
@@ -285,9 +270,6 @@ contains
     !
     ! -- number of lines read
     nlines = this%linesRead
-    !
-    ! -- return
-    return
   end function GetLinesRead
 
   !> @ brief Get a double precision real
@@ -361,9 +343,6 @@ contains
       trim(errmsg), trim(adjustl(this%line)), "'."
     call store_error(errmsg)
     call this%StoreErrorUnit()
-    !
-    ! -- return
-    return
   end subroutine ReadScalarError
 
   !> @ brief Get a string
@@ -399,9 +378,6 @@ contains
                 ival, rval, this%iout, this%iuext)
     string = this%line(istart:istop)
     this%laststring = this%line(istart:istop)
-    !
-    ! -- return
-    return
   end subroutine GetString
 
   !> @ brief Get an upper case string
@@ -417,9 +393,6 @@ contains
     !
     ! -- call base GetString method with convertToUpper variable
     call this%GetString(string, convertToUpper=.true.)
-    !
-    ! -- return
-    return
   end subroutine GetStringCaps
 
   !> @ brief Get the rest of a line
@@ -442,9 +415,6 @@ contains
     allocate (character(len=newlinelen) :: line)
     line(:) = this%line(this%lloc:lastpos)
     line(newlinelen:newlinelen) = ' '
-    !
-    ! -- return
-    return
   end subroutine GetRemainingLine
 
   !> @ brief Ensure that the block is closed
@@ -466,9 +436,6 @@ contains
       call store_error(errmsg)
       call this%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine terminateblock
 
   !> @ brief Get a cellid
@@ -518,9 +485,6 @@ contains
         cellid = trim(cellid)//' '//cint
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine GetCellid
 
   !> @ brief Get the current line
@@ -535,9 +499,6 @@ contains
     !
     ! -- get the current line
     line = this%line
-    !
-    ! -- return
-    return
   end subroutine GetCurrentLine
 
   !> @ brief Store the unit number
@@ -562,9 +523,6 @@ contains
     !
     ! -- store error unit
     call store_error_unit(this%iuext, terminate=lterminate)
-    !
-    ! -- return
-    return
   end subroutine StoreErrorUnit
 
   !> @ brief Get the unit number
@@ -580,9 +538,6 @@ contains
     !
     ! -- block parser unit number
     i = this%iuext
-    !
-    ! -- return
-    return
   end function GetUnit
 
   !> @ brief Disable development option in release mode
@@ -598,8 +553,6 @@ contains
     errmsg = "Invalid keyword '"//trim(this%laststring)// &
              "' detected in block '"//trim(this%blockname)//"'."
     call dev_feature(errmsg, this%iuext)
-    !
-    return
   end subroutine DevOpt
 
   ! -- static methods previously in InputOutput
@@ -714,9 +667,6 @@ contains
         end if
       end if
     end do mainloop
-    !
-    ! -- return
-    return
   end subroutine uget_block
 
   !> @brief Find the next block in a file
@@ -779,7 +729,6 @@ contains
         exit
       end if
     end do
-    return
   end subroutine uget_any_block
 
   !> @brief Evaluate if the end of a block has been found
@@ -834,9 +783,6 @@ contains
       call store_error(ermsg)
       call store_error_unit(iin)
     end select
-    !
-    ! -- return
-    return
   end subroutine uterminate_block
 
 end module BlockParserModule

--- a/src/Utilities/Budget.f90
+++ b/src/Utilities/Budget.f90
@@ -91,9 +91,6 @@ contains
     !
     ! -- Allocate scalars
     call this%allocate_scalars(name_model)
-    !
-    ! -- Return
-    return
   end subroutine budget_cr
 
   !> @ brief Define information for this object
@@ -142,9 +139,6 @@ contains
     else
       this%labeltitle = 'PACKAGE NAME'
     end if
-    !
-    ! -- Return
-    return
   end subroutine budget_df
 
   !> @ brief Convert a number to a string
@@ -173,7 +167,6 @@ contains
       ! -- value is within range where number looks good with F format
       write (string, '(f17.4)') val
     end if
-    return
   end subroutine value_to_string
 
   !> @ brief Output the budget table
@@ -315,9 +308,6 @@ contains
 299 FORMAT(1X, /12X, 'IN - OUT =', A, 14X, 'IN - OUT =', A)
 300 FORMAT(1X, /1X, 'PERCENT DISCREPANCY =', F15.2 &
            , 5X, 'PERCENT DISCREPANCY =', F15.2/)
-    !
-    ! -- Return
-    return
   end subroutine budget_ot
 
   !> @ brief Deallocate memory
@@ -345,9 +335,6 @@ contains
     deallocate (this%vbvl)
     deallocate (this%vbnm)
     deallocate (this%rowlabel)
-    !
-    ! -- Return
-    return
   end subroutine budget_da
 
   !> @ brief Reset the budget object
@@ -367,9 +354,6 @@ contains
       this%vbvl(3, i) = DZERO
       this%vbvl(4, i) = DZERO
     end do
-
-    ! -- Return
-    return
   end subroutine reset
 
   !> @ brief Add a single row of information
@@ -432,9 +416,6 @@ contains
       this%labeled = .true.
     end if
     this%msum = this%msum + 1
-    !
-    ! -- Return
-    return
   end subroutine add_single_entry
 
   !> @ brief Add multiple rows of information
@@ -508,9 +489,6 @@ contains
     if (count_errors() > 0) then
       call store_error('Could not add multi-entry', terminate=.TRUE.)
     end if
-    !
-    ! -- Return
-    return
   end subroutine add_multi_entry
 
   !> @ brief Update accumulators
@@ -531,9 +509,6 @@ contains
       this%vbvl(1, i) = this%vbvl(1, i) + this%vbvl(3, i) * delt
       this%vbvl(2, i) = this%vbvl(2, i) + this%vbvl(4, i) * delt
     end do
-    !
-    ! -- Return
-    return
   end subroutine finalize_step
 
   !> @ brief allocate scalar variables
@@ -570,8 +545,6 @@ contains
     this%bdzone = ''
     this%ibudcsv = 0
     this%icsvheader = 0
-    !
-    return
   end subroutine allocate_scalars
 
   !> @ brief allocate array variables
@@ -607,8 +580,6 @@ contains
     this%vbvl(:, :) = DZERO
     this%vbnm(:) = ''
     this%rowlabel(:) = ''
-    !
-    return
   end subroutine allocate_arrays
 
   !> @ brief Resize the budget object
@@ -650,9 +621,6 @@ contains
     deallocate (vbvl)
     deallocate (vbnm)
     deallocate (rowlabel)
-    !
-    ! -- return
-    return
   end subroutine resize
 
   !> @ brief Rate accumulator subroutine
@@ -677,7 +645,6 @@ contains
         rin = rin + flow(n)
       end if
     end do
-    return
   end subroutine rate_accumulator
 
   !> @ brief Set unit number for csv output file
@@ -692,7 +659,6 @@ contains
     class(BudgetType) :: this !< BudgetType object
     integer(I4B), intent(in) :: ibudcsv !< unit number for csv budget output
     this%ibudcsv = ibudcsv
-    return
   end subroutine set_ibudcsv
 
   !> @ brief Write csv output
@@ -749,9 +715,6 @@ contains
       ! -- flush the file
       flush (this%ibudcsv)
     end if
-    !
-    ! -- return
-    return
   end subroutine writecsv
 
   !> @ brief Write csv header
@@ -791,9 +754,6 @@ contains
       write (this%ibudcsv, '(a)', advance='NO') trim(adjustl(txt))
     end do
     write (this%ibudcsv, '(a)') 'TOTAL_IN,TOTAL_OUT,PERCENT_DIFFERENCE'
-    !
-    ! -- return
-    return
   end subroutine write_csv_header
 
 end module BudgetModule

--- a/src/Utilities/BudgetFileReader.f90
+++ b/src/Utilities/BudgetFileReader.f90
@@ -118,9 +118,6 @@ contains
     if (iout > 0) &
       write (iout, '(a, i0, a)') 'Detected ', this%nbudterms, &
       ' unique flow terms in budget file.'
-    !
-    ! -- return
-    return
   end subroutine initialize
 
   !< @brief read record
@@ -225,9 +222,6 @@ contains
         this%endoffile = .true.
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine read_record
 
   !< @brief finalize
@@ -241,9 +235,6 @@ contains
     if (allocated(this%nodedst)) deallocate (this%nodedst)
     if (allocated(this%flow)) deallocate (this%flow)
     if (allocated(this%auxvar)) deallocate (this%auxvar)
-    !
-    ! -- return
-    return
   end subroutine finalize
 
 end module BudgetFileReaderModule

--- a/src/Utilities/BudgetObject.f90
+++ b/src/Utilities/BudgetObject.f90
@@ -97,9 +97,6 @@ contains
     !
     ! -- Initialize budget table
     call budget_cr(this%budtable, name)
-    !
-    ! -- Return
-    return
   end subroutine budgetobject_cr
 
   !> @brief Define the new budget object
@@ -163,9 +160,6 @@ contains
     if (present(ibudcsv)) then
       call this%budtable%set_ibudcsv(ibudcsv)
     end if
-    !
-    ! -- Return
-    return
   end subroutine budgetobject_df
 
   !> @brief Define the new flow table object
@@ -276,9 +270,6 @@ contains
     call this%flowtab%initialize_column(text, 12, alignment=TABCENTER)
     text = 'PERCENT DIFFERENCE'
     call this%flowtab%initialize_column(text, 12, alignment=TABCENTER)
-    !
-    ! -- Return
-    return
   end subroutine flowtable_df
 
   !> @brief Add up accumulators and submit to budget table
@@ -313,9 +304,6 @@ contains
         call this%budtable%addentry(ratin, ratout, delt, flowtype)
       end select
     end do
-    !
-    ! -- Return
-    return
   end subroutine accumulate_terms
 
   !> @brief Write the flow table for each advanced package control volume
@@ -458,9 +446,6 @@ contains
       call this%flowtab%add_term(qerr)
       call this%flowtab%add_term(qpd)
     end do
-    !
-    ! -- Return
-    return
   end subroutine write_flowtable
 
   !> @brief Write the budget table
@@ -481,9 +466,6 @@ contains
       call this%budtable%budget_ot(kstp, kper, iout)
     end if
     call this%budtable%writecsv(totim)
-    !
-    ! -- Return
-    return
   end subroutine write_budtable
 
   !> @brief Write the budget table
@@ -508,9 +490,6 @@ contains
       call this%budterm(i)%save_flows(dis, ibinun, kstp, kper, delt, &
                                       pertim, totim, iout)
     end do
-    !
-    ! -- Return
-    return
   end subroutine save_flows
 
   !> @brief Read from a binary file into this BudgetObjectType
@@ -533,9 +512,6 @@ contains
       call this%budterm(i)%read_flows(dis, ibinun, kstp, kper, delt, &
                                       pertim, totim)
     end do
-    !
-    ! -- Return
-    return
   end subroutine read_flows
 
   !> @brief Deallocate
@@ -569,9 +545,6 @@ contains
       deallocate (this%budtable)
       nullify (this%budtable)
     end if
-    !
-    ! -- Return
-    return
   end subroutine budgetobject_da
 
   !> @brief Create a new budget object from a binary flow file
@@ -623,9 +596,6 @@ contains
         end do
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine budgetobject_cr_bfr
 
   !> @brief Initialize the budget file reader
@@ -642,9 +612,6 @@ contains
     allocate (this%bfr)
     call this%bfr%initialize(ibinun, iout, ncv)
     nbudterm = this%bfr%nbudterms
-    !
-    ! -- Return
-    return
   end subroutine bfr_init
 
   !> @brief Advance the binary file readers for setting the budget terms of
@@ -696,9 +663,6 @@ contains
         write (iout, fmtbudkstpkper) trim(this%name), kstp, kper, &
         this%bfr%kstp, this%bfr%kper
     end if
-    !
-    ! -- Return
-    return
   end subroutine bfr_advance
 
   !> @brief Copy the information from the binary file into budterms
@@ -717,9 +681,6 @@ contains
       call this%bfr%read_record(success, iout)
       call this%budterm(i)%fill_from_bfr(this%bfr, dis)
     end do
-    !
-    ! -- Return
-    return
   end subroutine fill_from_bfr
 
 end module BudgetObjectModule

--- a/src/Utilities/HeadFileReader.f90
+++ b/src/Utilities/HeadFileReader.f90
@@ -67,9 +67,6 @@ contains
     if (iout > 0) &
       write (iout, '(a, i0, a)') 'Detected ', this%nlay, &
       ' unique records in binary file.'
-    !
-    ! -- return
-    return
   end subroutine initialize
 
   !< @brief read record
@@ -126,9 +123,6 @@ contains
         this%endoffile = .true.
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine read_record
 
   !< @brief finalize
@@ -137,9 +131,6 @@ contains
     class(HeadFileReaderType) :: this
     close (this%inunit)
     if (allocated(this%head)) deallocate (this%head)
-    !
-    ! -- return
-    return
   end subroutine finalize
 
 end module HeadFileReaderModule

--- a/src/Utilities/Idm/DefinitionSelect.f90
+++ b/src/Utilities/Idm/DefinitionSelect.f90
@@ -65,9 +65,6 @@ contains
     ! -- cleanup
     if (allocated(param_cols)) deallocate (param_cols)
     if (allocated(parse_str)) deallocate (parse_str)
-    !
-    ! -- return
-    return
   end subroutine idt_parse_rectype
 
   !> @brief return input definition type datatype
@@ -89,9 +86,6 @@ contains
     else
       datatype = idt%datatype
     end if
-    !
-    ! -- return
-    return
   end function idt_datatype
 
   !> @brief Return parameter definition
@@ -131,9 +125,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(filename)
     end if
-    !
-    ! -- return
-    return
   end function get_param_definition_type
 
   !> @brief Return aggregate definition
@@ -167,9 +158,6 @@ contains
         '", subcomponent="', trim(subcomponent_type), '".'
       call store_error(errmsg, .true.)
     end if
-    !
-    ! -- return
-    return
   end function get_aggregate_definition_type
 
   !> @brief Return aggregate definition

--- a/src/Utilities/Idm/DynamicPackageParams.f90
+++ b/src/Utilities/Idm/DynamicPackageParams.f90
@@ -73,9 +73,6 @@ contains
     else
       call this%set_filtered_list()
     end if
-    !
-    ! --return
-    return
   end subroutine init
 
   !> @brief destroy
@@ -88,9 +85,6 @@ contains
     !
     ! -- deallocate
     if (allocated(this%params)) deallocate (this%params)
-    !
-    ! --return
-    return
   end subroutine destroy
 
   !> @brief array based input dynamic param filter
@@ -155,9 +149,6 @@ contains
     !
     ! -- cleanup
     deallocate (idt_idxs)
-    !
-    ! -- return
-    return
   end subroutine set_filtered_grid
 
   !> @brief create array of in scope list input columns
@@ -233,9 +224,6 @@ contains
     !
     ! -- cleanup
     deallocate (ra_cols)
-    !
-    ! -- return
-    return
   end subroutine set_filtered_list
 
   !> @brief allocate and set input array to filtered param set
@@ -259,9 +247,6 @@ contains
     do n = 1, nparam
       params(n) = this%params(n)
     end do
-    !
-    ! -- return
-    return
   end subroutine package_params
 
   !> @brief allocate character string type array
@@ -405,9 +390,6 @@ contains
         !call store_error_filename(sourcename)
       end select
     end if
-    !
-    ! -- return
-    return
   end function pkg_param_in_scope
 
 end module DynamicPackageParamsModule

--- a/src/Utilities/Idm/InputLoadType.f90
+++ b/src/Utilities/Idm/InputLoadType.f90
@@ -167,9 +167,6 @@ contains
     allocate (this%component_types(0))
     allocate (this%subcomponent_types(0))
     allocate (this%filenames(0))
-    !
-    ! -- return
-    return
   end subroutine subpkg_create
 
   !> @brief create a new package type
@@ -232,9 +229,6 @@ contains
     ! -- allocate and initialize filename for subpackage
     call mem_allocate(input_fname, LINELENGTH, 'INPUT_FNAME', subpkg_mempath)
     input_fname = filename
-    !
-    ! -- return
-    return
   end subroutine subpkg_add
 
   !> @brief create a new package type
@@ -250,9 +244,6 @@ contains
     deallocate (this%component_types)
     deallocate (this%subcomponent_types)
     deallocate (this%filenames)
-    !
-    ! -- return
-    return
   end subroutine subpkg_destroy
 
   !> @brief initialize static package loader
@@ -344,9 +335,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine create_subpkg_list
 
   subroutine static_destroy(this)
@@ -404,9 +392,6 @@ contains
     !
     ! -- set readasarrays
     this%readasarrays = (.not. mf6_input%block_dfns(iperblock)%aggregate)
-    !
-    ! -- return
-    return
   end subroutine dynamic_init
 
   !> @brief dynamic package loader define
@@ -612,9 +597,6 @@ contains
     !
     obj => model_dynamic
     call list%Add(obj)
-    !
-    ! -- return
-    return
   end subroutine AddDynamicModelToList
 
   !> @brief get model dynamic packages object from list
@@ -639,9 +621,6 @@ contains
         res => obj
       end select
     end if
-    !
-    ! -- return
-    return
   end function GetDynamicModelFromList
 
 end module InputLoadTypeModule

--- a/src/Utilities/Idm/ModflowInput.f90
+++ b/src/Utilities/Idm/ModflowInput.f90
@@ -107,9 +107,6 @@ contains
                                subcomponent_type)
     case default
     end select
-    !
-    ! -- return
-    return
   end function update_sc_type
 
   function read_as_arrays(filetype, filename, component_type, subcomponent_type) &
@@ -159,9 +156,6 @@ contains
     end if
     !
     call parser%clear()
-    !
-    ! -- return
-    return
   end function read_as_arrays
 
 end module ModflowInputModule

--- a/src/Utilities/Idm/SourceCommon.f90
+++ b/src/Utilities/Idm/SourceCommon.f90
@@ -48,9 +48,6 @@ contains
     case default
       sourcetype = 'MF6FILE'
     end select
-    !
-    ! -- return
-    return
   end function package_source_type
 
   !> @brief component from package or model type
@@ -89,9 +86,6 @@ contains
         'IDP input error, unrecognized component: "'//trim(component)//'"'
       call store_error(errmsg, .true.)
     end if
-    !
-    ! -- return
-    return
   end function idm_component_type
 
   !> @brief component from package or model type
@@ -129,9 +123,6 @@ contains
         subcomponent_type(idx:idx) = subcomponent(i:i)
       end if
     end do
-    !
-    ! -- return
-    return
   end function idm_subcomponent_type
 
   !> @brief model package subcomponent name
@@ -162,9 +153,6 @@ contains
       !
       subcomponent_name = subcomponent_type
     end if
-    !
-    ! -- return
-    return
   end function idm_subcomponent_name
 
   !> @brief input file extension
@@ -194,9 +182,6 @@ contains
     if (idx > 0) then
       ext = filename(idx + 1:len_trim(filename))
     end if
-    !
-    ! -- return
-    return
   end function file_ext
 
   subroutine get_shape_from_string(shape_string, array_shape, memoryPath)
@@ -221,9 +206,6 @@ contains
       call mem_setptr(int_ptr, array_shape_string(i), memoryPath)
       array_shape(i) = int_ptr
     end do
-    !
-    ! -- return
-    return
   end subroutine get_shape_from_string
 
   subroutine get_layered_shape(mshape, nlay, layer_shape)
@@ -427,9 +409,6 @@ contains
     ! -- allocate and set distype in model input context
     call mem_allocate(distype, 'DISENUM', model_mempath)
     distype = dis_type
-    !
-    ! -- return
-    return
   end subroutine set_model_shape
 
   function ifind_charstr(array, str)
@@ -456,9 +435,6 @@ contains
         exit findloop
       end if
     end do findloop
-    !
-    ! -- return
-    return
   end function ifind_charstr
 
   !> @brief enforce and set a single input filename provided via FILEIN keyword
@@ -505,9 +481,6 @@ contains
       found = .true.
       !
     end if
-    !
-    ! -- return
-    return
   end function filein_fname
 
   !> @brief store an error for input exceeding internal name length
@@ -534,9 +507,6 @@ contains
     !
     ! -- set truncated name
     mf6_name = trim(input_str)
-    !
-    ! -- return
-    return
   end subroutine inlen_check
 
 end module SourceCommonModule

--- a/src/Utilities/Idm/mf6blockfile/IdmMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/IdmMf6File.f90
@@ -88,9 +88,6 @@ contains
     !
     ! -- cleanup
     deallocate (parser)
-    !
-    ! -- return
-    return
   end subroutine input_load
 
   !> @brief static loader init
@@ -146,9 +143,6 @@ contains
       call input_load(this%input_name, this%mf6_input, &
                       this%component_input_name, iout, this%nc_vars)
     end if
-    !
-    ! -- return
-    return
   end function static_load
 
   !> @brief static loader destroy
@@ -200,9 +194,6 @@ contains
     !
     ! -- allocate and initialize loader
     call this%create_loader()
-    !
-    ! -- return
-    return
   end subroutine dynamic_init
 
   !> @brief define routine for dynamic loader
@@ -215,9 +206,6 @@ contains
     !
     ! -- read first ionper
     call this%read_ionper()
-    !
-    ! -- return
-    return
   end subroutine dynamic_df
 
   !> @brief advance routine for dynamic loader
@@ -227,9 +215,6 @@ contains
     !
     ! -- invoke loader advance
     call this%rp_loader%ad()
-    !
-    ! -- return
-    return
   end subroutine dynamic_ad
 
   !> @brief read and prepare routine for dynamic loader
@@ -256,9 +241,6 @@ contains
     else
       this%ionper = nper + 1
     end if
-    !
-    ! -- return
-    return
   end subroutine dynamic_rp
 
   !> @brief dynamic loader read ionper of next period block
@@ -307,9 +289,6 @@ contains
         call this%parser%StoreErrorUnit()
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine dynamic_read_ionper
 
   !> @brief allocate a dynamic loader based on load context
@@ -347,9 +326,6 @@ contains
                               this%iperblock, &
                               this%parser, &
                               this%iout)
-    !
-    ! -- return
-    return
   end subroutine dynamic_create_loader
 
   !> @brief dynamic loader destroy
@@ -373,9 +349,6 @@ contains
     !
     ! -- deallocate input context
     call this%DynamicPkgLoadType%destroy()
-    !
-    ! -- return
-    return
   end subroutine dynamic_destroy
 
   !> @brief open a model package files
@@ -408,9 +381,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(component_fname)
     end if
-    !
-    ! -- return
-    return
   end function open_mf6file
 
 end module IdmMf6FileModule

--- a/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
+++ b/src/Utilities/Idm/mf6blockfile/LoadMf6File.f90
@@ -112,9 +112,6 @@ contains
     !
     ! -- finalize static load
     call this%finalize()
-    !
-    ! --return
-    return
   end subroutine load
 
   !> @brief init
@@ -153,9 +150,6 @@ contains
     ! -- log lst file header
     call idm_log_header(this%mf6_input%component_name, &
                         this%mf6_input%subcomponent_name, this%iout)
-    !
-    ! -- return
-    return
   end subroutine init
 
   !> @brief load a single block
@@ -189,9 +183,6 @@ contains
     call this%block_post_process(iblk)
     !
     deallocate (this%block_tags)
-    !
-    ! --return
-    return
   end subroutine load_block
 
   !> @brief finalize
@@ -215,9 +206,6 @@ contains
     ! -- close logging block
     call idm_log_close(this%mf6_input%component_name, &
                        this%mf6_input%subcomponent_name, this%iout)
-    !
-    ! -- return
-    return
   end subroutine finalize
 
   !> @brief Post parse block handling
@@ -280,9 +268,6 @@ contains
       end if
     case default
     end select
-    !
-    ! -- return
-    return
   end subroutine block_post_process
 
   !> @brief parse block
@@ -353,9 +338,6 @@ contains
         call this%parse_block(iblk, .true.)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine parse_block
 
   subroutine parse_io_tag(this, iblk, pkgtype, which, tag)
@@ -379,9 +361,6 @@ contains
     !
     ! -- load io tag
     call load_io_tag(this%parser, idt, this%mf6_input%mempath, which, this%iout)
-    !
-    ! -- return
-    return
   end subroutine parse_io_tag
 
   subroutine parse_keyword_tag(this, iblk, tag, idt)
@@ -447,9 +426,6 @@ contains
         call this%parser%DevOpt()
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine parse_keyword_tag
 
   !> @brief load an individual input record into memory
@@ -538,9 +514,6 @@ contains
     !
     call expandarray(this%block_tags)
     this%block_tags(size(this%block_tags)) = trim(idt%tagname)
-    !
-    ! -- return
-    return
   end subroutine parse_tag
 
   function block_index_dfn(this, iblk) result(idt)
@@ -571,9 +544,6 @@ contains
     idt%tagname = varname
     idt%mf6varname = varname
     idt%datatype = 'INTEGER'
-    !
-    ! -- return
-    return
   end function block_index_dfn
 
   !> @brief parse a structured array record into memory manager
@@ -697,9 +667,6 @@ contains
     !
     ! -- clean up
     call block_params%destroy()
-    !
-    ! -- return
-    return
   end subroutine parse_structarray_block
 
   !> @brief load type keyword
@@ -1283,9 +1250,6 @@ contains
     if (ibinary == 0) then
       call parser%line_reader%bkspc(parser%getunit())
     end if
-    !
-    ! -- return
-    return
   end function read_control_record
 
 end module LoadMf6FileModule

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileListInput.f90
@@ -113,9 +113,6 @@ contains
     !
     ! -- finalize input context setup
     call this%bound_context%allocate_arrays()
-    !
-    ! -- return
-    return
   end subroutine bndlist_init
 
   subroutine bndlist_df(this)
@@ -125,9 +122,6 @@ contains
     !
     ! -- define tsmanager
     call this%tsmanager%tsmanager_df()
-    !
-    ! -- return
-    return
   end subroutine bndlist_df
 
   subroutine bndlist_ad(this)
@@ -136,9 +130,6 @@ contains
     !
     ! -- advance timeseries
     call this%tsmanager%ad()
-    !
-    ! -- return
-    return
   end subroutine bndlist_ad
 
   subroutine bndlist_reset(this)
@@ -147,9 +138,6 @@ contains
     !
     ! -- reset tsmanager
     call this%tsmanager%reset(this%mf6_input%subcomponent_name)
-    !
-    ! -- return
-    return
   end subroutine bndlist_reset
 
   subroutine bndlist_rp(this, parser)
@@ -199,9 +187,6 @@ contains
     ! -- close logging statement
     call idm_log_close(this%mf6_input%component_name, &
                        this%mf6_input%subcomponent_name, this%iout)
-    !
-    ! -- return
-    return
   end subroutine bndlist_rp
 
   subroutine bndlist_destroy(this)
@@ -214,9 +199,6 @@ contains
     call destructStructArray(this%structarray)
     !
     call this%bound_context%destroy()
-    !
-    ! -- return
-    return
   end subroutine bndlist_destroy
 
   subroutine bndlist_ts_link_bnd(this, structvector, ts_strloc)
@@ -258,9 +240,6 @@ contains
         tsLinkBnd%BndName = boundname
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine bndlist_ts_link_bnd
 
   subroutine bndlist_ts_link_aux(this, structvector, ts_strloc)
@@ -303,9 +282,6 @@ contains
       end if
       !
     end if
-    !
-    ! -- return
-    return
   end subroutine bndlist_ts_link_aux
 
   subroutine bndlist_ts_update(this, structarray)
@@ -340,9 +316,6 @@ contains
     if (count_errors() > 0) then
       call store_error_filename(this%input_name)
     end if
-    !
-    ! -- return
-    return
   end subroutine bndlist_ts_update
 
   subroutine bndlist_ts_link(this, structvector, ts_strloc)
@@ -365,9 +338,6 @@ contains
       !
     case default
     end select
-    !
-    ! -- return
-    return
   end subroutine bndlist_ts_link
 
   subroutine bndlist_create_structarray(this)
@@ -402,9 +372,6 @@ contains
       if (idt%mf6varname == 'BOUNDNAME') this%iboundname = icol
       !
     end do
-    !
-    ! -- return
-    return
   end subroutine bndlist_create_structarray
 
 end module Mf6FileListInputModule

--- a/src/Utilities/Idm/mf6blockfile/Mf6FileStoInput.f90
+++ b/src/Utilities/Idm/mf6blockfile/Mf6FileStoInput.f90
@@ -57,9 +57,6 @@ contains
     !
     ! -- initialize storage to TRANSIENT (model iss=0)
     this%storage = 'TRANSIENT'
-    !
-    ! -- return
-    return
   end subroutine sto_init
 
   subroutine sto_rp(this, parser)
@@ -104,9 +101,6 @@ contains
     ! -- close logging statement
     call idm_log_close(this%mf6_input%component_name, &
                        this%mf6_input%subcomponent_name, this%iout)
-    !
-    ! -- return
-    return
   end subroutine sto_rp
 
   subroutine sto_destroy(this)

--- a/src/Utilities/Idm/mf6blockfile/StructArray.f90
+++ b/src/Utilities/Idm/mf6blockfile/StructArray.f90
@@ -186,9 +186,6 @@ contains
     else
       this%startidx(icol) = this%startidx(icol - 1) + this%numcols(icol - 1)
     end if
-    !
-    ! -- return
-    return
   end subroutine mem_create_vector
 
   function count(this)
@@ -235,9 +232,6 @@ contains
     !
     sv%memtype = 1
     sv%int1d => int1d
-    !
-    ! -- return
-    return
   end subroutine allocate_int_type
 
   !> @brief allocate double input type
@@ -265,9 +259,6 @@ contains
     !
     sv%memtype = 2
     sv%dbl1d => dbl1d
-    !
-    ! -- return
-    return
   end subroutine allocate_dbl_type
 
   !> @brief allocate charstr input type
@@ -291,9 +282,6 @@ contains
     !
     sv%memtype = 3
     sv%charstr1d => charstr1d
-    !
-    ! -- return
-    return
   end subroutine allocate_charstr_type
 
   !> @brief allocate int1d input type
@@ -379,9 +367,6 @@ contains
       ! -- set pointer to dynamic shape
       call mem_setptr(sv%intvector_shape, sv%idt%shape, this%mempath)
     end if
-    !
-    ! -- return
-    return
   end subroutine allocate_int1d_type
 
   !> @brief allocate dbl1d input type
@@ -440,9 +425,6 @@ contains
                & unsupported shape "'//trim(sv%idt%shape)//'".'
       call store_error(errmsg, terminate=.TRUE.)
     end if
-    !
-    ! -- return
-    return
   end subroutine allocate_dbl1d_type
 
   subroutine load_deferred_vector(this, icol)
@@ -579,9 +561,6 @@ contains
                &unsupported memtype.'
       call store_error(errmsg, terminate=.TRUE.)
     end select
-    !
-    ! -- return
-    return
   end subroutine load_deferred_vector
 
   !> @brief load deferred vectors into managed memory
@@ -624,9 +603,6 @@ contains
         call this%load_deferred_vector(icol)
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine memload_vectors
 
   !> @brief log information about the StructArrayType
@@ -688,9 +664,6 @@ contains
       end select
       !
     end do
-    !
-    ! -- return
-    return
   end subroutine log_structarray_vars
 
   !> @brief reallocate local memory for deferred vectors if necessary
@@ -794,9 +767,6 @@ contains
         call store_error(errmsg, terminate=.TRUE.)
       end select
     end do
-    !
-    ! -- return
-    return
   end subroutine check_reallocate
 
   subroutine write_struct_vector(this, parser, sv_col, irow, timeseries, &
@@ -892,9 +862,6 @@ contains
       end do
       !
     end select
-    !
-    ! -- return
-    return
   end subroutine write_struct_vector
 
   !> @brief read from the block parser to fill the StructArrayType
@@ -947,9 +914,6 @@ contains
     if (iout > 0) then
       call this%log_structarray_vars(iout)
     end if
-    !
-    ! -- return
-    return
   end function read_from_parser
 
   !> @brief read from binary input to fill the StructArrayType
@@ -1068,9 +1032,6 @@ contains
     if (iout > 0) then
       call this%log_structarray_vars(iout)
     end if
-    !
-    ! -- return
-    return
   end function read_from_binary
 
 end module StructArrayModule

--- a/src/Utilities/Idm/mf6blockfile/StructVector.f90
+++ b/src/Utilities/Idm/mf6blockfile/StructVector.f90
@@ -85,9 +85,6 @@ contains
     else
       call this%add_ts_strloc(token, structarray_col, col, row)
     end if
-    !
-    ! -- return
-    return
   end function sv_read_token
 
   subroutine sv_add_ts_strloc(this, token, structarray_col, col, row)
@@ -110,9 +107,6 @@ contains
     !
     obj => str_field
     call this%ts_strlocs%Add(obj)
-    !
-    ! -- return
-    return
   end subroutine sv_add_ts_strloc
 
   function sv_get_ts_strloc(this, idx) result(res)
@@ -134,9 +128,6 @@ contains
         res => obj
       end select
     end if
-    !
-    ! -- return
-    return
   end function sv_get_ts_strloc
 
   !> @brief

--- a/src/Utilities/Idm/netcdf/NetCDFCommon.f90
+++ b/src/Utilities/Idm/netcdf/NetCDFCommon.f90
@@ -37,9 +37,6 @@ contains
     !
     ! -- open netcdf file
     call nf_verify(nf90_open(nc_fname, NF90_NOWRITE, ncid), nc_fname)
-    !
-    ! -- return
-    return
   end function nc_fopen
 
   !> @brief Close netcdf file
@@ -51,9 +48,6 @@ contains
     !
     ! -- close netcdf file
     call nf_verify(nf90_close(ncid), nc_fname)
-    !
-    ! -- return
-    return
   end subroutine nc_fclose
 
   !> @brief error check a netcdf-fortran interface call
@@ -118,9 +112,6 @@ contains
       call store_error(errmsg)
       call store_error_filename(nc_fname)
     end if
-    !
-    ! -- return
-    return
   end subroutine nf_verify
 
 end module NetCDFCommonModule

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -139,9 +139,6 @@ contains
           accarg, filact
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine openfile
 
   !> @brief Assign a free unopened unit number
@@ -163,9 +160,6 @@ contains
     end do
     iu = i
     iunext = iu + 1
-    !
-    ! -- Return
-    return
   end subroutine freeunitnumber
 
   !> @brief Get a free unit number
@@ -183,9 +177,6 @@ contains
     ! -- code
     call freeunitnumber(iunit)
     getunit = iunit
-    !
-    ! -- Return
-    return
   end function getunit
 
   !> @brief Convert to upper case
@@ -210,9 +201,6 @@ contains
       IF (word(k:k) >= 'a' .and. word(k:k) <= 'z') &
         word(k:k) = char(ichar(word(k:k)) - idiff)
     end do
-    !
-    ! -- Return
-    return
   end subroutine upcase
 
   !> @brief Convert to lower case
@@ -236,9 +224,6 @@ contains
         word(k:k) = char(ichar(word(k:k)) + idiff)
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine lowcase
 
   !> @brief Append processor id to a string
@@ -271,9 +256,6 @@ contains
     write (name_processor, '(a,a,i0,a)') &
       name(1:ipos0 - 1), '.p', proc_id, trim(adjustl(extension_local))
     name = name_processor
-    !
-    ! -- Return
-    return
   end subroutine append_processor_id
 
   !> @brief Create a formatted line
@@ -391,9 +373,6 @@ contains
       write (line(icol:istop), '(a)') sep
       icol = istop
     end if
-    !
-    ! -- Return
-    return
   end subroutine UWWORD
 
   !> @brief Extract a word from a string
@@ -579,9 +558,6 @@ contains
     call store_error(msg)
     call store_error(trim(line))
     call store_error_unit(in)
-    !
-    ! -- Return
-    return
   end subroutine URWORD
 
   !> @brief Print a label for a list
@@ -617,9 +593,6 @@ contains
     !
     ! -- Add a line of dashes.
     write (iout, fmtmsgout2) (DASH(j), j=1, nbuf)
-    !
-    ! -- Return
-    return
   end subroutine ULSTLB
 
   !> @brief Write header records for cell-by-cell flow terms for one component
@@ -645,9 +618,6 @@ contains
     write (ibdchn) naux + 1
     if (naux > 0) write (ibdchn) (auxtxt(n), n=1, naux)
     write (ibdchn) nlist
-    !
-    ! -- Return
-    return
   end subroutine UBDSV4
 
   !> @brief Write one value of cell-by-cell flow plus auxiliary data using a
@@ -665,9 +635,6 @@ contains
     else
       write (ibdchn) icrl, q
     end if
-    !
-    ! -- Return
-    return
   end subroutine UBDSVB
 
   !> @brief Output column numbers above a matrix printout
@@ -753,9 +720,6 @@ contains
 50  ntot = ntot
     if (ntot > 1000) ntot = 1000
     write (iout, fmtmsgout2) (DOT, i=1, ntot)
-    !
-    ! -- Return
-    return
   end subroutine UCOLNO
 
   !> @brief Print 1 layer array
@@ -930,9 +894,6 @@ contains
     !
     ! -- Flush file
     flush (iout)
-    !
-    ! -- Return
-    return
   end subroutine ULAPRW
 
   !> @brief Save 1 layer array on disk
@@ -953,9 +914,6 @@ contains
     !
     ! -- flush file
     flush (ICHN)
-    !
-    ! -- Return
-    return
   end subroutine ulasav
 
   !> @brief Record cell-by-cell flow terms for one component of flow as a 3-D
@@ -990,9 +948,6 @@ contains
     !
     ! -- flush file
     flush (ibdchn)
-    !
-    ! -- Return
-    return
   end subroutine ubdsv1
 
   !> @brief Write header records for cell-by-cell flow terms for one component
@@ -1043,9 +998,6 @@ contains
     write (ibdchn) naux + 1
     if (naux > 0) write (ibdchn) (auxtxt(n), n=1, naux)
     write (ibdchn) nlist
-    !
-    ! -- Return
-    return
   end subroutine ubdsv06
 
   !> @brief Write one value of cell-by-cell flow using a list structure.
@@ -1069,9 +1021,6 @@ contains
     else
       write (ibdchn) n, q
     end if
-    !
-    ! -- Return
-    return
   end subroutine ubdsvc
 
   !> @brief Write one value of cell-by-cell flow using a list structure.
@@ -1096,9 +1045,6 @@ contains
     else
       write (ibdchn) n, n2, q
     end if
-    !
-    ! -- Return
-    return
   end subroutine ubdsvd
 
   !> @brief Perform a case-insensitive comparison of two words
@@ -1115,9 +1061,6 @@ contains
     upword2 = word2
     call upcase(upword2)
     same_word = (upword1 == upword2)
-    !
-    ! -- Return
-    return
   end function same_word
 
   !> @brief Function for string manipulation
@@ -1131,9 +1074,6 @@ contains
     !
     res = str
     res = adjustr(res)
-    !
-    ! -- Return
-    return
   end function
 
   subroutine unitinquire(iu)
@@ -1157,9 +1097,6 @@ contains
     call write_message(line)
     write (line, fmtb) trim(fm), trim(seq), trim(unf), trim(frm)
     call write_message(line)
-    !
-    ! -- Return
-    return
   end subroutine unitinquire
 
   !> @brief Parse a line into words.
@@ -1198,9 +1135,6 @@ contains
       call URWORD(line, lloc, istart, istop, 0, idum, rdum, 0, 0)
       words(i) = line(istart:istop)
     end do
-    !
-    ! -- Return
-    return
   end subroutine ParseLine
 
   !> @brief Print 1 layer array with user formatting in wrap format
@@ -1245,9 +1179,6 @@ contains
     !
     ! -- flush file
     flush (IOUT)
-    !
-    ! -- Return
-    return
   end subroutine ulaprufw
 
   !> @brief This function reads a line of arbitrary length and returns it.
@@ -1319,9 +1250,6 @@ contains
     !
     ! An end-of-file condition returns an empty string.
     eof = .true.
-    !
-    ! -- Return
-    return
   end function read_line
 
   subroutine GetFileFromPath(pathname, filename)
@@ -1351,9 +1279,6 @@ contains
     if (istop >= istart) then
       filename = pathname(istart:istop)
     end if
-    !
-    ! -- Return
-    return
   end subroutine GetFileFromPath
 
   !> @brief Starting at position icol, define string as line(istart:istop).
@@ -1384,9 +1309,6 @@ contains
       bndname = line(istart:istop)
       call upcase(bndname)
     end if
-    !
-    ! -- Return
-    return
   end subroutine extract_idnum_or_bndname
 
   !> @brief Read auxiliary variables from an input line
@@ -1441,9 +1363,6 @@ contains
           trim(adjustl(text)), auxname(naux)
       end if
     end do auxloop
-    !
-    ! -- Return
-    return
   end subroutine urdaux
 
   !> @brief Define the print or save format
@@ -1579,9 +1498,6 @@ contains
     case ('E', 'G', 'S')
       call BuildFloatFormat(nvaluesp, nwidthp, ndigits, editdesc, cdatafmp)
     end select
-    !
-    ! -- Return
-    return
   end subroutine print_format
 
   !> @brief Build a fixed format for printing or saving a real array
@@ -1633,9 +1549,6 @@ contains
     ufmt = trim(ufmt)//cdigits
     ufmt = trim(ufmt)//')))'
     outfmt = ufmt
-    !
-    ! -- Return
-    return
   end subroutine BuildFixedFormat
 
   !> @brief Build a floating-point format for printing or saving a real array
@@ -1699,9 +1612,6 @@ contains
     ufmt = trim(ufmt)//cdigits
     ufmt = trim(ufmt)//')))'
     outfmt = ufmt
-    !
-    ! -- Return
-    return
   end subroutine BuildFloatFormat
 
   !> @brief Build a format for printing or saving an integer array
@@ -1744,9 +1654,6 @@ contains
     ufmt = trim(ufmt)//cwidth
     ufmt = trim(ufmt)//')))'
     outfmt = ufmt
-    !
-    ! -- Return
-    return
   end subroutine BuildIntFormat
 
   !> @brief Get the number of words in a string
@@ -1775,9 +1682,6 @@ contains
       if (istart == linelen) exit
       get_nwords = get_nwords + 1
     end do
-    !
-    ! -- Return
-    return
   end function get_nwords
 
   !> @brief Move the file pointer.
@@ -1817,9 +1721,6 @@ contains
     ! -- position the file pointer to ipos
     write (iu, pos=ipos, iostat=status)
     inquire (unit=iu, pos=ipos)
-    !
-    ! -- Return
-    return
   end subroutine fseek_stream
 
   !> @brief Read until non-comment line found and then return line.
@@ -1917,9 +1818,6 @@ contains
         end if
       end if
     end do pcomments
-    !
-    ! -- Return
-    return
   end subroutine u9rdcom
 
   !> @brief Read an unlimited length line from unit number lun into a deferred-

--- a/src/Utilities/Iunit.f90
+++ b/src/Utilities/Iunit.f90
@@ -54,9 +54,6 @@ contains
     do i = 1, niunit
       this%cunit(i) = cunit(i)
     end do
-    !
-    ! -- Return
-    return
   end subroutine init
 
   !> @brief Add an ftyp and unit number
@@ -115,9 +112,6 @@ contains
     end if
     this%iunit(irow)%iunit(this%iunit(irow)%nval) = iunit
     this%iunit(irow)%ipos(this%iunit(irow)%nval) = ipos
-    !
-    ! -- Return
-    return
   end subroutine
 
   !> @brief Get the last unit number for type ftyp or return 0 for iunit.

--- a/src/Utilities/ListReader.f90
+++ b/src/Utilities/ListReader.f90
@@ -115,9 +115,6 @@ contains
     !
     ! -- Set nlist for return
     nlist = this%nlist
-    !
-    ! -- Return
-    return
   end subroutine read_list
 
   !> @brief Check for a control record, and parse if found
@@ -150,9 +147,6 @@ contains
     case ('OPEN/CLOSE')
       call this%set_openclose()
     end select
-    !
-    ! -- Return
-    return
   end subroutine read_control_record
 
   !> @brief Set up for open/close file
@@ -233,9 +227,6 @@ contains
     if (this%ibinary /= 1) &
       call this%line_reader%rdcom(this%inlist, this%iout, this%line, &
                                   this%ierr)
-    !
-    ! -- Return
-    return
   end subroutine set_openclose
 
   !> @brief Read the data
@@ -255,9 +246,6 @@ contains
     if (this%iclose == 1) then
       close (this%inlist)
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_data
 
   !> @brief Read the data from a binary file
@@ -361,9 +349,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(this%inlist)
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_binary
 
   !> @brief Read the data from an ascii file
@@ -546,9 +531,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(this%inlist)
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_ascii
 
   !> @brief Check for valid cellid
@@ -597,9 +579,6 @@ contains
         call store_error(errmsg)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine check_cellid
 
   !> @brief Write input data to a list
@@ -758,9 +737,6 @@ contains
     deallocate (inputtab)
     nullify (inputtab)
     deallocate (words)
-    !
-    ! -- Return
-    return
   end subroutine write_list
 
 end module ListReaderModule

--- a/src/Utilities/LongLineReader.f90
+++ b/src/Utilities/LongLineReader.f90
@@ -91,7 +91,6 @@ contains
       this%iostat = ierr
     end if
     this%last_unit = iu
-    return
   end subroutine rdcom
 
   !> @brief Emulate a Fortran backspace
@@ -111,7 +110,6 @@ contains
     else
       this%nbackspace = 1
     end if
-    return
   end subroutine bkspc
 
 end module LongLineReaderModule

--- a/src/Utilities/Memory/Memory.f90
+++ b/src/Utilities/Memory/Memory.f90
@@ -77,9 +77,6 @@ contains
     call memtab%add_term(cmem)
     call memtab%add_term(this%isize)
     call memtab%add_term(cptr)
-    !
-    ! -- return
-    return
   end subroutine table_entry
 
   function mt_associated(this) result(al)

--- a/src/Utilities/Memory/MemoryHelper.f90
+++ b/src/Utilities/Memory/MemoryHelper.f90
@@ -151,9 +151,6 @@ contains
         res = mem_path(:idx)
       end if
     end if
-
-    return
-
   end function get_mem_path_context
 
   !> @brief Remove the context from the memory path

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -156,9 +156,6 @@ contains
     if (found) then
       var_type = mt%memtype
     end if
-    !
-    ! -- return
-    return
   end subroutine get_mem_type
 
   !> @ brief Get the variable rank
@@ -195,9 +192,6 @@ contains
       if (associated(mt%astr1d)) rank = 1
       if (associated(mt%acharstr1d)) rank = 1
     end if
-    !
-    ! -- return
-    return
   end subroutine get_mem_rank
 
   !> @ brief Get the memory size of a single element of the stored variable
@@ -223,9 +217,6 @@ contains
     if (found) then
       size = mt%element_size
     end if
-    !
-    ! -- return
-    return
   end subroutine get_mem_elem_size
 
   !> @ brief Get the variable memory shape
@@ -263,9 +254,6 @@ contains
     else
       mem_shape(1) = -1
     end if
-    !
-    ! -- return
-    return
   end subroutine get_mem_shape
 
   !> @ brief Get the number of elements for this variable
@@ -296,9 +284,6 @@ contains
     if (found) then
       isize = mt%isize
     end if
-    !
-    ! -- return
-    return
   end subroutine get_isize
 
   !> @ brief Get a memory type entry from the memory list
@@ -331,9 +316,6 @@ contains
         call store_error(errmsg, terminate=.TRUE.)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine get_from_memorystore
 
   !> @brief Issue allocation error message and stop program execution
@@ -398,9 +380,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_logical
 
   !> @brief Allocate a character string
@@ -450,9 +429,6 @@ contains
     !
     ! -- add defined length string to the memory manager list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_str
 
   !> @brief Allocate a 1-dimensional defined length string array
@@ -519,9 +495,6 @@ contains
     !
     ! -- add deferred length character array to the memory manager list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_str1d
 
   !> @brief Allocate a 1-dimensional array of deferred-length CharacterStringType
@@ -579,9 +552,6 @@ contains
     !
     ! -- add deferred length character array to the memory manager list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_charstr1d
 
   !> @brief Allocate a integer scalar
@@ -620,9 +590,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_int
 
   !> @brief Allocate a 1-dimensional integer array
@@ -666,9 +633,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_int1d
 
   !> @brief Allocate a 2-dimensional integer array
@@ -713,8 +677,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
   end subroutine allocate_int2d
 
   !> @brief Allocate a 3-dimensional integer array
@@ -761,9 +723,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_int3d
 
   !> @brief Allocate a real scalar
@@ -802,9 +761,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_dbl
 
   !> @brief Allocate a 1-dimensional real array
@@ -848,9 +804,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_dbl1d
 
   !> @brief Allocate a 2-dimensional real array
@@ -895,9 +848,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_dbl2d
 
   !> @brief Allocate a 3-dimensional real array
@@ -944,9 +894,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine allocate_dbl3d
 
   !> @brief Check in an existing 1d integer array with a new address (name + path)
@@ -986,9 +933,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine checkin_int1d
 
   !> @brief Check in an existing 2d integer array with a new address (name + path)
@@ -1029,9 +973,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine checkin_int2d
 
   !> @brief Check in an existing 1d double precision array with a new address (name + path)
@@ -1071,9 +1012,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine checkin_dbl1d
 
   !> @brief Check in an existing 2d double precision array with a new address (name + path)
@@ -1114,9 +1052,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine checkin_dbl2d
 
   !> @brief Check in an existing 1d CharacterStringType array with a new address (name + path)
@@ -1158,9 +1093,6 @@ contains
     !
     ! -- add memory type to the memory list
     call memorystore%add(mt)
-    !
-    ! -- return
-    return
   end subroutine checkin_charstr1d
 
   !> @brief Reallocate a 1-dimensional defined length string array
@@ -1242,9 +1174,6 @@ contains
                "mem_allocate instead."
       call store_error(errmsg, terminate=.TRUE.)
     end if
-    !
-    ! -- return
-    return
   end subroutine reallocate_str1d
 
   !> @brief Reallocate a 1-dimensional deferred length string array
@@ -1332,9 +1261,6 @@ contains
                "mem_allocate instead."
       call store_error(errmsg, terminate=.TRUE.)
     end if
-    !
-    ! -- return
-    return
   end subroutine reallocate_charstr1d
 
   !> @brief Reallocate a 1-dimensional integer array
@@ -1377,9 +1303,6 @@ contains
     mt%nrealloc = mt%nrealloc + 1
     mt%master = .true.
     nvalues_aint = nvalues_aint + isize - isizeold
-    !
-    ! -- return
-    return
   end subroutine reallocate_int1d
 
   !> @brief Reallocate a 2-dimensional integer array
@@ -1427,9 +1350,6 @@ contains
     mt%master = .true.
     nvalues_aint = nvalues_aint + isize - isizeold
     write (mt%memtype, "(a,' (',i0,',',i0,')')") 'INTEGER', ncol, nrow
-    !
-    ! -- return
-    return
   end subroutine reallocate_int2d
 
   !> @brief Reallocate a 1-dimensional real array
@@ -1473,9 +1393,6 @@ contains
     mt%master = .true.
     nvalues_adbl = nvalues_adbl + isize - isizeold
     write (mt%memtype, "(a,' (',i0,')')") 'DOUBLE', isize
-    !
-    ! -- return
-    return
   end subroutine reallocate_dbl1d
 
   !> @brief Reallocate a 2-dimensional real array
@@ -1523,9 +1440,6 @@ contains
     mt%master = .true.
     nvalues_adbl = nvalues_adbl + isize - isizeold
     write (mt%memtype, "(a,' (',i0,',',i0,')')") 'DOUBLE', ncol, nrow
-    !
-    ! -- return
-    return
   end subroutine reallocate_dbl2d
 
   !> @brief Set pointer to a logical scalar
@@ -1540,9 +1454,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     sclr => mt%logicalsclr
-    !
-    ! -- return
-    return
   end subroutine setptr_logical
 
   !> @brief Set pointer to integer scalar
@@ -1557,9 +1468,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     sclr => mt%intsclr
-    !
-    ! -- return
-    return
   end subroutine setptr_int
 
   !> @brief Set pointer to 1d integer array
@@ -1574,9 +1482,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     aint => mt%aint1d
-    !
-    ! -- return
-    return
   end subroutine setptr_int1d
 
   !> @brief Set pointer to 2d integer array
@@ -1591,9 +1496,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     aint => mt%aint2d
-    !
-    ! -- return
-    return
   end subroutine setptr_int2d
 
   !> @brief Set pointer to 3d integer array
@@ -1608,9 +1510,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     aint => mt%aint3d
-    !
-    ! -- return
-    return
   end subroutine setptr_int3d
 
   !> @brief Set pointer to a real scalar
@@ -1625,9 +1524,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     sclr => mt%dblsclr
-    !
-    ! -- return
-    return
   end subroutine setptr_dbl
 
   !> @brief Set pointer to a 1d real array
@@ -1642,9 +1538,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     adbl => mt%adbl1d
-    !
-    ! -- return
-    return
   end subroutine setptr_dbl1d
 
   !> @brief Set pointer to a 2d real array
@@ -1659,9 +1552,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     adbl => mt%adbl2d
-    !
-    ! -- return
-    return
   end subroutine setptr_dbl2d
 
   !> @brief Set pointer to a 3d real array
@@ -1676,9 +1566,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     adbl => mt%adbl3d
-    !
-    ! -- return
-    return
   end subroutine setptr_dbl3d
 
   !> @brief Set pointer to a string (scalar)
@@ -1693,9 +1580,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     asrt => mt%strsclr
-    !
-    ! -- return
-    return
   end subroutine setptr_str
 
   !> @brief Set pointer to a fixed-length string array
@@ -1711,9 +1595,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     astr1d => mt%astr1d
-    !
-    ! -- return
-    return
   end subroutine setptr_str1d
 
   !> @brief Set pointer to an array of CharacterStringType
@@ -1729,9 +1610,6 @@ contains
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
     acharstr1d => mt%acharstr1d
-    !
-    ! -- return
-    return
   end subroutine setptr_charstr1d
 
   !> @brief Make a copy of a 1-dimensional integer array
@@ -1760,9 +1638,6 @@ contains
     do n = 1, size(mt%aint1d)
       aint(n) = mt%aint1d(n)
     end do
-    !
-    ! -- return
-    return
   end subroutine copyptr_int1d
 
   !> @brief Make a copy of a 2-dimensional integer array
@@ -1798,9 +1673,6 @@ contains
         aint(j, i) = mt%aint2d(j, i)
       end do
     end do
-    !
-    ! -- return
-    return
   end subroutine copyptr_int2d
 
   !> @brief Make a copy of a 1-dimensional real array
@@ -1829,9 +1701,6 @@ contains
     do n = 1, size(mt%adbl1d)
       adbl(n) = mt%adbl1d(n)
     end do
-    !
-    ! -- return
-    return
   end subroutine copyptr_dbl1d
 
   !> @brief Make a copy of a 2-dimensional real array
@@ -1867,9 +1736,6 @@ contains
         adbl(j, i) = mt%adbl2d(j, i)
       end do
     end do
-    !
-    ! -- return
-    return
   end subroutine copyptr_dbl2d
 
   !> @brief Copy values from a 1-dimensional real array in the memory
@@ -1887,9 +1753,6 @@ contains
     do n = 1, size(mt%adbl1d)
       adbl(n) = mt%adbl1d(n)
     end do
-    !
-    ! -- return
-    return
   end subroutine copy_dbl1d
 
   !> @brief Set the pointer for an integer scalar to
@@ -1921,9 +1784,6 @@ contains
     mt%master = .false.
     mt%mastername = name_target
     mt%masterPath = mem_path_target
-    !
-    ! -- return
-    return
   end subroutine reassignptr_int
 
   !> @brief Set the pointer for a 1-dimensional integer array to
@@ -1955,9 +1815,6 @@ contains
     mt%master = .false.
     mt%mastername = name_target
     mt%masterPath = mem_path_target
-    !
-    ! -- return
-    return
   end subroutine reassignptr_int1d
 
   !> @brief Set the pointer for a 2-dimensional integer array to
@@ -1993,9 +1850,6 @@ contains
     mt%master = .false.
     mt%mastername = name_target
     mt%masterPath = mem_path_target
-    !
-    ! -- return
-    return
   end subroutine reassignptr_int2d
 
   !> @brief Set the pointer for a 1-dimensional real array to
@@ -2027,9 +1881,6 @@ contains
     mt%master = .false.
     mt%mastername = name_target
     mt%masterPath = mem_path_target
-    !
-    ! -- return
-    return
   end subroutine reassignptr_dbl1d
 
   !> @brief Set the pointer for a 2-dimensional real array to
@@ -2065,9 +1916,6 @@ contains
     mt%master = .false.
     mt%mastername = name_target
     mt%masterPath = mem_path_target
-    !
-    ! -- return
-    return
   end subroutine reassignptr_dbl2d
 
   !> @brief Deallocate a variable-length character string
@@ -2106,9 +1954,6 @@ contains
         nullify (sclr)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_str
 
   !> @brief Deallocate an array of defined-length character strings
@@ -2150,9 +1995,6 @@ contains
         nullify (astr1d)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_str1d
 
   !> @brief Deallocate an array of deferred-length character strings
@@ -2196,9 +2038,6 @@ contains
         nullify (astr1d)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_charstr1d
 
   !> @brief Deallocate a logical scalar
@@ -2231,9 +2070,6 @@ contains
         nullify (sclr)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_logical
 
   !> @brief Deallocate a integer scalar
@@ -2265,9 +2101,6 @@ contains
         nullify (sclr)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_int
 
   !> @brief Deallocate a real scalar
@@ -2299,9 +2132,6 @@ contains
         nullify (sclr)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_dbl
 
   !> @brief Deallocate a 1-dimensional integer array
@@ -2342,9 +2172,6 @@ contains
         nullify (aint)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_int1d
 
   !> @brief Deallocate a 2-dimensional integer array
@@ -2385,9 +2212,6 @@ contains
         nullify (aint)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_int2d
 
   !> @brief Deallocate a 3-dimensional integer array
@@ -2428,9 +2252,6 @@ contains
         nullify (aint)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_int3d
 
   !> @brief Deallocate a 1-dimensional real array
@@ -2471,9 +2292,6 @@ contains
         nullify (adbl)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_dbl1d
 
   !> @brief Deallocate a 2-dimensional real array
@@ -2514,9 +2332,6 @@ contains
         nullify (adbl)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_dbl2d
 
   !> @brief Deallocate a 3-dimensional real array
@@ -2557,9 +2372,6 @@ contains
         nullify (adbl)
       end if
     end if
-    !
-    ! -- return
-    return
   end subroutine deallocate_dbl3d
 
   !> @brief Set the memory print option
@@ -2587,7 +2399,6 @@ contains
     case default
       error_msg = "Unknown memory print option '"//trim(keyword)//"."
     end select
-    return
   end subroutine mem_set_print_option
 
   !> @brief Create a table if memory_print_option is 'SUMMARY'
@@ -2635,9 +2446,6 @@ contains
     ! -- total memory allocated
     text = 'TOTAL'
     call memtab%initialize_column(text, 15, alignment=TABCENTER)
-    !
-    ! -- return
-    return
   end subroutine mem_summary_table
 
   !> @brief Create a table if memory_print_option is 'ALL'
@@ -2679,9 +2487,6 @@ contains
     ! -- is it a pointer
     text = 'ASSOCIATED VARIABLE'
     call memtab%initialize_column(text, LENMEMADDRESS, alignment=TABLEFT)
-    !
-    ! -- return
-    return
   end subroutine mem_detailed_table
 
   !> @brief Write a row for the memory_print_option 'SUMMARY' table
@@ -2703,9 +2508,6 @@ contains
     call memtab%add_term(rint)
     call memtab%add_term(rreal)
     call memtab%add_term(bytes)
-    !
-    ! -- return
-    return
   end subroutine mem_summary_line
 
   !> @brief Determine appropriate memory unit and conversion factor
@@ -2737,9 +2539,6 @@ contains
       fact = DEM9
       cunits = 'GIGABYTES'
     end if
-    !
-    ! -- return
-    return
   end subroutine mem_units
 
   !> @brief Create and fill a table with the total allocated memory
@@ -2815,9 +2614,6 @@ contains
     !
     ! -- deallocate table
     call mem_cleanup_table()
-    !
-    ! -- return
-    return
   end subroutine mem_summary_total
 
   !> @brief Generic function to clean a memory manager table
@@ -2829,9 +2625,6 @@ contains
     call memtab%table_da()
     deallocate (memtab)
     nullify (memtab)
-    !
-    ! -- return
-    return
   end subroutine mem_cleanup_table
 
   !> @brief Write memory manager memory usage based on the
@@ -2933,9 +2726,6 @@ contains
     !
     ! -- Write total memory allocation
     call mem_summary_total(iout, simbytes)
-    !
-    ! -- return
-    return
   end subroutine mem_write_usage
 
   subroutine mem_print_detailed(iout)
@@ -3024,9 +2814,6 @@ contains
     if (count_errors() > 0) then
       call store_error('Could not clear memory list.', terminate=.TRUE.)
     end if
-    !
-    ! -- return
-    return
   end subroutine mem_da
 
   !> @brief Create a array with unique first components from all memory paths.
@@ -3065,9 +2852,6 @@ contains
         cunique(size(cunique)) = context_component
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine mem_unique_origins
 
 end module MemoryManagerModule

--- a/src/Utilities/Observation/Obs.f90
+++ b/src/Utilities/Observation/Obs.f90
@@ -229,9 +229,6 @@ contains
     allocate (obs)
     call obs%allocate_scalars()
     obs%inUnitObs => inobs
-    !
-    ! -- return
-    return
   end subroutine obs_cr
 
   !> @ brief Process IDstring provided for each observation
@@ -280,9 +277,6 @@ contains
       call store_error(errmsg)
       call store_error_unit(inunitobs)
     end if
-    !
-    ! -- return
-    return
   end subroutine DefaultObsIdProcessor
 
   ! Type-bound public procedures
@@ -307,9 +301,6 @@ contains
     !
     ! -- Initialize block parser
     call this%parser%Initialize(this%inUnitObs, this%iout)
-    !
-    ! -- return
-    return
   end subroutine obs_df
 
   !> @ brief Allocate and read package observations
@@ -328,9 +319,6 @@ contains
     if (this%active) then
       call this%obs_ar2(this%dis)
     end if
-    !
-    ! -- return
-    return
   end subroutine obs_ar
 
   !> @ brief Advance package observations
@@ -351,9 +339,6 @@ contains
       obsrv => this%get_obs(i)
       call obsrv%ResetCurrentValue()
     end do
-    !
-    ! -- return
-    return
   end subroutine obs_ad
 
   !> @ brief Clear observation output lines
@@ -367,9 +352,6 @@ contains
     class(ObsType), target :: this
     !
     call this%obsOutputList%ResetAllObsEmptyLines()
-    !
-    ! -- return
-    return
   end subroutine obs_bd_clear
 
   !> @ brief Output observation data
@@ -392,9 +374,6 @@ contains
       call this%write_obs_simvals()
       call this%obsOutputList%WriteAllObsLineReturns()
     end if
-    !
-    ! -- return
-    return
   end subroutine obs_ot
 
   !> @ brief Deallocate observation data
@@ -440,9 +419,6 @@ contains
     !
     ! -- nullify
     nullify (this%inUnitObs)
-    !
-    ! -- return
-    return
   end subroutine obs_da
 
   !> @ brief Save a simulated value
@@ -473,9 +449,6 @@ contains
     else
       obsrv%CurrentTimeStepEndValue = simval
     end if
-    !
-    ! -- return
-    return
   end subroutine SaveOneSimval
 
   !> @ brief Store observation type
@@ -526,9 +499,6 @@ contains
     ! -- Assign members
     this%obsData(indx)%ObsTypeID = obsTypeUpper
     this%obsData(indx)%Cumulative = cumulative
-    !
-    ! -- return
-    return
   end subroutine StoreObsType
 
   ! Type-bound private procedures
@@ -551,9 +521,6 @@ contains
     ! -- Initialize
     this%active = .false.
     this%inputFilename = ''
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   !> @ brief Read observation options and output formats
@@ -581,9 +548,6 @@ contains
       ! -- define output formats
       call this%define_fmts()
     end if
-    !
-    ! -- return
-    return
   end subroutine obs_ar1
 
   !> @ brief Call procedure provided by package
@@ -623,9 +587,6 @@ contains
     if (count_errors() > 0) then
       call store_error_unit(this%inunitobs)
     end if
-    !
-    ! -- return
-    return
   end subroutine obs_ar2
 
   !> @ brief Read observation options block
@@ -735,9 +696,6 @@ contains
     ! -- Assign type variables
     if (localprecision > 0) this%iprecision = localprecision
     if (localdigits >= 0) this%idigits = localdigits
-    !
-    ! -- return
-    return
   end subroutine read_obs_options
 
   !> @ brief Define observation output formats
@@ -756,9 +714,6 @@ contains
     else
       write (this%obsfmtcont, 50) this%idigits + 7, this%idigits
     end if
-    !
-    ! -- return
-    return
   end subroutine define_fmts
 
   !> @ brief Read observations
@@ -777,9 +732,6 @@ contains
     !
     ! -- build headers
     call this%build_headers()
-    !
-    ! -- return
-    return
   end subroutine read_observations
 
   !> @ brief Get the number of observations
@@ -794,9 +746,6 @@ contains
     class(ObsType) :: this
     !
     get_num = this%obsList%Count()
-    !
-    ! -- return
-    return
   end function get_num
 
   !> @ brief Build observation headers
@@ -872,9 +821,6 @@ contains
         idx = idx + 1
       end do obsfile
     end do all_obsfiles
-    !
-    ! -- return
-    return
   end subroutine build_headers
 
   !> @ brief Get an array of observations
@@ -897,9 +843,6 @@ contains
     if (nObs > 0) then
       call this%set_obs_array(nObs, obsArray)
     end if
-    !
-    ! -- return
-    return
   end subroutine get_obs_array
 
   !> @ brief Get an ObsDataType object
@@ -929,9 +872,6 @@ contains
       call store_error(errmsg)
       call store_error_unit(this%inUnitObs)
     end if
-    !
-    ! -- return
-    return
   end function get_obs_datum
 
   !> @ brief Set observation array values
@@ -955,9 +895,6 @@ contains
       obsrv => this%get_obs(i)
       obsArray(i)%obsrv => obsrv
     end do
-    !
-    ! -- return
-    return
   end subroutine set_obs_array
 
   !> @ brief Get an ObserveType object
@@ -973,9 +910,6 @@ contains
     class(ObserveType), pointer :: obsrv !< observation ObserveType
     !
     obsrv => GetObsFromList(this%obsList, indx)
-    !
-    ! -- return
-    return
   end function get_obs
 
   !> @ brief Read observation blocks
@@ -1129,9 +1063,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- return
-    return
   end subroutine read_obs_blocks
 
   !> @ brief Write observation data
@@ -1166,9 +1097,6 @@ contains
         call write_unfmtd_obs(obsrv, iprec, this%obsOutputList, simval)
       end if
     end do
-    !
-    ! --return
-    return
   end subroutine write_obs_simvals
 
 end module ObsModule

--- a/src/Utilities/Observation/ObsOutput.f90
+++ b/src/Utilities/Observation/ObsOutput.f90
@@ -48,9 +48,6 @@ contains
     class(ObsOutputType), intent(inout) :: this
     !
     this%empty_line = .TRUE.
-    !
-    ! -- return
-    return
   end subroutine ResetObsEmptyLine
 
   !> @ brief Write line return for observation
@@ -65,9 +62,6 @@ contains
     ! -- write a line return to end of observation output line
     !    for this totim
     write (this%nunit, '(a)', advance='YES') ''
-    !
-    ! --return
-    return
   end subroutine WriteObsLineReturn
 
   ! Non-type-bound procedures
@@ -91,9 +85,6 @@ contains
     class default
       continue
     end select
-    !
-    ! -- return
-    return
   end function CastAsObsOutputType
 
   !> @ brief Construct and assign ObsOutputType object
@@ -111,9 +102,6 @@ contains
     allocate (newObsOutput)
     newObsOutput%filename = fname
     newObsOutput%nunit = nunit
-    !
-    ! -- return
-    return
   end subroutine ConstructObsOutput
 
   !> @ brief Add observation output to a list
@@ -130,9 +118,6 @@ contains
     !
     obj => obsOutput
     call list%Add(obj)
-    !
-    ! -- return
-    return
   end subroutine AddObsOutputToList
 
   !> @ brief Get observation output from a list
@@ -151,9 +136,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsObsOutputType(obj)
-    !
-    ! --return
-    return
   end function GetObsOutputFromList
 
 end module ObsOutputModule

--- a/src/Utilities/Observation/ObsOutputList.f90
+++ b/src/Utilities/Observation/ObsOutputList.f90
@@ -54,9 +54,6 @@ contains
       obsOutput => this%Get(i)
       call obsOutput%ResetObsEmptyLine()
     end do
-    !
-    ! -- return
-    return
   end subroutine ResetAllObsEmptyLines
 
   !> @ brief Count the number of ObsOutputType objects
@@ -71,9 +68,6 @@ contains
     class(ObsOutputListType), intent(inout) :: this
     !
     Count = this%ObsOutputs%Count()
-    !
-    ! -- return
-    return
   end function Count
 
   !> @ brief Determine if a file name is in the list of ObsOutputType objects
@@ -99,9 +93,6 @@ contains
         exit loop1
       end if
     end do loop1
-    !
-    ! -- return
-    return
   end function ContainsFile
 
   !> @ brief Add a ObsOutputType object to the list
@@ -120,9 +111,6 @@ contains
     !
     call ConstructObsOutput(obsOutput, fname, nunit)
     call AddObsOutputToList(this%ObsOutputs, obsOutput)
-    !
-    ! -- return
-    return
   end subroutine Add
 
   !> @ brief Write line returns for all ObsOutputListType
@@ -145,9 +133,6 @@ contains
         call obsOutput%WriteObsLineReturn()
       end if
     end do
-    !
-    ! -- return
-    return
   end subroutine WriteAllObsLineReturns
 
   !> @ brief Get an item from a ObsOutputListType
@@ -163,9 +148,6 @@ contains
     type(ObsOutputType), pointer :: obsOutput
     !
     obsOutput => GetObsOutputFromList(this%ObsOutputs, indx)
-    !
-    ! -- return
-    return
   end function Get
 
   !> @ brief Clear a ObsOutputListType
@@ -178,9 +160,6 @@ contains
     class(ObsOutputListType), intent(inout) :: this
     !
     call this%ObsOutputs%Clear()
-    !
-    ! -- return
-    return
   end subroutine Clear
 
   !> @ brief Deallocate a ObsOutputListType
@@ -202,9 +181,6 @@ contains
     end do
     !
     call this%ObsOutputs%Clear(.true.)
-    !
-    ! -- return
-    return
   end subroutine DeallocObsOutputList
 
 end module ObsOutputListModule

--- a/src/Utilities/Observation/ObsUtility.f90
+++ b/src/Utilities/Observation/ObsUtility.f90
@@ -63,9 +63,6 @@ contains
     !    issue with ifort (IFORT) 19.1.0.166 20191121 for Linux
     !    that occurred on some Linux systems.
     flush (nunit)
-    !
-    ! -- return
-    return
   end subroutine write_fmtd_obs
 
   !> @ brief Write unformatted observation
@@ -115,9 +112,6 @@ contains
       valdbl = value
       write (nunit) valdbl
     end if
-    !
-    ! -- return
-    return
   end subroutine write_unfmtd_obs
 
 end module ObsUtilityModule

--- a/src/Utilities/Observation/Observe.f90
+++ b/src/Utilities/Observation/Observe.f90
@@ -120,9 +120,6 @@ contains
     !
     ! -- Reset current value to zero.
     this%CurrentTimeStepEndValue = DZERO
-    !
-    ! -- return
-    return
   end subroutine ResetCurrentValue
 
   !> @ brief Write observation input data
@@ -161,9 +158,6 @@ contains
     call obstab%add_term('ALL TIMES')
     call obstab%add_term('"'//trim(this%IDstring)//'"')
     call obstab%add_term(fnameout)
-    !
-    ! -- return
-    return
   end subroutine WriteTo
 
   !> @ brief Reset a observation index
@@ -185,9 +179,6 @@ contains
     !
     ! -- Allocate observation index array to size 0
     allocate (this%indxbnds(0))
-    !
-    ! -- return
-    return
   end subroutine ResetObsIndex
 
   !> @ brief Add a observation index
@@ -211,9 +202,6 @@ contains
     !
     ! -- add index to observation index
     this%indxbnds(this%indxbnds_count) = indx
-    !
-    ! -- return
-    return
   end subroutine AddObsIndex
 
   !> @ brief Deallocate a observation
@@ -227,9 +215,6 @@ contains
     if (allocated(this%indxbnds)) then
       deallocate (this%indxbnds)
     end if
-    !
-    ! -- return
-    return
   end subroutine da
 
   ! Non-type-bound procedures
@@ -303,9 +288,6 @@ contains
     newObservation%UnitNumber = numunit
     newObservation%FormattedOutput = formatted
     newObservation%IndxObsOutput = indx
-    !
-    ! -- return
-    return
   end subroutine ConstructObservation
 
   !> @ brief Cast a object as a ObserveType
@@ -326,9 +308,6 @@ contains
     type is (ObserveType)
       res => obj
     end select
-    !
-    ! -- return
-    return
   end function CastAsObserveType
 
   !> @ brief Add a ObserveType to a list
@@ -345,9 +324,6 @@ contains
     !
     obj => obs
     call list%Add(obj)
-    !
-    ! -- return
-    return
   end subroutine AddObsToList
 
   !> @ brief Get an ObserveType from a list
@@ -366,9 +342,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsObserveType(obj)
-    !
-    ! -- return
-    return
   end function GetObsFromList
 
 end module ObserveModule

--- a/src/Utilities/PackageBudget.f90
+++ b/src/Utilities/PackageBudget.f90
@@ -76,7 +76,6 @@ contains
     this%budtxt = ''
     this%naux = 0
     this%nbound = 0
-    return
   end subroutine initialize
 
   !> @ brief Set names for this PackageBudgetType object
@@ -90,7 +89,6 @@ contains
     character(len=LENPACKAGENAME) :: budtxt !< name of budget term (CHD, RCH, EVT, DRN-TO-MVR, etc.)
     this%name = name
     this%budtxt = budtxt
-    return
   end subroutine set_name
 
   !> @ brief Set aux names for this PackageBudgetType object
@@ -108,7 +106,6 @@ contains
     call mem_reallocate(this%auxname, LENAUXNAME, naux, 'AUXNAME', &
                         this%memoryPath)
     this%auxname(:) = auxname(:)
-    return
   end subroutine set_auxname
 
   !> @ brief Point members of this class to data stored in GWF packages
@@ -143,8 +140,6 @@ contains
                          flowvarname, mem_path_target)
     call mem_reassignptr(this%auxvar, 'AUXVAR', this%memoryPath, &
                          auxvarname, mem_path_target)
-    !
-    return
   end subroutine set_pointers
 
   !> @ brief Copy data read from a budget file into this object
@@ -193,7 +188,6 @@ contains
     integer(I4B), intent(in) :: i !< entry number
     real(DP) :: flow
     flow = this%flow(i)
-    return
   end function get_flow
 
   !> @ brief Deallocate
@@ -211,7 +205,6 @@ contains
     call mem_deallocate(this%nodelist, 'NODELIST', this%memoryPath)
     call mem_deallocate(this%flow, 'FLOW', this%memoryPath)
     call mem_deallocate(this%auxvar, 'AUXVAR', this%memoryPath)
-    return
   end subroutine da
 
 end module PackageBudgetModule

--- a/src/Utilities/Sim.f90
+++ b/src/Utilities/Sim.f90
@@ -244,9 +244,6 @@ contains
     else
       call sim_warnings%store(msg)
     end if
-    !
-    ! -- return
-    return
   end subroutine store_warning
 
   !> @brief Store deprecation warning message

--- a/src/Utilities/SmoothingFunctions.f90
+++ b/src/Utilities/SmoothingFunctions.f90
@@ -35,7 +35,6 @@ contains
       y = DONE
       dydx = DZERO
     end if
-    return
   end subroutine sSCurve
 
   !> @ brief sCubicLinear
@@ -67,7 +66,6 @@ contains
       y = DONE
       dydx = DZERO
     end if
-    return
   end subroutine sCubicLinear
 
   !> @ brief sCubic
@@ -103,7 +101,6 @@ contains
       y = DONE
       dydx = DZERO
     end if
-    return
   end subroutine sCubic
 
   !> @ brief sLinear
@@ -130,7 +127,6 @@ contains
       y = DONE
       dydx = DZERO
     end if
-    return
   end subroutine sLinear
 
   !> @ brief sQuadratic
@@ -157,7 +153,6 @@ contains
       y = DONE
       dydx = DZERO
     end if
-    return
   end subroutine sQuadratic
 
   !> @ brief sChSmooth
@@ -201,7 +196,6 @@ contains
       end if
       smooth = y
     end if
-    return
   end subroutine sChSmooth
 
   !> @ brief sLinearSaturation
@@ -227,7 +221,6 @@ contains
     else
       y = (x - bot) / b
     end if
-    return
   end function sLinearSaturation
 
   !> @ brief sCubicSaturation
@@ -273,7 +266,6 @@ contains
       y = DONE
     end if
 
-    return
   end function sCubicSaturation
 
   !> @ brief sQuadraticSaturation
@@ -329,7 +321,6 @@ contains
       end if
     end if
 
-    return
   end function sQuadraticSaturation
 
   !> @ brief sQuadraticSaturation
@@ -364,7 +355,6 @@ contains
       y = seff * (DONE - sr) + sr
     end if
 
-    return
   end function svanGenuchtenSaturation
 
   !> @ brief Derivative of the quadratic saturation function
@@ -413,7 +403,6 @@ contains
     end if
     y = y / b
 
-    return
   end function sQuadraticSaturationDerivative
 
   !> @ brief sQSaturation
@@ -468,9 +457,6 @@ contains
     else
       y = DONE
     end if
-    !
-    ! -- return
-    return
   end function sQSaturation
 
   !> @ brief sQSaturationDerivative
@@ -527,9 +513,6 @@ contains
     else
       y = DZERO
     end if
-    !
-    ! -- return
-    return
   end function sQSaturationDerivative
 
   !> @ brief sSlope
@@ -576,9 +559,6 @@ contains
     !
     ! -- calculate y from ym and yp contributions
     y = yi + ym + yp
-    !
-    ! -- return
-    return
   end function sSlope
 
   !> @ brief sSlopeDerivative
@@ -620,9 +600,6 @@ contains
     !
     ! -- calculate derivative from individual contributions
     y = DHALF * (sm + sp) - DHALF * rho * (sm - sp)
-    !
-    ! -- return
-    return
   end function sSlopeDerivative
 
   !> @ brief sQuadratic0sp
@@ -665,9 +642,6 @@ contains
     else
       y = x
     end if
-    !
-    ! -- return
-    return
   end function sQuadratic0sp
 
   !> @ brief sQuadratic0spDerivative
@@ -710,9 +684,6 @@ contains
     else
       y = 1
     end if
-    !
-    ! -- return
-    return
   end function sQuadratic0spDerivative
 
   !> @ brief sQuadraticSlope
@@ -762,9 +733,6 @@ contains
     !
     ! -- add value at xi
     y = y + yi
-    !
-    ! -- return
-    return
   end function sQuadraticSlope
 
   !> @ brief sQuadraticSlopeDerivative
@@ -810,9 +778,6 @@ contains
     else
       y = sp
     end if
-    !
-    ! -- return
-    return
   end function sQuadraticSlopeDerivative
 
 end module SmoothingModule

--- a/src/Utilities/Sparse.f90
+++ b/src/Utilities/Sparse.f90
@@ -61,9 +61,6 @@ contains
       this%row(i)%icolarray = 0
       this%row(i)%nnz = 0
     end do
-    !
-    ! -- return
-    return
   end subroutine initialize
 
   ! overload
@@ -141,9 +138,6 @@ contains
       end do
       ia(i + 1) = ipos
     end do
-    !
-    ! -- return
-    return
   end subroutine filliaja
 
   subroutine addconnection(this, i, j, inodup, iaddop)
@@ -169,9 +163,6 @@ contains
       this%nnz_od = this%nnz_od + iadded
     end if
     if (present(iaddop)) iaddop = iadded
-    !
-    ! -- return
-    return
   end subroutine addconnection
 
   subroutine insert(j, thisrow, inodup, iadded)
@@ -221,9 +212,6 @@ contains
     thisrow%nnz = thisrow%nnz + 1
     thisrow%icolarray(thisrow%nnz) = j
     iadded = 1
-    !
-    ! -- return
-    return
   end subroutine insert
 
   subroutine sort(this, with_csr)
@@ -248,9 +236,6 @@ contains
       call sortintarray(nval - start_idx + 1, &
                         this%row(i)%icolarray(start_idx:nval))
     end do
-    !
-    ! -- return
-    return
   end subroutine sort
 
   subroutine sortintarray(nval, iarray)
@@ -272,9 +257,6 @@ contains
         end if
       end do
     end do
-    !
-    ! -- return
-    return
   end subroutine sortintarray
 
   subroutine csr_diagsum(ia, flowja)
@@ -296,7 +278,6 @@ contains
         flowja(iposdiag) = flowja(iposdiag) + flowja(ipos)
       end do
     end do
-    return
   end subroutine csr_diagsum
 
 end module SparseModule

--- a/src/Utilities/StringList.f90
+++ b/src/Utilities/StringList.f90
@@ -16,7 +16,6 @@ contains
     !
     allocate (newCharCont)
     newCharCont = text
-    return
   end subroutine ConstructCharacterContainer
 
   function CastAsCharacterStringType(obj) result(res)
@@ -31,7 +30,6 @@ contains
     type is (CharacterStringType)
       res => obj
     end select
-    return
   end function CastAsCharacterStringType
 
   subroutine AddStringToList(list, string)
@@ -49,8 +47,6 @@ contains
       obj => newCharacterContainer
       call list%Add(obj)
     end if
-    !
-    return
   end subroutine AddStringToList
 
   function GetStringFromList(list, indx) result(string)
@@ -71,8 +67,6 @@ contains
     else
       string = ''
     end if
-    !
-    return
   end function GetStringFromList
 
 end module StringListModule

--- a/src/Utilities/Table.f90
+++ b/src/Utilities/Table.f90
@@ -104,9 +104,6 @@ contains
     ! -- initialize variables
     this%name = name
     this%title = title
-    !
-    ! -- Return
-    return
   end subroutine table_cr
 
   !< @brief Define the new table object
@@ -179,9 +176,6 @@ contains
     this%ntableterm = ntableterm
     this%ientry = 0
     this%icount = 0
-    !
-    ! -- return
-    return
   end subroutine table_df
 
   !< @brief Initialize data for a column
@@ -228,9 +222,6 @@ contains
       ! -- reset ientry
       this%ientry = 0
     end if
-    !
-    ! -- return
-    return
   end subroutine initialize_column
 
   !< @brief Set the table object header
@@ -304,9 +295,6 @@ contains
         end if
       end do
     end do
-    !
-    ! -- return
-    return
   end subroutine set_header
 
   !< @brief Allocate allocatable character arrays
@@ -351,9 +339,6 @@ contains
       this%header(1) = linesep(1:width)
       this%header(nlines + 2) = linesep(1:width)
     end if
-    !
-    ! -- return
-    return
   end subroutine allocate_strings
 
   !< @brief Write the table header
@@ -392,9 +377,6 @@ contains
     this%first_entry = .FALSE.
     this%ientry = 0
     this%icount = 0
-    !
-    ! -- return
-    return
   end subroutine write_header
 
   !< @brief Write the data line
@@ -416,9 +398,6 @@ contains
     this%ientry = 0
     this%iloc = 1
     this%icount = this%icount + 1
-    !
-    ! -- return
-    return
   end subroutine write_line
 
   !< @brief Private method that test for last line. If last line the
@@ -434,9 +413,6 @@ contains
     if (this%icount == this%maxbound) then
       call this%finalize_table()
     end if
-    !
-    ! -- return
-    return
   end subroutine finalize
 
   !< @brief Public method to finalize the table
@@ -455,9 +431,6 @@ contains
     !
     ! -- reinitialize variables
     call this%reset()
-    !
-    ! -- return
-    return
   end subroutine finalize_table
 
   !< @brief deallocate
@@ -501,9 +474,6 @@ contains
     deallocate (this%ientry)
     deallocate (this%iloc)
     deallocate (this%icount)
-    !
-    ! -- Return
-    return
   end subroutine table_da
 
   !< @brief convert a line to the correct number of columns
@@ -545,9 +515,6 @@ contains
     !
     ! -- clean up local allocatable array
     deallocate (words)
-    !
-    ! -- Return
-    return
   end subroutine line_to_columns
 
   !< @brief evaluate if error condition occurs when adding data to dataline
@@ -566,9 +533,6 @@ contains
         ') that only has', this%ntableterm, 'columns.'
       call store_error(errmsg, terminate=.TRUE.)
     end if
-    !
-    ! -- Return
-    return
   end subroutine add_error
 
   !< @brief add integer value to the dataline
@@ -632,9 +596,6 @@ contains
     if (this%allow_finalization) then
       call this%finalize()
     end if
-    !
-    ! -- Return
-    return
   end subroutine add_integer
 
   !< @brief add long integer value to the dataline
@@ -700,9 +661,6 @@ contains
     if (this%allow_finalization) then
       call this%finalize()
     end if
-    !
-    ! -- Return
-    return
   end subroutine add_long_integer
 
   !< @brief add real value to the dataline
@@ -773,9 +731,6 @@ contains
         call this%finalize()
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine add_real
 
   !< @brief add string value to the dataline
@@ -840,9 +795,6 @@ contains
     if (this%allow_finalization) then
       call this%finalize()
     end if
-    !
-    ! -- Return
-    return
   end subroutine add_string
 
   !< @brief reset maxbound
@@ -859,9 +811,6 @@ contains
     !
     ! -- reset counters
     call this%reset()
-    !
-    ! -- return
-    return
   end subroutine set_maxbound
 
   !< @brief reset kstp and kper
@@ -877,9 +826,6 @@ contains
     ! -- set maxbound
     this%kstp = kstp
     this%kper = kper
-    !
-    ! -- return
-    return
   end subroutine set_kstpkper
 
   !< @brief reset title
@@ -893,9 +839,6 @@ contains
     !
     ! -- set maxbound
     this%title = title
-    !
-    ! -- return
-    return
   end subroutine set_title
 
   !< @brief reset iout
@@ -909,9 +852,6 @@ contains
     !
     ! -- set iout
     this%iout = iout
-    !
-    ! -- return
-    return
   end subroutine set_iout
 
   !< @brief print list entry
@@ -933,9 +873,6 @@ contains
     if (this%ntableterm > 3) then
       call this%add_term(bname)
     end if
-    !
-    ! -- return
-    return
   end subroutine print_list_entry
 
   !< @brief print separator
@@ -967,9 +904,6 @@ contains
         write (this%iout, '(/)')
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine print_separator
 
   !< @brief Private method to reset table counters
@@ -984,9 +918,6 @@ contains
     this%ientry = 0
     this%icount = 0
     this%first_entry = .TRUE.
-    !
-    ! -- return
-    return
   end subroutine reset
 
 end module TableModule

--- a/src/Utilities/TableTerm.f90
+++ b/src/Utilities/TableTerm.f90
@@ -146,9 +146,6 @@ contains
     class(TableTermType) :: this
     ! -- local
     get_width = this%width
-    !
-    ! -- return
-    return
   end function get_width
 
   !< @brief get column alignment
@@ -161,9 +158,6 @@ contains
     class(TableTermType) :: this
     ! -- local
     get_alignment = this%alignment
-    !
-    ! -- return
-    return
   end function get_alignment
 
   !< @brief get the number of lines in initial_lines
@@ -176,9 +170,6 @@ contains
     class(TableTermType) :: this
     ! -- local
     get_header_lines = this%nheader_lines
-    !
-    ! -- return
-    return
   end function get_header_lines
 
   !< @brief allocate table term scalars
@@ -196,9 +187,6 @@ contains
     !
     ! -- initialize scalars
     this%nheader_lines = 0
-    !
-    ! -- return
-    return
   end subroutine allocate_scalars
 
   !< @brief deallocate table terms

--- a/src/Utilities/TimeSeries/TimeArray.f90
+++ b/src/Utilities/TimeSeries/TimeArray.f90
@@ -67,9 +67,6 @@ contains
     !
     allocate (newTa)
     allocate (newTa%taArray(isize))
-    !
-    ! -- Return
-    return
   end subroutine ConstructTimeArray
 
   !> @brief Cast an unlimited polymorphic object as TimeArrayType
@@ -87,9 +84,6 @@ contains
     type is (TimeArrayType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsTimeArrayType
 
   !> @brief Add a time array to a to list
@@ -103,9 +97,6 @@ contains
     !
     obj => timearray
     call list%Add(obj)
-    !
-    ! -- Return
-    return
   end subroutine AddTimeArrayToList
 
   !> @brief Retrieve a time array from a list
@@ -121,9 +112,6 @@ contains
     !
     obj => list%GetItem(indx)
     res => CastAsTimeArrayType(obj)
-    !
-    ! -- Return
-    return
   end function GetTimeArrayFromList
 
   !> @brief Deallocate memory
@@ -134,9 +122,6 @@ contains
     !
     deallocate (this%taArray)
     this%taArray => null()
-    !
-    ! -- Return
-    return
   end subroutine ta_da
 
 end module TimeArrayModule

--- a/src/Utilities/TimeSeries/TimeArraySeries.f90
+++ b/src/Utilities/TimeSeries/TimeArraySeries.f90
@@ -77,9 +77,6 @@ contains
       call store_error(errmsg, terminate=.TRUE.)
     end if
     newTas%datafile = filename
-    !
-    ! -- Return
-    return
   end subroutine ConstructTimeArraySeries
 
   ! -- Public procedures
@@ -205,9 +202,6 @@ contains
       call store_error(errmsg)
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine tas_init
 
   !> @brief Populate an array time-weighted average value for a specified time
@@ -234,9 +228,6 @@ contains
       ! -- time0 and time1 are the same, so skip the integration step.
       call this%get_values_at_time(nvals, values, time0)
     end if
-    !
-    ! -- Return
-    return
   end subroutine GetAverageValues
 
   !> @brief Return unit number
@@ -248,9 +239,6 @@ contains
     class(TimeArraySeriesType) :: this
     !
     GetInunit = this%inunit
-    !
-    ! -- Return
-    return
   end function GetInunit
 
   ! -- Private procedures
@@ -341,9 +329,6 @@ contains
     !
     if (time0 <= time) taEarlier => ta0
     if (time1 >= time) taLater => ta1
-    !
-    ! -- Return
-    return
   end subroutine get_surrounding_records
 
   !> @brief Read next time array from input file and append to list
@@ -420,9 +405,6 @@ contains
         call this%parser%terminateblock()
       end if
     end if
-    !
-    ! -- Return
-    return
   end function read_next_array
 
   !> @brief Return an array of values for a specified time, same units as
@@ -507,9 +489,6 @@ contains
       call store_error(errmsg)
       call store_error_unit(this%inunit)
     end if
-    !
-    ! -- Return
-    return
   end subroutine get_values_at_time
 
   !> @brief Populates an array with integrated values for a specified time span
@@ -640,9 +619,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine get_integrated_values
 
   !> @brief Deallocate fromNode and all previous nodes in list;
@@ -680,9 +656,6 @@ contains
       end do
       fromNode => null()
     end if
-    !
-    ! -- Return
-    return
   end subroutine DeallocateBackward
 
   !> @brief Return pointer to ListNodeType object for the node representing
@@ -752,9 +725,6 @@ contains
     end if
     !
     if (time0 <= time) tslNode => node0
-    !
-    ! -- Return
-    return
   end subroutine get_latest_preceding_node
 
   !> @brief Deallocate memory
@@ -776,9 +746,6 @@ contains
     ! -- Deallocate the list of time arrays
     call this%list%Clear(.true.)
     deallocate (this%list)
-    !
-    ! -- Return
-    return
   end subroutine tas_da
 
   ! -- Procedures not type-bound
@@ -798,9 +765,6 @@ contains
     type is (TimeArraySeriesType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsTimeArraySeriesType
 
   !> @brief Get time array from list
@@ -816,9 +780,6 @@ contains
     !
     obj => list%GetItem(indx)
     res => CastAsTimeArraySeriesType(obj)
-    !
-    ! -- Return
-    return
   end function GetTimeArraySeriesFromList
 
 end module TimeArraySeriesModule

--- a/src/Utilities/TimeSeries/TimeArraySeriesLink.f90
+++ b/src/Utilities/TimeSeries/TimeArraySeriesLink.f90
@@ -45,9 +45,6 @@ contains
     this%bndarray => null()
     this%rmultarray => null()
     this%TimeArraySeries => null()
-    !
-    ! -- Return
-    return
   end subroutine tasl_da
 
   !> @brief Construct a time series of arrays that are linked
@@ -73,9 +70,6 @@ contains
     newTasLink%BndArray => bndArray
     newTasLink%Iprpak = iprpak
     newTasLink%Text = text
-    !
-    ! -- Return
-    return
   end subroutine ConstructTimeArraySeriesLink
 
   !> @brief Cast an unlimited polymorphic object as TimeArraySeriesLinkType
@@ -93,9 +87,6 @@ contains
     type is (TimeArraySeriesLinkType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsTimeArraySeriesLinkType
 
   !> @brief Add time-array series to list
@@ -110,9 +101,6 @@ contains
     !
     obj => tasLink
     call list%Add(obj)
-    !
-    ! -- Return
-    return
   end subroutine AddTimeArraySeriesLinkToList
 
   !> @brief Get time-array series from a list and return
@@ -128,9 +116,6 @@ contains
     !
     obj => list%GetItem(idx)
     res => CastAsTimeArraySeriesLinkType(obj)
-    !
-    ! -- Return
-    return
   end function GetTimeArraySeriesLinkFromList
 
 end module TimeArraySeriesLinkModule

--- a/src/Utilities/TimeSeries/TimeArraySeriesManager.f90
+++ b/src/Utilities/TimeSeries/TimeArraySeriesManager.f90
@@ -69,9 +69,6 @@ contains
     this%iout = iout
     allocate (this%boundTasLinks)
     allocate (this%tasfiles(0))
-    !
-    ! -- Return
-    return
   end subroutine tasmanager_cr
 
   !> @brief Define the time-array series manager
@@ -96,9 +93,6 @@ contains
       call tasptr%tas_init(this%tasfiles(i), this%modelname, &
                            this%iout, this%tasnames(i))
     end do
-    !
-    ! -- Return
-    return
   end subroutine tasmanager_df
 
   !> @brief Time step (or subtime step) advance.
@@ -184,9 +178,6 @@ contains
         end if
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine tasmgr_ad
 
   !> @brief Deallocate
@@ -223,9 +214,6 @@ contains
     ! -- nullify pointers
     this%dis => null()
     this%boundTasLinks => null()
-    !
-    ! -- Return
-    return
   end subroutine tasmgr_da
 
   !> @brief Add a time-array series file
@@ -242,9 +230,6 @@ contains
     call ExpandArray(this%tasfiles, 1)
     indx = size(this%tasfiles)
     this%tasfiles(indx) = fname
-    !
-    ! -- Return
-    return
   end subroutine add_tasfile
 
   !> @brief Zero out arrays that are represented with time series
@@ -283,9 +268,6 @@ contains
         end if
       end do
     end if
-    !
-    ! -- Return
-    return
   end subroutine Reset
 
   !> @brief Make link from time-array series to package array
@@ -334,9 +316,6 @@ contains
     !
     ! -- Add link to list of links
     call this%tasmgr_add_link(newTasLink)
-    !
-    ! -- Return
-    return
   end subroutine MakeTasLink
 
   !> @brief Get link from the boundtaslinks list
@@ -353,9 +332,6 @@ contains
     if (associated(this%boundTasLinks)) then
       tasLink => GetTimeArraySeriesLinkFromList(this%boundTasLinks, indx)
     end if
-    !
-    ! -- Return
-    return
   end function GetLink
 
   !> @brief Count number of links in the boundtaslinks list
@@ -371,9 +347,6 @@ contains
     else
       CountLinks = 0
     end if
-    !
-    ! -- Return
-    return
   end function CountLinks
 
   ! -- Private procedures
@@ -405,9 +378,6 @@ contains
         tasLink%BndArray(i) = tasLink%BndArray(i) * area
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine tasmgr_convert_flux
 
   !> @brief Add a time arrays series link
@@ -419,9 +389,6 @@ contains
     ! -- local
     !
     call AddTimeArraySeriesLinkToList(this%boundTasLinks, tasLink)
-    !
-    ! -- Return
-    return
   end subroutine tasmgr_add_link
 
 end module TimeArraySeriesManagerModule

--- a/src/Utilities/TimeSeries/TimeSeries.f90
+++ b/src/Utilities/TimeSeries/TimeSeries.f90
@@ -98,9 +98,6 @@ contains
     !
     allocate (newTimeSeriesFile)
     allocate (newTimeSeriesFile%parser)
-    !
-    ! -- Return
-    return
   end subroutine ConstructTimeSeriesFile
 
   !> @brief Cast an unlimited polymorphic object as class(TimeSeriesFileType)
@@ -118,9 +115,6 @@ contains
     type is (TimeSeriesFileType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsTimeSeriesFileType
 
   !> @brief Cast an unlimited polymorphic object as class(TimeSeriesFileType)
@@ -138,9 +132,6 @@ contains
     class is (TimeSeriesFileType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsTimeSeriesFileClass
 
   !> @brief Add time series file to list
@@ -154,9 +145,6 @@ contains
     !
     obj => tsfile
     call list%Add(obj)
-    !
-    ! -- Return
-    return
   end subroutine AddTimeSeriesFileToList
 
   !> @brief Get time series from list
@@ -176,9 +164,6 @@ contains
     if (.not. associated(res)) then
       res => CastAsTimeSeriesFileClass(obj)
     end if
-    !
-    ! -- Return
-    return
   end function GetTimeSeriesFileFromList
 
   !> @brief Compare two time series; if they are identical, return true
@@ -209,9 +194,6 @@ contains
     end do
     !
     same = .true.
-    !
-    ! -- Return
-    return
   end function SameTimeSeries
 
   ! Type-bound procedures of TimeSeriesType
@@ -247,9 +229,6 @@ contains
     case (LINEAREND)
       GetValue = this%get_value_at_time(time1, extend)
     end select
-    !
-    ! -- Return
-    return
   end function GetValue
 
   !> @brief Initialize time series
@@ -284,9 +263,6 @@ contains
       errmsg = 'Name not specified for time series.'
       call store_error(errmsg, terminate=.TRUE.)
     end if
-    !
-    ! -- Return
-    return
   end subroutine initialize_time_series
 
   !> @brief Get surrounding records
@@ -376,9 +352,6 @@ contains
     !
     if (time0 < time .or. is_close(time0, time)) tsrecEarlier => tsrec0
     if (time1 > time .or. is_close(time1, time)) tsrecLater => tsrec1
-    !
-    ! -- Return
-    return
   end subroutine get_surrounding_records
 
   !> @brief Get surrounding nodes
@@ -476,9 +449,6 @@ contains
       tsrecLater => tsrec1
       nodeLater => tsNode1
     end if
-    !
-    ! -- Return
-    return
   end subroutine get_surrounding_nodes
 
   !> @brief Read next record
@@ -499,9 +469,6 @@ contains
     if (.not. read_next_record) then
       this%tsfile%finishedReading = .true.
     end if
-    !
-    ! -- Return
-    return
   end function read_next_record
 
   !> @brief Get value for a time
@@ -584,9 +551,6 @@ contains
       write (errmsg, 10) time, trim(this%Name)
       call store_error(errmsg, terminate=.TRUE.)
     end if
-    !
-    ! -- Return
-    return
   end function get_value_at_time
 
   !> @brief Get integrated value
@@ -723,9 +687,6 @@ contains
         end if
       end if
     end if
-    !
-    ! -- Return
-    return
   end function get_integrated_value
 
   !> @brief Get average value
@@ -758,9 +719,6 @@ contains
       value = this%get_value_at_time(time0, extendToEndOfSimulation)
     end if
     get_average_value = value
-    !
-    ! -- Return
-    return
   end function get_average_value
 
   !> @brief Get latest preceding node
@@ -831,9 +789,6 @@ contains
     end if
     !
     if (time0 < time .or. is_close(time0, time)) tslNode => tsNode0
-    !
-    ! -- Return
-    return
   end subroutine get_latest_preceding_node
 
   !> @brief Deallocate
@@ -846,9 +801,6 @@ contains
       call this%list%Clear(.true.)
       deallocate (this%list)
     end if
-    !
-    ! -- Return
-    return
   end subroutine ts_da
 
   !> @brief Add ts record
@@ -862,9 +814,6 @@ contains
     !
     obj => tsr
     call this%list%Add(obj)
-    !
-    ! -- Return
-    return
   end subroutine AddTimeSeriesRecord
 
   !> @brief Get current ts record
@@ -883,9 +832,6 @@ contains
     if (associated(obj)) then
       res => CastAsTimeSeriesRecordType(obj)
     end if
-    !
-    ! -- Return
-    return
   end function GetCurrentTimeSeriesRecord
 
   !> @brief Get previous ts record
@@ -904,9 +850,6 @@ contains
     if (associated(obj)) then
       res => CastAsTimeSeriesRecordType(obj)
     end if
-    !
-    ! -- Return
-    return
   end function GetPreviousTimeSeriesRecord
 
   !> @brief Get next ts record
@@ -925,9 +868,6 @@ contains
     if (associated(obj)) then
       res => CastAsTimeSeriesRecordType(obj)
     end if
-    !
-    ! -- Return
-    return
   end function GetNextTimeSeriesRecord
 
   !> @brief Get ts record
@@ -956,9 +896,6 @@ contains
         exit
       end if
     end do
-    !
-    ! -- Return
-    return
   end function GetTimeSeriesRecord
 
   !> @brief Reset
@@ -968,9 +905,6 @@ contains
     class(TimeSeriesType) :: this
     !
     call this%list%Reset()
-    !
-    ! -- Return
-    return
   end subroutine Reset
 
   !> @brief Insert a time series record
@@ -1050,9 +984,6 @@ contains
         call this%AddTimeSeriesRecord(tsr)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine InsertTsr
 
   !> @brief Find latest time
@@ -1080,9 +1011,6 @@ contains
     obj => this%list%GetItem(nrecords)
     tsr => CastAsTimeSeriesRecordType(obj)
     endtime = tsr%tsrTime
-    !
-    ! -- Return
-    return
   end function FindLatestTime
 
   !> @brief Clear the list of time series records
@@ -1093,9 +1021,6 @@ contains
     logical, optional, intent(in) :: destroy
     !
     call this%list%Clear(destroy)
-    !
-    ! -- Return
-    return
   end subroutine Clear
 
 ! Type-bound procedures of TimeSeriesFileType
@@ -1113,9 +1038,6 @@ contains
     else
       Count = 0
     end if
-    !
-    ! -- Return
-    return
   end function Count
 
   !> @brief Get time series
@@ -1131,9 +1053,6 @@ contains
     if (indx > 0 .and. indx <= this%nTimeSeries) then
       res => this%timeSeries(indx)
     end if
-    !
-    ! -- Return
-    return
   end function GetTimeSeries
 
   !> @brief Open time-series tsfile file and read options and first record,
@@ -1340,9 +1259,6 @@ contains
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()
     end if
-    !
-    ! -- Return
-    return
   end subroutine Initializetsfile
 
   !> @brief Read time series file line
@@ -1379,9 +1295,6 @@ contains
       call AddTimeSeriesRecordToList(this%timeSeries(i)%list, tsRecord)
     end do tsloop
     read_tsfile_line = .true.
-    !
-    ! -- Return
-    return
   end function read_tsfile_line
 
   !> @brief Deallocate memory
@@ -1404,9 +1317,6 @@ contains
     !
     deallocate (this%timeSeries)
     deallocate (this%parser)
-    !
-    ! -- Return
-    return
   end subroutine tsf_da
 
 end module TimeSeriesModule

--- a/src/Utilities/TimeSeries/TimeSeriesFileList.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesFileList.f90
@@ -51,9 +51,6 @@ contains
     !
     ! -- Add the time-series tsfile to the list
     call this%add_time_series_tsfile(tsfile)
-    !
-    ! -- Return
-    return
   end subroutine Add
 
   subroutine Clear(this)
@@ -62,9 +59,6 @@ contains
     class(TimeSeriesFileListType), intent(inout) :: this
     !
     call this%tsfileList%Clear()
-    !
-    ! -- Return
-    return
   end subroutine Clear
 
   function Counttsfiles(this)
@@ -76,9 +70,6 @@ contains
     !
     Counttsfiles = this%tsfileList%Count()
     !
-    !
-    ! -- Return
-    return
   end function Counttsfiles
 
   function CountTimeSeries(this)
@@ -99,9 +90,6 @@ contains
         CountTimeSeries = CountTimeSeries + tsfile%Count()
       end if
     end do
-    !
-    ! -- Return
-    return
   end function CountTimeSeries
 
   function Gettsfile(this, indx) result(res)
@@ -113,9 +101,6 @@ contains
     type(TimeSeriesFileType), pointer :: res
     !
     res => GetTimeSeriesFileFromList(this%tsfileList, indx)
-    !
-    ! -- Return
-    return
   end function Gettsfile
 
   ! -- Private procedures
@@ -128,9 +113,6 @@ contains
     !
     call AddTimeSeriesFileToList(this%tsfileList, tsfile)
     this%numtsfiles = this%numtsfiles + 1
-    !
-    ! -- Return
-    return
   end subroutine add_time_series_tsfile
 
   subroutine tsfl_da(this)
@@ -148,9 +130,6 @@ contains
     !
     call this%tsfileList%Clear(.true.)
     !
-    !
-    ! -- Return
-    return
   end subroutine tsfl_da
 
 end module TimeSeriesFileListModule

--- a/src/Utilities/TimeSeries/TimeSeriesLink.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesLink.f90
@@ -71,9 +71,6 @@ contains
     if (present(text)) then
       newTsLink%Text = text
     end if
-    !
-    ! -- Return
-    return
   end subroutine ConstructTimeSeriesLink
 
   !> @brief Cast an unlimited polymorphic object as TimeSeriesLinkType
@@ -94,9 +91,6 @@ contains
     class default
       continue
     end select
-    !
-    ! -- Return
-    return
   end function CastAsTimeSeriesLinkType
 
   !> @brief Get time series link from a list
@@ -114,9 +108,6 @@ contains
     tsLink => null()
     obj => list%GetItem(indx)
     tsLink => CastAsTimeSeriesLinkType(obj)
-    !
-    ! -- Return
-    return
   end function GetTimeSeriesLinkFromList
 
   !> @brief Add time series link to a list
@@ -131,9 +122,6 @@ contains
     !
     obj => tslink
     call list%Add(obj)
-    !
-    ! -- Return
-    return
   end subroutine AddTimeSeriesLinkToList
 
 end module TimeSeriesLinkModule

--- a/src/Utilities/TimeSeries/TimeSeriesManager.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesManager.f90
@@ -78,9 +78,6 @@ contains
     allocate (this%auxvarTsLinks)
     allocate (this%tsfileList)
     allocate (this%tsfiles(1000))
-    !
-    ! -- Return
-    return
   end subroutine tsmanager_cr
 
   !> @brief Define time series manager object
@@ -92,9 +89,6 @@ contains
     if (this%numtsfiles > 0) then
       call this%HashBndTimeSeries()
     end if
-    !
-    ! -- Return
-    return
   end subroutine tsmanager_df
 
   !> @brief Add a time series file to this manager
@@ -132,9 +126,6 @@ contains
     !
     ! --
     call this%tsfileList%Add(fname, this%iout, tsfile)
-    !
-    ! -- Return
-    return
   end subroutine add_tsfile
 
   !> @brief Time step (or subtime step) advance. Call this each time step or
@@ -305,9 +296,6 @@ contains
         write (this%iout, '()')
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine tsmgr_ad
 
   !> @brief Deallocate memory
@@ -335,9 +323,6 @@ contains
     end if
     !
     deallocate (this%tsfiles)
-    !
-    ! -- Return
-    return
   end subroutine tsmgr_da
 
   !> @brief Call this when a new BEGIN PERIOD block is read for a new stress
@@ -387,9 +372,6 @@ contains
         end if
       end if
     end do
-    !
-    ! -- Return
-    return
   end subroutine Reset
 
   !> @brief Make link
@@ -422,9 +404,6 @@ contains
       tsLink%Text = text
       tsLink%BndName = bndName
     end if
-    !
-    ! -- Return
-    return
   end subroutine make_link
 
   !> @brief Get link
@@ -451,9 +430,6 @@ contains
     if (associated(list)) then
       tsLink => GetTimeSeriesLinkFromList(list, indx)
     end if
-    !
-    ! -- Return
-    return
   end function GetLink
 
   !> @brief Count links
@@ -471,9 +447,6 @@ contains
     elseif (auxOrBnd == 'AUX') then
       CountLinks = this%auxvarTsLinks%count()
     end if
-    !
-    ! -- Return
-    return
   end function CountLinks
 
   !> @brief Get time series
@@ -494,9 +467,6 @@ contains
     if (indx > 0) then
       res => this%TsContainers(indx)%timeSeries
     end if
-    !
-    ! -- Return
-    return
   end function get_time_series
 
   !> @brief Store all boundary (stress) time series links in TsContainers
@@ -533,9 +503,6 @@ contains
         end if
       end do
     end do
-    !
-    ! -- Return
-    return
   end subroutine HashBndTimeSeries
 
   ! -- Non-type-bound procedures
@@ -684,9 +651,6 @@ contains
         call store_error(errmsg)
       end if
     end if
-    !
-    ! -- Return
-    return
   end subroutine read_value_or_time_series_adv
 
 ! -- private subroutines
@@ -747,9 +711,6 @@ contains
         call tsManager%auxvarTsLinks%RemoveNode(removeLink, .TRUE.)
       end if
     end if
-    !
-    ! -- Return
-    return
   end function remove_existing_link
 
   !> @brief Determine if a timeseries link with varName is defined.
@@ -797,9 +758,6 @@ contains
         end if
       end if
     end do csearchlinks
-    !
-    ! -- Return
-    return
   end function var_timeseries
 
 end module TimeSeriesManagerModule

--- a/src/Utilities/TimeSeries/TimeSeriesRecord.f90
+++ b/src/Utilities/TimeSeries/TimeSeriesRecord.f90
@@ -26,9 +26,6 @@ contains
     allocate (newTsRecord)
     newTsRecord%tsrTime = time
     newTsRecord%tsrValue = value
-    !
-    ! -- Return
-    return
   end subroutine ConstructTimeSeriesRecord
 
   !> @brief Cast an unlimited polymorphic object as TimeSeriesRecordType
@@ -47,9 +44,6 @@ contains
     type is (TimeSeriesRecordType)
       res => obj
     end select
-    !
-    ! -- Return
-    return
   end function CastAsTimeSeriesRecordType
 
   !> @brief Add time series record to list
@@ -64,9 +58,6 @@ contains
     !
     obj => tsrecord
     call list%Add(obj)
-    !
-    ! -- Return
-    return
   end subroutine AddTimeSeriesRecordToList
 
 end module TimeSeriesRecordModule

--- a/src/Utilities/Timer.f90
+++ b/src/Utilities/Timer.f90
@@ -28,9 +28,6 @@ contains
     call date_and_time(values=ibdt)
     write (line, fmtdt) (ibdt(i), i=1, 3), (ibdt(i), i=5, 7)
     call write_message(line, skipafter=1)
-    !
-    ! -- Return
-    return
   end subroutine print_start_time
 
   !> @brief Get end time and calculate elapsed time
@@ -152,9 +149,6 @@ contains
         WRITE (IOUT, fmttmd) NSECS, MSECS
       END IF
     END IF
-    !
-    ! -- Return
-    return
   end subroutine elapsed_time
 
   !> @brief Get end time and calculate elapsed time
@@ -175,9 +169,6 @@ contains
       call CPU_TIME(dt)
       ts = ts + dt - t1
     end if
-    !
-    ! -- Return
-    return
   end subroutine code_timer
 
 end module TimerModule

--- a/src/Utilities/comarg.f90
+++ b/src/Utilities/comarg.f90
@@ -248,9 +248,6 @@ contains
     if (icountcmd > 0) then
       call write_message('')
     end if
-    !
-    ! -- return
-    return
   end subroutine GetCommandLineArguments
 
   !> @brief Write command line argument usage
@@ -306,9 +303,6 @@ contains
       'retrieve program information'
     call write_message(line)
     call write_message('', fmt=OPTIONSFMT)
-    !
-    ! -- return
-    return
   end subroutine write_usage
 
 end module CommandArguments

--- a/src/Utilities/compilerversion.F90
+++ b/src/Utilities/compilerversion.F90
@@ -48,9 +48,6 @@ contains
     write (txt, '(a,3(1x,a))') &
       'MODFLOW 6 compiled', trim(adjustl(c_date)), &
       'with', trim(adjustl(compiler_version()))
-    !
-    ! -- return
-    return
   end subroutine get_compiler
 
   !> @ brief Get compilation date
@@ -74,9 +71,6 @@ contains
     !
     ! -- write compilation date string
     write (txt, '(a)') trim(adjustl(c_date))
-    !
-    ! -- return
-    return
   end subroutine get_compile_date
 
   !> @ brief Get compilation options
@@ -92,9 +86,6 @@ contains
     ! -- set txt string
     write (txt, '(a)') &
       'MODFLOW 6 compiler options:'//' '//trim(adjustl(compiler_options()))
-    !
-    ! -- return
-    return
   end subroutine get_compile_options
 
 end module CompilerVersion

--- a/src/Utilities/defmacro.F90
+++ b/src/Utilities/defmacro.F90
@@ -44,8 +44,6 @@ contains
 # endif
 #endif
     !
-    ! return
-    return
   end function get_os
 
   !> @brief Determine if this is the extended version
@@ -76,8 +74,6 @@ contains
       isextended = .TRUE.
     end if
     !
-    ! return
-    return
   end function is_extended
 
   !> @brief Determine if using petsc
@@ -99,8 +95,6 @@ contains
     petscused = .TRUE.
 #endif
     !
-    ! return
-    return
   end function using_petsc
 
   !> @brief Determine if using netcdf
@@ -122,8 +116,6 @@ contains
     netcdfused = .TRUE.
 #endif
     !
-    ! return
-    return
   end function using_netcdf
 
 end module DefinedMacros

--- a/src/Utilities/kind.f90
+++ b/src/Utilities/kind.f90
@@ -55,9 +55,6 @@ contains
     write (iout, '(/a)') 'Logical Variables'
     write (iout, '(2x,a,i0)') 'KIND: ', LGP
     write (iout, '(2x,a,i0)') 'SIZE IN BITS: ', bit_size(ldum)
-    !
-    ! -- Return
-    return
   end subroutine write_kindinfo
 
 end module KindModule

--- a/src/Utilities/sort.f90
+++ b/src/Utilities/sort.f90
@@ -144,9 +144,6 @@ contains
         j = j - 1
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine qsort_int1d
 
   !< @brief quick sort that also includes an index number
@@ -275,9 +272,6 @@ contains
         j = j - 1
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine qsort_dbl1d
 
   subroutine unique_values_int1d(a, b)
@@ -330,9 +324,6 @@ contains
     ! -- allocate tarr and create idxarr
     deallocate (tarr)
     deallocate (indxarr)
-    !
-    ! -- return
-    return
   end subroutine unique_values_int1d
 
   subroutine unique_values_dbl1d(a, b)
@@ -385,9 +376,6 @@ contains
     ! -- allocate tarr and create idxarr
     deallocate (tarr)
     deallocate (indxarr)
-    !
-    ! -- return
-    return
   end subroutine unique_values_dbl1d
 
   !< @brief heap selection
@@ -470,9 +458,6 @@ contains
         j = j - 1
       end do
     end if
-    !
-    ! -- return
-    return
   end subroutine selectn
 
   subroutine rswap(a, b)
@@ -486,9 +471,6 @@ contains
     d = a
     a = b
     b = d
-    !
-    ! -- return
-    return
   end subroutine rswap
 
   subroutine iswap(ia, ib)
@@ -502,9 +484,6 @@ contains
     id = ia
     ia = ib
     ib = id
-    !
-    ! -- return
-    return
   end subroutine iswap
 
 end module SortModule

--- a/src/mf6core.f90
+++ b/src/mf6core.f90
@@ -260,9 +260,6 @@ contains
     !
     call write_message(line)
     call write_listfile_header(iout)
-    !
-    ! -- return
-    return
   end subroutine create_lstfile
 
   !> @brief Create simulation input context
@@ -291,9 +288,6 @@ contains
     !
     ! -- load in scope exchanges
     call load_exchanges(iout)
-    !
-    ! -- return
-    return
   end subroutine static_input_load
 
   !> @brief Define the simulation
@@ -653,9 +647,6 @@ contains
       call converge_reset()
 
     end if
-    !
-    ! -- return
-    return
   end subroutine sim_step_retry
 
   !> @brief Finalize time step
@@ -742,10 +733,6 @@ contains
     !
     ! -- Check if we're done
     call converge_check(hasConverged)
-    !
-    ! -- return
-    return
-
   end function Mf6FinalizeTimestep
 
 end module Mf6CoreModule

--- a/src/mf6lists.f90
+++ b/src/mf6lists.f90
@@ -37,8 +37,6 @@ contains
     call solutiongrouplist%Clear()
     call baseexchangelist%Clear()
     call baseconnectionlist%Clear()
-
-    return
   end subroutine lists_da
 
 end module ListsModule


### PR DESCRIPTION
We've all had a good chuckle over all the unnecessary return statements, and the associated preceding comment:

        ! -- return
        return
    end subroutine

But it's time to bid 'em adieu.  Per the style guide [here](https://modflow6.readthedocs.io/en/latest/_dev/styleguide.html): "Don’t end procedures with a return statement; use return only to return early."

The following files were left untouched so as not to create conflicts with @mjreno's #1967:

src/Utilities/Idm/BoundInputContext.f90
src/Utilities/Idm/IdmLoad.f90
src/Utilities/Idm/ModelPackageInputs.f90
src/Utilities/Idm/SourceLoad.f90
src/Utilities/Idm/mf6blockfile/Mf6FileGridInput.f90
src/Utilities/netcdf/NCArrayReader.f90
src/Utilities/netcdf/NCContextBuild.f90
src/Utilities/Idm/netcdf/NCFileVars.f90
 
- [x] Replaced section above with description of pull request
- [ ] Formatted new and modified Fortran source files with `fprettify`
