### PR TITLE
fix(netcdf): rerun should overwrite netcdf output file

### DIFF
--- a/src/Utilities/Export/DisNCStructured.f90
+++ b/src/Utilities/Export/DisNCStructured.f90
@@ -149,7 +149,7 @@ contains
     !
     ! -- create the netcdf file
     call nf_verify(nf90_create(this%nc_fname, &
-                               IOR(NF90_CLOBBER, NF90_NETCDF4), this%ncid), &
+                               IAND(NF90_CLOBBER, NF90_NETCDF4), this%ncid), &
                    this%nc_fname)
   end subroutine dis_export_init
 

--- a/src/Utilities/Export/MeshNCModel.f90
+++ b/src/Utilities/Export/MeshNCModel.f90
@@ -126,7 +126,7 @@ contains
     !
     ! -- create the netcdf file
     call nf_verify(nf90_create(this%nc_fname, &
-                               IOR(NF90_CLOBBER, NF90_NETCDF4), this%ncid), &
+                               IAND(NF90_CLOBBER, NF90_NETCDF4), this%ncid), &
                    this%nc_fname)
   end subroutine mesh_init
 


### PR DESCRIPTION
Change file creation mode to logical AND of 'NC_CLOBBER' (= recreate when present) and 'NF90_NETCDF4' (desired file format) instead of OR

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Closed issue #2050
- [x] Formatted new and modified Fortran source files with `fprettify`