### PR TITLE
chore: reformat Python code with line length = 88

### DIFF
--- a/autotest/build_exes.py
+++ b/autotest/build_exes.py
@@ -23,9 +23,7 @@ def test_meson_build(bin_path):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        "Rebuild local development version of MODFLOW 6"
-    )
+    parser = argparse.ArgumentParser("Rebuild local development version of MODFLOW 6")
     parser.add_argument(
         "-p", "--path", help="path to bin directory", default=top_bin_path
     )

--- a/autotest/common_regression.py
+++ b/autotest/common_regression.py
@@ -487,9 +487,7 @@ def get_regression_files(
             for extension in extensions:
                 if file_name.lower().endswith(extension):
                     files0.append(fpth0)
-                    fpth1 = os.path.join(
-                        workspace, "mf6_regression", file_name
-                    )
+                    fpth1 = os.path.join(workspace, "mf6_regression", file_name)
                     files1.append(fpth1)
                     break
     return files0, files1
@@ -579,9 +577,7 @@ def setup_model(namefile, dst, remove_existing=True, extrafiles=None):
             print(f"{srcf} does not exist")
 
 
-def setup_mf6(
-    src, dst, mfnamefile="mfsim.nam", extrafiles=None, remove_existing=True
-):
+def setup_mf6(src, dst, mfnamefile="mfsim.nam", extrafiles=None, remove_existing=True):
     """
     Setup an MF6 simulation test, copying input files from the source
     to the destination workspace.
@@ -664,9 +660,7 @@ def setup_mf6(
     return mf6inp, mf6outp
 
 
-def setup_mf6_comparison(
-    src, dst, cmp_exe="mf6", overwrite=True, verbose=False
-):
+def setup_mf6_comparison(src, dst, cmp_exe="mf6", overwrite=True, verbose=False):
     """Setup an output comparison for MODFLOW 6 simulation.
 
     Parameters

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -129,9 +129,7 @@ def pytest_addoption(parser):
 
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--parallel"):
-        skip_parallel = pytest.mark.skip(
-            reason="need --parallel option to run"
-        )
+        skip_parallel = pytest.mark.skip(reason="need --parallel option to run")
         for item in items:
             if "parallel" in item.keywords:
                 item.add_marker(skip_parallel)

--- a/autotest/cross_section_functions.py
+++ b/autotest/cross_section_functions.py
@@ -127,10 +127,7 @@ def wetted_area(
 
             # write to screen
             if verbose:
-                print(
-                    f"{idx}->{idx + 1} ({x0},{x1}) - "
-                    f"perimeter={x1 - x0} - area={a}"
-                )
+                print(f"{idx}->{idx + 1} ({x0},{x1}) - perimeter={x1 - x0} - area={a}")
 
     return area
 
@@ -199,9 +196,7 @@ def is_neighb_vert(x, h, idx):
 
     # Assess left neighbor first
     if idx > 0:
-        if (
-            cnt > 2
-        ):  # only x-sections w/ 3 or more pts may host a vertical side
+        if cnt > 2:  # only x-sections w/ 3 or more pts may host a vertical side
             idxm1 = idx - 1
             if x[idxm1] == x[idx] and h[idxm1] != h[idx]:
                 leftvert = True

--- a/autotest/framework.py
+++ b/autotest/framework.py
@@ -91,9 +91,7 @@ def run_parallel(workspace, target, ncpus) -> Tuple[bool, List[str]]:
     if get_ostag() in ["win64"]:
         mpiexec_cmd = ["mpiexec", "-np", str(ncpus), target, "-p"]
     else:
-        mpiexec_cmd = (
-            ["mpiexec"] + oversubscribed + ["-np", str(ncpus), target, "-p"]
-        )
+        mpiexec_cmd = ["mpiexec"] + oversubscribed + ["-np", str(ncpus), target, "-p"]
 
     proc = Popen(mpiexec_cmd, stdout=PIPE, stderr=STDOUT, cwd=workspace)
 
@@ -145,9 +143,7 @@ def write_input(*sims, overwrite: bool = True, verbose: bool = True):
                 warn("Workspace is not empty, not writing input files")
                 return
             if verbose:
-                print(
-                    f"Writing mf6 simulation '{sim.name}' to: {sim.sim_path}"
-                )
+                print(f"Writing mf6 simulation '{sim.name}' to: {sim.sim_path}")
             sim.write_simulation()
         elif isinstance(sim, flopy.mbase.BaseModel):
             workspace = Path(sim.model_ws)
@@ -155,9 +151,7 @@ def write_input(*sims, overwrite: bool = True, verbose: bool = True):
                 warn("Workspace is not empty, not writing input files")
                 return
             if verbose:
-                print(
-                    f"Writing {type(sim)} model '{sim.name}' to: {sim.model_ws}"
-                )
+                print(f"Writing {type(sim)} model '{sim.name}' to: {sim.model_ws}")
             sim.write_input()
         else:
             raise ValueError(f"Unsupported simulation/model type: {type(sim)}")
@@ -316,9 +310,7 @@ class TestFramework:
                 file1 = files1[i]
                 ext = os.path.splitext(file1)[1][1:].lower()
                 outfile = os.path.splitext(os.path.basename(file1))[0]
-                outfile = os.path.join(
-                    self.workspace, outfile + "." + ext + ".cmp.out"
-                )
+                outfile = os.path.join(self.workspace, outfile + "." + ext + ".cmp.out")
                 file2 = None if files2 is None else files2[i]
 
                 # set exfile
@@ -356,9 +348,7 @@ class TestFramework:
         extension = "hds"
         for i, (fpth0, fpth1) in enumerate(zip(files0, files1)):
             outfile = os.path.splitext(os.path.basename(fpth0))[0]
-            outfile = os.path.join(
-                self.workspace, outfile + f".{extension}.cmp.out"
-            )
+            outfile = os.path.join(self.workspace, outfile + f".{extension}.cmp.out")
             success = compare_heads(
                 None,
                 None,
@@ -388,9 +378,7 @@ class TestFramework:
         extension = "ucn"
         for i, (fpth0, fpth1) in enumerate(zip(files0, files1)):
             outfile = os.path.splitext(os.path.basename(fpth0))[0]
-            outfile = os.path.join(
-                self.workspace, outfile + f".{extension}.cmp.out"
-            )
+            outfile = os.path.join(self.workspace, outfile + f".{extension}.cmp.out")
             success = compare_heads(
                 None,
                 None,
@@ -422,23 +410,17 @@ class TestFramework:
                 f"{EXTTEXT[extension]} comparison {i + 1}",
                 f"{self.name} ({os.path.basename(fpth0)})",
             )
-            success = self._compare_budget_files(
-                extension, fpth0, fpth1, rclose
-            )
+            success = self._compare_budget_files(extension, fpth0, fpth1, rclose)
             if not success:
                 return False
         return True
 
-    def _compare_budget_files(
-        self, extension, fpth0, fpth1, rclose=0.001
-    ) -> bool:
+    def _compare_budget_files(self, extension, fpth0, fpth1, rclose=0.001) -> bool:
         success = True
         if os.stat(fpth0).st_size * os.stat(fpth0).st_size == 0:
             return success, ""
         outfile = os.path.splitext(os.path.basename(fpth0))[0]
-        outfile = os.path.join(
-            self.workspace, outfile + f".{extension}.cmp.out"
-        )
+        outfile = os.path.join(self.workspace, outfile + f".{extension}.cmp.out")
         fcmp = open(outfile, "w")
         fcmp.write("Performing CELL-BY-CELL to CELL-BY-CELL comparison\n")
         fcmp.write(f"{fpth0}\n")
@@ -608,9 +590,7 @@ class TestFramework:
             elif "mf6" in target.name:
                 # parallel test if configured
                 if self.parallel and ncpus > 1:
-                    print(
-                        f"Parallel test {self.name} on {self.ncpus} processes"
-                    )
+                    print(f"Parallel test {self.name} on {self.ncpus} processes")
                     try:
                         success, buff = run_parallel(workspace, target, ncpus)
                     except Exception:
@@ -641,9 +621,7 @@ class TestFramework:
                 try:
                     nf_ext = ".mpsim" if "mp7" in target.name else ".nam"
                     namefile = next(iter(workspace.glob(f"*{nf_ext}")), None)
-                    assert (
-                        namefile
-                    ), f"Control file with extension {nf_ext} not found"
+                    assert namefile, f"Control file with extension {nf_ext} not found"
                     success, buff = flopy.run_model(
                         target, namefile, workspace, report=True
                     )
@@ -660,9 +638,7 @@ class TestFramework:
 
         except Exception:
             success = False
-            warn(
-                f"Unhandled error in comparison model {self.name}:\n{format_exc()}"
-            )
+            warn(f"Unhandled error in comparison model {self.name}:\n{format_exc()}")
 
         return success, buff
 
@@ -701,21 +677,15 @@ class TestFramework:
         else:
             self.sims = [MFSimulation.load(sim_ws=self.workspace)]
             self.buffs = [None]
-            assert (
-                len(self.xfail) == 1
-            ), "Invalid xfail: expected a single boolean"
-            assert (
-                len(self.ncpus) == 1
-            ), "Invalid ncpus: expected a single integer"
+            assert len(self.xfail) == 1, "Invalid xfail: expected a single boolean"
+            assert len(self.ncpus) == 1, "Invalid ncpus: expected a single integer"
 
         # run models/simulations
         for i, sim_or_model in enumerate(self.sims):
             tgts = self.targets
             workspace = get_workspace(sim_or_model)
             exe_path = (
-                Path(sim_or_model.exe_name)
-                if sim_or_model.exe_name
-                else tgts["mf6"]
+                Path(sim_or_model.exe_name) if sim_or_model.exe_name else tgts["mf6"]
             )
             target = (
                 exe_path
@@ -724,9 +694,7 @@ class TestFramework:
             )
             xfail = self.xfail[i]
             ncpus = self.ncpus[i]
-            success, buff = self._run_sim_or_model(
-                workspace, target, xfail, ncpus
-            )
+            success, buff = self._run_sim_or_model(workspace, target, xfail, ncpus)
             self.buffs[i] = buff  # store model output for assertions later
             assert success, (
                 f"{'Simulation' if 'mf6' in str(target) else 'Model'} "
@@ -736,9 +704,7 @@ class TestFramework:
         # setup and run comparison model(s), if enabled
         if self.compare:
             # get expected output files from main simulation
-            _, self.outp = get_mf6_files(
-                self.workspace / "mfsim.nam", self.verbose
-            )
+            _, self.outp = get_mf6_files(self.workspace / "mfsim.nam", self.verbose)
 
             # try to autodetect comparison type if enabled
             if self.compare == "auto":
@@ -774,9 +740,7 @@ class TestFramework:
                         workspace = self.workspace / self.compare
                         success, _ = self._run_sim_or_model(
                             workspace,
-                            self.targets.get(
-                                self.compare, self.targets["mf6"]
-                            ),
+                            self.targets.get(self.compare, self.targets["mf6"]),
                         )
                         assert success, f"Comparison model failed: {workspace}"
 

--- a/autotest/get_exes.py
+++ b/autotest/get_exes.py
@@ -41,13 +41,9 @@ def test_rebuild_release(rebuilt_bin_path: Path):
     print(f"Rebuilding and installing last release to: {rebuilt_bin_path}")
     release = get_release(repository)
     assets = release["assets"]
-    asset = next(
-        iter([a for a in assets if a["name"] == get_asset_name(a)]), None
-    )
+    asset = next(iter([a for a in assets if a["name"] == get_asset_name(a)]), None)
     if not asset:
-        warn(
-            f"Couldn't find asset for OS {get_ostag()}, available assets:\n{assets}"
-        )
+        warn(f"Couldn't find asset for OS {get_ostag()}, available assets:\n{assets}")
 
     with TemporaryDirectory() as td:
         # download the release
@@ -59,9 +55,7 @@ def test_rebuild_release(rebuilt_bin_path: Path):
         )
 
         # update IDEVELOPMODE
-        source_files_path = (
-            download_path / asset["name"].replace(".zip", "") / "src"
-        )
+        source_files_path = download_path / asset["name"].replace(".zip", "") / "src"
         version_file_path = source_files_path / "Utilities" / "version.f90"
         with open(version_file_path) as f:
             lines = f.read().splitlines()
@@ -89,9 +83,7 @@ def test_get_executables(downloaded_bin_path: Path):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        "Get executables needed for MODFLOW 6 testing"
-    )
+    parser = argparse.ArgumentParser("Get executables needed for MODFLOW 6 testing")
     parser.add_argument("-p", "--path", help="path to top-level bin directory")
     args = parser.parse_args()
     bin_path = Path(args.path).resolve() if args.path else top_bin_path

--- a/autotest/test_chf_dfw.py
+++ b/autotest/test_chf_dfw.py
@@ -48,9 +48,7 @@ def build_models(idx, test):
         outer_dvclose=1.0e-7,
         inner_dvclose=1.0e-8,
     )
-    chf = flopy.mf6.ModflowChf(
-        sim, modelname=name, save_flows=True, print_flows=True
-    )
+    chf = flopy.mf6.ModflowChf(sim, modelname=name, save_flows=True, print_flows=True)
 
     dx = 1000.0
     nreach = 3

--- a/autotest/test_chf_dfw_beg2022.py
+++ b/autotest/test_chf_dfw_beg2022.py
@@ -219,9 +219,7 @@ def make_plot(test, mfsim):
     x = df_mfswr["TOTTIME"] - 86400.0
     x = x / 60.0 / 60.0
     ax.plot(x, -df_mfswr["QCRFLOW"], "go:", mfc="none", label="MODFLOW-SWR")
-    ax.plot(
-        times / 60.0 / 60.0, qoutflow, "bo:", mfc="none", label="MODFLOW 6"
-    )
+    ax.plot(times / 60.0 / 60.0, qoutflow, "bo:", mfc="none", label="MODFLOW 6")
     ax.set_xlim(0, 24.0)
     ax.set_ylim(19, 26)
     plt.xlabel("time, in hours")

--- a/autotest/test_chf_dfw_bowl.py
+++ b/autotest/test_chf_dfw_bowl.py
@@ -250,10 +250,7 @@ def check_output(idx, test):
     for v in stage_all[-1].flatten():
         print(f"{v:18.8f},")
 
-    msg = (
-        "Simulated stage does not match with the answer "
-        "stored from a previous run."
-    )
+    msg = "Simulated stage does not match with the answer stored from a previous run."
     assert np.allclose(stage_all[-1].flatten(), stage_answer, atol=1.0e-5), msg
 
 

--- a/autotest/test_chf_dfw_loop.py
+++ b/autotest/test_chf_dfw_loop.py
@@ -251,18 +251,10 @@ def build_models(idx, test):
     )
 
     xfraction = (
-        [0.0, 10.0, 20.0, 30.0]
-        + [0, 20.0, 40.0, 60.0]
-        + [0.0, 15.0, 30.0, 45.0]
+        [0.0, 10.0, 20.0, 30.0] + [0, 20.0, 40.0, 60.0] + [0.0, 15.0, 30.0, 45.0]
     )
-    height = (
-        [10.0, 0.0, 0.0, 10.0]
-        + [20.0, 0.0, 0.0, 20.0]
-        + [15.0, 0.0, 0.0, 15.0]
-    )
-    mannfraction = (
-        [1.0, 1.0, 1.0, 1.0] + [1.0, 1.0, 1.0, 1.0] + [1.0, 1.0, 1.0, 1.0]
-    )
+    height = [10.0, 0.0, 0.0, 10.0] + [20.0, 0.0, 0.0, 20.0] + [15.0, 0.0, 0.0, 15.0]
+    mannfraction = [1.0, 1.0, 1.0, 1.0] + [1.0, 1.0, 1.0, 1.0] + [1.0, 1.0, 1.0, 1.0]
 
     cxsdata = list(zip(xfraction, height, mannfraction))
     cxs = flopy.mf6.ModflowChfcxs(
@@ -398,12 +390,8 @@ def make_plot(test):
         lw=0.0,
         label="MF6 Gauge 5",
     )
-    ax.plot(
-        answer_flow["TOTIME"], answer_flow["FLOW45"], "b-", label="SWR Gauge 4"
-    )
-    ax.plot(
-        answer_flow["TOTIME"], answer_flow["FLOW56"], "g-", label="SWR Gauge 5"
-    )
+    ax.plot(answer_flow["TOTIME"], answer_flow["FLOW45"], "b-", label="SWR Gauge 4")
+    ax.plot(answer_flow["TOTIME"], answer_flow["FLOW56"], "g-", label="SWR Gauge 5")
     # ax.plot(obsvals["time"], answer["STAGE0000000014"], marker="o", mfc="none", mec="k", lw=0., label="swr")
     ax.set_xscale("log")
     plt.xlabel("time, in seconds")

--- a/autotest/test_chf_dis.py
+++ b/autotest/test_chf_dis.py
@@ -170,21 +170,13 @@ def check_grb_disv1d(fpth):
     ), "grb botm not correct"
     cellx = np.linspace(dx / 2, nreach * dx - dx / 2, nreach)
     celly = np.zeros(nreach)
-    assert np.allclose(
-        grb._datadict["CELLX"], cellx.flatten()
-    ), "cellx is not right"
-    assert np.allclose(
-        grb._datadict["CELLY"], celly.flatten()
-    ), "celly is not right"
-    assert (
-        grb._datadict["IAVERT"].shape[0] == nodes + 1
-    ), "iavert size not right"
+    assert np.allclose(grb._datadict["CELLX"], cellx.flatten()), "cellx is not right"
+    assert np.allclose(grb._datadict["CELLY"], celly.flatten()), "celly is not right"
+    assert grb._datadict["IAVERT"].shape[0] == nodes + 1, "iavert size not right"
     assert (
         grb._datadict["IAVERT"][-1] - 1 == grb._datadict["JAVERT"].shape[0]
     ), "javert size not right"
-    assert (
-        grb.ia.shape[0] == grb.ncells + 1
-    ), "ia in grb file is not correct size"
+    assert grb.ia.shape[0] == grb.ncells + 1, "ia in grb file is not correct size"
     assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
     assert np.allclose(
         grb.idomain.reshape((nodes,)), idomain.reshape((nodes,))

--- a/autotest/test_chf_dis_fdc.py
+++ b/autotest/test_chf_dis_fdc.py
@@ -174,25 +174,15 @@ def check_grb_disv1d(fpth):
     assert np.allclose(
         grb.bot.reshape((nodes,)), np.zeros((nodes,))
     ), "grb botm not correct"
-    cellx = np.array(
-        [0.0, 2 * dx]
-    )  # node centers pushed all the way to left and right
+    cellx = np.array([0.0, 2 * dx])  # node centers pushed all the way to left and right
     celly = np.zeros(nreach)
-    assert np.allclose(
-        grb._datadict["CELLX"], cellx.flatten()
-    ), "cellx is not right"
-    assert np.allclose(
-        grb._datadict["CELLY"], celly.flatten()
-    ), "celly is not right"
-    assert (
-        grb._datadict["IAVERT"].shape[0] == nodes + 1
-    ), "iavert size not right"
+    assert np.allclose(grb._datadict["CELLX"], cellx.flatten()), "cellx is not right"
+    assert np.allclose(grb._datadict["CELLY"], celly.flatten()), "celly is not right"
+    assert grb._datadict["IAVERT"].shape[0] == nodes + 1, "iavert size not right"
     assert (
         grb._datadict["IAVERT"][-1] - 1 == grb._datadict["JAVERT"].shape[0]
     ), "javert size not right"
-    assert (
-        grb.ia.shape[0] == grb.ncells + 1
-    ), "ia in grb file is not correct size"
+    assert grb.ia.shape[0] == grb.ncells + 1, "ia in grb file is not correct size"
     assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
     assert np.allclose(
         grb.idomain.reshape((nodes,)), idomain.reshape((nodes,))
@@ -252,9 +242,7 @@ def check_output(idx, test):
     print(f"{cn=} {cm=} {cond=}")
     print(f"Known flow is {flow} cubic meters per seconds")
     print(f"Simulated flow is {flow_sim} cubic meters per seconds")
-    assert np.allclose(
-        flow, flow_sim
-    ), "known flow and simulated flow not the same"
+    assert np.allclose(flow, flow_sim), "known flow and simulated flow not the same"
 
     makeplot = False
     if makeplot:

--- a/autotest/test_gwe_bad_input.py
+++ b/autotest/test_gwe_bad_input.py
@@ -231,9 +231,7 @@ def build_gwe_model(idx, sim, gwename, side="left"):
         xorigin = ncol * delr
 
     # Instantiate GWE model
-    gwe = flopy.mf6.ModflowGwe(
-        sim, modelname=gwename, model_nam_file=f"{gwename}.nam"
-    )
+    gwe = flopy.mf6.ModflowGwe(sim, modelname=gwename, model_nam_file=f"{gwename}.nam")
     gwe.name_file.save_flows = True
 
     # Instantiating MODFLOW 6 transport discretization package
@@ -309,9 +307,7 @@ def build_gwe_model(idx, sim, gwename, side="left"):
         pname="OC" + pckg_suffix,
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
     )
@@ -343,9 +339,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 time discretization
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # left model
     gwf1 = build_gwf_model(sim, "gwfleft", side="left")
@@ -472,12 +466,8 @@ def check_output(idx, test):
         fpth2 = os.path.join(test.workspace, gwename2)
 
         # load temperatures
-        tobj1 = flopy.utils.HeadFile(
-            fpth1, precision="double", text="TEMPERATURE"
-        )
-        tobj2 = flopy.utils.HeadFile(
-            fpth2, precision="double", text="TEMPERATURE"
-        )
+        tobj1 = flopy.utils.HeadFile(fpth1, precision="double", text="TEMPERATURE")
+        tobj2 = flopy.utils.HeadFile(fpth2, precision="double", text="TEMPERATURE")
         temps1 = tobj1.get_alldata()
         temps2 = tobj2.get_alldata()
         temps_all = np.concatenate((temps1, temps2), axis=3)

--- a/autotest/test_gwe_cnd.py
+++ b/autotest/test_gwe_cnd.py
@@ -140,9 +140,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 time discretization
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # Instantiating MODFLOW 6 groundwater flow model
     gwf = flopy.mf6.ModflowGwf(
@@ -332,9 +330,7 @@ def build_models(idx, test):
         gwe,
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
     )
@@ -361,9 +357,7 @@ def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{gwename}.ucn")
     try:
         # load temperatures
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         conc1 = cobj.get_alldata()
     except:
         assert False, f'could not load concentration data from "{fpth}"'

--- a/autotest/test_gwe_drycell_cnd0.py
+++ b/autotest/test_gwe_drycell_cnd0.py
@@ -130,9 +130,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 time discretization
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # Instantiating MODFLOW 6 groundwater flow model
     gwf = flopy.mf6.ModflowGwf(
@@ -311,9 +309,7 @@ def build_models(idx, test):
         pname="OC-2",
         budget_filerecord=f"{gwename1}.cbc",
         temperature_filerecord=f"{gwename1}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
     )
@@ -353,9 +349,7 @@ def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{gwename}.ucn")
     try:
         # load temperatures
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         conc1 = cobj.get_alldata()
     except:
         assert False, f'could not load temperature data from "{fpth}"'
@@ -394,22 +388,14 @@ def check_output(idx, test):
 
     # The 'pass-through' cell (layer 1, row 1, column 4 - see diagram at top
     # of script) should be warming more than its two neighbors to the right.
-    msg4 = (
-        "Pass through cell should be warming up at a higher rate than "
-        "the dry cells."
-    )
+    msg4 = "Pass through cell should be warming up at a higher rate than the dry cells."
     assert np.all(conc1[:, 0, 0, 3] > conc1[:, 0, 0, 4]), msg4
 
     # Pass through cell should not be as warm as the cell from which it
     # receives water, since that cell will have already robbed the water
     # passing through of some of its heat
-    msg5 = (
-        "Pass through cell should not be as warm as its neighbor to "
-        "the left"
-    )
-    assert np.all(
-        np.round(conc1[:, 0, 0, 3] - conc1[:, 0, 0, 2], 8) <= 0
-    ), msg5
+    msg5 = "Pass through cell should not be as warm as its neighbor to the left"
+    assert np.all(np.round(conc1[:, 0, 0, 3] - conc1[:, 0, 0, 2], 8) <= 0), msg5
 
 
 # - No need to change any code below

--- a/autotest/test_gwe_drycell_cnd1.py
+++ b/autotest/test_gwe_drycell_cnd1.py
@@ -169,9 +169,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 time discretization
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # Instantiating MODFLOW 6 groundwater flow model
     gwf = flopy.mf6.ModflowGwf(
@@ -346,9 +344,7 @@ def build_models(idx, test):
         pname="OC-2",
         budget_filerecord=f"{gwename1}.cbc",
         temperature_filerecord=f"{gwename1}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
     )
@@ -426,9 +422,7 @@ def check_output(idx, test):
 
     try:
         # load temperatures
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         conc1 = cobj.get_alldata()
     except:
         assert False, f'could not load temperature data from "{fpth}"'

--- a/autotest/test_gwe_drycell_cnd2.py
+++ b/autotest/test_gwe_drycell_cnd2.py
@@ -204,9 +204,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 time discretization
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # Instantiating MODFLOW 6 groundwater flow model
     gwf = flopy.mf6.ModflowGwf(
@@ -343,9 +341,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 transport initial concentrations
-    flopy.mf6.ModflowGwtic(
-        gwt, strt=strt_conc, pname="IC-2", filename=f"{gwtname}.ic"
-    )
+    flopy.mf6.ModflowGwtic(gwt, strt=strt_conc, pname="IC-2", filename=f"{gwtname}.ic")
 
     # Instantiating MODFLOW 6 transport advection package
     flopy.mf6.ModflowGwtadv(
@@ -398,9 +394,7 @@ def build_models(idx, test):
         pname="OC-2",
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -459,9 +453,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 transport initial concentrations
-    flopy.mf6.ModflowGweic(
-        gwe, strt=strt_temp, pname="IC-3", filename=f"{gwename}.ic"
-    )
+    flopy.mf6.ModflowGweic(gwe, strt=strt_temp, pname="IC-3", filename=f"{gwename}.ic")
 
     # Instantiating MODFLOW 6 transport advection package
     flopy.mf6.ModflowGweadv(
@@ -512,9 +504,7 @@ def build_models(idx, test):
         pname="OC-3",
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
     )
@@ -554,9 +544,7 @@ def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
         # load temperatures
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc1 = cobj.get_alldata()
     except:
         assert False, f'could not load concentration data from "{fpth}"'
@@ -565,9 +553,7 @@ def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{gwename}.ucn")
     try:
         # load temperatures
-        tobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        tobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         temp1 = tobj.get_alldata()
     except:
         assert False, f'could not load temperature data from "{fpth}"'

--- a/autotest/test_gwe_drycell_cnd4.py
+++ b/autotest/test_gwe_drycell_cnd4.py
@@ -281,9 +281,7 @@ def add_gwf_model(sim, gwfname, newton=False):
 
 
 def add_gwe_model(sim, gwename):
-    gwe = flopy.mf6.ModflowGwe(
-        sim, modelname=gwename, model_nam_file=f"{gwename}.nam"
-    )
+    gwe = flopy.mf6.ModflowGwe(sim, modelname=gwename, model_nam_file=f"{gwename}.nam")
     gwe.name_file.save_flows = True
 
     imsgwe = flopy.mf6.ModflowIms(
@@ -320,14 +318,10 @@ def add_gwe_model(sim, gwename):
     )
 
     # Instantiating MODFLOW 6 transport initial concentrations
-    flopy.mf6.ModflowGweic(
-        gwe, strt=strt_temp, pname="IC", filename=f"{gwename}.ic"
-    )
+    flopy.mf6.ModflowGweic(gwe, strt=strt_temp, pname="IC", filename=f"{gwename}.ic")
 
     # Instantiating MODFLOW 6 transport advection package
-    flopy.mf6.ModflowGweadv(
-        gwe, scheme=scheme, pname="ADV", filename=f"{gwename}.adv"
-    )
+    flopy.mf6.ModflowGweadv(gwe, scheme=scheme, pname="ADV", filename=f"{gwename}.adv")
 
     # Instantiating MODFLOW 6 transport dispersion package
     flopy.mf6.ModflowGwecnd(
@@ -371,9 +365,7 @@ def add_gwe_model(sim, gwename):
         pname="OC",
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
     )
@@ -425,9 +417,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 time discretization
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # Build two flow models, one with NWT, one without
     sim = add_gwf_model(sim, gwfname1, newton=True)

--- a/autotest/test_gwe_esl01.py
+++ b/autotest/test_gwe_esl01.py
@@ -86,9 +86,7 @@ tdis_rc = []
 for i in np.arange(nper):
     tdis_rc.append((perlen[i], nstp[i], ttsmult))
 
-Joules_added_for_1degC_rise = (
-    delr * delc * (top - botm[0]) * (1 - prsity) * cps * rhos
-)
+Joules_added_for_1degC_rise = delr * delc * (top - botm[0]) * (1 - prsity) * cps * rhos
 
 # ### Create MODFLOW 6 GWE
 #
@@ -111,9 +109,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 time discretization
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # Instantiating MODFLOW 6 groundwater flow model
     gwf = flopy.mf6.ModflowGwf(
@@ -203,9 +199,7 @@ def build_models(idx, test):
     # ----------------------------------
     # Instantiating MODFLOW 6 GWE model
     # ----------------------------------
-    gwe = flopy.mf6.ModflowGwe(
-        sim, modelname=gwename, model_nam_file=f"{gwename}.nam"
-    )
+    gwe = flopy.mf6.ModflowGwe(sim, modelname=gwename, model_nam_file=f"{gwename}.nam")
     gwe.name_file.save_flows = True
 
     imsgwe = flopy.mf6.ModflowIms(
@@ -242,9 +236,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 transport initial concentrations
-    flopy.mf6.ModflowGweic(
-        gwe, strt=strt_temp1, pname="IC-2", filename=f"{gwename}.ic"
-    )
+    flopy.mf6.ModflowGweic(gwe, strt=strt_temp1, pname="IC-2", filename=f"{gwename}.ic")
 
     # Instantiating MODFLOW 6 transport advection package
     flopy.mf6.ModflowGweadv(
@@ -283,9 +275,7 @@ def build_models(idx, test):
         pname="OC-1",
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
     )
@@ -333,9 +323,7 @@ def check_output(idx, test):
 
     try:
         # load temperatures
-        tobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        tobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         temps = tobj.get_alldata()
     except:
         assert False, f'could not load temperature data from "{fpth}"'
@@ -349,9 +337,7 @@ def check_output(idx, test):
         "in stress period "
     )
     for index in np.arange(4):
-        assert np.isclose(temps[index, 0, 0, 0], known_ans[index]), msg0 + str(
-            index
-        )
+        assert np.isclose(temps[index, 0, 0, 0], known_ans[index]), msg0 + str(index)
 
 
 # - No need to change any code below

--- a/autotest/test_gwe_esl02.py
+++ b/autotest/test_gwe_esl02.py
@@ -202,9 +202,7 @@ def build_models(idx, test):
     # ----------------------------------
     # Instantiating MODFLOW 6 GWE model
     # ----------------------------------
-    gwe = flopy.mf6.ModflowGwe(
-        sim, modelname=gwename, model_nam_file=f"{gwename}.nam"
-    )
+    gwe = flopy.mf6.ModflowGwe(sim, modelname=gwename, model_nam_file=f"{gwename}.nam")
     gwe.name_file.save_flows = True
 
     imsgwe = flopy.mf6.ModflowIms(
@@ -241,9 +239,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 transport initial concentrations
-    flopy.mf6.ModflowGweic(
-        gwe, strt=strt_temp1, pname="IC-1", filename=f"{gwename}.ic"
-    )
+    flopy.mf6.ModflowGweic(gwe, strt=strt_temp1, pname="IC-1", filename=f"{gwename}.ic")
 
     # Instantiating MODFLOW 6 transport advection package
     flopy.mf6.ModflowGweadv(
@@ -282,9 +278,7 @@ def build_models(idx, test):
         pname="OC-1",
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
     )
@@ -334,9 +328,7 @@ def check_output(idx, test):
 
     try:
         # load temperatures
-        tobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        tobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         temps = tobj.get_alldata()
     except:
         assert False, f'could not load temperature data from "{fpth}"'

--- a/autotest/test_gwe_esl_analyt_sln.py
+++ b/autotest/test_gwe_esl_analyt_sln.py
@@ -216,9 +216,7 @@ def build_models(idx, test, ener_input):
     )
 
     # Initial conditions
-    flopy.mf6.ModflowGwfic(
-        gwf, strt=strt, pname="IC-HD", filename=f"{gwfname}.ic"
-    )
+    flopy.mf6.ModflowGwfic(gwf, strt=strt, pname="IC-HD", filename=f"{gwfname}.ic")
 
     # Node property flow
     flopy.mf6.ModflowGwfnpf(
@@ -308,9 +306,7 @@ def build_models(idx, test, ener_input):
     )
 
     # Initial conditions
-    flopy.mf6.ModflowGweic(
-        gwe, strt=T_0, pname="IC-1", filename=f"{gwename}.ic"
-    )
+    flopy.mf6.ModflowGweic(gwe, strt=T_0, pname="IC-1", filename=f"{gwename}.ic")
 
     # Advection
     flopy.mf6.ModflowGweadv(
@@ -389,9 +385,7 @@ def build_models(idx, test, ener_input):
         gwe,
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
     )

--- a/autotest/test_gwe_lke_conduction.py
+++ b/autotest/test_gwe_lke_conduction.py
@@ -368,10 +368,7 @@ def build_models(idx, test):
                     ilak = int(lakibnd[k, i, j] - 1)
                     # back
                     if i > 0:
-                        if (
-                            lakibnd[k, i - 1, j] == 0
-                            and ibound[k, i - 1, j] == 1
-                        ):
+                        if lakibnd[k, i - 1, j] == 0 and ibound[k, i - 1, j] == 1:
                             ilakconn += 1
                             # by setting belev==telev, MF6 will automatically
                             # re-assign elevations based on cell dimensions
@@ -391,10 +388,7 @@ def build_models(idx, test):
 
                     # left
                     if j > 0:
-                        if (
-                            lakibnd[k, i, j - 1] == 0
-                            and ibound[k, i, j - 1] == 1
-                        ):
+                        if lakibnd[k, i, j - 1] == 0 and ibound[k, i, j - 1] == 1:
                             ilakconn += 1
                             h = [
                                 ilak,
@@ -412,10 +406,7 @@ def build_models(idx, test):
 
                     # right
                     if j < ncol - 1:
-                        if (
-                            lakibnd[k, i, j + 1] == 0
-                            and ibound[k, i, j + 1] == 1
-                        ):
+                        if lakibnd[k, i, j + 1] == 0 and ibound[k, i, j + 1] == 1:
                             ilakconn += 1
                             h = [
                                 ilak,
@@ -433,10 +424,7 @@ def build_models(idx, test):
 
                     # front
                     if i < nrow - 1:
-                        if (
-                            lakibnd[k, i + 1, j] == 0
-                            and ibound[k, i + 1, j] == 1
-                        ):
+                        if lakibnd[k, i + 1, j] == 0 and ibound[k, i + 1, j] == 1:
                             ilakconn += 1
                             h = [
                                 ilak,
@@ -470,9 +458,7 @@ def build_models(idx, test):
                     lak_lkup_dict.update({ilakconn: (k, i, j)})
 
     strtStg = strt_lk_stg[idx]
-    lakpackagedata = [
-        [0, strtStg, len(lakeconnectiondata), strt_lk_temp[idx], "lake1"]
-    ]
+    lakpackagedata = [[0, strtStg, len(lakeconnectiondata), strt_lk_temp[idx], "lake1"]]
     lak_pkdat_dict = {"filename": "lak_pakdata.in", "data": lakpackagedata}
 
     lakeperioddata = {0: []}
@@ -529,9 +515,7 @@ def build_models(idx, test):
     # Create GWE model
     # -----------------
 
-    gwe = flopy.mf6.ModflowGwe(
-        sim, modelname=gwename, model_nam_file=f"{gwename}.nam"
-    )
+    gwe = flopy.mf6.ModflowGwe(sim, modelname=gwename, model_nam_file=f"{gwename}.nam")
     gwe.name_file.save_flows = True
 
     imsgwe = flopy.mf6.ModflowIms(
@@ -607,27 +591,21 @@ def build_models(idx, test):
         ("CHD-L", "AUX", "TEMPERATURE"),
         ("CHD-R", "AUX", "TEMPERATURE"),
     ]
-    flopy.mf6.ModflowGwessm(
-        gwe, sources=sourcerecarray, filename=f"{gwename}.ssm"
-    )
+    flopy.mf6.ModflowGwessm(gwe, sources=sourcerecarray, filename=f"{gwename}.ssm")
 
     # Instantiating MODFLOW 6 transport output control package
     flopy.mf6.ModflowGweoc(
         gwe,
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 17, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 17, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         filename=f"{gwename}.oc",
     )
 
     # Instantiating MODFLOW 6 lake energy transport (lke) package
-    lkepackagedata = [
-        (0, strt_lk_temp[idx], K_therm_lakebed, lkbdthkcnd[idx], "lake1")
-    ]
+    lkepackagedata = [(0, strt_lk_temp[idx], K_therm_lakebed, lkbdthkcnd[idx], "lake1")]
 
     # lkeperioddata = {0: [(0, "STATUS", "CONSTANT"), (0, "TEMPERATURE", 4.0)]}
 
@@ -685,13 +663,13 @@ def check_output(idx, test):
     fname = gwename + ".ucn"
     fname = os.path.join(test.workspace, fname)
     assert os.path.isfile(fname)
-    gwtempobj = flopy.utils.HeadFile(
-        fname, precision="double", text="TEMPERATURE"
-    )
+    gwtempobj = flopy.utils.HeadFile(fname, precision="double", text="TEMPERATURE")
     gwe_temps = gwtempobj.get_alldata()
 
     # gw exchng (item 'GWF') should be zero in heat transport budget
-    srchStr = "LKE-1 BUDGET FOR ENTIRE MODEL AT END OF TIME STEP    1, STRESS PERIOD   1"
+    srchStr = (
+        "LKE-1 BUDGET FOR ENTIRE MODEL AT END OF TIME STEP    1, STRESS PERIOD   1"
+    )
     fname = gwename + ".lst"
     fname = os.path.join(test.workspace, fname)
 
@@ -710,18 +688,12 @@ def check_output(idx, test):
         "There should be a cooling trend in the lake based on heat loss "
         "to the groundwater system"
     )
-    msg4 = (
-        "There should be a warming trend in the groundwater adjacent "
-        "to the lake"
-    )
+    msg4 = "There should be a warming trend in the groundwater adjacent to the lake"
     msg5 = (
         "Budget item 'GWF' should reflect heat entering the lake "
         "(via gw/sw exchange)"
     )
-    msg6 = (
-        "Budget item 'GWF' should reflect heat exiting the lake "
-        "(via gw/sw exchange)"
-    )
+    msg6 = "Budget item 'GWF' should reflect heat exiting the lake (via gw/sw exchange)"
 
     if name[-1] == "n":
         assert in_bud_lst["GWF"] == 0.0, msg1

--- a/autotest/test_gwe_mve.py
+++ b/autotest/test_gwe_mve.py
@@ -69,10 +69,7 @@ nouter, ninner = 300, 300
 hclose, rclose, relax = 1e-6, 1e-3, 0.97
 
 top = np.stack(
-    [
-        [30.9, 30.8, 30.6, 30.6, 30.5, 30.4, 30.3, 30.2, 30.1, 30.0]
-        for _ in range(3)
-    ],
+    [[30.9, 30.8, 30.6, 30.6, 30.5, 30.4, 30.3, 30.2, 30.1, 30.0] for _ in range(3)],
     axis=0,
 )
 botm = [25.0, 10, 0.0]
@@ -190,9 +187,7 @@ for k in np.arange(nlay):
                 uze_perdat.append([ct, "INFILTRATION", 1.0])
                 # generate a lookup dictionary based on the top layer
                 if k == 0:
-                    drn_pkdat.append(
-                        [(k, i, j), top[i, j] - drn_depth, drn_cond, ddrn]
-                    )
+                    drn_pkdat.append([(k, i, j), top[i, j] - drn_depth, drn_cond, ddrn])
                     uzf_id_lkup.update({(i, j): ct})
 
 
@@ -225,12 +220,8 @@ for i in np.arange(nrow):
                 ]
             )
         elif iuzfbnd[i, j] > 0 and j + 1 == ncol - 1:
-            mvr_pkdat.append(
-                ["UZF-1", uzf_id_lkup[(i, j)], "SFR-1", i, "FACTOR", 1.0]
-            )
-            mvr_pkdat.append(
-                ["DRN-1", uzf_id_lkup[(i, j)], "SFR-1", i, "FACTOR", 1.0]
-            )
+            mvr_pkdat.append(["UZF-1", uzf_id_lkup[(i, j)], "SFR-1", i, "FACTOR", 1.0])
+            mvr_pkdat.append(["DRN-1", uzf_id_lkup[(i, j)], "SFR-1", i, "FACTOR", 1.0])
 
 extdp = 3.0
 extwc = 0.05
@@ -346,9 +337,7 @@ def build_mf6_model(idx, ws):
     )
 
     # create tdis package
-    flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -498,9 +487,7 @@ def build_mf6_model(idx, ws):
     # ----------
 
     gwename = "gwe-" + name
-    gwe = flopy.mf6.ModflowGwe(
-        sim, modelname=gwename, model_nam_file=f"{gwename}.nam"
-    )
+    gwe = flopy.mf6.ModflowGwe(sim, modelname=gwename, model_nam_file=f"{gwename}.nam")
     gwe.name_file.save_flows = True
 
     imsgwe = flopy.mf6.ModflowIms(
@@ -544,9 +531,7 @@ def build_mf6_model(idx, ws):
     )
 
     # Instantiating MODFLOW 6 transport advection package
-    flopy.mf6.ModflowGweadv(
-        gwe, scheme=scheme, pname="ADV", filename=f"{gwename}.adv"
-    )
+    flopy.mf6.ModflowGweadv(gwe, scheme=scheme, pname="ADV", filename=f"{gwename}.adv")
 
     # Instantiating MODFLOW 6 transport dispersion package
     flopy.mf6.ModflowGwecnd(
@@ -641,9 +626,7 @@ def build_mf6_model(idx, ws):
         temperature_filerecord=f"{gwename}.ucn",
         budget_filerecord=f"{gwename}.bud",
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
-        temperatureprintrecord=[
-            ("COLUMNS", 3, "WIDTH", 20, "DIGITS", 8, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 3, "WIDTH", 20, "DIGITS", 8, "GENERAL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         filename=f"{gwename}.oc",
     )
@@ -676,23 +659,17 @@ def check_output(idx, test):
     # Get the model budget items
     fname = os.path.join(ws, gwfname + ".cbc")
     assert os.path.isfile(fname)
-    modobj = flopy.utils.CellBudgetFile(
-        fname, precision="double", verbose=True
-    )
+    modobj = flopy.utils.CellBudgetFile(fname, precision="double", verbose=True)
 
     # Get the MVR results from GWF
     fname = os.path.join(ws, gwfname + ".mvr.bud")
     assert os.path.isfile(fname)
-    mvrobj = flopy.utils.CellBudgetFile(
-        fname, precision="double", verbose=True
-    )
+    mvrobj = flopy.utils.CellBudgetFile(fname, precision="double", verbose=True)
 
     # Get the MVE results from GWE
     fname = os.path.join(ws, gwename + ".mve.bud")
     assert os.path.isfile(fname)
-    mveobj = flopy.utils.CellBudgetFile(
-        fname, precision="double", verbose=False
-    )
+    mveobj = flopy.utils.CellBudgetFile(fname, precision="double", verbose=False)
 
     ckstpkper = mveobj.get_kstpkper()
 
@@ -703,10 +680,7 @@ def check_output(idx, test):
     mvedat = mveobj.get_data(text="MVE-FLOW")
 
     msg0 = "Accumulated cascading runoff is not as expected"
-    msg1 = (
-        "Rejected infiltration being passed to MVR where it  should not "
-        "be happening"
-    )
+    msg1 = "Rejected infiltration being passed to MVR where it  should not be happening"
     msg2 = (
         "The accumulated cascading runoff that is finally passed to SFR "
         "is not as expected"
@@ -785,9 +759,7 @@ def check_output(idx, test):
                     for ct, val in enumerate(itm):
                         if ct == 0:
                             assert np.isclose(itm[ct][-1], accum_runoff), msg2
-                            assert np.isclose(
-                                itm_e[ct][-1], accum_energy
-                            ), msg9
+                            assert np.isclose(itm_e[ct][-1], accum_energy), msg9
                         else:
                             assert itm[ct][-1] == 0, msg3
                             assert itm_e[ct][-1] == 0, msg10
@@ -836,9 +808,7 @@ def check_output(idx, test):
                     for ct, val in enumerate(itm):
                         if ct == 0:
                             assert np.isclose(itm[ct][-1], accum_runoff), msg2
-                            assert np.isclose(
-                                itm_e[ct][-1], accum_energy
-                            ), msg9
+                            assert np.isclose(itm_e[ct][-1], accum_energy), msg9
                         else:
                             assert itm[ct][-1] == 0, msg3
                             assert itm_e[ct][-1] == 0, msg10

--- a/autotest/test_gwe_obs.py
+++ b/autotest/test_gwe_obs.py
@@ -276,9 +276,7 @@ def build_gwf_model(sim, gwfname, idx, head1=2.0, head2=2.0):
 def build_gwe_model(sim, gwename, idx):
     conn_type = conn_types[idx]
 
-    gwe = flopy.mf6.ModflowGwe(
-        sim, modelname=gwename, model_nam_file=f"{gwename}.nam"
-    )
+    gwe = flopy.mf6.ModflowGwe(sim, modelname=gwename, model_nam_file=f"{gwename}.nam")
     gwe.name_file.save_flows = True
 
     imsgwe = flopy.mf6.ModflowIms(
@@ -315,14 +313,10 @@ def build_gwe_model(sim, gwename, idx):
     )
 
     # Instantiating MODFLOW 6 energy transport initial temperature
-    flopy.mf6.ModflowGweic(
-        gwe, strt=strt_temp, pname="IC", filename=f"{gwename}.ic"
-    )
+    flopy.mf6.ModflowGweic(gwe, strt=strt_temp, pname="IC", filename=f"{gwename}.ic")
 
     # Instantiating MODFLOW 6 transport advection package
-    flopy.mf6.ModflowGweadv(
-        gwe, scheme=scheme, pname="ADV", filename=f"{gwename}.adv"
-    )
+    flopy.mf6.ModflowGweadv(gwe, scheme=scheme, pname="ADV", filename=f"{gwename}.adv")
 
     # Instantiating MODFLOW 6 energy transport dispersion package
     flopy.mf6.ModflowGwecnd(
@@ -362,9 +356,7 @@ def build_gwe_model(sim, gwename, idx):
         pname="OC",
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
     )
@@ -460,9 +452,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 time discretization
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     gwf1 = build_gwf_model(sim, gwfname + "-1", idx, 10.0, 7.0)
     gwf2 = build_gwf_model(sim, gwfname + "-2", idx, 4.0, 4.0)

--- a/autotest/test_gwe_sfe_strmbedcond.py
+++ b/autotest/test_gwe_sfe_strmbedcond.py
@@ -530,9 +530,7 @@ def build_models(idx, test):
     # Instantiating MODFLOW 6 transport source-sink mixing package
     # [b/c at least one boundary back is active (SFR), ssm must be on]
     sourcerecarray = [("CHD-1", "AUX", "TEMPERATURE")]
-    flopy.mf6.ModflowGwessm(
-        gwe, sources=sourcerecarray, filename=f"{gwename}.ssm"
-    )
+    flopy.mf6.ModflowGwessm(gwe, sources=sourcerecarray, filename=f"{gwename}.ssm")
 
     # Instantiate Streamflow Energy Transport package
     sfepackagedata = []
@@ -567,9 +565,7 @@ def build_models(idx, test):
         gwe,
         temperature_filerecord=f"{gwename}.ucn",
         saverecord=[("TEMPERATURE", "ALL")],
-        temperatureprintrecord=[
-            ("COLUMNS", 3, "WIDTH", 20, "DIGITS", 8, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 3, "WIDTH", 20, "DIGITS", 8, "GENERAL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         filename=f"{gwename}.oc",
     )
@@ -629,30 +625,26 @@ def check_output(idx, test):
 
     # Sub-scenario checks
     # initialize search term
-    srchStr = "SFE-1 BUDGET FOR ENTIRE MODEL AT END OF TIME STEP    1, STRESS PERIOD   1"
+    srchStr = (
+        "SFE-1 BUDGET FOR ENTIRE MODEL AT END OF TIME STEP    1, STRESS PERIOD   1"
+    )
     fname = "gwe-" + name + ".lst"
     fname = os.path.join(test.workspace, fname)
 
     # gw exchng (item 'GWF') should be zero in heat transport budget
     T_in, T_out, in_bud_lst, out_bud_lst = get_bud(fname, srchStr)
-    assert np.isclose(
-        T_in, T_out, atol=0.1
-    ), "There is a heat budget discrepancy"
+    assert np.isclose(T_in, T_out, atol=0.1), "There is a heat budget discrepancy"
 
     # Get temperature of streamwater
     fname1 = "gwe-" + name + ".sfe.bin"
     fname1 = os.path.join(test.workspace, fname1)
-    sfeobj = flopy.utils.HeadFile(
-        fname1, precision="double", text="TEMPERATURE"
-    )
+    sfeobj = flopy.utils.HeadFile(fname1, precision="double", text="TEMPERATURE")
     sfe_temps = sfeobj.get_alldata()
 
     # Get temperature of gw
     fname2 = "gwe-" + name + ".ucn"
     fname2 = os.path.join(test.workspace, fname2)
-    gwobj = flopy.utils.HeadFile(
-        fname2, precision="double", text="TEMPERATURE"
-    )
+    gwobj = flopy.utils.HeadFile(fname2, precision="double", text="TEMPERATURE")
     gw_temps = gwobj.get_alldata()
 
     msg1 = "Budget item 'GWF' should be 0.0 for this scenario"
@@ -684,9 +676,7 @@ def check_output(idx, test):
             )
             assert slp < 0.0, msg3
 
-            slp = trenddetector(
-                np.arange(0, gw_temps.shape[-2]), gw_temps[0, 0, 1, :]
-            )
+            slp = trenddetector(np.arange(0, gw_temps.shape[-2]), gw_temps[0, 0, 1, :])
             assert slp > 0.0, msg4
 
         else:
@@ -710,9 +700,7 @@ def check_output(idx, test):
             )
             assert slp < 0.0, msg3
 
-            slp = trenddetector(
-                np.arange(0, gw_temps.shape[-2]), gw_temps[0, 0, 1, :]
-            )
+            slp = trenddetector(np.arange(0, gw_temps.shape[-2]), gw_temps[0, 0, 1, :])
             assert slp > 0.0, msg4
 
         else:
@@ -736,9 +724,7 @@ def check_output(idx, test):
             )
             assert slp < 0.0, msg3
 
-            slp = trenddetector(
-                np.arange(0, gw_temps.shape[-2]), gw_temps[0, 0, 1, :]
-            )
+            slp = trenddetector(np.arange(0, gw_temps.shape[-2]), gw_temps[0, 0, 1, :])
             assert slp < 0.0, msg4
 
         else:
@@ -768,9 +754,7 @@ def check_output(idx, test):
             )
             assert slp > 0.0, msg3
 
-            slp = trenddetector(
-                np.arange(0, gw_temps.shape[-2]), gw_temps[0, 0, 1, :]
-            )
+            slp = trenddetector(np.arange(0, gw_temps.shape[-2]), gw_temps[0, 0, 1, :])
             assert slp > 0.0, msg4
 
 

--- a/autotest/test_gwe_split_analyt.py
+++ b/autotest/test_gwe_split_analyt.py
@@ -327,9 +327,7 @@ def get_gwe_model(idx, sim, gwename, gwepath, ener_input, side="right"):
         gwe,
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
     )
@@ -354,9 +352,7 @@ def build_models(idx, test):
 
     # Build MODFLOW 6 files
     ws = test.workspace
-    sim = flopy.mf6.MFSimulation(
-        sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws)
 
     # Create tdis package
     tdis_rc = []
@@ -374,9 +370,7 @@ def build_models(idx, test):
     gwf2 = assemble_half_model(sim, "flow2", "flow2", side="right")
 
     # Add the exchange data
-    exgdata = [
-        ((0, 0, ncol - 1), (0, 0, 0), 1, delr / 2, delr / 2, delc, 0.0, delr)
-    ]
+    exgdata = [((0, 0, ncol - 1), (0, 0, 0), 1, delr / 2, delr / 2, delc, 0.0, delr)]
     flopy.mf6.ModflowGwfgwf(
         sim,
         exgtype="GWF6-GWF6",
@@ -410,14 +404,10 @@ def build_models(idx, test):
     sim.register_ims_package(imsgwf, [gwf1.name, gwf2.name])
 
     # Create first gwe model
-    gwe1 = get_gwe_model(
-        idx, sim, "energy1", "energy1", ener_input, side="left"
-    )
+    gwe1 = get_gwe_model(idx, sim, "energy1", "energy1", ener_input, side="left")
 
     # Create second gwe model
-    gwe2 = get_gwe_model(
-        idx, sim, "energy2", "energy2", ener_input, side="right"
-    )
+    gwe2 = get_gwe_model(idx, sim, "energy2", "energy2", ener_input, side="right")
 
     # Create GWE GWE exchange
     flopy.mf6.ModflowGwegwe(
@@ -543,9 +533,7 @@ def check_output(idx, test):
     gwename = "energy1"
     fpth = os.path.join(test.workspace, gwename, f"{gwename}.ucn")
     try:
-        tobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        tobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         sim_temps_l = tobj.get_alldata()
     except:
         assert False, f'could not load data from "{fpth}"'
@@ -553,9 +541,7 @@ def check_output(idx, test):
     gwename = "energy2"
     fpth = os.path.join(test.workspace, gwename, f"{gwename}.ucn")
     try:
-        tobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        tobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         sim_temps_r = tobj.get_alldata()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwe_ssm01.py
+++ b/autotest/test_gwe_ssm01.py
@@ -47,9 +47,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -202,9 +200,7 @@ def build_models(idx, test):
         gwe,
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
     )

--- a/autotest/test_gwe_ssm02.py
+++ b/autotest/test_gwe_ssm02.py
@@ -63,9 +63,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -218,9 +216,7 @@ def build_models(idx, test):
         time_series_namerecord=time_series_namerecord,
         interpolation_methodrecord=interpolation_methodrecord,
     )
-    np.savetxt(
-        os.path.join(ws, f"{gwfname}.rch4.tas.dat"), recharge_rate, fmt="%7.1f"
-    )
+    np.savetxt(os.path.join(ws, f"{gwfname}.rch4.tas.dat"), recharge_rate, fmt="%7.1f")
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(
@@ -392,9 +388,7 @@ def build_models(idx, test):
         gwe,
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
     )

--- a/autotest/test_gwe_stallman.py
+++ b/autotest/test_gwe_stallman.py
@@ -129,9 +129,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 time discretization
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=per_mf6, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=per_mf6, time_units=time_units)
 
     # Instantiating MODFLOW 6 groundwater flow model
     gwf = flopy.mf6.ModflowGwf(
@@ -311,9 +309,7 @@ def build_models(idx, test):
         gwe,
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
     )
@@ -339,9 +335,7 @@ def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{gwename}.ucn")
     try:
         # load temperatures
-        tobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        tobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         times = tobj.get_times()
         sim_temps = tobj.get_data(totim=times[540])
     except:

--- a/autotest/test_gwe_uze00.py
+++ b/autotest/test_gwe_uze00.py
@@ -52,9 +52,7 @@ def temp_analyt(t, z, t0, tinfil, v, d):
             )
         else:
             zeta = 1.0 / (1.0 + 0.47047 * ztermp)
-            polyterm = zeta * (
-                0.3480242 + zeta * (-0.0958798 + zeta * 0.7478556)
-            )
+            polyterm = zeta * (0.3480242 + zeta * (-0.0958798 + zeta * 0.7478556))
             temp = t0 + 0.5 * (tinfil - t0) * (
                 math.erfc(ztermm) + math.exp(vterm - ztermp**2) * polyterm
             )
@@ -77,9 +75,7 @@ delc = 1.0
 delz = 0.1  # 10 cm
 strt = 0.05
 top = 10.0005
-botm = [
-    9.9995
-]  # Top layer is very thin for application of the boundary condition
+botm = [9.9995]  # Top layer is very thin for application of the boundary condition
 for i in np.arange(1, nlay):
     bot = 10.0 - (i * delz)
     botm.append(round(bot, 1))
@@ -158,9 +154,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    flopy.mf6.ModflowTdis(
-        sim, time_units=time_units, nper=nper, perioddata=tdis_rc
-    )
+    flopy.mf6.ModflowTdis(sim, time_units=time_units, nper=nper, perioddata=tdis_rc)
 
     gwfname = "gwf_" + name
     gwename = "gwe_" + name
@@ -281,9 +275,7 @@ def build_models(idx, test):
     # ----------------------------------
     # Instantiating MODFLOW 6 GWE model
     # ----------------------------------
-    gwe = flopy.mf6.ModflowGwe(
-        sim, modelname=gwename, model_nam_file=f"{gwename}.nam"
-    )
+    gwe = flopy.mf6.ModflowGwe(sim, modelname=gwename, model_nam_file=f"{gwename}.nam")
     gwe.name_file.save_flows = True
 
     imsgwe = flopy.mf6.ModflowIms(
@@ -328,9 +320,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 transport advection package
-    flopy.mf6.ModflowGweadv(
-        gwe, scheme=scheme, pname="ADV", filename=f"{gwename}.adv"
-    )
+    flopy.mf6.ModflowGweadv(gwe, scheme=scheme, pname="ADV", filename=f"{gwename}.adv")
 
     # Instantiating MODFLOW 6 transport dispersion package
     flopy.mf6.ModflowGwecnd(
@@ -413,9 +403,7 @@ def build_models(idx, test):
         pname="OC",
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("TEMPERATURE", "ALL"), ("BUDGET", "ALL")],
         filename=f"{gwename}.oc",
@@ -502,24 +490,17 @@ def check_output(idx, test):
         "Simulated fits to analytical solution are "
         "falling outside established bounds on day 1"
     )
-    assert (
-        np.max(analytical_sln[1, :18] - temps[1, 0, 0, :18]) <= 1.52921097880
-    ), msg1
-    assert (
-        np.min(analytical_sln[1, :18] - temps[1, 0, 0, :18]) >= -0.32260871278
-    ), msg1
+    assert np.max(analytical_sln[1, :18] - temps[1, 0, 0, :18]) <= 1.52921097880, msg1
+    assert np.min(analytical_sln[1, :18] - temps[1, 0, 0, :18]) >= -0.32260871278, msg1
 
     # Ensure that the differences on day 10 fall within established bounds
     msg2 = (
         "Simulated fits to analytical solution are "
         "falling outside established bounds on day 10"
     )
+    assert np.max(analytical_sln[10, :37] - temps[10, 0, 0, :37]) <= 0.15993441016, msg2
     assert (
-        np.max(analytical_sln[10, :37] - temps[10, 0, 0, :37]) <= 0.15993441016
-    ), msg2
-    assert (
-        np.min(analytical_sln[10, :37] - temps[10, 0, 0, :37])
-        >= -0.22298707253
+        np.min(analytical_sln[10, :37] - temps[10, 0, 0, :37]) >= -0.22298707253
     ), msg2
 
     # Ensure that the differences on day 50 fall within established bounds
@@ -527,12 +508,9 @@ def check_output(idx, test):
         "Simulated fits to analytical solution are "
         "falling outside established bounds on day 50"
     )
+    assert np.max(analytical_sln[50, :82] - temps[50, 0, 0, :82]) <= 0.09327747258, msg3
     assert (
-        np.max(analytical_sln[50, :82] - temps[50, 0, 0, :82]) <= 0.09327747258
-    ), msg3
-    assert (
-        np.min(analytical_sln[50, :82] - temps[50, 0, 0, :82])
-        >= -0.21182907402
+        np.min(analytical_sln[50, :82] - temps[50, 0, 0, :82]) >= -0.21182907402
     ), msg3
 
     # Ensure that the differences on day 50 fall within established bounds
@@ -540,12 +518,9 @@ def check_output(idx, test):
         "Simulated fits to analytical solution are "
         "falling outside established bounds on day 50"
     )
+    assert np.max(analytical_sln[50, :82] - temps[50, 0, 0, :82]) <= 0.09327747258, msg3
     assert (
-        np.max(analytical_sln[50, :82] - temps[50, 0, 0, :82]) <= 0.09327747258
-    ), msg3
-    assert (
-        np.min(analytical_sln[50, :82] - temps[50, 0, 0, :82])
-        >= -0.21182907402
+        np.min(analytical_sln[50, :82] - temps[50, 0, 0, :82]) >= -0.21182907402
     ), msg3
 
     # Ensure that the differences on day 100 fall within established bounds
@@ -566,12 +541,8 @@ def check_output(idx, test):
                 analytical_sln[i, j] = temp
 
         # first transient stress period
-        line1 = plt.plot(
-            analytical_sln[1], z, "-", color="red", label="Analytical"
-        )
-        line2 = plt.plot(
-            temps[1, 0, 0], z, "-.", color="blue", label="MODFLOW 6"
-        )
+        line1 = plt.plot(analytical_sln[1], z, "-", color="red", label="Analytical")
+        line2 = plt.plot(temps[1, 0, 0], z, "-.", color="blue", label="MODFLOW 6")
         # 10th transient stress period
         plt.plot(analytical_sln[10], z, "-", color="red")
         plt.plot(temps[10, 0, 0], z, "-.", color="blue")

--- a/autotest/test_gwe_vs_gwt.py
+++ b/autotest/test_gwe_vs_gwt.py
@@ -145,9 +145,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # Instantiating MODFLOW 6 groundwater flow model
     gwf = flopy.mf6.ModflowGwf(
@@ -204,14 +202,10 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 storage package (steady flow conditions, so no actual storage, using to print values in .lst file)
-    flopy.mf6.ModflowGwfsto(
-        gwf, ss=0, sy=0, pname="STO-1", filename=f"{gwfname}.sto"
-    )
+    flopy.mf6.ModflowGwfsto(gwf, ss=0, sy=0, pname="STO-1", filename=f"{gwfname}.sto")
 
     # Instantiating MODFLOW 6 initial conditions package for flow model
-    flopy.mf6.ModflowGwfic(
-        gwf, strt=strt, pname="IC-1", filename=f"{gwfname}.ic"
-    )
+    flopy.mf6.ModflowGwfic(gwf, strt=strt, pname="IC-1", filename=f"{gwfname}.ic")
 
     # Instantiating MODFLOW 6 constant head package
     flopy.mf6.ModflowGwfchd(
@@ -291,9 +285,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 heat transport initial temperatures
-    flopy.mf6.ModflowGweic(
-        gwe, strt=strt_temp, pname="IC-1", filename=f"{gwename}.ic"
-    )
+    flopy.mf6.ModflowGweic(gwe, strt=strt_temp, pname="IC-1", filename=f"{gwename}.ic")
 
     # Instantiating MODFLOW 6 heat transport advection package
     if mixelm >= 0:
@@ -341,9 +333,7 @@ def build_models(idx, test):
         gwe,
         budget_filerecord=f"{gwename}.cbc",
         temperature_filerecord=f"{gwename}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
     )
@@ -404,9 +394,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 transport initial concentrations
-    flopy.mf6.ModflowGwtic(
-        gwt, strt=strt_temp, pname="IC-1", filename=f"{gwtname}.ic"
-    )
+    flopy.mf6.ModflowGwtic(gwt, strt=strt_temp, pname="IC-1", filename=f"{gwtname}.ic")
 
     # Instantiating MODFLOW 6 transport advection package
     flopy.mf6.ModflowGwtadv(
@@ -448,9 +436,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -478,9 +464,7 @@ def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{gwename}.ucn")
     try:
         # load temperatures
-        tobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        tobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         temps = tobj.get_alldata()
     except:
         assert False, f'could not load temperature data from "{fpth}"'
@@ -488,9 +472,7 @@ def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
         # load temperatures (though stored as "concentrations")
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_alldata()
     except:
         assert False, f'could not load concentration data from "{fpth}"'

--- a/autotest/test_gwegwe_exchng_with_comp2gwt.py
+++ b/autotest/test_gwegwe_exchng_with_comp2gwt.py
@@ -152,14 +152,10 @@ for i in np.arange(nrow):
             # Check to see if two touching cells in adjacent models are both active
             # Check
             if idomain_ur[0, i, j] > 0 and idomain_ll[0, i + 1, j] > 0:
-                exgdata.append(
-                    ((0, i, j), (0, i + 1, j), 1, 5, 5, 10, 270.0, 10.0)
-                )
+                exgdata.append(((0, i, j), (0, i + 1, j), 1, 5, 5, 10, 270.0, 10.0))
         if j < (ncol - 1):
             if idomain_ur[0, i, j + 1] > 0 and idomain_ll[0, i, j] > 0:
-                exgdata.append(
-                    ((0, i, j + 1), (0, i, j), 1, 5, 5, 10, 180.0, 10.0)
-                )
+                exgdata.append(((0, i, j + 1), (0, i, j), 1, 5, 5, 10, 180.0, 10.0))
 
 
 # Boundary conditions
@@ -248,9 +244,7 @@ def build_models(idx, test):
     for i in range(nper):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # add both solutions to the simulation
     add_flow(sim)
@@ -590,18 +584,14 @@ def add_upper_gwemodel(sim, scheme):
 
     # Instantiating MODFLOW 6 heat transport source-sink mixing package
     sourcerecarray = [("WEL-1", "AUX", "TEMPERATURE")]
-    flopy.mf6.ModflowGwessm(
-        gwe, sources=sourcerecarray, filename=f"{mname}.ssm"
-    )
+    flopy.mf6.ModflowGwessm(gwe, sources=sourcerecarray, filename=f"{mname}.ssm")
 
     # Instantiating MODFLOW 6 heat transport output control package
     flopy.mf6.ModflowGweoc(
         gwe,
         budget_filerecord=f"{mname}.cbc",
         temperature_filerecord=f"{mname}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
     )
@@ -668,9 +658,7 @@ def add_lower_gwemodel(sim, scheme):
 
     # Instantiating MODFLOW 6 heat transport source-sink mixing package
     sourcerecarray = [("CHD-1", "AUX", "TEMPERATURE")]
-    flopy.mf6.ModflowGwessm(
-        gwe, sources=sourcerecarray, filename=f"{mname}.ssm"
-    )
+    flopy.mf6.ModflowGwessm(gwe, sources=sourcerecarray, filename=f"{mname}.ssm")
 
     # Instantiating MODFLOW 6 heat transport output control package
     # flopy.mf6.ModflowGweoc(
@@ -687,9 +675,7 @@ def add_lower_gwemodel(sim, scheme):
         gwe,
         budget_filerecord=f"{mname}.cbc",
         temperature_filerecord=f"{mname}.ucn",
-        temperatureprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        temperatureprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("TEMPERATURE", "LAST"), ("BUDGET", "LAST")],
     )
@@ -804,17 +790,13 @@ def add_upper_gwtmodel(sim, scheme):
 
     # Instantiating MODFLOW 6 source-sink mixing package transport
     sourcerecarray = [("WEL-1", "AUX", "TEMPERATURE")]
-    flopy.mf6.ModflowGwtssm(
-        gwt, sources=sourcerecarray, filename=f"{mname}.ssm"
-    )
+    flopy.mf6.ModflowGwtssm(gwt, sources=sourcerecarray, filename=f"{mname}.ssm")
 
     flopy.mf6.ModflowGwtoc(
         gwt,
         budget_filerecord=f"{mname}.cbc",
         concentration_filerecord=f"{mname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -877,18 +859,14 @@ def add_lower_gwtmodel(sim, scheme):
 
     # Instantiating MODFLOW 6 solute transport source-sink mixing package
     sourcerecarray = [("CHD-1", "AUX", "TEMPERATURE")]
-    flopy.mf6.ModflowGwtssm(
-        gwt, sources=sourcerecarray, filename=f"{mname}.ssm"
-    )
+    flopy.mf6.ModflowGwtssm(gwt, sources=sourcerecarray, filename=f"{mname}.ssm")
 
     # Instantiating MODFLOW 6 solute transport output control package
     flopy.mf6.ModflowGwtoc(
         gwt,
         budget_filerecord=f"{mname}.cbc",
         concentration_filerecord=f"{mname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )

--- a/autotest/test_gwf_ats01.py
+++ b/autotest/test_gwf_ats01.py
@@ -114,9 +114,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -166,9 +164,7 @@ def build_models(idx, test):
     obs_lst.append(["obs1", "head", (0, 0, 0)])
     obs_lst.append(["obs2", "head", (0, 0, 1)])
     obs_dict = {f"{gwfname}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     return sim, None
 

--- a/autotest/test_gwf_ats02.py
+++ b/autotest/test_gwf_ats02.py
@@ -58,9 +58,7 @@ def build_models(idx, test):
 
     if True:
         ats_filerecord = name + ".ats"
-        atsperiod = [
-            (i, dt0, dtmin, dtmax, dtadj, dtfailadj) for i in range(nper)
-        ]
+        atsperiod = [(i, dt0, dtmin, dtmax, dtadj, dtfailadj) for i in range(nper)]
         tdis.ats.initialize(
             maxats=len(atsperiod),
             perioddata=atsperiod,
@@ -163,9 +161,7 @@ def build_models(idx, test):
     obs_lst.append(["obs1", "head", (0, 0, 0)])
     obs_lst.append(["obs2", "head", (4, 0, 0)])
     obs_dict = {f"{gwfname}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     return sim, None
 
@@ -189,9 +185,7 @@ def make_plot(test):
     for ilay in range(5):
         h = head[:, ilay]
         h = np.ma.masked_where(h < 0, h)
-        (botline,) = plt.plot(
-            [times.min(), times.max()], [botm[ilay], botm[ilay]]
-        )
+        (botline,) = plt.plot([times.min(), times.max()], [botm[ilay], botm[ilay]])
         plt.plot(
             times,
             h,
@@ -222,9 +216,7 @@ def check_output(idx, test):
     except:
         assert False, f'could not load data from "{fpth}"'
     # ensure layer 1 is dry with the DRY value
-    assert (
-        np.max(tc["OBS1"][:201]) == -1.0e30
-    ), "layer 1 should be dry for this period"
+    assert np.max(tc["OBS1"][:201]) == -1.0e30, "layer 1 should be dry for this period"
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_ats03.py
+++ b/autotest/test_gwf_ats03.py
@@ -115,9 +115,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -182,9 +180,7 @@ def build_models(idx, test):
     obs_lst.append(["obs1", "head", (0, 0, 0)])
     obs_lst.append(["obs2", "head", (0, 0, ncol - 1)])
     obs_dict = {f"{gwfname}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     return sim, None
 

--- a/autotest/test_gwf_ats_lak01.py
+++ b/autotest/test_gwf_ats_lak01.py
@@ -298,9 +298,7 @@ def budcsv_to_cumulative(fpth):
     budcsv_cumulative["time"][1:] = budcsv["time"][:]
     for name in budcsv.dtype.names[1:]:
         for i in range(nrow):
-            dt = (
-                budcsv_cumulative["time"][i + 1] - budcsv_cumulative["time"][i]
-            )
+            dt = budcsv_cumulative["time"][i + 1] - budcsv_cumulative["time"][i]
             budcsv_cumulative[name][i + 1] = (
                 budcsv_cumulative[name][i] + budcsv[name][i] * dt
             )
@@ -314,9 +312,7 @@ def listfile_to_cumulative(listfile):
     return mflist.get_cumulative()
 
 
-def compare_listbudget_and_budgetcsv(
-    listfile, budcsvfile, verbose, check, atol
-):
+def compare_listbudget_and_budgetcsv(listfile, budcsvfile, verbose, check, atol):
     """Read a budgetcsv file, convert it to a cumulative budget
     and then compare it with the cumulative budget in a list file"""
 
@@ -331,9 +327,7 @@ def compare_listbudget_and_budgetcsv(
 
     # if print budget is not active for every time step, then the list file
     # budget may not be complete and comparable to budcsvfile
-    assert (
-        budcsvcum.shape[0] - 1 == budlstcum.shape[0]
-    ), "File sizes are different."
+    assert budcsvcum.shape[0] - 1 == budlstcum.shape[0], "File sizes are different."
 
     allclose_list = []
     for name1 in budlstcum.dtype.names[3:]:
@@ -351,9 +345,7 @@ def compare_listbudget_and_budgetcsv(
                     msg = f"{name2} is same: {allclose}.  Min diff: {mindiff} Max diff {maxdiff}"
                     if verbose:
                         print(msg)
-                    allclose_list.append(
-                        (allclose, name1, mindiff, maxdiff, msg)
-                    )
+                    allclose_list.append((allclose, name1, mindiff, maxdiff, msg))
 
     if check:
         for rec in allclose_list:
@@ -399,9 +391,7 @@ def check_output(idx, test):
             node, node2, q = r
             n0 = node - 1
             if ilak[n0] == 1:
-                kk, ii, jj = get_kij_from_node(
-                    n0, botm.shape[1], botm.shape[2]
-                )
+                kk, ii, jj = get_kij_from_node(n0, botm.shape[1], botm.shape[2])
                 tp = botm[kk - 1, ii, jj]
                 if stage_current > tp and q != 0.0:
                     all_passed = False
@@ -484,9 +474,7 @@ def check_output(idx, test):
     verbose = True
     check = True
     atol = 0.001
-    compare_listbudget_and_budgetcsv(
-        listfile, budcsvfile, verbose, check, atol
-    )
+    compare_listbudget_and_budgetcsv(listfile, budcsvfile, verbose, check, atol)
 
 
 @pytest.mark.slow

--- a/autotest/test_gwf_auxvars.py
+++ b/autotest/test_gwf_auxvars.py
@@ -36,9 +36,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
@@ -75,9 +73,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=True, icelltype=1, k=1.0, k33=0.01
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=1, k=1.0, k33=0.01)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -210,9 +206,7 @@ def build_models(idx, test):
     # <ifno> <finf> <pet> <extdp> <extwc> <ha> <hroot> <rootact> [<aux(naux)>]
     perioddata = []
     for p in packagedata:
-        perioddata.append(
-            (p[0], 0.001, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, auxvar1, auxvar2)
-        )
+        perioddata.append((p[0], 0.001, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, auxvar1, auxvar2))
     uzf = flopy.mf6.ModflowGwfuzf(
         gwf,
         boundnames=True,

--- a/autotest/test_gwf_auxvars02.py
+++ b/autotest/test_gwf_auxvars02.py
@@ -34,9 +34,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
@@ -73,9 +71,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=True, icelltype=1, k=1.0, k33=0.01
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=1, k=1.0, k33=0.01)
 
     # chd files
     chdlist0 = []

--- a/autotest/test_gwf_bnd_negative_cond.py
+++ b/autotest/test_gwf_bnd_negative_cond.py
@@ -98,9 +98,7 @@ def build_models(idx, test):
     spd = [
         [(0, 0, 0), 1.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     bnd_loc = (0, 0, 1)
     cond = 1.0
@@ -149,10 +147,7 @@ def check_output(idx, test):
             + "MULTIPLIER ( -1.00    ) IS LESS THAN ZERO"
         )
     else:
-        tag = (
-            f"1. {pak} BOUNDARY (1) CONDUCTANCE "
-            + "( -1.00    ) IS LESS THAN ZERO"
-        )
+        tag = f"1. {pak} BOUNDARY (1) CONDUCTANCE " + "( -1.00    ) IS LESS THAN ZERO"
     with open(test.workspace / "mfsim.lst", "r") as f:
         lines = f.readlines()
         error_count = 0

--- a/autotest/test_gwf_boundname01.py
+++ b/autotest/test_gwf_boundname01.py
@@ -52,9 +52,7 @@ def get_model(idx, ws):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register
     imsgwf = flopy.mf6.ModflowIms(

--- a/autotest/test_gwf_buy_lak01.py
+++ b/autotest/test_gwf_buy_lak01.py
@@ -58,9 +58,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name

--- a/autotest/test_gwf_buy_lak02.py
+++ b/autotest/test_gwf_buy_lak02.py
@@ -68,9 +68,7 @@ def build_models(idx, test):
         sim_ws=test.workspace,
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name

--- a/autotest/test_gwf_buy_maw01.py
+++ b/autotest/test_gwf_buy_maw01.py
@@ -58,17 +58,13 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
 
     newtonoptions = "NEWTON UNDER_RELAXATION"
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=gwfname, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, newtonoptions=newtonoptions)
 
     imsgwf = flopy.mf6.ModflowIms(
         sim,
@@ -134,8 +130,7 @@ def build_models(idx, test):
     ]
     # <ifno> <icon> <cellid(ncelldim)> <scrn_top> <scrn_bot> <hk_skin> <radius_skin>
     mawconnectiondata = [
-        [0, icon, (icon, 0, 0), top, mawbottom, -999.0, -999.0]
-        for icon in range(nlay)
+        [0, icon, (icon, 0, 0), top, mawbottom, -999.0, -999.0] for icon in range(nlay)
     ]
     # <ifno> <mawsetting>
     mawperioddata = [[0, "STATUS", "ACTIVE"]]

--- a/autotest/test_gwf_buy_sfr01.py
+++ b/autotest/test_gwf_buy_sfr01.py
@@ -52,9 +52,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -273,15 +271,11 @@ def build_models(idx, test):
     )
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # storage
     porosity = 1.0
-    sto = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
     # sources
     sourcerecarray = [
         ("CHD-1", "AUX", "CONCENTRATION"),
@@ -353,9 +347,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -383,9 +375,7 @@ def check_output(idx, test):
     assert os.path.isfile(fname)
     cobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")
     csftall = cobj.get_alldata()
-    csft = csftall[
-        -2
-    ].flatten()  # because it's lagged, get two time steps back
+    csft = csftall[-2].flatten()  # because it's lagged, get two time steps back
 
     # load the aquifer concentrations
     fname = gwtname + ".ucn"
@@ -450,9 +440,7 @@ def check_output(idx, test):
         # print(n, hsfr, hgwf, rhosfr, rhogwf, qcalc, qsim)
         # if not np.allclose(qcalc, qsim):
         #    print('reach {} flow {} not equal {}'.format(n, qcalc, qsim))
-        assert np.allclose(
-            qcalc, qsim
-        ), f"reach {n} flow {qcalc} not equal {qsim}"
+        assert np.allclose(qcalc, qsim), f"reach {n} flow {qcalc} not equal {qsim}"
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_chd01.py
+++ b/autotest/test_gwf_chd01.py
@@ -41,9 +41,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -126,9 +124,7 @@ def check_output(idx, test):
 
     # This is the answer to this problem.
     hres = np.linspace(1, 0, 100)
-    assert np.allclose(
-        hres, head
-    ), "simulated head do not match with known solution."
+    assert np.allclose(hres, head), "simulated head do not match with known solution."
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_chd02.py
+++ b/autotest/test_gwf_chd02.py
@@ -84,9 +84,7 @@ def check_output(idx, test):
             5.000,
         ]
     )
-    assert np.allclose(
-        hres, head
-    ), "simulated head does not match with known solution."
+    assert np.allclose(hres, head), "simulated head does not match with known solution."
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_csub_db01_nr.py
+++ b/autotest/test_gwf_csub_db01_nr.py
@@ -115,9 +115,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     if newton:
@@ -154,9 +152,7 @@ def build_models(idx, test):
     )
 
     # create gwf model
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=name, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, newtonoptions=newtonoptions)
 
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
@@ -375,9 +371,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_dbgeo01.py
+++ b/autotest/test_gwf_csub_dbgeo01.py
@@ -206,9 +206,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
@@ -246,9 +244,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt[idx], filename=f"{name}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -329,9 +325,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-compaction difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         line += f" {'CSUB':>15s}"

--- a/autotest/test_gwf_csub_distypes.py
+++ b/autotest/test_gwf_csub_distypes.py
@@ -417,8 +417,7 @@ def check_output(idx, test):
         comp = comp.sum(axis=0)
         zdis = zdis[0]
         assert np.allclose(comp, zdis), (
-            "sum of compaction is not equal to the "
-            + f"z-displacement at time {totim}"
+            "sum of compaction is not equal to the " + f"z-displacement at time {totim}"
         )
 
 

--- a/autotest/test_gwf_csub_inelastic.py
+++ b/autotest/test_gwf_csub_inelastic.py
@@ -79,9 +79,7 @@ def build_mf6(idx, ws, update=None):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
@@ -119,9 +117,7 @@ def build_mf6(idx, ws, update=None):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt6, filename=f"{name}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -218,9 +214,7 @@ def check_output(idx, test):
     msg = f"maximum absolute void ratio difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         line += f" {'VOID':>15s}"

--- a/autotest/test_gwf_csub_ndb01_nr.py
+++ b/autotest/test_gwf_csub_ndb01_nr.py
@@ -115,9 +115,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     if newton:
@@ -154,9 +152,7 @@ def build_models(idx, test):
     )
 
     # create gwf model
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=name, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, newtonoptions=newtonoptions)
 
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
@@ -347,9 +343,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_sk01.py
+++ b/autotest/test_gwf_csub_sk01.py
@@ -162,9 +162,7 @@ def get_model(idx, workspace):
         sim_ws=str(workspace),
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution
     ims = flopy.mf6.ModflowIms(
@@ -183,9 +181,7 @@ def get_model(idx, workspace):
     )
 
     # create gwf model
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=name, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, newtonoptions=newtonoptions)
 
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
@@ -355,9 +351,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-compaction difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             line = f"{tc0['time'][i]:10.2g}"
@@ -419,9 +413,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_sk02.py
+++ b/autotest/test_gwf_csub_sk02.py
@@ -188,9 +188,7 @@ def get_model(idx, ws):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -223,9 +221,7 @@ def get_model(idx, ws):
         beta = 0.0
         wc = 0.0
 
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=name, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, newtonoptions=newtonoptions)
 
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
@@ -352,9 +348,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-compaction difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             line = f"{tc0['time'][i]:10.2g}"
@@ -416,9 +410,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_sk03.py
+++ b/autotest/test_gwf_csub_sk03.py
@@ -108,9 +108,7 @@ tsname = "FR"
 tsnames.append(tsname)
 sig0.append([(0, 9, 0), tsname])
 
-datestart = datetime.datetime.strptime(
-    "03/21/1938 00:00:00", "%m/%d/%Y %H:%M:%S"
-)
+datestart = datetime.datetime.strptime("03/21/1938 00:00:00", "%m/%d/%Y %H:%M:%S")
 train1 = 2.9635  # 3.9009
 train2 = 2.8274
 fcar1 = 0.8165
@@ -267,9 +265,7 @@ def get_model(idx, ws):
     sc = sske
     compression_indices = None
 
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=name, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, newtonoptions=newtonoptions)
 
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
@@ -564,9 +560,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_sk04_nr.py
+++ b/autotest/test_gwf_csub_sk04_nr.py
@@ -86,9 +86,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     if newton:
@@ -125,9 +123,7 @@ def build_models(idx, test):
     )
 
     # create gwf model
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=name, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, newtonoptions=newtonoptions)
 
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
@@ -296,9 +292,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_sub01.py
+++ b/autotest/test_gwf_csub_sub01.py
@@ -83,9 +83,7 @@ def get_model(idx, ws):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution
     ims = flopy.mf6.ModflowIms(
@@ -122,9 +120,7 @@ def get_model(idx, ws):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{name}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -247,9 +243,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-compaction difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         line += f" {'CSUB':>15s}"
@@ -341,9 +335,7 @@ def cbc_compare(test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_sub01_adjmat.py
+++ b/autotest/test_gwf_csub_sub01_adjmat.py
@@ -104,9 +104,7 @@ def get_model(idx, dir, adjustmat=False):
     sim.name_file.memory_print_option = "all"
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
@@ -144,9 +142,7 @@ def get_model(idx, dir, adjustmat=False):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{name}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -184,9 +180,7 @@ def get_model(idx, dir, adjustmat=False):
         ("sk", "sk", (0, 0, 1)),
     ]
     tags = ["dbcomp", "dbthick", "dbporo"]
-    for jdx, otype in enumerate(
-        ["delay-compaction", "delay-thickness", "delay-theta"]
-    ):
+    for jdx, otype in enumerate(["delay-compaction", "delay-thickness", "delay-theta"]):
         for n in range(ndcell[idx]):
             tag = f"{tags[jdx]}{n + 1:02d}"
             obs.append((tag, otype, (0, n)))
@@ -241,9 +235,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-compaction difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         line += f" {'CSUB':>15s}"
@@ -277,10 +269,7 @@ def check_output(idx, test):
     for key in calc.dtype.names:
         diff = calc[key] - ovalsi[key]
         diffmax = np.abs(diff).max()
-        msg = (
-            f"maximum absolute interbed {key} "
-            + f"difference ({diffmax:15.7g}) "
-        )
+        msg = f"maximum absolute interbed {key} " + f"difference ({diffmax:15.7g}) "
         if diffmax > dtol:
             test.success = False
             msg += f"exceeds {dtol:15.7g}"
@@ -301,16 +290,11 @@ def check_output(idx, test):
         ovals["THICK"] = tc[tagb]
         ovals["THETA"] = tc[tagp]
         calc = np.zeros((comp.shape[0]), dtype=dtype)
-        calc["THETA"], calc["THICK"] = calc_theta_thick(
-            comp, thickini=thickini
-        )
+        calc["THETA"], calc["THICK"] = calc_theta_thick(comp, thickini=thickini)
         for key in calc.dtype.names:
             diff = calc[key] - ovals[key]
             diffmax = np.abs(diff).max()
-            msg = (
-                f"maximum absolute {key}({n + 1}) difference "
-                + f"({diffmax:15.7g}) "
-            )
+            msg = f"maximum absolute {key}({n + 1}) difference " + f"({diffmax:15.7g}) "
             if diffmax > dtol:
                 test.success = False
                 msg += f"exceeds {dtol:15.7g}"
@@ -326,10 +310,7 @@ def check_output(idx, test):
     for key in calci.dtype.names:
         diff = calci[key] - ovalsi[key]
         diffmax = np.abs(diff).max()
-        msg = (
-            f"maximum absolute interbed {key} difference "
-            + f"({diffmax:15.7g}) "
-        )
+        msg = f"maximum absolute interbed {key} difference " + f"({diffmax:15.7g}) "
         msg += "calculated from individual interbed cell values "
         if diffmax > dtol:
             test.success = False
@@ -409,9 +390,7 @@ def cbc_compare(test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_sub01_elastic.py
+++ b/autotest/test_gwf_csub_sub01_elastic.py
@@ -96,17 +96,13 @@ def build_mf6(idx, ws, newton=None):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name, newtonoptions=newton)
 
     # create iterative model solution and register the gwf model with it
-    ims = flopy.mf6.ModflowIms(
-        sim, print_option="SUMMARY", complexity="complex"
-    )
+    ims = flopy.mf6.ModflowIms(sim, print_option="SUMMARY", complexity="complex")
     sim.register_ims_package(ims, [gwf.name])
 
     dis = flopy.mf6.ModflowGwfdis(
@@ -125,9 +121,7 @@ def build_mf6(idx, ws, newton=None):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{name}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -209,9 +203,7 @@ def check_output(idx, test):
     msg = "maximum compaction difference " + f"({diffmax}) in tag: {tagmax}"
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         for tag in tc.dtype.names[1:]:
@@ -305,9 +297,7 @@ def cbc_compare(test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_sub01_pch.py
+++ b/autotest/test_gwf_csub_sub01_pch.py
@@ -89,9 +89,7 @@ def get_model(idx, dir, pch=None):
     sim.name_file.memory_print_option = "all"
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name)
@@ -129,9 +127,7 @@ def get_model(idx, dir, pch=None):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{name}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -242,9 +238,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-compaction difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         line += f" {'CSUB':>15s}"
@@ -336,9 +330,7 @@ def cbc_compare(test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_sub02.py
+++ b/autotest/test_gwf_csub_sub02.py
@@ -109,9 +109,7 @@ def get_model(idx, ws):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution
     ims = flopy.mf6.ModflowIms(
@@ -130,9 +128,7 @@ def get_model(idx, ws):
     )
 
     # create gwf model
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=name, model_nam_file=f"{name}.nam"
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, model_nam_file=f"{name}.nam")
 
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
@@ -150,9 +146,7 @@ def get_model(idx, ws):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{name}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,

--- a/autotest/test_gwf_csub_sub03.py
+++ b/autotest/test_gwf_csub_sub03.py
@@ -130,9 +130,7 @@ dz = [5.894, 5.08]
 nz = [1, 1]
 dstart = []
 for k in ldnd:
-    pth = str(
-        project_root_path / "autotest" / "data" / f"ibc03_dstart{k + 1}.ref"
-    )
+    pth = str(project_root_path / "autotest" / "data" / f"ibc03_dstart{k + 1}.ref")
     v = np.genfromtxt(pth)
     dstart.append(v.copy())
 
@@ -221,9 +219,7 @@ def get_model(idx, ws):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution
     ims = flopy.mf6.ModflowIms(

--- a/autotest/test_gwf_csub_subwt01.py
+++ b/autotest/test_gwf_csub_subwt01.py
@@ -127,9 +127,7 @@ def get_model(idx, ws):
         sim_ws=ws,
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution
     ims = flopy.mf6.ModflowIms(
@@ -148,9 +146,7 @@ def get_model(idx, ws):
     )
 
     # create gwf model
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=name, save_flows=True, print_input=True
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True, print_input=True)
 
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
@@ -169,9 +165,7 @@ def get_model(idx, ws):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{name}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -271,9 +265,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-compaction difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         line += f" {'CSUB':>15s}"
@@ -365,9 +357,7 @@ def cbc_compare(test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_subwt02.py
+++ b/autotest/test_gwf_csub_subwt02.py
@@ -221,9 +221,7 @@ def get_model(idx, ws):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution
     ims = flopy.mf6.ModflowIms(
@@ -441,9 +439,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-compaction difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     f = open(fpth, "w")
     line = f"{'TOTIM':>15s}"
     line += f" {'CSUB':>15s}"
@@ -538,9 +534,7 @@ def cbc_compare(test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_subwt03.py
+++ b/autotest/test_gwf_csub_subwt03.py
@@ -218,9 +218,7 @@ def build_mf6(idx, ws, interbed=False):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -261,9 +259,7 @@ def build_mf6(idx, ws, interbed=False):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{name}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -378,9 +374,7 @@ def check_output(idx, test):
     msg = "maximum compaction difference " + f"({diffmax}) in tag: {tagmax}"
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.comp.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         for tag in tc.dtype.names[1:]:
@@ -474,9 +468,7 @@ def cbc_compare(test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_wc01.py
+++ b/autotest/test_gwf_csub_wc01.py
@@ -227,9 +227,7 @@ def build_mf6(idx, ws, interbed=False):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -270,9 +268,7 @@ def build_mf6(idx, ws, interbed=False):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{name}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -372,9 +368,7 @@ def check_output(idx, test):
     )
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.wcomp.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.wcomp.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         for tag in tc.dtype.names[1:]:
@@ -468,9 +462,7 @@ def cbc_compare(test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_wtgeo.py
+++ b/autotest/test_gwf_csub_wtgeo.py
@@ -166,9 +166,7 @@ def get_model(idx, ws):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
@@ -473,9 +471,7 @@ def get_model(idx, ws):
 
 def build_models(idx, test):
     sim = get_model(idx, test.workspace)  # modflow6 files
-    mc = get_model(
-        idx, os.path.join(test.workspace, cmppth)
-    )  # build comparison files
+    mc = get_model(idx, os.path.join(test.workspace, cmppth))  # build comparison files
     return sim, mc
 
 
@@ -594,9 +590,7 @@ def cbc_compare(test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_zdisp01.py
+++ b/autotest/test_gwf_csub_zdisp01.py
@@ -201,9 +201,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     zthick = [top - botm[0], botm[0] - botm[1], botm[1] - botm[2]]
@@ -298,9 +296,7 @@ def build_models(idx, test):
     )
 
     # drain
-    drn = flopy.mf6.ModflowGwfdrn(
-        gwf, maxbound=maxdrd, stress_period_data=drd6
-    )
+    drn = flopy.mf6.ModflowGwfdrn(gwf, maxbound=maxdrd, stress_period_data=drd6)
 
     # wel file
     wel = flopy.mf6.ModflowGwfwel(
@@ -413,9 +409,7 @@ def check_output(idx, test):
     fn = f"{os.path.basename(test.name)}.total_comp.hds"
     fpth = os.path.join(test.workspace, "mfnwt", fn)
     try:
-        sobj = flopy.utils.HeadFile(
-            fpth, text="LAYER COMPACTION", verbose=False
-        )
+        sobj = flopy.utils.HeadFile(fpth, text="LAYER COMPACTION", verbose=False)
         tc0 = sobj.get_ts((2, wrp[0], wcp[0]))
     except:
         assert False, f'could not load data from "{fpth}"'
@@ -490,9 +484,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_csub_zdisp02.py
+++ b/autotest/test_gwf_csub_zdisp02.py
@@ -135,9 +135,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
 
-    flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     flopy.mf6.ModflowIms(
         sim,
@@ -173,9 +171,7 @@ def build_models(idx, test):
 
     flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{name}.ic")
 
-    flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=vka
-    )
+    flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=vka)
 
     flopy.mf6.ModflowGwfsto(
         gwf,
@@ -230,9 +226,7 @@ def build_models(idx, test):
 def check_output(idx, test):
     with open(pl.Path(test.workspace) / "mfsim.lst", "r") as f:
         lines = f.readlines()
-    tag = (
-        "1. Package convergence data is requested but delay interbeds are not"
-    )
+    tag = "1. Package convergence data is requested but delay interbeds are not"
     found = False
     for line in lines[::-1]:
         if tag in line:

--- a/autotest/test_gwf_disv_uzf.py
+++ b/autotest/test_gwf_disv_uzf.py
@@ -141,9 +141,7 @@ def build_models(idx, test):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -175,19 +173,13 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=True, icelltype=1, k=0.1, k33=1
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=1, k=0.1, k33=1)
 
     # aquifer storage
-    sto = flopy.mf6.ModflowGwfsto(
-        gwf, iconvert=1, ss=1e-5, sy=0.2, transient=True
-    )
+    sto = flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=1e-5, sy=0.2, transient=True)
 
     # general-head boundary
-    ghb = flopy.mf6.ModflowGwfghb(
-        gwf, print_flows=True, stress_period_data=ghb_spd
-    )
+    ghb = flopy.mf6.ModflowGwfghb(gwf, print_flows=True, stress_period_data=ghb_spd)
 
     # unsaturated-zone flow
     etobs = []
@@ -234,9 +226,7 @@ def build_models(idx, test):
             obs_lst.append(["obs_" + str(i + 1), "head", (k, i)])
 
     obs_dict = {f"{name}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     return sim, None
 

--- a/autotest/test_gwf_drn_ddrn01.py
+++ b/autotest/test_gwf_drn_ddrn01.py
@@ -66,9 +66,7 @@ def get_model(idx, ws, name):
         inner_dvclose=1e-9,
         rcloserecord=[0.01, "strict"],
     )
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=name, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name, newtonoptions=newtonoptions)
     dis = flopy.mf6.ModflowGwfdis(
         gwf,
         nlay=nlay,
@@ -80,9 +78,7 @@ def get_model(idx, ws, name):
         botm=botm,
     )
     npf = flopy.mf6.ModflowGwfnpf(gwf, k=kh, icelltype=1)
-    sto = flopy.mf6.ModflowGwfsto(
-        gwf, sy=sy, ss=ss, transient={0: True}, iconvert=1
-    )
+    sto = flopy.mf6.ModflowGwfsto(gwf, sy=sy, ss=ss, transient={0: True}, iconvert=1)
     drn = flopy.mf6.ModflowGwfdrn(
         gwf,
         auxiliary=["ddrn"],
@@ -147,9 +143,7 @@ def check_output(idx, test):
     msg = f"maximum absolute discharge difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.disc.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.disc.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         line += f" {'DRN':>15s}"

--- a/autotest/test_gwf_drn_ddrn02.py
+++ b/autotest/test_gwf_drn_ddrn02.py
@@ -69,9 +69,7 @@ def get_model(ws, name, uzf=False):
         botm=botm,
     )
     npf = flopy.mf6.ModflowGwfnpf(gwf, k=kh, icelltype=1)
-    sto = flopy.mf6.ModflowGwfsto(
-        gwf, sy=sy, ss=ss, transient={0: True}, iconvert=1
-    )
+    sto = flopy.mf6.ModflowGwfsto(gwf, sy=sy, ss=ss, transient={0: True}, iconvert=1)
     if uzf:
         uzf = flopy.mf6.ModflowGwfuzf(
             gwf, simulate_gwseep=True, packagedata=uzf_pd, print_input=True
@@ -143,9 +141,7 @@ def check_output(idx, test):
     msg = f"maximum absolute discharge difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.disc.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.disc.cmp.out")
     with open(fpth, "w") as f:
         line = f"{'TOTIM':>15s}"
         line += f" {'DRN':>15s}"

--- a/autotest/test_gwf_errors.py
+++ b/autotest/test_gwf_errors.py
@@ -135,9 +135,7 @@ def test_sim_errors(function_tmpdir, targets):
     with pytest.raises(RuntimeError):
         # verify that the correct number of errors are reported
         chdkwargs = {}
-        chdkwargs["stress_period_data"] = {
-            0: [[(0, 0, 0), 0.0] for i in range(10)]
-        }
+        chdkwargs["stress_period_data"] = {0: [[(0, 0, 0), 0.0] for i in range(10)]}
         sim = get_minimal_gwf_simulation(
             str(function_tmpdir), exe=mf6, chdkwargs=chdkwargs
         )
@@ -154,9 +152,7 @@ def test_sim_maxerrors(function_tmpdir, targets):
         simnamefilekwargs = {}
         simnamefilekwargs["maxerrors"] = 5
         chdkwargs = {}
-        chdkwargs["stress_period_data"] = {
-            0: [[(0, 0, 0), 0.0] for i in range(10)]
-        }
+        chdkwargs["stress_period_data"] = {0: [[(0, 0, 0), 0.0] for i in range(10)]}
         sim = get_minimal_gwf_simulation(
             str(function_tmpdir),
             exe=mf6,
@@ -177,9 +173,7 @@ def test_disu_errors(function_tmpdir, targets):
     mf6 = targets["mf6"]
 
     with pytest.raises(RuntimeError):
-        disukwargs = get_disu_kwargs(
-            3, 3, 3, np.ones(3), np.ones(3), 0, [-1, -2, -3]
-        )
+        disukwargs = get_disu_kwargs(3, 3, 3, np.ones(3), np.ones(3), 0, [-1, -2, -3])
         top = disukwargs["top"]
         bot = disukwargs["bot"]
         top[9] = 2.0
@@ -195,8 +189,7 @@ def test_disu_errors(function_tmpdir, targets):
             "1. Top elevation (    2.00000    ) for cell 10 is above bottom elevation (",
             "-1.00000    ) for cell 1. Based on node numbering rules cell 10 must be",
             "below cell 1.",
-            "UNIT ERROR REPORT:"
-            "1. ERROR OCCURRED WHILE READING FILE './test.disu'",
+            "UNIT ERROR REPORT:1. ERROR OCCURRED WHILE READING FILE './test.disu'",
         ]
         run_mf6_error(str(function_tmpdir), mf6, err_str)
 

--- a/autotest/test_gwf_evt01.py
+++ b/autotest/test_gwf_evt01.py
@@ -34,9 +34,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)
@@ -83,9 +81,7 @@ def build_models(idx, test):
 
     nseg = 4
     surf_rate_specified = True
-    evtspd = [
-        [(0, 0, 1), 95.0, 0.001, 90.0, 0.25, 0.5, 0.75, 1.0, 0.0, 1.0, 0.1]
-    ]
+    evtspd = [[(0, 0, 1), 95.0, 0.001, 90.0, 0.25, 0.5, 0.75, 1.0, 0.0, 1.0, 0.1]]
 
     # nseg = 4
     # surf_rate_specified = False

--- a/autotest/test_gwf_evt02.py
+++ b/autotest/test_gwf_evt02.py
@@ -34,9 +34,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)

--- a/autotest/test_gwf_henry_nr.py
+++ b/autotest/test_gwf_henry_nr.py
@@ -94,9 +94,7 @@ def build_models(idx, test):
     sim.name_file.continue_ = False
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     imsgwf = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_gwf_ifmod_buy.py
+++ b/autotest/test_gwf_ifmod_buy.py
@@ -74,13 +74,9 @@ h_right = -2.0
 h_start = -2.0
 
 # head boundaries
-left_chd = [
-    [(ilay, irow, 0), h_left] for irow in range(nrow) for ilay in range(nlay)
-]
+left_chd = [[(ilay, irow, 0), h_left] for irow in range(nrow) for ilay in range(nlay)]
 right_chd = [
-    [(ilay, irow, ncol - 1), h_right]
-    for irow in range(nrow)
-    for ilay in range(nlay)
+    [(ilay, irow, ncol - 1), h_right] for irow in range(nrow) for ilay in range(nlay)
 ]
 right_chd_split = [
     [(ilay, irow, ncol_right - 1), h_right]
@@ -116,9 +112,7 @@ def get_model(idx, dir):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=dir
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -384,9 +378,7 @@ def add_gwtrefmodel(sim):
         gwt,
         budget_filerecord=f"{mname_gwtref}.cbc",
         concentration_filerecord=f"{mname_gwtref}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -430,9 +422,7 @@ def add_gwtleftmodel(sim):
         gwt,
         budget_filerecord=f"{mname_gwtleft}.cbc",
         concentration_filerecord=f"{mname_gwtleft}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -478,9 +468,7 @@ def add_gwtrightmodel(sim):
         gwt,
         budget_filerecord=f"{mname_gwtright}.cbc",
         concentration_filerecord=f"{mname_gwtright}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )

--- a/autotest/test_gwf_ifmod_idomain.py
+++ b/autotest/test_gwf_ifmod_idomain.py
@@ -120,9 +120,7 @@ def get_model(idx, dir):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=dir
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_gwf_ifmod_mult_exg.py
+++ b/autotest/test_gwf_ifmod_mult_exg.py
@@ -87,9 +87,7 @@ def get_model(idx, dir):
         memory_print_option="all",
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -106,9 +104,7 @@ def get_model(idx, dir):
 
     # boundary data
     left_chd = [
-        [(ilay, irow, 0), h_left]
-        for irow in range(nrow)
-        for ilay in range(nlay)
+        [(ilay, irow, 0), h_left] for irow in range(nrow) for ilay in range(nlay)
     ]
     right_chd = [
         [(ilay, irow, ncol - 1), h_right]
@@ -214,12 +210,8 @@ def get_model(idx, dir):
     )
 
     exgdata = lgr.get_exchange_data(angldegx=True, cdist=True)
-    exgdata_north = [
-        e for e in exgdata if (e[0])[1] < 3
-    ]  # northern three rows
-    exgdata_south = [
-        e for e in exgdata if (e[0])[1] > 2
-    ]  # southern three rows
+    exgdata_north = [e for e in exgdata if (e[0])[1] < 3]  # northern three rows
+    exgdata_south = [e for e in exgdata if (e[0])[1] > 2]  # southern three rows
 
     # north, has XT3D
     flopy.mf6.ModflowGwfgwf(

--- a/autotest/test_gwf_ifmod_newton.py
+++ b/autotest/test_gwf_ifmod_newton.py
@@ -127,9 +127,7 @@ def get_model(idx, ws):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_gwf_ifmod_rewet.py
+++ b/autotest/test_gwf_ifmod_rewet.py
@@ -133,9 +133,7 @@ def get_model(idx, dir):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=dir
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_gwf_ifmod_vert.py
+++ b/autotest/test_gwf_ifmod_vert.py
@@ -90,9 +90,7 @@ def get_model(idx, dir):
 
     # boundary stress period data
     left_chd = [
-        [(ilay, irow, 0), h_left]
-        for ilay in range(nlay)
-        for irow in range(nrow)
+        [(ilay, irow, 0), h_left] for ilay in range(nlay) for irow in range(nrow)
     ]
     right_chd = [
         [(ilay, irow, ncol - 1), h_right]
@@ -112,9 +110,7 @@ def get_model(idx, dir):
         memory_print_option="ALL",
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -250,12 +246,8 @@ def check_output(idx, test):
 
     # (note that without XT3D on the exchange, the 'error'
     # is of order 1e-3!!)
-    deviations = np.array(
-        [np.std(heads_c[0, :, icol]) for icol in range(grb_c.ncol)]
-    )
-    assert np.any(
-        deviations < 1e-12
-    ), "head values deviate too much from theory"
+    deviations = np.array([np.std(heads_c[0, :, icol]) for icol in range(grb_c.ncol)])
+    assert np.any(deviations < 1e-12), "head values deviate too much from theory"
 
     # check flowja residual
     for mname in [parent_name, child_name]:

--- a/autotest/test_gwf_ifmod_xt3d01.py
+++ b/autotest/test_gwf_ifmod_xt3d01.py
@@ -98,9 +98,7 @@ def get_model(idx, dir):
 
     # boundary stress period data
     left_chd = [
-        [(ilay, irow, 0), h_left]
-        for ilay in range(nlay)
-        for irow in range(nrow)
+        [(ilay, irow, 0), h_left] for ilay in range(nlay) for irow in range(nrow)
     ]
     right_chd = [
         [(ilay, irow, ncol - 1), h_right]
@@ -120,9 +118,7 @@ def get_model(idx, dir):
         memory_print_option="ALL",
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_gwf_ifmod_xt3d02.py
+++ b/autotest/test_gwf_ifmod_xt3d02.py
@@ -101,9 +101,7 @@ def get_model(idx, dir):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=dir
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_gwf_ifmod_xt3d03.py
+++ b/autotest/test_gwf_ifmod_xt3d03.py
@@ -99,9 +99,7 @@ def get_model(idx, dir):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=dir
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -279,9 +277,7 @@ def create_gwf_model(sim, mname, dis_params):
         right_chd = []
     elif mname == "tr" or mname == "br":
         left_chd = []
-        right_chd = [
-            [(0, irow, ncol_split - 1), h_right] for irow in range(nrow_split)
-        ]
+        right_chd = [[(0, irow, ncol_split - 1), h_right] for irow in range(nrow_split)]
     chd_data = left_chd + right_chd
     chd_spd = {0: chd_data}
     chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd_spd)

--- a/autotest/test_gwf_ims_rcm_reorder.py
+++ b/autotest/test_gwf_ims_rcm_reorder.py
@@ -88,9 +88,7 @@ def build_model(idx, ws):
     # chd data
     spd = [[(0, i, 0), chd_left] for i in range(nrow)]
     spd += [[(0, i, ncol - 1), chd_right] for i in range(nrow)]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # output control
     hdspth = f"{name}.hds"

--- a/autotest/test_gwf_lak_bedleak.py
+++ b/autotest/test_gwf_lak_bedleak.py
@@ -81,9 +81,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=True, icelltype=1, k=1.0, k33=0.01
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=1, k=1.0, k33=0.01)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,

--- a/autotest/test_gwf_lak_status.py
+++ b/autotest/test_gwf_lak_status.py
@@ -104,9 +104,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=True, icelltype=1, k=1.0, k33=0.01
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=1, k=1.0, k33=0.01)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -284,9 +282,7 @@ def check_lake_obs(idx, test):
     obs = np.genfromtxt(fpth, names=True, delimiter=",")
     stage = obs["LAKESTAGE"].tolist()
     print(stage)
-    assert (
-        stage[0] == stage[2]
-    ), "Period 1 and period 3 stages should be equal."
+    assert stage[0] == stage[2], "Period 1 and period 3 stages should be equal."
     assert stage[1] == dnodata, "Period 2 stage should equal dnodata"
 
 

--- a/autotest/test_gwf_lak_wetlakbedarea01.py
+++ b/autotest/test_gwf_lak_wetlakbedarea01.py
@@ -247,9 +247,7 @@ def build_models(idx, test):
     # Instantiate LAK package
     lak_conn = []
     if use_embedded_lak:
-        lak_conn.append(
-            [0, 0, (0, 0, 1), "embeddedv", lak_bedleak, 0.0, 0.0, 1.0, 0.0]
-        )
+        lak_conn.append([0, 0, (0, 0, 1), "embeddedv", lak_bedleak, 0.0, 0.0, 1.0, 0.0])
     else:
         lak_conn.append(
             [
@@ -264,9 +262,7 @@ def build_models(idx, test):
                 10.0,
             ]
         )
-        lak_conn.append(
-            [0, 1, (1, 0, 1), "vertical", lak_bedleak, 0.0, 0.0, 0.0, 0.0]
-        )
+        lak_conn.append([0, 1, (1, 0, 1), "vertical", lak_bedleak, 0.0, 0.0, 0.0, 0.0])
 
     lak_packagedata = [0, lak_strt, len(lak_conn)]
     budpth = f"{gwfname}.lak.cbc"
@@ -354,9 +350,7 @@ def check_output(idx, test):
     gwfname = "gwf-" + name
 
     # read flow results from model
-    sim1 = flopy.mf6.MFSimulation.load(
-        sim_ws=test.workspace, load_only=["dis"]
-    )
+    sim1 = flopy.mf6.MFSimulation.load(sim_ws=test.workspace, load_only=["dis"])
     gwf = sim1.get_model(gwfname)
 
     # get final lake stage

--- a/autotest/test_gwf_lak_wetlakbedarea02.py
+++ b/autotest/test_gwf_lak_wetlakbedarea02.py
@@ -337,9 +337,7 @@ def check_output(idx, test):
     gwfname = "gwf-" + name
 
     # read flow results from model
-    sim1 = flopy.mf6.MFSimulation.load(
-        sim_ws=test.workspace, load_only=["dis"]
-    )
+    sim1 = flopy.mf6.MFSimulation.load(sim_ws=test.workspace, load_only=["dis"])
     gwf = sim1.get_model(gwfname)
 
     # get final lake stage

--- a/autotest/test_gwf_lakobs01.py
+++ b/autotest/test_gwf_lakobs01.py
@@ -61,9 +61,7 @@ def build_model(dir, exe):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = name
@@ -221,9 +219,7 @@ def test_mf6model(function_tmpdir, targets):
             expected_msg = True
             error_count += 1
 
-    assert error_count == 1, (
-        "error count = " + str(error_count) + "but should equal 1"
-    )
+    assert error_count == 1, "error count = " + str(error_count) + "but should equal 1"
 
     # fix the error and attempt to rerun model
     orig_fl = str(function_tmpdir / (cases + ".lak.obs"))

--- a/autotest/test_gwf_lakobs02.py
+++ b/autotest/test_gwf_lakobs02.py
@@ -48,9 +48,7 @@ def build_models(idx, test):
     )
 
     # create gwf model
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=name
-    )  # , newtonoptions="newton")
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=name)  # , newtonoptions="newton")
 
     imsgwf = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_gwf_libmf6_evt01.py
+++ b/autotest/test_gwf_libmf6_evt01.py
@@ -57,9 +57,7 @@ def get_model(ws, name, bmi=False):
         memory_print_option="all",
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
@@ -109,9 +107,7 @@ def get_model(ws, name, bmi=False):
 
     # evapotranspiration
     if not bmi:
-        evt = flopy.mf6.ModflowGwfevta(
-            gwf, surface=top, rate=et_max, depth=et_depth
-        )
+        evt = flopy.mf6.ModflowGwfevta(gwf, surface=top, rate=et_max, depth=et_depth)
     wel = flopy.mf6.ModflowGwfwel(gwf, stress_period_data=[[(0, 0, 0), 0.0]])
 
     # output control
@@ -220,11 +216,7 @@ def api_func(exe, idx, model_ws=None):
             kiter += 1
 
             if has_converged:
-                msg = (
-                    f"Component {1}"
-                    + f" converged in {kiter}"
-                    + " outer iterations"
-                )
+                msg = f"Component {1}" + f" converged in {kiter}" + " outer iterations"
                 print(msg)
                 break
 

--- a/autotest/test_gwf_libmf6_ghb01.py
+++ b/autotest/test_gwf_libmf6_ghb01.py
@@ -83,9 +83,7 @@ def get_model(ws, name, api=False):
         memory_print_option="all",
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(

--- a/autotest/test_gwf_libmf6_ifmod01.py
+++ b/autotest/test_gwf_libmf6_ifmod01.py
@@ -69,9 +69,7 @@ def get_model(dir, name):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=dir
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -88,9 +86,7 @@ def get_model(dir, name):
 
     # submodel on the left:
     left_chd = [
-        [(ilay, irow, 0), h_left]
-        for irow in range(nrow)
-        for ilay in range(nlay)
+        [(ilay, irow, 0), h_left] for irow in range(nrow) for ilay in range(nlay)
     ]
     chd_spd_left = {0: left_chd}
 
@@ -257,9 +253,7 @@ def check_interface_models(mf6):
     # XT3D flag should be set to 1
     mem_addr = mf6.get_var_address("IXT3D", ifm_name_left, "NPF")
     ixt3d = mf6.get_value_ptr(mem_addr)[0]
-    assert (
-        ixt3d == 1
-    ), f"Interface model for {name_left} should have XT3D enabled"
+    assert ixt3d == 1, f"Interface model for {name_left} should have XT3D enabled"
 
     # check if n2 > n1, then cell 1 is below 2
     mem_addr = mf6.get_var_address("TOP", ifm_name_left, "DIS")

--- a/autotest/test_gwf_libmf6_ifmod02.py
+++ b/autotest/test_gwf_libmf6_ifmod02.py
@@ -95,9 +95,7 @@ def get_model(dir, name):
         memory_print_option="all",
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -114,9 +112,7 @@ def get_model(dir, name):
 
     # boundary for submodels on the left:
     left_chd = [
-        [(ilay, irow, 0), h_left]
-        for irow in range(nrow)
-        for ilay in range(nlay)
+        [(ilay, irow, 0), h_left] for irow in range(nrow) for ilay in range(nlay)
     ]
     chd_spd_left = {0: left_chd}
 
@@ -359,9 +355,7 @@ def check_interface_models(mf6):
     addr = mf6.get_var_address("IDXTOGLOBALIDX", gfc_topleft_1, "GC")
     idxToGlobalIdx_1 = mf6.get_value_ptr(addr)
     assert np.size(idxToGlobalIdx_1) == 12
-    assert np.array_equal(
-        idxToGlobalIdx_1, [3, 4, 5, 21, 22, 8, 9, 10, 26, 27, 14, 15]
-    )
+    assert np.array_equal(idxToGlobalIdx_1, [3, 4, 5, 21, 22, 8, 9, 10, 26, 27, 14, 15])
     addr = mf6.get_var_address("ia", gfc_topleft_1, "gc/con")
     ia_1 = mf6.get_value_ptr(addr)
     addr = mf6.get_var_address("ja", gfc_topleft_1, "gc/con")
@@ -398,9 +392,7 @@ def check_interface_models(mf6):
     addr = mf6.get_var_address("IDXTOGLOBALIDX", gfc_topleft_2, "GC")
     idxToGlobalIdx_2 = mf6.get_value_ptr(addr)
     assert np.size(idxToGlobalIdx_2) == 10
-    assert np.array_equal(
-        idxToGlobalIdx_2, [6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-    )
+    assert np.array_equal(idxToGlobalIdx_2, [6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 
 
 @requires_pkg("modflowapi")

--- a/autotest/test_gwf_libmf6_ifmod03.py
+++ b/autotest/test_gwf_libmf6_ifmod03.py
@@ -86,9 +86,7 @@ def get_model(dir, name):
         memory_print_option="all",
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_gwf_libmf6_rch01.py
+++ b/autotest/test_gwf_libmf6_rch01.py
@@ -78,9 +78,7 @@ def get_model(ws, name, rech):
         memory_print_option="all",
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
@@ -200,11 +198,7 @@ def api_func(exe, idx, model_ws=None):
             kiter += 1
 
             if has_converged:
-                msg = (
-                    f"Component {1}"
-                    + f" converged in {kiter}"
-                    + " outer iterations"
-                )
+                msg = f"Component {1}" + f" converged in {kiter}" + " outer iterations"
                 print(msg)
                 break
 

--- a/autotest/test_gwf_libmf6_rch02.py
+++ b/autotest/test_gwf_libmf6_rch02.py
@@ -76,9 +76,7 @@ def get_model(ws, name, exe, rech=rch_spd):
         memory_print_option="all",
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
@@ -241,9 +239,7 @@ def api_func(exe, idx, model_ws=None):
         est_iter = 0
         while est_iter < 100:
             # base simulation loop
-            has_converged = run_perturbation(
-                mf6, max_iter, new_recharge, rch_tag, rch
-            )
+            has_converged = run_perturbation(mf6, max_iter, new_recharge, rch_tag, rch)
             if not has_converged:
                 return False, open(output_file_path).readlines()
             h0 = head.reshape((nrow, ncol))[5, 5]
@@ -278,9 +274,7 @@ def api_func(exe, idx, model_ws=None):
                 rch += dr
 
         # solution with final estimated recharge for the timestep
-        has_converged = run_perturbation(
-            mf6, max_iter, new_recharge, rch_tag, rch
-        )
+        has_converged = run_perturbation(mf6, max_iter, new_recharge, rch_tag, rch)
         if not has_converged:
             return False, open(output_file_path).readlines()
 

--- a/autotest/test_gwf_libmf6_riv01.py
+++ b/autotest/test_gwf_libmf6_riv01.py
@@ -67,9 +67,7 @@ def get_model(ws, name, riv_spd):
         memory_print_option="all",
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
@@ -113,9 +111,7 @@ def get_model(ws, name, riv_spd):
     chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd_spd)
 
     # riv package
-    riv = flopy.mf6.ModflowGwfriv(
-        gwf, stress_period_data=riv_spd, pname=riv_packname
-    )
+    riv = flopy.mf6.ModflowGwfriv(gwf, stress_period_data=riv_spd, pname=riv_packname)
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(
@@ -134,14 +130,8 @@ def build_models(idx, test):
     name = cases[idx]
 
     # create river data
-    rd = [
-        [(0, 0, icol), riv_stage, riv_cond, riv_bot]
-        for icol in range(1, ncol - 1)
-    ]
-    rd2 = [
-        [(0, 0, icol), riv_stage2, riv_cond, riv_bot]
-        for icol in range(1, ncol - 1)
-    ]
+    rd = [[(0, 0, icol), riv_stage, riv_cond, riv_bot] for icol in range(1, ncol - 1)]
+    rd2 = [[(0, 0, icol), riv_stage2, riv_cond, riv_bot] for icol in range(1, ncol - 1)]
     sim = get_model(ws, name, riv_spd={0: rd, 5: rd2})
 
     # build comparison model with zeroed values
@@ -217,11 +207,7 @@ def api_func(exe, idx, model_ws=None):
             kiter += 1
 
             if has_converged:
-                msg = (
-                    f"Component {1}"
-                    + f" converged in {kiter}"
-                    + " outer iterations"
-                )
+                msg = f"Component {1}" + f" converged in {kiter}" + " outer iterations"
                 print(msg)
                 break
 

--- a/autotest/test_gwf_libmf6_riv02.py
+++ b/autotest/test_gwf_libmf6_riv02.py
@@ -67,9 +67,7 @@ def get_model(ws, name, riv_spd, api=False):
         memory_print_option="all",
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
@@ -137,14 +135,8 @@ def build_models(idx, test):
     name = cases[idx]
 
     # create river data
-    rd = [
-        [(0, 0, icol), riv_stage, riv_cond, riv_bot]
-        for icol in range(1, ncol - 1)
-    ]
-    rd2 = [
-        [(0, 0, icol), riv_stage2, riv_cond, riv_bot]
-        for icol in range(1, ncol - 1)
-    ]
+    rd = [[(0, 0, icol), riv_stage, riv_cond, riv_bot] for icol in range(1, ncol - 1)]
+    rd2 = [[(0, 0, icol), riv_stage2, riv_cond, riv_bot] for icol in range(1, ncol - 1)]
     sim = get_model(ws, name, riv_spd={0: rd, 5: rd2})
 
     # build comparison model with zeroed values

--- a/autotest/test_gwf_libmf6_sto01.py
+++ b/autotest/test_gwf_libmf6_sto01.py
@@ -77,9 +77,7 @@ def get_model(ws, name, sy):
         memory_print_option="all",
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(

--- a/autotest/test_gwf_maw01.py
+++ b/autotest/test_gwf_maw01.py
@@ -46,9 +46,7 @@ def build_model(idx, ws, mf6):
 
     # create tdis package
     tdis_rc = [(perlen[i], nstp[i], tsmult[i]) for i in range(nper)]
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.MFModel(

--- a/autotest/test_gwf_maw02.py
+++ b/autotest/test_gwf_maw02.py
@@ -59,15 +59,11 @@ compare = False
 
 def build_model(idx, ws, mf6):
     name = cases[idx]
-    sim = flopy.mf6.MFSimulation(
-        sim_name=name, version="mf6", exe_name=mf6, sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=name, version="mf6", exe_name=mf6, sim_ws=ws)
 
     # create tdis package
     tdis_rc = [(perlen[i], nstp[i], tsmult[i]) for i in range(nper)]
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.MFModel(
@@ -274,9 +270,7 @@ def eval_results(name, workspace):
         f.write(line + "\n")
     f.close()
 
-    assert diffmax < budtol, (
-        msg + f"diffmax {diffmax} exceeds tolerance {budtol}"
-    )
+    assert diffmax < budtol, msg + f"diffmax {diffmax} exceeds tolerance {budtol}"
     assert diffv < budtol, msg + f"diffv {diffv} exceeds tolerance {budtol}"
 
 

--- a/autotest/test_gwf_maw03.py
+++ b/autotest/test_gwf_maw03.py
@@ -64,9 +64,7 @@ def build_model(idx, ws, mf6):
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=ws, exe_name=mf6)
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.MFModel(
@@ -151,9 +149,7 @@ def build_model(idx, ws, mf6):
         gwf,
         budget_filerecord=f"{name}.cbc",
         head_filerecord=f"{name}.hds",
-        headprintrecord=[
-            ("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        headprintrecord=[("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("HEAD", "ALL")],
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         filename=f"{name}.oc",
@@ -188,10 +184,7 @@ def eval_results(name, workspace):
     elif test_name.endswith("b"):
         # M1RATE should have a minimum value less than 200 and
         # M1HEAD should not exceed 0.400001
-        msg = (
-            "Injection rate should fall below 200 and the head should not"
-            "exceed 0.4"
-        )
+        msg = "Injection rate should fall below 200 and the head should notexceed 0.4"
         assert tc["M1RATE"].min() < 200.0, msg
         assert tc["M1HEAD"].max() < 0.400001, msg
 

--- a/autotest/test_gwf_maw04.py
+++ b/autotest/test_gwf_maw04.py
@@ -122,16 +122,12 @@ def build_model(idx, ws, mf6):
     name = ex[idx]
     well = wells[idx]
     # build MODFLOW 6 files
-    sim = flopy.mf6.MFSimulation(
-        sim_name=name, version="mf6", exe_name=mf6, sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=name, version="mf6", exe_name=mf6, sim_ws=ws)
     # create tdis package
     tdis_rc = []
     for kper in range(nper):
         tdis_rc.append((perlen[kper], nstp[kper], tsmult[kper]))
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution
     ims = flopy.mf6.ModflowIms(
@@ -159,9 +155,7 @@ def build_model(idx, ws, mf6):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=confined, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=confined, k=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -172,9 +166,7 @@ def build_model(idx, ws, mf6):
         transient={1: True},
     )
     # constant head
-    chd = flopy.mf6.ModflowGwfchd(
-        gwf, stress_period_data=chd_spd, save_flows=False
-    )
+    chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd_spd, save_flows=False)
     # multi-aquifer well
     maw = flopy.mf6.ModflowGwfmaw(
         gwf,

--- a/autotest/test_gwf_maw05.py
+++ b/autotest/test_gwf_maw05.py
@@ -51,17 +51,13 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
 
     newtonoptions = "NEWTON UNDER_RELAXATION"
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=gwfname, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, newtonoptions=newtonoptions)
 
     imsgwf = flopy.mf6.ModflowIms(
         sim,
@@ -114,13 +110,10 @@ def build_models(idx, test):
     mawcondeqn = "THIEM"
     mawngwfnodes = nlay
     # <ifno> <radius> <bottom> <strt> <condeqn> <ngwfnodes>
-    mawpackagedata = [
-        [0, mawradius, mawbottom, mstrt, mawcondeqn, mawngwfnodes]
-    ]
+    mawpackagedata = [[0, mawradius, mawbottom, mstrt, mawcondeqn, mawngwfnodes]]
     # <ifno> <icon> <cellid(ncelldim)> <scrn_top> <scrn_bot> <hk_skin> <radius_skin>
     mawconnectiondata = [
-        [0, icon, (icon, 0, 0), top, mawbottom, -999.0, -999.0]
-        for icon in range(nlay)
+        [0, icon, (icon, 0, 0), top, mawbottom, -999.0, -999.0] for icon in range(nlay)
     ]
     # <ifno> <mawsetting>
     mawperioddata = [[0, "STATUS", "ACTIVE"]]
@@ -143,9 +136,7 @@ def build_models(idx, test):
             ("whead", "head", (0,)),
         ]
     }
-    maw.obs.initialize(
-        filename=opth, digits=20, print_input=True, continuous=obsdata
-    )
+    maw.obs.initialize(filename=opth, digits=20, print_input=True, continuous=obsdata)
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(

--- a/autotest/test_gwf_maw06.py
+++ b/autotest/test_gwf_maw06.py
@@ -73,17 +73,13 @@ def build_models(idx, test):
         memory_print_option="summary",
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
 
     newtonoptions = "NEWTON UNDER_RELAXATION"
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=gwfname, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, newtonoptions=newtonoptions)
 
     imsgwf = flopy.mf6.ModflowIms(
         sim,
@@ -136,8 +132,7 @@ def build_models(idx, test):
     mawpackagedata = [[0, mawradius, bot, mstrt, mawcondeqn, mawngwfnodes]]
     # <ifno> <icon> <cellid(ncelldim)> <scrn_top> <scrn_bot> <hk_skin> <radius_skin>
     mawconnectiondata = [
-        [0, icon, (icon, 0, 0), top, bot, mawcond, -999]
-        for icon in range(nlay)
+        [0, icon, (icon, 0, 0), top, bot, mawcond, -999] for icon in range(nlay)
     ]
     # <ifno> <mawsetting>
     mawperioddata = [[0, "STATUS", "ACTIVE"]]
@@ -163,9 +158,7 @@ def build_models(idx, test):
             ("whead", "head", (0,)),
         ]
     }
-    maw.obs.initialize(
-        filename=opth, digits=20, print_input=True, continuous=obsdata
-    )
+    maw.obs.initialize(filename=opth, digits=20, print_input=True, continuous=obsdata)
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(

--- a/autotest/test_gwf_maw07.py
+++ b/autotest/test_gwf_maw07.py
@@ -73,17 +73,13 @@ def build_models(idx, test):
         memory_print_option="summary",
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
 
     newtonoptions = "NEWTON UNDER_RELAXATION"
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=gwfname, newtonoptions=newtonoptions
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, newtonoptions=newtonoptions)
 
     imsgwf = flopy.mf6.ModflowIms(
         sim,
@@ -136,8 +132,7 @@ def build_models(idx, test):
     mawpackagedata = [[0, mawradius, bot, mstrt, mawcondeqn, mawngwfnodes]]
     # <ifno> <icon> <cellid(ncelldim)> <scrn_top> <scrn_bot> <hk_skin> <radius_skin>
     mawconnectiondata = [
-        [0, icon, (icon, 0, 0), top, bot, mawcond, -999]
-        for icon in range(nlay)
+        [0, icon, (icon, 0, 0), top, bot, mawcond, -999] for icon in range(nlay)
     ]
     # <ifno> <mawsetting>
     mawperioddata = {}
@@ -165,9 +160,7 @@ def build_models(idx, test):
             ("whead", "head", (0,)),
         ]
     }
-    maw.obs.initialize(
-        filename=opth, digits=20, print_input=True, continuous=obsdata
-    )
+    maw.obs.initialize(filename=opth, digits=20, print_input=True, continuous=obsdata)
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(
@@ -276,9 +269,7 @@ def check_output(idx, test):
             qmaw = ra_maw[i]["q"]
             qgwf = ra_gwf[i]["q"]
             if istp == 0:
-                assert np.allclose(
-                    qmaw, 0.0
-                ), "inactive well, flow should be 0."
+                assert np.allclose(qmaw, 0.0), "inactive well, flow should be 0."
             msg = f"step {istp} record {i} comparing qmaw with qgwf: {qmaw} {qgwf}"
             print(msg)
             assert np.allclose(qmaw, -qgwf), msg

--- a/autotest/test_gwf_maw08.py
+++ b/autotest/test_gwf_maw08.py
@@ -131,9 +131,7 @@ def build_models(idx, test):
     mawpackagedata["ngwfnodes"] = 2
 
     # <ifno> <icon> <cellid(ncelldim)> <scrn_top> <scrn_bot> <hk_skin> <radius_skin>
-    mawconnectiondata = flopy.mf6.ModflowGwfmaw.connectiondata.empty(
-        gwf, maxbound=2
-    )
+    mawconnectiondata = flopy.mf6.ModflowGwfmaw.connectiondata.empty(gwf, maxbound=2)
     mawconnectiondata["icon"] = [0, 1]
     mawconnectiondata["cellid"] = cellids
     mawconnectiondata["scrn_top"] = 100.0
@@ -160,9 +158,7 @@ def build_models(idx, test):
             ("whead", "head", (0,)),
         ]
     }
-    maw.obs.initialize(
-        filename=opth, digits=20, print_input=True, continuous=obsdata
-    )
+    maw.obs.initialize(filename=opth, digits=20, print_input=True, continuous=obsdata)
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(

--- a/autotest/test_gwf_maw09.py
+++ b/autotest/test_gwf_maw09.py
@@ -60,9 +60,7 @@ def build_models(idx, test):
         memory_print_option="summary",
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", perioddata=[(20.0, 50, 1.1)]
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", perioddata=[(20.0, 50, 1.1)])
 
     imsgwf = flopy.mf6.ModflowIms(
         sim,
@@ -143,9 +141,7 @@ def build_models(idx, test):
     )
 
     # storage
-    sto = flopy.mf6.ModflowGwfsto(
-        gwf, ss=0.0, sy=1.0, transient=True, iconvert=1
-    )
+    sto = flopy.mf6.ModflowGwfsto(gwf, ss=0.0, sy=1.0, transient=True, iconvert=1)
 
     # <ifno> <radius> <bottom> <strt> <condeqn> <ngwfnodes>
     mawpackagedata = flopy.mf6.ModflowGwfmaw.packagedata.empty(gwf, maxbound=1)
@@ -156,9 +152,7 @@ def build_models(idx, test):
     mawpackagedata["ngwfnodes"] = 2
 
     # <ifno> <icon> <cellid(ncelldim)> <scrn_top> <scrn_bot> <hk_skin> <radius_skin>
-    mawconnectiondata = flopy.mf6.ModflowGwfmaw.connectiondata.empty(
-        gwf, maxbound=2
-    )
+    mawconnectiondata = flopy.mf6.ModflowGwfmaw.connectiondata.empty(gwf, maxbound=2)
     mawconnectiondata["icon"] = [0, 1]
     mawconnectiondata["cellid"] = cellids
     mawconnectiondata["scrn_top"] = 100.0
@@ -186,9 +180,7 @@ def build_models(idx, test):
             ("whead", "head", (0,)),
         ]
     }
-    maw.obs.initialize(
-        filename=opth, digits=20, print_input=True, continuous=obsdata
-    )
+    maw.obs.initialize(filename=opth, digits=20, print_input=True, continuous=obsdata)
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(

--- a/autotest/test_gwf_maw10.py
+++ b/autotest/test_gwf_maw10.py
@@ -85,9 +85,7 @@ def build_models(idx, test):
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=ws)
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.MFModel(
@@ -182,9 +180,7 @@ def build_models(idx, test):
         gwf,
         budget_filerecord=f"{name}.cbc",
         head_filerecord=f"{name}.hds",
-        headprintrecord=[
-            ("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        headprintrecord=[("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("HEAD", "ALL")],
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         filename=f"{name}.oc",
@@ -219,9 +215,7 @@ def check_output(idx, test):
     except:
         assert False, f'could not load data from "{fpthobs}"'
     try:
-        tcmfr = np.genfromtxt(
-            fpthmfr, names=True, delimiter=",", deletechars=""
-        )
+        tcmfr = np.genfromtxt(fpthmfr, names=True, delimiter=",", deletechars="")
     except:
         assert False, f'could not load data from "{fpthmfr}"'
 

--- a/autotest/test_gwf_maw_obs.py
+++ b/autotest/test_gwf_maw_obs.py
@@ -39,13 +39,9 @@ def build_model(dir, exe):
 
     # build MODFLOW 6 files
     ws = dir
-    sim = flopy.mf6.MFSimulation(
-        sim_name=name, version="mf6", exe_name=exe, sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=name, version="mf6", exe_name=exe, sim_ws=ws)
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.MFModel(

--- a/autotest/test_gwf_mf6io_app2_examples_distypes.py
+++ b/autotest/test_gwf_mf6io_app2_examples_distypes.py
@@ -44,9 +44,7 @@ vk = [10.0, 0.01, 20.0]
 concentration = 1.0
 
 canal_head = 330.0
-canal_coordinates = [
-    (0.5 * delr, y1_base - delc * (i + 0.5)) for i in range(nrow)
-]
+canal_coordinates = [(0.5 * delr, y1_base - delc * (i + 0.5)) for i in range(nrow)]
 
 river_head = 320.0
 river_coordinates = [

--- a/autotest/test_gwf_multimvr.py
+++ b/autotest/test_gwf_multimvr.py
@@ -484,9 +484,7 @@ def get_parent_mvr_info(frac):
     # return the appropriate mvr info for the current scenario
     mvrperioddata = [("WEL-1", 0, "SFR-parent", 10, "FACTOR", 1.0)]
     if frac is not None:
-        mvrperioddata.append(
-            ("SFR-parent", 15, "SFR-parent", 16, "FACTOR", frac)
-        )
+        mvrperioddata.append(("SFR-parent", 15, "SFR-parent", 16, "FACTOR", frac))
 
     mvrspd = {0: mvrperioddata}
 
@@ -578,9 +576,7 @@ def instantiate_base_simulation(sim_ws, gwfname, gwfnamec):
     for i in range(len(perlen)):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # Instantiate the gwf model (parent model)
     gwf = flopy.mf6.ModflowGwf(
@@ -997,9 +993,7 @@ def build_models(idx, test):
 
 
 def check_output(idx, test):
-    gwf_srch_str1 = (
-        " SFR-PARENT PACKAGE - SUMMARY OF FLOWS FOR EACH CONTROL VOLUME"
-    )
+    gwf_srch_str1 = " SFR-PARENT PACKAGE - SUMMARY OF FLOWS FOR EACH CONTROL VOLUME"
     gwf_srch_str2 = " WATER MOVER PACKAGE (MVR) FLOW RATES   "
     sim_srch_str = " WATER MOVER PACKAGE (MVR) FLOW RATES "
 
@@ -1086,9 +1080,7 @@ def check_output(idx, test):
         gwf_transferred_50 = parent_sfr_mvr_amount / (
             parent_sfr_mvr_amount + sim_mvr_amount
         )
-        sim_transferred_50 = sim_mvr_amount / (
-            parent_sfr_mvr_amount + sim_mvr_amount
-        )
+        sim_transferred_50 = sim_mvr_amount / (parent_sfr_mvr_amount + sim_mvr_amount)
         assert np.allclose(
             np.array([gwf_transferred_50, sim_transferred_50]),
             np.array([0.5, 0.5]),
@@ -1103,9 +1095,7 @@ def check_output(idx, test):
         gwf_transferred_75 = parent_sfr_mvr_amount / (
             parent_sfr_mvr_amount + sim_mvr_amount
         )
-        sim_transferred_75 = sim_mvr_amount / (
-            parent_sfr_mvr_amount + sim_mvr_amount
-        )
+        sim_transferred_75 = sim_mvr_amount / (parent_sfr_mvr_amount + sim_mvr_amount)
         assert np.allclose(
             np.array([gwf_transferred_75, sim_transferred_75]),
             np.array([0.75, 0.25]),

--- a/autotest/test_gwf_mvr01.py
+++ b/autotest/test_gwf_mvr01.py
@@ -38,9 +38,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -95,9 +93,7 @@ def build_models(idx, test):
         [(0, 0, 0), 1.0],
         [(0, nrow - 1, ncol - 1), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # drn file
     drn6 = [

--- a/autotest/test_gwf_newton01.py
+++ b/autotest/test_gwf_newton01.py
@@ -37,9 +37,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
     )
     # create tdis package
-    flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     flopy.mf6.ModflowIms(
@@ -73,9 +71,7 @@ def build_models(idx, test):
     flopy.mf6.ModflowGwfnpf(gwf, icelltype=1, k=hk)
 
     # gwf observation
-    flopy.mf6.ModflowUtlobs(
-        gwf, digits=10, print_input=True, continuous=obs_recarray
-    )
+    flopy.mf6.ModflowUtlobs(gwf, digits=10, print_input=True, continuous=obs_recarray)
 
     # chd files
     flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=cd6)

--- a/autotest/test_gwf_newton_under_relaxation.py
+++ b/autotest/test_gwf_newton_under_relaxation.py
@@ -107,15 +107,11 @@ def check_output(idx, test):
     mf6sim = flopy.mf6.MFSimulation.load(sim_ws=test.workspace)
     if idx == 1:
         mfsplit = flopy.mf6.utils.Mf6Splitter(mf6sim)
-        mfsplit.load_node_mapping(
-            mf6sim, pl.Path(f"{test.workspace}/mapping.json")
-        )
+        mfsplit.load_node_mapping(mf6sim, pl.Path(f"{test.workspace}/mapping.json"))
         head_dict = {}
         for modelname in mf6sim.model_names:
             mnum = int(modelname.split("_")[-1])
-            head_dict[mnum] = (
-                mf6sim.get_model(modelname).output.head().get_data()
-            )
+            head_dict[mnum] = mf6sim.get_model(modelname).output.head().get_data()
         heads = mfsplit.reconstruct_array(head_dict)
     else:
         heads = mf6sim.get_model().output.head().get_data()

--- a/autotest/test_gwf_noptc01.py
+++ b/autotest/test_gwf_noptc01.py
@@ -56,9 +56,7 @@ def get_model(idx, dir, no_ptcrecord):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(

--- a/autotest/test_gwf_npf01_75x75.py
+++ b/autotest/test_gwf_npf01_75x75.py
@@ -63,9 +63,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.MFModel(

--- a/autotest/test_gwf_npf02_rewet.py
+++ b/autotest/test_gwf_npf02_rewet.py
@@ -84,9 +84,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
     # set ims csv files
     csv0 = f"{name}.outer.ims.csv"
     csv1 = f"{name}.inner.ims.csv"
@@ -140,9 +138,7 @@ def build_models(idx, test):
     for jdx in range(nmodels):
         mname = mnames[jdx]
 
-        gwf = flopy.mf6.ModflowGwf(
-            sim, modelname=mname, model_nam_file=f"{mname}.nam"
-        )
+        gwf = flopy.mf6.ModflowGwf(sim, modelname=mname, model_nam_file=f"{mname}.nam")
 
         dis = flopy.mf6.ModflowGwfdis(
             gwf,
@@ -196,9 +192,7 @@ def build_models(idx, test):
             gwf,
             budget_filerecord=f"{mname}.cbc",
             head_filerecord=f"{mname}.hds",
-            headprintrecord=[
-                ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-            ],
+            headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
             saverecord=[("HEAD", "LAST")],
             printrecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
         )

--- a/autotest/test_gwf_npf03_sfr.py
+++ b/autotest/test_gwf_npf03_sfr.py
@@ -81,9 +81,7 @@ def build_models(idx, test):
         sim_ws=ws,
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # set ims csv files
     csv0 = f"{name}.outer.ims.csv"
@@ -180,9 +178,7 @@ def build_models(idx, test):
         i1 = i0 + ncolst[jdx]
         hkt = hk[:, i0:i1]
 
-        gwf = flopy.mf6.ModflowGwf(
-            sim, modelname=mname, model_nam_file=f"{mname}.nam"
-        )
+        gwf = flopy.mf6.ModflowGwf(sim, modelname=mname, model_nam_file=f"{mname}.nam")
 
         dis = flopy.mf6.ModflowGwfdis(
             gwf,
@@ -200,9 +196,7 @@ def build_models(idx, test):
         ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{mname}.ic")
 
         # node property flow
-        npf = flopy.mf6.ModflowGwfnpf(
-            gwf, save_flows=False, icelltype=0, k=hkt
-        )
+        npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=0, k=hkt)
 
         # chd files
         if jdx == 0:
@@ -288,9 +282,7 @@ def build_models(idx, test):
         # maw files
         if jdx == nmodels - 1:
             mpd = [[0, 0.25, bot, strt, "THIEM", 1, "MYWELL"]]
-            mcd = [
-                [0, 0, (0, 15, int(ncolst[jdx]) - 31), top, bot, 999.0, 999.0]
-            ]
+            mcd = [[0, 0, (0, 15, int(ncolst[jdx]) - 31), top, bot, 999.0, 999.0]]
             perioddata = [[0, "RATE", -1e-5]]
             maw = flopy.mf6.ModflowGwfmaw(
                 gwf,
@@ -325,9 +317,7 @@ def build_models(idx, test):
             gwf,
             budget_filerecord=f"{mname}.cbc",
             head_filerecord=f"{mname}.hds",
-            headprintrecord=[
-                ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-            ],
+            headprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
             saverecord=[("HEAD", "LAST")],
             printrecord=[("HEAD", "LAST"), ("BUDGET", "LAST")],
         )

--- a/autotest/test_gwf_npf04_spdis.py
+++ b/autotest/test_gwf_npf04_spdis.py
@@ -51,9 +51,7 @@ def build_models(idx, test):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, nper=2, perioddata=[(1.0, 1, 1.0), (1.0, 1, 1.0)]
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, nper=2, perioddata=[(1.0, 1, 1.0), (1.0, 1, 1.0)])
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=namea, save_flows=True)

--- a/autotest/test_gwf_npf05_anisotropy.py
+++ b/autotest/test_gwf_npf05_anisotropy.py
@@ -39,9 +39,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)

--- a/autotest/test_gwf_npf_thickstrt.py
+++ b/autotest/test_gwf_npf_thickstrt.py
@@ -51,9 +51,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.MFModel(
@@ -184,9 +182,7 @@ def check_output(idx, test):
     }
 
     hres = answer_dict[idx]
-    assert np.allclose(
-        hres, head
-    ), "simulated head do not match with known solution."
+    assert np.allclose(hres, head), "simulated head do not match with known solution."
 
     fpth = os.path.join(test.workspace, f"{name}.cbc")
     cobj = flopy.utils.CellBudgetFile(fpth, precision="double")

--- a/autotest/test_gwf_npf_tvk01.py
+++ b/autotest/test_gwf_npf_tvk01.py
@@ -38,9 +38,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name

--- a/autotest/test_gwf_npf_tvk02.py
+++ b/autotest/test_gwf_npf_tvk02.py
@@ -39,9 +39,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -170,9 +168,7 @@ def check_output(idx, test):
 
     # Check against manually calculated results
     expected_results = []
-    expected_results.append(
-        0.5
-    )  # TVK SP1: No changes. Check initial solution.
+    expected_results.append(0.5)  # TVK SP1: No changes. Check initial solution.
     expected_results.append(0.4)  # TVK SP2: Increase K1.
     expected_results.append(0.75)  # TVK SP3: Decrease K1.
     expected_results.append(0.6)  # TVK SP4: Revert K1 and increase K3.

--- a/autotest/test_gwf_npf_tvk03.py
+++ b/autotest/test_gwf_npf_tvk03.py
@@ -39,9 +39,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -170,9 +168,7 @@ def check_output(idx, test):
 
     # Check against manually calculated results
     expected_results = []
-    expected_results.append(
-        0.5
-    )  # TVK SP1: No changes. Check initial solution.
+    expected_results.append(0.5)  # TVK SP1: No changes. Check initial solution.
     expected_results.append(0.4)  # TVK SP2: Increase K3.
     expected_results.append(0.75)  # TVK SP3: Decrease K3.
     expected_results.append(0.6)  # TVK SP4: Revert K3 and increase K1.

--- a/autotest/test_gwf_npf_tvk04.py
+++ b/autotest/test_gwf_npf_tvk04.py
@@ -39,9 +39,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -174,9 +172,7 @@ def check_output(idx, test):
 
     # comment when done testing
     print(f"Total outflow in stress period 1 is {str(sp_x[0][8])}")
-    print(
-        f"Total outflow in stress period 2 after increasing K33 is {str(sp_x[1][8])}"
-    )
+    print(f"Total outflow in stress period 2 after increasing K33 is {str(sp_x[1][8])}")
     errmsg = "Expect higher flow rate in period 2 compared to period 1, but found equal or higher flow rate in period 1"
     assert 2.0 * sp_x[0][8] < sp_x[1][8], errmsg
 

--- a/autotest/test_gwf_npf_tvk05.py
+++ b/autotest/test_gwf_npf_tvk05.py
@@ -39,9 +39,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name

--- a/autotest/test_gwf_obs01.py
+++ b/autotest/test_gwf_obs01.py
@@ -6,9 +6,7 @@ import pytest
 from framework import TestFramework
 
 cell_dimensions = (300,)
-cases = [
-    f"gwf_obs01{chr(ord('a') + idx)}" for idx in range(len(cell_dimensions))
-]
+cases = [f"gwf_obs01{chr(ord('a') + idx)}" for idx in range(len(cell_dimensions))]
 h0, h1 = 1.0, 0.0
 
 
@@ -71,9 +69,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     flopy.mf6.ModflowIms(
@@ -110,9 +106,7 @@ def build_models(idx, test):
         botm=botm,
         idomain=np.ones((nlay, nrow, ncol), dtype=int),
     )
-    flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=get_obs(idx)
-    )
+    flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=get_obs(idx))
 
     # initial conditions
     flopy.mf6.ModflowGwfic(gwf, strt=get_strt_array(idx))

--- a/autotest/test_gwf_obs02.py
+++ b/autotest/test_gwf_obs02.py
@@ -43,9 +43,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     flopy.mf6.ModflowIms(
@@ -90,9 +88,7 @@ def build_models(idx, test):
         fname = f"{name}.{i}.obs.csv"
         obsdict[fname] = obslst
 
-    flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obsdict
-    )
+    flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obsdict)
 
     # initial conditions
     flopy.mf6.ModflowGwfic(gwf, strt=1.0)
@@ -134,9 +130,7 @@ def check_output(idx, test):
         for j in range(ncol):
             obsname_true = f"h_{i}_{j}".upper()
             obsname_found = rec.dtype.names[j + 1].upper()
-            errmsg = (
-                'obsname in {} is incorrect.  Looking for "{}" but found "{}"'
-            )
+            errmsg = 'obsname in {} is incorrect.  Looking for "{}" but found "{}"'
             errmsg = errmsg.format(fname, obsname_true, obsname_found)
             assert obsname_true == obsname_found, errmsg
         headcsv[0, i, :] = np.array(rec.tolist()[1:])
@@ -145,9 +139,7 @@ def check_output(idx, test):
     hobj = flopy.utils.HeadFile(fn)
     headbin = hobj.get_data()
 
-    assert np.allclose(
-        headcsv, headbin
-    ), "headcsv not equal head from binary file"
+    assert np.allclose(headcsv, headbin), "headcsv not equal head from binary file"
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_pertim.py
+++ b/autotest/test_gwf_pertim.py
@@ -50,9 +50,7 @@ def build_models(idx, test):
         print_option="ALL",
         complexity="simple",
     )
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwf = flopy.mf6.ModflowGwf(
         sim,
@@ -124,9 +122,7 @@ def check_output(idx, test):
     q_out_sim = inc["CHD2_OUT"]
 
     assert np.allclose([q_in_sim], [q_in]), f"CHD_IN <> {q_in} ({q_in_sim})"
-    assert np.allclose(
-        [q_out_sim], [q_out]
-    ), f"CHD2_OUT <> {q_out} ({q_out_sim})"
+    assert np.allclose([q_out_sim], [q_out]), f"CHD2_OUT <> {q_out} ({q_out_sim})"
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_ptc01.py
+++ b/autotest/test_gwf_ptc01.py
@@ -61,9 +61,7 @@ def build_mf6(idx, ws, storage=True):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -104,9 +102,7 @@ def build_mf6(idx, ws, storage=True):
 
     # storage
     if storage:
-        flopy.mf6.ModflowGwfsto(
-            gwf, iconvert=1, ss=ss, sy=sy, steady_state={0: True}
-        )
+        flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=ss, sy=sy, steady_state={0: True})
 
     # recharge
     rch = flopy.mf6.ModflowGwfrcha(gwf, readasarrays=True, recharge=rech)

--- a/autotest/test_gwf_rch01.py
+++ b/autotest/test_gwf_rch01.py
@@ -45,9 +45,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # set ims csv files
     csv0 = f"{name}.outer.ims.csv"

--- a/autotest/test_gwf_rch02.py
+++ b/autotest/test_gwf_rch02.py
@@ -37,9 +37,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # set ims csv files
     csv0 = f"{name}.outer.ims.csv"

--- a/autotest/test_gwf_rch03.py
+++ b/autotest/test_gwf_rch03.py
@@ -37,9 +37,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # set ims csv files
     csv0 = f"{name}.outer.ims.csv"
@@ -111,9 +109,7 @@ def build_models(idx, test):
         [0, 1, 0, 1, 0],
         [0, 0, 0, 0, 0],
     ]
-    rch = flopy.mf6.ModflowGwfrcha(
-        gwf, print_flows=True, recharge=recharge, irch=irch
-    )
+    rch = flopy.mf6.ModflowGwfrcha(gwf, print_flows=True, recharge=recharge, irch=irch)
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(

--- a/autotest/test_gwf_returncodes.py
+++ b/autotest/test_gwf_returncodes.py
@@ -57,9 +57,7 @@ def get_sim(ws, exe, idomain, continue_flag=False, nouter=500):
         continue_=continue_flag,
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -110,9 +108,7 @@ def get_sim(ws, exe, idomain, continue_flag=False, nouter=500):
         c6 = [[0, 0, 0, 1.0], [0, nrow - 1, ncol - 1, 0.0]]
         cd6 = {0: c6}
         maxchd = len(cd6[0])
-        chd = flopy.mf6.ModflowGwfchd(
-            gwf, stress_period_data=cd6, maxbound=maxchd
-        )
+        chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=cd6, maxbound=maxchd)
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(

--- a/autotest/test_gwf_sfr_badfactor.py
+++ b/autotest/test_gwf_sfr_badfactor.py
@@ -41,9 +41,7 @@ def build_models(idx, test, timeseries=False):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
     # set ims csv files
     csv0 = f"{name}.outer.ims.csv"
     csv1 = f"{name}.inner.ims.csv"
@@ -98,9 +96,7 @@ def build_models(idx, test, timeseries=False):
         [(0, 0, 0), 1.0],
         [(0, nrow - 1, ncol - 1), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # drn file
     drn6 = [

--- a/autotest/test_gwf_sfr_gwdischarge.py
+++ b/autotest/test_gwf_sfr_gwdischarge.py
@@ -57,9 +57,7 @@ def build_models(idx, test):
 
     # sfr data
     # <ifno> <cellid(ncelldim)> <rlen> <rwid> <rgrd> <rtp> <rbth> <rhk> <man> <ncon> <ustrf> <ndv>
-    package_data = [
-        (0, (0, 0, 0), delr, 1.0, 1e-3, 0.0, 1.0, 1.0, 0.001, 0, 0.0, 0)
-    ]
+    package_data = [(0, (0, 0, 0), delr, 1.0, 1e-3, 0.0, 1.0, 1.0, 0.001, 0, 0.0, 0)]
     connection_data = [(0)]
 
     sfr_obs = {

--- a/autotest/test_gwf_sfr_inactive01.py
+++ b/autotest/test_gwf_sfr_inactive01.py
@@ -59,9 +59,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
@@ -102,9 +100,7 @@ def build_models(idx, test):
         [(0, 0, 0), 1.0],
         [(0, nrow - 1, ncol - 1), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # sfr file
     packagedata = [

--- a/autotest/test_gwf_sfr_inactive02.py
+++ b/autotest/test_gwf_sfr_inactive02.py
@@ -161,9 +161,7 @@ def check_output(idx, test):
         assert (
             stage[idx, 2] == HDRY
         ), f"reach 3 stage is not HDRY in stress period {idx + 1}"
-    assert (
-        stage[1, 1] == HNOFLO
-    ), "reach 4 stage is not HNOFLO in stress period 2"
+    assert stage[1, 1] == HNOFLO, "reach 4 stage is not HNOFLO in stress period 2"
 
     bobj = sfr.output.budget()
     data_names = (
@@ -179,9 +177,7 @@ def check_output(idx, test):
     )
     for name in data_names:
         v = bobj.get_data(text=name, totim=2.0)[0]
-        assert (
-            v["q"][1] == 0.0
-        ), f"{name} flow for reach 2 is not zero ({v['q'][1]})"
+        assert v["q"][1] == 0.0, f"{name} flow for reach 2 is not zero ({v['q'][1]})"
 
     # skip GWF for reach 3 since it is not connected
     # to a GWF cell (data_names[0])

--- a/autotest/test_gwf_sfr_kinematic01.py
+++ b/autotest/test_gwf_sfr_kinematic01.py
@@ -89,12 +89,8 @@ def build_models(idx, test):
     )
     npf = flopy.mf6.ModflowGwfnpf(gwf, icelltype=1)
     ic = flopy.mf6.ModflowGwfic(gwf, strt=top)
-    sto = flopy.mf6.ModflowGwfsto(
-        gwf, iconvert=1, ss=1e-6, sy=0.2, transient={0: True}
-    )
-    ghb = flopy.mf6.ModflowGwfghb(
-        gwf, stress_period_data=[(0, 0, 0, top, 5.0)]
-    )
+    sto = flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=1e-6, sy=0.2, transient={0: True})
+    ghb = flopy.mf6.ModflowGwfghb(gwf, stress_period_data=[(0, 0, 0, top, 5.0)])
     oc = flopy.mf6.ModflowGwfoc(gwf, printrecord=[("budget", "all")])
 
     # sfr file
@@ -149,9 +145,7 @@ def build_models(idx, test):
 def check_output(idx, test):
     print("Checking sfr external outflow")
     name = cases[idx]
-    obs_values = flopy.utils.Mf6Obs(
-        test.workspace / f"{name}.sfr.obs.csv"
-    ).get_data()
+    obs_values = flopy.utils.Mf6Obs(test.workspace / f"{name}.sfr.obs.csv").get_data()
     # fmt: off
     test_values = {storage_weights[0]: np.array(
         [ 

--- a/autotest/test_gwf_sfr_npoint01.py
+++ b/autotest/test_gwf_sfr_npoint01.py
@@ -90,16 +90,12 @@ np_data = {
         "n": np.array([roughness] * 3, dtype=float),
     },
     xsect_types[7]: {
-        "x": np.array(
-            [0.0, 0.2 * rwid, 0.5 * rwid, 0.7 * rwid, rwid], dtype=float
-        ),
+        "x": np.array([0.0, 0.2 * rwid, 0.5 * rwid, 0.7 * rwid, rwid], dtype=float),
         "h": np.array([1.0, 0.0, 0.5, 0.0, 1.0], dtype=float),
         "n": np.array([roughness] * 5, dtype=float),
     },
     xsect_types[8]: {
-        "x": np.array(
-            [0.0, 0.1 * rwid, 0.5 * rwid, 0.9 * rwid, rwid], dtype=float
-        ),
+        "x": np.array([0.0, 0.1 * rwid, 0.5 * rwid, 0.9 * rwid, rwid], dtype=float),
         "h": np.array([1.0, 1.0, 0.0, 1.0, 1.0], dtype=float),
         "n": np.array([roughness] * 5, dtype=float),
     },
@@ -178,9 +174,7 @@ def build_models(idx, test):
     spd = [
         [(0, 0, 0), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # sfr file
     packagedata = []
@@ -264,9 +258,7 @@ def build_models(idx, test):
             ("area", "wet-area", (nreaches - 1,)),
         ]
     }
-    sfr.obs.initialize(
-        filename=fname, digits=25, print_input=True, continuous=sfr_obs
-    )
+    sfr.obs.initialize(filename=fname, digits=25, print_input=True, continuous=sfr_obs)
     if crosssections is not None:
         stations = np_data[xsect_type]["x"] / rwid
         heights = np_data[xsect_type]["h"]

--- a/autotest/test_gwf_sfr_npoint02.py
+++ b/autotest/test_gwf_sfr_npoint02.py
@@ -105,9 +105,7 @@ def build_models(idx, test):
     spd = [
         [(0, 0, 0), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # sfr file
     packagedata = []
@@ -187,9 +185,7 @@ def build_models(idx, test):
             ("width", "wet-width", (nreaches - 1,)),
         ]
     }
-    sfr.obs.initialize(
-        filename=fname, digits=25, print_input=True, continuous=sfr_obs
-    )
+    sfr.obs.initialize(filename=fname, digits=25, print_input=True, continuous=sfr_obs)
 
     # output control
     budpth = f"{name}.cbc"
@@ -233,9 +229,7 @@ def check_output(idx, test):
         )
         d.append(cdepth[0])
 
-    assert np.allclose(
-        obs["DEPTH"], d
-    ), "sfr depth not equal to calculated depth"
+    assert np.allclose(obs["DEPTH"], d), "sfr depth not equal to calculated depth"
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_sfr_npoint03.py
+++ b/autotest/test_gwf_sfr_npoint03.py
@@ -125,9 +125,7 @@ def build_model(idx, ws, base=False):
     spd = [
         [(0, 0, 0), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # sfr data
     if base:
@@ -283,15 +281,11 @@ def check_output(idx, test):
 
     q0 = obs0["OUTFLOW_DOWNSTREAM"]
     q1 = obs1["OUTFLOW_DOWNSTREAM"]
-    assert np.allclose(
-        q0, q1
-    ), f"downstream outflows not equal ('{test.name}')"
+    assert np.allclose(q0, q1), f"downstream outflows not equal ('{test.name}')"
 
     d0 = obs0["DEPTH_UPSTREAM"]
     d1 = obs1["DEPTH_UPSTREAM"]
-    assert np.allclose(
-        d0, d1
-    ), f"upstream depths are not equal ('{test.name}')"
+    assert np.allclose(d0, d1), f"upstream depths are not equal ('{test.name}')"
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_sfr_reorder.py
+++ b/autotest/test_gwf_sfr_reorder.py
@@ -87,9 +87,7 @@ def build_model(idx, ws):
     spd = [
         [(0, 0, 0), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # sfr file
     packagedata = []
@@ -209,9 +207,7 @@ def check_output(idx, test):
 
     assert np.allclose(obs0["INFLOW"], obs1["INFLOW"]), "inflows are not equal"
 
-    assert np.allclose(
-        obs0["OUTFLOW"], obs1["OUTFLOW"]
-    ), "outflows are not equal"
+    assert np.allclose(obs0["OUTFLOW"], obs1["OUTFLOW"]), "outflows are not equal"
 
     fpth = os.path.join(test.workspace, f"{name}.lst")
     with open(fpth, "r") as f:
@@ -229,9 +225,7 @@ def check_output(idx, test):
             break
     actual = np.arange(nreaches, dtype=int)[::-1]
 
-    assert np.array_equal(
-        order, actual
-    ), "DAG did not correctly reorder reaches."
+    assert np.array_equal(order, actual), "DAG did not correctly reorder reaches."
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_sfr_tbedk.py
+++ b/autotest/test_gwf_sfr_tbedk.py
@@ -176,9 +176,7 @@ def check_output(idx, test):
     obs_data = sfr.output.obs().get_data()
     o1 = obs_data["GWFR1"]
     o2 = obs_data["GWFR2"][::-1]
-    assert np.allclose(
-        o1, o2
-    ), f"GWFR1 ({o1}) not equal to reversed GWFR2 ({o2})"
+    assert np.allclose(o1, o2), f"GWFR1 ({o1}) not equal to reversed GWFR2 ({o2})"
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_sfr_wetstrmbedarea.py
+++ b/autotest/test_gwf_sfr_wetstrmbedarea.py
@@ -366,10 +366,7 @@ def check_output(idx, test):
         )
         assert np.isclose(wa, shared_area[0, j], atol=1e-4), msg
 
-    msg = (
-        "Wetted streambed area of all reaches should be zero in stess "
-        "period 2"
-    )
+    msg = "Wetted streambed area of all reaches should be zero in stess period 2"
     for val in list(sfrstg[1])[1:]:
         assert val == 0.0, msg
 

--- a/autotest/test_gwf_sto01.py
+++ b/autotest/test_gwf_sto01.py
@@ -105,9 +105,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     top = tops[idx]
@@ -223,9 +221,7 @@ def build_models(idx, test):
         top=top,
         botm=botm,
     )
-    bas = flopy.modflow.ModflowBas(
-        mc, ibound=ib, strt=strt, hnoflo=hnoflo, stoper=0.01
-    )
+    bas = flopy.modflow.ModflowBas(mc, ibound=ib, strt=strt, hnoflo=hnoflo, stoper=0.01)
     upw = flopy.modflow.ModflowUpw(
         mc,
         laytyp=laytyp,
@@ -312,9 +308,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out"
-    )
+    fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.bud.cmp.out")
     with open(fpth, "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:

--- a/autotest/test_gwf_sto02.py
+++ b/autotest/test_gwf_sto02.py
@@ -49,9 +49,7 @@ def build_models(idx, test):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -98,9 +96,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,

--- a/autotest/test_gwf_sto03.py
+++ b/autotest/test_gwf_sto03.py
@@ -75,9 +75,7 @@ def get_model(name, ws, newton_bool, offset=0.0):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     if newton_bool:

--- a/autotest/test_gwf_sto_tvs01.py
+++ b/autotest/test_gwf_sto_tvs01.py
@@ -44,9 +44,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -174,9 +172,7 @@ def check_output(idx, test):
 
     # Check against manually calculated results
     expected_results = []
-    expected_results.append(
-        0.8
-    )  # TVS SP1: No changes. Check initial solution.
+    expected_results.append(0.8)  # TVS SP1: No changes. Check initial solution.
     expected_results.append(3000.823)  # TVS SP2: Decrease SY1.
     expected_results.append(300.5323)  # TVS SP3: Increase SS1.
     expected_results.append(0.399976)  # TVS SP4: Increase SY1.

--- a/autotest/test_gwf_tdis.py
+++ b/autotest/test_gwf_tdis.py
@@ -47,9 +47,7 @@ def test_tdis_tsmult(tsmult, simple_sim, targets):
     tdis.write()
 
     # Run within libmf6
-    mf6 = XmiWrapper(
-        lib_path=targets["libmf6"], working_directory=sim.sim_path
-    )
+    mf6 = XmiWrapper(lib_path=targets["libmf6"], working_directory=sim.sim_path)
 
     mf6.initialize()
     dt_list = []

--- a/autotest/test_gwf_ts_maw01.py
+++ b/autotest/test_gwf_ts_maw01.py
@@ -47,9 +47,7 @@ def get_model(ws, name, timeseries=False):
         sim_ws=ws,
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -99,9 +97,7 @@ def get_model(ws, name, timeseries=False):
         [(0, 0, 0), 1.0],
         [(0, nrow - 1, ncol - 1), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # drn file
     drn6 = [

--- a/autotest/test_gwf_ts_sfr01.py
+++ b/autotest/test_gwf_ts_sfr01.py
@@ -47,9 +47,7 @@ def get_model(ws, name, timeseries=False):
         sim_ws=ws,
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
     # set ims csv files
     csv0 = f"{name}.outer.ims.csv"
     csv1 = f"{name}.inner.ims.csv"
@@ -105,9 +103,7 @@ def get_model(ws, name, timeseries=False):
         [(0, 0, 0), 1.0],
         [(0, nrow - 1, ncol - 1), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # drn file
     drn6 = [

--- a/autotest/test_gwf_ts_sfr02.py
+++ b/autotest/test_gwf_ts_sfr02.py
@@ -47,9 +47,7 @@ def get_model(ws, name, timeseries=False):
         sim_ws=ws,
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -98,9 +96,7 @@ def get_model(ws, name, timeseries=False):
         [(0, 0, 0), 1.0],
         [(0, nrow - 1, ncol - 1), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # drn file
     drn6 = [

--- a/autotest/test_gwf_ts_uzf01.py
+++ b/autotest/test_gwf_ts_uzf01.py
@@ -47,9 +47,7 @@ def get_model(ws, name, timeseries=False):
         sim_ws=ws,
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
     # create iterative model solution and register the gwf model with it
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -98,9 +96,7 @@ def get_model(ws, name, timeseries=False):
         [(0, 0, 0), 1.0],
         [(0, nrow - 1, ncol - 1), 0.0],
     ]
-    chd = flopy.mf6.modflow.ModflowGwfchd(
-        gwf, stress_period_data=spd, pname="chd-1"
-    )
+    chd = flopy.mf6.modflow.ModflowGwfchd(gwf, stress_period_data=spd, pname="chd-1")
 
     # drn file
     drn6 = [
@@ -438,9 +434,7 @@ def get_model(ws, name, timeseries=False):
         ts_methods = ["linearend"] * len(ts_names)
         ts_data = []
         for t in ts_times:
-            ts_data.append(
-                (t, finf, pet, extdp, extwc, ha, hroot, rootact, temp, conc)
-            )
+            ts_data.append((t, finf, pet, extdp, extwc, ha, hroot, rootact, temp, conc))
         perioddata = [
             [
                 0,

--- a/autotest/test_gwf_utl01_binaryinput.py
+++ b/autotest/test_gwf_utl01_binaryinput.py
@@ -43,9 +43,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.MFModel(

--- a/autotest/test_gwf_utl02_timeseries.py
+++ b/autotest/test_gwf_utl02_timeseries.py
@@ -32,9 +32,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.MFModel(

--- a/autotest/test_gwf_utl03_obs01.py
+++ b/autotest/test_gwf_utl03_obs01.py
@@ -53,9 +53,7 @@ def build_mf6(idx, ws, binaryobs=True):
     # build MODFLOW 6 files
     sim = flopy.mf6.MFSimulation(sim_name=name, version="mf6", sim_ws=ws)
     # create tdis package
-    flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -204,8 +202,7 @@ def check_output(idx, test):
         assert d0.shape[0] == d1.shape[0], msg
         for name in names0:
             msg = (
-                f"The values for column '{name}' "
-                + "are not within 1e-5 of each other"
+                f"The values for column '{name}' " + "are not within 1e-5 of each other"
             )
             assert np.allclose(d0[name], d1[name], rtol=1e-5), msg
 

--- a/autotest/test_gwf_utl04_auxmult.py
+++ b/autotest/test_gwf_utl04_auxmult.py
@@ -42,9 +42,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(sim, modelname=name, save_flows=True)

--- a/autotest/test_gwf_utl05_budparse.py
+++ b/autotest/test_gwf_utl05_budparse.py
@@ -43,9 +43,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name

--- a/autotest/test_gwf_utl06_tas.py
+++ b/autotest/test_gwf_utl06_tas.py
@@ -56,9 +56,7 @@ def build_models(idx, test):
         sim_name=sim_name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf"

--- a/autotest/test_gwf_uzf01.py
+++ b/autotest/test_gwf_uzf01.py
@@ -43,9 +43,7 @@ def build_models(idx, test):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create iterative model solution and register the gwf model with it
     nouter, ninner = 100, 10
@@ -91,9 +89,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -203,9 +199,7 @@ def build_models(idx, test):
     obs_lst.append(["obs1", "head", (0, 0, 0)])
     obs_lst.append(["obs2", "head", (1, 0, 0)])
     obs_dict = {f"{name}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     return sim, None
 

--- a/autotest/test_gwf_uzf02.py
+++ b/autotest/test_gwf_uzf02.py
@@ -52,9 +52,7 @@ def build_models(idx, test):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = name
@@ -103,9 +101,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -214,9 +210,7 @@ def build_models(idx, test):
     obs_lst = []
     obs_lst.append(["obs1", "head", (0, 0, 0)])
     obs_dict = {f"{gwfname}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     return sim, None
 

--- a/autotest/test_gwf_uzf03.py
+++ b/autotest/test_gwf_uzf03.py
@@ -53,9 +53,7 @@ def build_models(idx, test):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = name
@@ -104,9 +102,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -133,8 +129,7 @@ def build_models(idx, test):
     # note: for specifying lake number, use fortran indexing!
     uzf_obs = {
         name + ".uzf.obs.csv": [
-            (f"wc{k + 1}", "water-content", k + 1, 0.5 * delv)
-            for k in range(nlay)
+            (f"wc{k + 1}", "water-content", k + 1, 0.5 * delv) for k in range(nlay)
         ]
     }
 
@@ -216,9 +211,7 @@ def build_models(idx, test):
     obs_lst.append(["obs1", "head", (0, 0, 0)])
     obs_lst.append(["obs2", "head", (1, 0, 0)])
     obs_dict = {f"{gwfname}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     return sim, None
 

--- a/autotest/test_gwf_uzf04.py
+++ b/autotest/test_gwf_uzf04.py
@@ -57,9 +57,7 @@ def build_models(idx, test):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = name
@@ -108,9 +106,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -204,9 +200,7 @@ def build_models(idx, test):
     obs_lst = []
     obs_lst.append(["obs1", "head", (0, 0, 0)])
     obs_dict = {f"{gwfname}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     return sim, None
 
@@ -243,9 +237,7 @@ def check_output(idx, test):
     print("Ending volume of mobile water in unsat zone is ", vw)
     print("Storage change for mobile water in unsat zone should be ", qsto)
     print("Simulated storage is ", qstosim)
-    assert np.allclose(
-        qsto, qstosim
-    ), "Simulated storage not equal known storage"
+    assert np.allclose(qsto, qstosim), "Simulated storage not equal known storage"
     assert np.allclose(
         vw, volume_mobile_sim
     ), "Simulated mobile water volume in aux does not match known result"

--- a/autotest/test_gwf_uzf05.py
+++ b/autotest/test_gwf_uzf05.py
@@ -54,9 +54,7 @@ def build_models(idx, test):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = name
@@ -105,9 +103,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -203,9 +199,7 @@ def build_models(idx, test):
     obs_lst = []
     obs_lst.append(["obs1", "head", (0, 0, 0)])
     obs_dict = {f"{gwfname}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     return sim, None
 

--- a/autotest/test_gwf_uzf_auxmult.py
+++ b/autotest/test_gwf_uzf_auxmult.py
@@ -102,9 +102,7 @@ def build_models(idx, test):
     )
 
     # create tdis package
-    flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -240,9 +238,7 @@ def check_output(idx, test):
     name = cases[idx]
 
     errmsg0 = "flow model should have run successfully but didn't\n"
-    errmsg1 = (
-        "flow model designed to fail, but seems to have run successfully\n"
-    )
+    errmsg1 = "flow model designed to fail, but seems to have run successfully\n"
 
     with open(test.workspace / "mfsim.lst", "r") as f:
         lines = f.readlines()

--- a/autotest/test_gwf_uzf_gwet.py
+++ b/autotest/test_gwf_uzf_gwet.py
@@ -36,9 +36,7 @@ def build_models(idx, test):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -78,21 +76,15 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=True, icelltype=1, k=100.0, k33=10
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=1, k=100.0, k33=10)
 
     # aquifer storage
-    sto = flopy.mf6.ModflowGwfsto(
-        gwf, iconvert=1, ss=1e-5, sy=0.2, transient=True
-    )
+    sto = flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=1e-5, sy=0.2, transient=True)
 
     # chd files
     chdval = -3.0
     chdspd = {0: [[(2, 0, 0), chdval], [(2, 0, ncol - 1), chdval]]}
-    chd = flopy.mf6.ModflowGwfchd(
-        gwf, print_flows=True, stress_period_data=chdspd
-    )
+    chd = flopy.mf6.ModflowGwfchd(gwf, print_flows=True, stress_period_data=chdspd)
 
     # transient uzf info
     # ifno  cellid landflg ivertcn surfdp vks thtr thts thti eps [bndnm]

--- a/autotest/test_gwf_uzf_surfdep.py
+++ b/autotest/test_gwf_uzf_surfdep.py
@@ -33,14 +33,10 @@ def build_model(dir, exe):
 
     # build MODFLOW 6 files
     ws = dir
-    sim = flopy.mf6.MFSimulation(
-        sim_name=name, version="mf6", exe_name=exe, sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=name, version="mf6", exe_name=exe, sim_ws=ws)
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -80,21 +76,15 @@ def build_model(dir, exe):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=True, icelltype=1, k=100.0, k33=10
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=True, icelltype=1, k=100.0, k33=10)
 
     # aquifer storage
-    sto = flopy.mf6.ModflowGwfsto(
-        gwf, iconvert=1, ss=1e-5, sy=0.2, transient=True
-    )
+    sto = flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=1e-5, sy=0.2, transient=True)
 
     # chd files
     chdval = -3.0
     chdspd = {0: [[(2, 0, 0), chdval]]}
-    chd = flopy.mf6.ModflowGwfchd(
-        gwf, print_flows=True, stress_period_data=chdspd
-    )
+    chd = flopy.mf6.ModflowGwfchd(gwf, print_flows=True, stress_period_data=chdspd)
 
     # transient uzf info
     # ifno  cellid landflg ivertcn surfdp vks thtr thts thti eps [bndnm]
@@ -199,8 +189,6 @@ def test_mf6model(function_tmpdir, targets):
         if "SURFDEP" and "cannot" in line:
             error_count += 1
 
-    assert error_count == 8, (
-        "error count = " + str(error_count) + "but should equal 8"
-    )
+    assert error_count == 8, "error count = " + str(error_count) + "but should equal 8"
 
     print("Finished running surfdep check")

--- a/autotest/test_gwf_uzf_wc_output.py
+++ b/autotest/test_gwf_uzf_wc_output.py
@@ -234,9 +234,7 @@ def build_mf6_model(idx, ws):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -281,14 +279,10 @@ def build_mf6_model(idx, ws):
     )
 
     # aquifer storage
-    sto = flopy.mf6.ModflowGwfsto(
-        gwf, iconvert=1, ss=ss, sy=sy, transient=True
-    )
+    sto = flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=ss, sy=sy, transient=True)
 
     # ghb files
-    ghb = flopy.mf6.ModflowGwfghb(
-        gwf, print_flows=True, stress_period_data=ghbspd
-    )
+    ghb = flopy.mf6.ModflowGwfghb(gwf, print_flows=True, stress_period_data=ghbspd)
 
     # transient uzf info
     uzf_obs = {
@@ -384,9 +378,7 @@ def build_mfnwt_model(idx, ws):
 
     # Instantiate link mass-transport package (for writing cell-by-cell
     # water contents)
-    flopy.modflow.ModflowLmt(
-        mf, output_file_format="formatted", package_flows=["UZF"]
-    )
+    flopy.modflow.ModflowLmt(mf, output_file_format="formatted", package_flows=["UZF"])
 
     # Instantiate general head boundary package
     ghb = flopy.modflow.ModflowGhb(mf, stress_period_data=nwt_ghb_spdat)

--- a/autotest/test_gwf_vsc01.py
+++ b/autotest/test_gwf_vsc01.py
@@ -72,9 +72,7 @@ def build_models(idx, test):
 
     # Instantiating time discretization
     tdis_ds = ((perlen, nstp, 1.0),)
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_ds, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True)
 
     # Instantiating solver
@@ -139,8 +137,7 @@ def build_models(idx, test):
     # Instantiating GHB
     ghbcond = hydraulic_conductivity[idx] * delv * delc / (0.5 * delr)
     ghbspd = [
-        [(0, i, ncol - 1), top, ghbcond, initial_temperature]
-        for i in range(nrow)
+        [(0, i, ncol - 1), top, ghbcond, initial_temperature] for i in range(nrow)
     ]
     flopy.mf6.ModflowGwfghb(
         gwf,
@@ -279,8 +276,9 @@ def check_output(idx, test):
 
         # Ensure latest simulated value hasn't changed from stored answer
         assert np.allclose(sim_val_2, stored_ans, atol=1e-4), (
-            "Flow in the " + cases[1] + " test problem (simulates "
-            "viscosity) has changed,\n should be "
+            "Flow in the "
+            + cases[1]
+            + " test problem (simulates viscosity) has changed,\n should be "
             + str(stored_ans)
             + " but instead is "
             + str(sim_val_2)
@@ -303,9 +301,7 @@ def check_output(idx, test):
     vsc_filerecord = f"{gwfname}.vsc.bin"
     fname = os.path.join(test.workspace, vsc_filerecord)
     if os.path.isfile(fname):
-        vscobj = flopy.utils.HeadFile(
-            fname, precision="double", text="VISCOSITY"
-        )
+        vscobj = flopy.utils.HeadFile(fname, precision="double", text="VISCOSITY")
         try:
             data = vscobj.get_alldata()
             print(data.shape)

--- a/autotest/test_gwf_vsc02.py
+++ b/autotest/test_gwf_vsc02.py
@@ -74,9 +74,7 @@ def build_models(idx, test):
 
     # Instantiating time discretization
     tdis_ds = ((perlen, nstp, 1.0),)
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_ds, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True)
 
     # Instantiating solver
@@ -140,9 +138,7 @@ def build_models(idx, test):
 
     # Instantiating GHB
     ghbcond = hydraulic_conductivity[idx] * delv * delc / (0.5 * delr)
-    ghbspd = [
-        [(0, i, 0), top + 3, ghbcond, initial_temperature] for i in range(nrow)
-    ]
+    ghbspd = [[(0, i, 0), top + 3, ghbcond, initial_temperature] for i in range(nrow)]
     flopy.mf6.ModflowGwfghb(
         gwf,
         stress_period_data=ghbspd,
@@ -152,8 +148,7 @@ def build_models(idx, test):
 
     # Instantiating DRN
     drnspd = [
-        [(0, i, ncol - 1), top, 1.2 * ghbcond, initial_temperature]
-        for i in range(nrow)
+        [(0, i, ncol - 1), top, 1.2 * ghbcond, initial_temperature] for i in range(nrow)
     ]
     flopy.mf6.ModflowGwfdrn(
         gwf,
@@ -282,8 +277,9 @@ def check_output(idx, test):
 
         # Ensure latest simulated value hasn't changed from stored answer
         assert np.allclose(sim_val_2, stored_ans, atol=1e-4), (
-            "Flow in the " + cases[1] + " test problem (simulates "
-            "viscosity) has changed,\n should be "
+            "Flow in the "
+            + cases[1]
+            + " test problem (simulates viscosity) has changed,\n should be "
             + str(stored_ans)
             + " but instead is "
             + str(sim_val_2)

--- a/autotest/test_gwf_vsc03_sfr.py
+++ b/autotest/test_gwf_vsc03_sfr.py
@@ -513,9 +513,7 @@ def check_output(idx, test):
             )
 
             # lower reaches
-            assert abs(stored_ans_dn[-(i + 1)]) < abs(
-                with_vsc_bud_last[-(i + 1), 2]
-            ), (
+            assert abs(stored_ans_dn[-(i + 1)]) < abs(with_vsc_bud_last[-(i + 1), 2]), (
                 "GW/SW not as expected in lower reaches of viscosity test "
                 "problem that uses SFR.  This test activates the VSC package that "
                 "should elicit a known relative change in the GW/SW exchange"

--- a/autotest/test_gwf_vsc04_lak.py
+++ b/autotest/test_gwf_vsc04_lak.py
@@ -319,10 +319,7 @@ def build_models(idx, test):
                     ilak = int(lakibnd[k, i, j] - 1)
                     # back
                     if i > 0:
-                        if (
-                            lakibnd[k, i - 1, j] == 0
-                            and ibound[k, i - 1, j] == 1
-                        ):
+                        if lakibnd[k, i - 1, j] == 0 and ibound[k, i - 1, j] == 1:
                             ilakconn += 1
                             # by setting belev==telev, MF6 will automatically
                             # re-assign elevations based on cell dimensions
@@ -342,10 +339,7 @@ def build_models(idx, test):
 
                     # left
                     if j > 0:
-                        if (
-                            lakibnd[k, i, j - 1] == 0
-                            and ibound[k, i, j - 1] == 1
-                        ):
+                        if lakibnd[k, i, j - 1] == 0 and ibound[k, i, j - 1] == 1:
                             ilakconn += 1
                             h = [
                                 ilak,
@@ -363,10 +357,7 @@ def build_models(idx, test):
 
                     # right
                     if j < ncol - 1:
-                        if (
-                            lakibnd[k, i, j + 1] == 0
-                            and ibound[k, i, j + 1] == 1
-                        ):
+                        if lakibnd[k, i, j + 1] == 0 and ibound[k, i, j + 1] == 1:
                             ilakconn += 1
                             h = [
                                 ilak,
@@ -384,10 +375,7 @@ def build_models(idx, test):
 
                     # front
                     if i < nrow - 1:
-                        if (
-                            lakibnd[k, i + 1, j] == 0
-                            and ibound[k, i + 1, j] == 1
-                        ):
+                        if lakibnd[k, i + 1, j] == 0 and ibound[k, i + 1, j] == 1:
                             ilakconn += 1
                             h = [
                                 ilak,
@@ -481,9 +469,7 @@ def build_models(idx, test):
 
     # create gwt model
     # ----------------
-    gwt = flopy.mf6.ModflowGwt(
-        sim, modelname=gwtname, model_nam_file=f"{gwtname}.nam"
-    )
+    gwt = flopy.mf6.ModflowGwt(sim, modelname=gwtname, model_nam_file=f"{gwtname}.nam")
     gwt.name_file.save_flows = True
 
     imsgwt = flopy.mf6.ModflowIms(
@@ -522,9 +508,7 @@ def build_models(idx, test):
     flopy.mf6.ModflowGwtic(gwt, strt=strtconc, filename=f"{gwtname}.ic")
 
     # Instantiate mobile storage and transfer package
-    sto = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
 
     # Instantiating MODFLOW 6 transport advection package
     if mixelm == 0:
@@ -538,27 +522,21 @@ def build_models(idx, test):
     flopy.mf6.ModflowGwtadv(gwt, scheme=scheme, filename=f"{gwtname}.adv")
 
     # Instantiate dispersion package
-    flopy.mf6.ModflowGwtdsp(
-        gwt, alh=al, ath1=ath1, atv=atv, filename=f"{gwtname}.dsp"
-    )
+    flopy.mf6.ModflowGwtdsp(gwt, alh=al, ath1=ath1, atv=atv, filename=f"{gwtname}.dsp")
 
     # Instantiate source/sink mixing package
     sourcerecarray = [
         ("CHD-L", "AUX", "TEMPERATURE"),
         ("CHD-R", "AUX", "TEMPERATURE"),
     ]
-    flopy.mf6.ModflowGwtssm(
-        gwt, sources=sourcerecarray, filename=f"{gwtname}.ssm"
-    )
+    flopy.mf6.ModflowGwtssm(gwt, sources=sourcerecarray, filename=f"{gwtname}.ssm")
 
     # Instantiating MODFLOW 6 transport output control package
     flopy.mf6.ModflowGwtoc(
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 17, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 17, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         filename=f"{gwtname}.oc",
@@ -712,20 +690,14 @@ def check_output(idx, test):
         # than their 'no vsc' counterpart
         assert np.allclose(
             np.array(left_chk_ans), np.array(left_chk_no_vsc), atol=1e-3
-        ), (
-            "Lake inflow in no-VSC LAK simulation do not match established "
-            "solution."
-        )
+        ), "Lake inflow in no-VSC LAK simulation do not match established solution."
 
         # Check that all the flows leaving the lak in the 'with vsc' model are less
         # than their 'no vsc' counterpart (keep in mind values are negative, which
         # affects how the comparison is made)
         assert np.allclose(
             np.array(right_chk_ans), np.array(right_chk_no_vsc), atol=1e-3
-        ), (
-            "Lake outflow in no-VSC LAK simulation do not match established "
-            "solution."
-        )
+        ), "Lake outflow in no-VSC LAK simulation do not match established solution."
 
     elif idx == 1:
         with_vsc_bud_last = np.array(outbud[-1].tolist())
@@ -748,20 +720,16 @@ def check_output(idx, test):
 
         # Check that all the flows entering the lak in the 'with vsc' model are greater
         # than their 'no vsc' counterpart
-        assert (
-            np.greater(
-                np.array(left_chk_with_vsc), np.array(left_chk_no_vsc)
-            ).all()
-        ), "Lake inflow did no increase with VSC turned on and should have."
+        assert np.greater(
+            np.array(left_chk_with_vsc), np.array(left_chk_no_vsc)
+        ).all(), "Lake inflow did no increase with VSC turned on and should have."
 
         # Check that all the flows leaving the lak in the 'with vsc' model are less
         # than their 'no vsc' counterpart (keep in mind values are negative, which
         # affects how the comparison is made)
-        assert (
-            np.greater(
-                np.array(right_chk_with_vsc), np.array(right_chk_no_vsc)
-            ).all()
-        ), "Lake outflow did no decrease with VSC turned on and should have."
+        assert np.greater(
+            np.array(right_chk_with_vsc), np.array(right_chk_no_vsc)
+        ).all(), "Lake outflow did no decrease with VSC turned on and should have."
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwf_vsc05_hfb.py
+++ b/autotest/test_gwf_vsc05_hfb.py
@@ -81,9 +81,7 @@ def build_models(idx, test):
 
     # Instantiating time discretization
     tdis_ds = ((perlen, nstp, 1.0),)
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_ds, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_ds, time_units=time_units)
     gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True)
 
     # Instantiating solver
@@ -157,8 +155,7 @@ def build_models(idx, test):
     # Instantiating GHB (rightside, "outflow" boundary)
     ghbcond = hydraulic_conductivity[idx] * delv * delc / (0.5 * delr)
     ghbspd = [
-        [(0, i, ncol - 1), top, ghbcond, initial_temperature]
-        for i in range(nrow)
+        [(0, i, ncol - 1), top, ghbcond, initial_temperature] for i in range(nrow)
     ]
     flopy.mf6.ModflowGwfghb(
         gwf,
@@ -277,9 +274,7 @@ def check_output(idx, test):
     # read flow results from model
     name = cases[idx]
     gwfname = "gwf-" + name
-    sim1 = flopy.mf6.MFSimulation.load(
-        sim_ws=test.workspace, load_only=["dis"]
-    )
+    sim1 = flopy.mf6.MFSimulation.load(sim_ws=test.workspace, load_only=["dis"])
     gwf = sim1.get_model(gwfname)
 
     # Get grid data
@@ -326,9 +321,7 @@ def check_output(idx, test):
 
         # Ensure with and without VSC simulations give nearly identical flow results
         # for each cell-to-cell exchange between columns 5 and 6
-        assert np.allclose(
-            no_vsc_bud_last[:, 2], stored_ans[:, 2], atol=1e-3
-        ), (
+        assert np.allclose(no_vsc_bud_last[:, 2], stored_ans[:, 2], atol=1e-3), (
             "Flow in models "
             + cases[0]
             + " and the established answer should be approximately "
@@ -338,9 +331,7 @@ def check_output(idx, test):
     elif idx == 1:
         with_vsc_bud_last = np.array(vals_to_store)
 
-        assert np.allclose(
-            with_vsc_bud_last[:, 2], stored_ans[:, 2], atol=1e-3
-        ), (
+        assert np.allclose(with_vsc_bud_last[:, 2], stored_ans[:, 2], atol=1e-3), (
             "Flow in models "
             + cases[1]
             + " and the established answer should be approximately "
@@ -354,9 +345,7 @@ def check_output(idx, test):
         # 3 is less than what's in the "with viscosity" model
         assert np.less(no_vsc_low_k_bud_last[:, 2], stored_ans[:, 2]).all(), (
             "Exit flow from model the established answer "
-            "should be greater than flow existing "
-            + cases[2]
-            + ", but it is not."
+            "should be greater than flow existing " + cases[2] + ", but it is not."
         )
 
 

--- a/autotest/test_gwf_wel01.py
+++ b/autotest/test_gwf_wel01.py
@@ -173,15 +173,15 @@ def check_output(idx, test):
     # MODFLOW 6 AFR CSV output file
     fpth = os.path.join(test.workspace, "wel01.afr.csv")
     try:
-        afroutput = np.genfromtxt(
-            fpth, names=True, delimiter=",", deletechars=""
-        )
+        afroutput = np.genfromtxt(fpth, names=True, delimiter=",", deletechars="")
     except:
         assert False, f'could not load data from "{fpth}"'
 
     a1 = afroutput["rate-requested"]
     a2 = afroutput["rate-actual"] + afroutput["wel-reduction"]
-    errmsg = "Auto flow reduce requested rate must equal actual rate plus reduced rate.\n"
+    errmsg = (
+        "Auto flow reduce requested rate must equal actual rate plus reduced rate.\n"
+    )
     errmsg += f"{a1} /= {a2}"
     assert np.allclose(a1, a2), errmsg
 

--- a/autotest/test_gwf_zb01.py
+++ b/autotest/test_gwf_zb01.py
@@ -118,9 +118,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     top = tops[idx]
@@ -328,9 +326,7 @@ def check_output(idx, test):
     msg = f"maximum absolute total-budget difference ({diffmax}) "
 
     # write summary
-    with open(
-        test.workspace / f"{os.path.basename(test.name)}.bud.cmp.out", "w"
-    ) as f:
+    with open(test.workspace / f"{os.path.basename(test.name)}.bud.cmp.out", "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:
                 line = f"{'TIME':>10s}"
@@ -351,14 +347,10 @@ def check_output(idx, test):
     for i, (key0, key) in enumerate(zip(zone_lst, bud_lst)):
         diffzb[:, i] = zbsum[key0] - d[key]
     diffzbmax = np.abs(diffzb).max()
-    msg += (
-        f"\nmaximum absolute zonebudget-cell by cell difference ({diffzbmax}) "
-    )
+    msg += f"\nmaximum absolute zonebudget-cell by cell difference ({diffzbmax}) "
 
     # write summary
-    with open(
-        test.workspace / f"{os.path.basename(test.name)}.zbud.cmp.out", "w"
-    ) as f:
+    with open(test.workspace / f"{os.path.basename(test.name)}.zbud.cmp.out", "w") as f:
         for i in range(diff.shape[0]):
             if i == 0:
                 line = f"{'TIME':>10s}"

--- a/autotest/test_gwfgwf_lgr.py
+++ b/autotest/test_gwfgwf_lgr.py
@@ -98,16 +98,12 @@ def get_model(idx, test):
     # boundary stress period data
     left_chd = [
         [(ilay, irow, 0), h_left]
-        for ilay in range(
-            1
-        )  # apply chd only to top layer to drive vertical flow
+        for ilay in range(1)  # apply chd only to top layer to drive vertical flow
         for irow in range(nrow)
     ]
     right_chd = [
         [(ilay, irow, ncol - 1), h_right]
-        for ilay in range(
-            1
-        )  # apply chd only to top layer to drive vertical flow
+        for ilay in range(1)  # apply chd only to top layer to drive vertical flow
         for irow in range(nrow)
     ]
     chd_data = left_chd + right_chd
@@ -123,9 +119,7 @@ def get_model(idx, test):
         memory_print_option="ALL",
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_gwt_adv01.py
+++ b/autotest/test_gwt_adv01.py
@@ -47,9 +47,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -180,9 +178,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme=scheme[idx], filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme=scheme[idx], filename=f"{gwtname}.adv")
 
     # mass storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
@@ -198,9 +194,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -244,9 +238,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_adv01_fmi.py
+++ b/autotest/test_gwt_adv01_fmi.py
@@ -46,9 +46,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwt model
     gwtname = "gwt_" + name
@@ -95,9 +93,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme=scheme[idx], filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme=scheme[idx], filename=f"{gwtname}.adv")
 
     # mass storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
@@ -139,20 +135,14 @@ def build_models(idx, test):
             ("SATURATION", np.float64),
         ]
     )
-    sat = np.array(
-        [(i, i, 0.0, 1.0) for i in range(nlay * nrow * ncol)], dtype=dt
-    )
+    sat = np.array([(i, i, 0.0, 1.0) for i in range(nlay * nrow * ncol)], dtype=dt)
 
     fname = os.path.join(ws, "mybudget.bud")
     with open(fname, "wb") as fbin:
         for kstp in range(1):  # nstp[0]):
             write_budget(fbin, flowja, kstp=kstp + 1)
-            write_budget(
-                fbin, spdis, text="      DATA-SPDIS", imeth=6, kstp=kstp + 1
-            )
-            write_budget(
-                fbin, sat, text="        DATA-SAT", imeth=6, kstp=kstp + 1
-            )
+            write_budget(fbin, spdis, text="      DATA-SPDIS", imeth=6, kstp=kstp + 1)
+            write_budget(fbin, sat, text="        DATA-SAT", imeth=6, kstp=kstp + 1)
             write_budget(
                 fbin,
                 wel,
@@ -183,9 +173,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -220,9 +208,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_adv01_gwtgwt.py
+++ b/autotest/test_gwt_adv01_gwtgwt.py
@@ -95,9 +95,7 @@ def get_gwf_model(sim, gwfname, gwfpath, modelshape, chdspd=None, welspd=None):
     return gwf
 
 
-def get_gwt_model(
-    sim, gwtname, gwtpath, modelshape, scheme, sourcerecarray=None
-):
+def get_gwt_model(sim, gwtname, gwtpath, modelshape, scheme, sourcerecarray=None):
     nlay, nrow, ncol, xshift, yshift = modelshape
     delr = 1.0
     delc = 1.0
@@ -144,9 +142,7 @@ def get_gwt_model(
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -188,9 +184,7 @@ def build_models(idx, test):
 
     # build MODFLOW 6 files
     ws = test.workspace
-    sim = flopy.mf6.MFSimulation(
-        sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws)
     # create tdis package
     tdis = flopy.mf6.ModflowTdis(
         sim, time_units="DAYS", nper=nper, perioddata=tdis_rc, pname="sim.tdis"
@@ -334,9 +328,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, gwtname, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc1 = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
@@ -345,9 +337,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, gwtname, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc2 = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
@@ -711,9 +701,7 @@ def check_output(idx, test):
         for fjf in flow_ja_face:
             fjf = fjf.flatten()
             res = fjf[ia[:-1]]
-            errmsg = (
-                f"min or max flowja residual too large {res.min()} {res.max()}"
-            )
+            errmsg = f"min or max flowja residual too large {res.min()} {res.max()}"
             # TODO: this is not implemented yet:
             # assert np.allclose(res, 0.0, atol=1.0e-6), errmsg
 

--- a/autotest/test_gwt_adv02.py
+++ b/autotest/test_gwt_adv02.py
@@ -92,9 +92,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -239,9 +237,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme=scheme[idx], filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme=scheme[idx], filename=f"{gwtname}.adv")
 
     # mass storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
@@ -257,9 +253,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -303,9 +297,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_adv02_gwtgwt.py
+++ b/autotest/test_gwt_adv02_gwtgwt.py
@@ -99,9 +99,7 @@ def get_gwf_model(sim, gwfname, gwfpath, modelshape, chdspd=None, welspd=None):
     return gwf
 
 
-def get_gwt_model(
-    sim, gwtname, gwtpath, modelshape, scheme, sourcerecarray=None
-):
+def get_gwt_model(sim, gwtname, gwtpath, modelshape, scheme, sourcerecarray=None):
     nlay, nrow, ncol, xshift, yshift = modelshape
     delr = 1.0
     delc = 1.0
@@ -147,9 +145,7 @@ def get_gwt_model(
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -170,9 +166,7 @@ def build_models(idx, test):
 
     # build MODFLOW 6 files
     ws = test.workspace
-    sim = flopy.mf6.MFSimulation(
-        sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws)
     # create tdis package
     tdis = flopy.mf6.ModflowTdis(
         sim, time_units="DAYS", nper=nper, perioddata=tdis_rc, pname="sim.tdis"
@@ -183,9 +177,7 @@ def build_models(idx, test):
 
     for imodel in range(number_of_models):
         if imodel == 0:
-            welspd = {
-                0: [[(k, 0, 0), 1.0, concentration] for k in range(nlay)]
-            }
+            welspd = {0: [[(k, 0, 0), 1.0, concentration] for k in range(nlay)]}
         else:
             welspd = None
 
@@ -319,9 +311,7 @@ def check_output(idx, test):
     for imodel in range(number_of_models):
         gwtname = f"transport{imodel + 1}"
         fpth = pl.Path(test.workspace) / gwtname / f"{gwtname}.ucn"
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
         conclist.append(conc)
     conc_sim = np.hstack(conclist)

--- a/autotest/test_gwt_adv03.py
+++ b/autotest/test_gwt_adv03.py
@@ -98,9 +98,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -270,9 +268,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme=scheme[idx], filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme=scheme[idx], filename=f"{gwtname}.adv")
 
     # mass storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
@@ -288,9 +284,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -334,9 +328,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         times = cobj.get_times()
         tdistplot = times[int(len(times) / 5)]
         conc = cobj.get_data(totim=tdistplot)

--- a/autotest/test_gwt_adv04.py
+++ b/autotest/test_gwt_adv04.py
@@ -60,9 +60,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -108,9 +106,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{gwfname}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
     # storage
     # sto = flopy.mf6.ModflowGwfsto(gwf, save_flows=False,
     #                              iconvert=laytyp[idx],
@@ -188,9 +184,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme=scheme[idx], filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme=scheme[idx], filename=f"{gwtname}.adv")
 
     # mass storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
@@ -206,9 +200,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -231,9 +223,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
@@ -241,15 +231,14 @@ def check_output(idx, test):
     # Check to make sure that the concentrations are symmetric in both the
     # up-down and left-right directions
     concud = np.flipud(conc)
-    assert np.allclose(concud, conc), (
-        "simulated concentrations are not " "symmetric in up-down direction."
-    )
+    assert np.allclose(
+        concud, conc
+    ), "simulated concentrations are not symmetric in up-down direction."
 
     conclr = np.fliplr(conc)
-    assert np.allclose(conclr, conc), (
-        "simulated concentrations are not "
-        "symmetric in left-right direction."
-    )
+    assert np.allclose(
+        conclr, conc
+    ), "simulated concentrations are not symmetric in left-right direction."
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwt_adv_ats.py
+++ b/autotest/test_gwt_adv_ats.py
@@ -50,9 +50,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # set dt0, dtmin, dtmax, dtadj, dtfailadj
     dt0 = 0.01
@@ -61,9 +59,7 @@ def build_models(idx, test):
     dtadj = 2.0
     dtfailadj = 5.0
     ats_filerecord = name + ".ats"
-    atsperiod = [
-        (0, dt0, dtmin, dtmax[i], dtadj, dtfailadj) for i in range(nper)
-    ]
+    atsperiod = [(0, dt0, dtmin, dtmax[i], dtadj, dtfailadj) for i in range(nper)]
     tdis.ats.initialize(
         maxats=len(atsperiod),
         perioddata=atsperiod,
@@ -219,9 +215,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -265,9 +259,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
         times = cobj.times
     except:

--- a/autotest/test_gwt_buy_solute_heat.py
+++ b/autotest/test_gwt_buy_solute_heat.py
@@ -41,9 +41,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "flow"
@@ -127,9 +125,7 @@ def build_models(idx, test):
     ghb_cond = 10.0 * (1.0 * 10.0) / 5.0
     ghb_salinity = 35.0
     ghb_temperature = 5.0
-    ghb_density = (
-        1000.0 + 0.7 * ghb_salinity - 0.375 * (ghb_temperature - 25.0)
-    )
+    ghb_density = 1000.0 + 0.7 * ghb_salinity - 0.375 * (ghb_temperature - 25.0)
     ghblist1 = []
     for k in range(nlay):
         ghblist1.append(
@@ -340,16 +336,12 @@ def make_plot(sim):
 
     fname = gwtsname + ".ucn"
     fname = os.path.join(ws, fname)
-    cobj = flopy.utils.HeadFile(
-        fname, text="CONCENTRATION"
-    )  # , precision='double')
+    cobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")  # , precision='double')
     conc = cobj.get_alldata()
 
     fname = gwthname + ".ucn"
     fname = os.path.join(ws, fname)
-    tobj = flopy.utils.HeadFile(
-        fname, text="CONCENTRATION"
-    )  # , precision='double')
+    tobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")  # , precision='double')
     temperature = tobj.get_alldata()
 
     fname = gwfname + ".buy.bin"
@@ -370,9 +362,7 @@ def make_plot(sim):
     pxs.plot_bc(ftype="GHB")
     a = conc[idxtime]
     pa = pxs.plot_array(a, cmap="jet", alpha=0.25)
-    cs = pxs.contour_array(
-        a, levels=35.0 * np.array([0.01, 0.5, 0.99]), colors="y"
-    )
+    cs = pxs.contour_array(a, levels=35.0 * np.array([0.01, 0.5, 0.99]), colors="y")
     plt.colorbar(pa, shrink=0.5)
     ax.set_title("SALINITY")
 
@@ -383,9 +373,7 @@ def make_plot(sim):
     pxs.plot_bc(ftype="GHB")
     a = temperature[idxtime]
     pa = pxs.plot_array(a, cmap="jet", alpha=0.25)
-    cs = pxs.contour_array(
-        a, levels=5 + 20.0 * np.array([0.01, 0.5, 0.99]), colors="y"
-    )
+    cs = pxs.contour_array(a, levels=5 + 20.0 * np.array([0.01, 0.5, 0.99]), colors="y")
     plt.colorbar(pa, shrink=0.5)
     ax.set_title("TEMPERATURE")
 
@@ -425,16 +413,12 @@ def check_output(idx, test):
 
     fname = gwtsname + ".ucn"
     fname = os.path.join(ws, fname)
-    cobj = flopy.utils.HeadFile(
-        fname, text="CONCENTRATION"
-    )  # , precision='double')
+    cobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")  # , precision='double')
     conc = cobj.get_alldata()
 
     fname = gwthname + ".ucn"
     fname = os.path.join(ws, fname)
-    tobj = flopy.utils.HeadFile(
-        fname, text="CONCENTRATION"
-    )  # , precision='double')
+    tobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")  # , precision='double')
     temperature = tobj.get_alldata()
 
     # density is lagged, so use c and t from previous timestep

--- a/autotest/test_gwt_disu01.py
+++ b/autotest/test_gwt_disu01.py
@@ -64,9 +64,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -103,9 +101,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{gwfname}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
 
     # chd files
     chd = flopy.mf6.ModflowGwfchd(
@@ -168,9 +164,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="upstream", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="upstream", filename=f"{gwtname}.adv")
 
     # dispersion must be off as disu package does not have ANGLDEGX specified
     # dsp = flopy.mf6.ModflowGwtdsp(
@@ -198,9 +192,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -223,9 +215,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
@@ -234,15 +224,14 @@ def check_output(idx, test):
     # up-down and left-right directions
     conc = conc.reshape((21, 21))
     concud = np.flipud(conc)
-    assert np.allclose(concud, conc), (
-        "simulated concentrations are not " "symmetric in up-down direction."
-    )
+    assert np.allclose(
+        concud, conc
+    ), "simulated concentrations are not symmetric in up-down direction."
 
     conclr = np.fliplr(conc)
-    assert np.allclose(conclr, conc), (
-        "simulated concentrations are not "
-        "symmetric in left-right direction."
-    )
+    assert np.allclose(
+        conclr, conc
+    ), "simulated concentrations are not symmetric in left-right direction."
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwt_dsp01.py
+++ b/autotest/test_gwt_dsp01.py
@@ -45,9 +45,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -163,9 +161,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # dispersion
     xt3d_off = not xt3d[idx]
@@ -208,9 +204,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -245,9 +239,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_dsp01_fmi.py
+++ b/autotest/test_gwt_dsp01_fmi.py
@@ -46,9 +46,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwt model
     gwtname = "gwt_" + name
@@ -140,9 +138,7 @@ def build_models(idx, test):
             ("qz", np.float64),
         ]
     )
-    spdis = np.array(
-        [(id1, id1, 0.0, 0.0, 0.0, 0.0) for id1 in range(100)], dtype=dt
-    )
+    spdis = np.array([(id1, id1, 0.0, 0.0, 0.0, 0.0) for id1 in range(100)], dtype=dt)
 
     dt = np.dtype(
         [
@@ -152,20 +148,14 @@ def build_models(idx, test):
             ("SATURATION", np.float64),
         ]
     )
-    sat = np.array(
-        [(i, i, 0.0, 1.0) for i in range(nlay * nrow * ncol)], dtype=dt
-    )
+    sat = np.array([(i, i, 0.0, 1.0) for i in range(nlay * nrow * ncol)], dtype=dt)
 
     fname = os.path.join(ws, "mybudget.bud")
     with open(fname, "wb") as fbin:
         for kstp in range(1):  # nstp[0]):
             write_budget(fbin, flowja, kstp=kstp + 1)
-            write_budget(
-                fbin, spdis, text="      DATA-SPDIS", imeth=6, kstp=kstp + 1
-            )
-            write_budget(
-                fbin, sat, text="        DATA-SAT", imeth=6, kstp=kstp + 1
-            )
+            write_budget(fbin, spdis, text="      DATA-SPDIS", imeth=6, kstp=kstp + 1)
+            write_budget(fbin, sat, text="        DATA-SAT", imeth=6, kstp=kstp + 1)
     fbin.close()
 
     # flow model interface
@@ -180,9 +170,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -196,9 +184,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_dsp01_gwtgwt.py
+++ b/autotest/test_gwt_dsp01_gwtgwt.py
@@ -127,9 +127,7 @@ def get_gwt_model(sim, gwtname, gwtpath, modelshape):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -150,9 +148,7 @@ def build_models(idx, test):
 
     # build MODFLOW 6 files
     ws = test.workspace
-    sim = flopy.mf6.MFSimulation(
-        sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws)
     # create tdis package
     tdis = flopy.mf6.ModflowTdis(
         sim, time_units="DAYS", nper=nper, perioddata=tdis_rc, pname="sim.tdis"
@@ -169,9 +165,7 @@ def build_models(idx, test):
     gwf1 = get_gwf_model(sim, "flow1", "flow1", (nlay, nrow, ncol, 0.0, 0.0))
 
     # Create gwf2 model
-    gwf2 = get_gwf_model(
-        sim, "flow2", "flow2", (nlay, nrow, ncol, 50.0 * gdelr, 0.0)
-    )
+    gwf2 = get_gwf_model(sim, "flow2", "flow2", (nlay, nrow, ncol, 50.0 * gdelr, 0.0))
 
     # gwf-gwf with interface model enabled
     gwfgwf_data = [[(0, 0, ncol - 1), (0, 0, 0), 1, 0.5, 0.5, 1.0, 0.0, 1.0]]
@@ -206,9 +200,7 @@ def build_models(idx, test):
     sim.register_ims_package(imsgwf, [gwf1.name, gwf2.name])
 
     # Create gwt model
-    gwt1 = get_gwt_model(
-        sim, "transport1", "transport1", (nlay, nrow, ncol, 0.0, 0.0)
-    )
+    gwt1 = get_gwt_model(sim, "transport1", "transport1", (nlay, nrow, ncol, 0.0, 0.0))
 
     # Create gwt model
     gwt2 = get_gwt_model(
@@ -270,9 +262,7 @@ def check_output(idx, test):
     gwtname = "transport1"
     fpth = os.path.join(test.workspace, "transport1", f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc1 = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
@@ -280,9 +270,7 @@ def check_output(idx, test):
     gwtname = "transport2"
     fpth = os.path.join(test.workspace, "transport2", f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc2 = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_dsp01_noadv.py
+++ b/autotest/test_gwt_dsp01_noadv.py
@@ -45,9 +45,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwt model
     gwtname = "gwt_" + name
@@ -124,9 +122,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -140,9 +136,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_dsp02.py
+++ b/autotest/test_gwt_dsp02.py
@@ -92,9 +92,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -221,9 +219,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="upstream", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="upstream", filename=f"{gwtname}.adv")
 
     # dispersion
     xt3d_off = not xt3d[idx]
@@ -255,9 +251,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -280,9 +274,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_dsp03.py
+++ b/autotest/test_gwt_dsp03.py
@@ -98,9 +98,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -263,9 +261,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="upstream", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="upstream", filename=f"{gwtname}.adv")
 
     # dispersion
     xt3d_off = not xt3d[idx]
@@ -296,9 +292,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -321,9 +315,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         times = cobj.get_times()
         tdistplot = times[int(len(times) / 5)]
         conc = cobj.get_data(totim=tdistplot)

--- a/autotest/test_gwt_dsp04.py
+++ b/autotest/test_gwt_dsp04.py
@@ -52,9 +52,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -168,9 +166,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # advection
     xt3d_off = not xt3d[idx]
@@ -202,9 +198,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -227,9 +221,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
@@ -237,15 +229,14 @@ def check_output(idx, test):
     # Check to make sure that the concentrations are symmetric in both the
     # up-down and left-right directions
     concud = np.flipud(conc)
-    assert np.allclose(concud, conc), (
-        "simulated concentrations are not " "symmetric in up-down direction."
-    )
+    assert np.allclose(
+        concud, conc
+    ), "simulated concentrations are not symmetric in up-down direction."
 
     conclr = np.fliplr(conc)
-    assert np.allclose(conclr, conc), (
-        "simulated concentrations are not "
-        "symmetric in left-right direction."
-    )
+    assert np.allclose(
+        conclr, conc
+    ), "simulated concentrations are not symmetric in left-right direction."
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwt_dsp05_noadv.py
+++ b/autotest/test_gwt_dsp05_noadv.py
@@ -42,9 +42,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwt model
     gwtname = "gwt_" + name
@@ -121,9 +119,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -137,9 +133,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_fmi01.py
+++ b/autotest/test_gwt_fmi01.py
@@ -45,9 +45,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwt model
     gwtname = "gwt_" + name
@@ -104,9 +102,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -144,20 +140,14 @@ def build_models(idx, test):
             ("SATURATION", np.float64),
         ]
     )
-    sat = np.array(
-        [(i, i, 0.0, 1.0) for i in range(nlay * nrow * ncol)], dtype=dt
-    )
+    sat = np.array([(i, i, 0.0, 1.0) for i in range(nlay * nrow * ncol)], dtype=dt)
 
     fname = os.path.join(ws, "mybudget.bud")
     with open(fname, "wb") as fbin:
         for kstp in range(nstp[0]):
             write_budget(fbin, flowja, kstp=kstp + 1)
-            write_budget(
-                fbin, spdis, text="      DATA-SPDIS", imeth=6, kstp=kstp + 1
-            )
-            write_budget(
-                fbin, sat, text="        DATA-SAT", imeth=6, kstp=kstp + 1
-            )
+            write_budget(fbin, spdis, text="      DATA-SPDIS", imeth=6, kstp=kstp + 1)
+            write_budget(fbin, sat, text="        DATA-SAT", imeth=6, kstp=kstp + 1)
     fbin.close()
 
     # flow model interface

--- a/autotest/test_gwt_henry.py
+++ b/autotest/test_gwt_henry.py
@@ -41,9 +41,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -176,9 +174,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=35.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # dispersion
     diffc = 0.57024
@@ -192,9 +188,7 @@ def build_models(idx, test):
 
     # mass storage and transfer
     porosity = 0.35
-    mst = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    mst = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
 
     # sources
     sourcerecarray = [
@@ -210,9 +204,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -235,9 +227,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
@@ -279,7 +269,7 @@ def check_output(idx, test):
 
     cres = np.array(cres)
     assert np.allclose(cres, conc[-1, :, :]), (
-        "simulated concentrations " "do not match with known solution.",
+        "simulated concentrations do not match with known solution.",
         cres,
         conc[-1, :, :],
     )

--- a/autotest/test_gwt_henry_gwtgwt.py
+++ b/autotest/test_gwt_henry_gwtgwt.py
@@ -168,9 +168,7 @@ def get_gwt_model(sim, model_shape, model_desc, adv_scheme):
     _ = flopy.mf6.ModflowGwtic(gwt, strt=35.0, filename=f"{gwtname}.ic")
 
     # advection
-    _ = flopy.mf6.ModflowGwtadv(
-        gwt, scheme=adv_scheme, filename=f"{gwtname}.adv"
-    )
+    _ = flopy.mf6.ModflowGwtadv(gwt, scheme=adv_scheme, filename=f"{gwtname}.adv")
 
     # dispersion
     diffc = 0.57024
@@ -184,9 +182,7 @@ def get_gwt_model(sim, model_shape, model_desc, adv_scheme):
 
     # mass storage and transfer
     porosity = 0.35
-    _ = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    _ = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
 
     # sources
     if model_desc == "right":
@@ -203,18 +199,14 @@ def get_gwt_model(sim, model_shape, model_desc, adv_scheme):
             ("CHD-1", "AUX", "CONCENTRATION"),
         ]
 
-    _ = flopy.mf6.ModflowGwtssm(
-        gwt, sources=sourcerecarray, filename=f"{gwtname}.ssm"
-    )
+    _ = flopy.mf6.ModflowGwtssm(gwt, sources=sourcerecarray, filename=f"{gwtname}.ssm")
 
     # output control
     _ = flopy.mf6.ModflowGwtoc(
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -235,9 +227,7 @@ def build_models(idx, test):
         sim_ws=ws,
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create flow models and GWF-GWF exchange
     gwf_ref = get_gwf_model(sim, (nlay, nrow, ncol), "ref")
@@ -259,9 +249,7 @@ def build_models(idx, test):
         relaxation_factor=relax,
         filename="gwf.ims",
     )
-    sim.register_ims_package(
-        imsgwf_ref, [gwf_ref.name, gwf_left.name, gwf_right.name]
-    )
+    sim.register_ims_package(imsgwf_ref, [gwf_ref.name, gwf_left.name, gwf_right.name])
 
     angldegx = 0.0
     cdist = delr
@@ -290,12 +278,8 @@ def build_models(idx, test):
     )
 
     # create transport models and GWT-GWT exchange
-    gwt_ref = get_gwt_model(
-        sim, (nlay, nrow, ncol), "ref", advection_scheme[idx]
-    )
-    gwt_left = get_gwt_model(
-        sim, (nlay, nrow, ncol_sub), "left", advection_scheme[idx]
-    )
+    gwt_ref = get_gwt_model(sim, (nlay, nrow, ncol), "ref", advection_scheme[idx])
+    gwt_left = get_gwt_model(sim, (nlay, nrow, ncol_sub), "left", advection_scheme[idx])
     gwt_right = get_gwt_model(
         sim, (nlay, nrow, ncol_sub), "right", advection_scheme[idx]
     )
@@ -315,9 +299,7 @@ def build_models(idx, test):
         relaxation_factor=relax,
         filename="gwt.ims",
     )
-    sim.register_ims_package(
-        imsgwt_ref, [gwt_ref.name, gwt_left.name, gwt_right.name]
-    )
+    sim.register_ims_package(imsgwt_ref, [gwt_ref.name, gwt_left.name, gwt_right.name])
 
     _ = flopy.mf6.ModflowGwtgwt(
         sim,
@@ -383,27 +365,21 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, "gwt_ref.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc_ref = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
 
     fpth = os.path.join(test.workspace, "gwt_left.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc_left = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
 
     fpth = os.path.join(test.workspace, "gwt_right.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc_right = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_henry_nr.py
+++ b/autotest/test_gwt_henry_nr.py
@@ -96,9 +96,7 @@ def build_models(idx, test):
     sim.name_file.continue_ = False
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -324,9 +322,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "ALL")],
     )
@@ -366,9 +362,7 @@ def get_patch_collection(modelgrid, head, conc, cmap="jet", zorder=None):
                 poly, closed=True, edgecolor="k", facecolor="red"
             )
             patches.append(patch)
-    pc = matplotlib.collections.PatchCollection(
-        patches, cmap=cmap, zorder=zorder
-    )
+    pc = matplotlib.collections.PatchCollection(patches, cmap=cmap, zorder=zorder)
     pc.set_array(conc.flatten())
     return pc
 
@@ -424,9 +418,7 @@ def make_plot(sim, headall, concall):
         )
         ax.add_patch(patch)
         # aquifer polygon
-        aqpoly = np.array(
-            [[0, 0], [lx, 0], [lx, fz * lz], [lx * fx, lz], [0, lz]]
-        )
+        aqpoly = np.array([[0, 0], [lx, 0], [lx, fz * lz], [lx * fx, lz], [0, lz]])
         patch = matplotlib.patches.Polygon(
             aqpoly, closed=True, facecolor=".7", zorder=1
         )
@@ -476,9 +468,7 @@ def check_output(idx, test):
     # load concs
     fname = os.path.join(ws, gwtname + ".ucn")
     assert os.path.isfile(fname)
-    concobj = flopy.utils.HeadFile(
-        fname, text="concentration", precision="double"
-    )
+    concobj = flopy.utils.HeadFile(fname, text="concentration", precision="double")
     conc = concobj.get_alldata()
 
     # extract 10 simulated heads and concs for cell (0, 0, 20)

--- a/autotest/test_gwt_henry_openclose.py
+++ b/autotest/test_gwt_henry_openclose.py
@@ -41,9 +41,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -176,9 +174,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=35.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # dispersion
     diffc = 0.57024
@@ -192,9 +188,7 @@ def build_models(idx, test):
 
     # mass storage and transfer
     porosity = 0.35
-    mst = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    mst = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
 
     # sources
     sourcerecarray = [
@@ -210,9 +204,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -238,9 +230,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
@@ -282,7 +272,7 @@ def check_output(idx, test):
 
     cres = np.array(cres)
     assert np.allclose(cres, conc[-1, :, :]), (
-        "simulated concentrations " "do not match with known solution.",
+        "simulated concentrations do not match with known solution.",
         cres,
         conc[-1, :, :],
     )

--- a/autotest/test_gwt_ims_issue655.py
+++ b/autotest/test_gwt_ims_issue655.py
@@ -70,9 +70,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     if newton[idx]:
@@ -125,9 +123,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{gwfname}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk, k33=hk)
 
     # storage
     sto = flopy.mf6.ModflowGwfsto(
@@ -210,9 +206,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="upstream", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="upstream", filename=f"{gwtname}.adv")
 
     # mass storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
@@ -228,9 +222,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -261,9 +253,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_alldata().flatten()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_ist01.py
+++ b/autotest/test_gwt_ist01.py
@@ -49,9 +49,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -200,9 +198,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )

--- a/autotest/test_gwt_ist02.py
+++ b/autotest/test_gwt_ist02.py
@@ -105,9 +105,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -152,9 +150,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=0, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=0, k=hk, k33=hk)
 
     # chd files
     chdspdict = {
@@ -284,9 +280,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -359,9 +353,7 @@ def check_output(idx, test):
     simvals = np.genfromtxt(fname, names=True, delimiter=",", deletechars="")
 
     # interpolate mf6 results to same times as mt3d
-    mf6conc_interp = np.interp(
-        mt3d_times, simvals["time"], simvals["(1-1-300)"]
-    )
+    mf6conc_interp = np.interp(mt3d_times, simvals["time"], simvals["(1-1-300)"])
 
     # calculate difference between mf6 and mt3d
     atol = 0.05

--- a/autotest/test_gwt_ist03.py
+++ b/autotest/test_gwt_ist03.py
@@ -52,9 +52,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -99,9 +97,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=0, k=hk, k33=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=0, k=hk, k33=hk)
 
     # chd files
     chdspdict = {
@@ -234,9 +230,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )

--- a/autotest/test_gwt_lkt01.py
+++ b/autotest/test_gwt_lkt01.py
@@ -54,9 +54,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -140,9 +138,7 @@ def build_models(idx, test):
     con_data.append(
         (0, 1, (0, 0, 3), "HORIZONTAL", DNODATA, 10, 10, connlen, connwidth)
     )
-    con_data.append(
-        (0, 2, (0, 0, 2), "VERTICAL", DNODATA, 10, 10, connlen, connwidth)
-    )
+    con_data.append((0, 2, (0, 0, 2), "VERTICAL", DNODATA, 10, 10, connlen, connwidth))
     p_data = [
         (0, "STATUS", "CONSTANT"),
         (0, "STAGE", -0.4),
@@ -240,15 +236,11 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # storage
     porosity = 0.30
-    sto = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
     # sources
     sourcerecarray = [
         ("CHD-1", "AUX", "CONCENTRATION"),
@@ -312,9 +304,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[
             ("CONCENTRATION", "ALL"),
@@ -378,12 +368,8 @@ def check_output(idx, test):
     fname = os.path.join(test.workspace, fname)
     cobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")
     caq = cobj.get_alldata()
-    answer = np.array(
-        [4.86242795, 27.24270616, 64.55536421, 27.24270616, 4.86242795]
-    )
-    assert np.allclose(
-        caq[-1].flatten(), answer
-    ), f"{caq[-1].flatten()} {answer}"
+    answer = np.array([4.86242795, 27.24270616, 64.55536421, 27.24270616, 4.86242795])
+    assert np.allclose(caq[-1].flatten(), answer), f"{caq[-1].flatten()} {answer}"
 
     # lkt observation results
     fpth = os.path.join(test.workspace, gwtname + ".lkt.obs.csv")

--- a/autotest/test_gwt_lkt02.py
+++ b/autotest/test_gwt_lkt02.py
@@ -52,9 +52,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -139,17 +137,11 @@ def build_models(idx, test):
     con_data.append(
         (0, 0, (0, 0, 1), "HORIZONTAL", DNODATA, 10, 10, connlen, connwidth)
     )
-    con_data.append(
-        (0, 1, (0, 0, 2), "VERTICAL", DNODATA, 10, 10, connlen, connwidth)
-    )
+    con_data.append((0, 1, (0, 0, 2), "VERTICAL", DNODATA, 10, 10, connlen, connwidth))
     # lake 2
-    con_data.append(
-        (1, 0, (0, 0, 3), "VERTICAL", DNODATA, 10, 10, connlen, connwidth)
-    )
+    con_data.append((1, 0, (0, 0, 3), "VERTICAL", DNODATA, 10, 10, connlen, connwidth))
     # lake 3
-    con_data.append(
-        (2, 0, (0, 0, 4), "VERTICAL", DNODATA, 10, 10, connlen, connwidth)
-    )
+    con_data.append((2, 0, (0, 0, 4), "VERTICAL", DNODATA, 10, 10, connlen, connwidth))
     con_data.append(
         (2, 1, (0, 0, 5), "HORIZONTAL", DNODATA, 10, 10, connlen, connwidth)
     )
@@ -257,15 +249,11 @@ def build_models(idx, test):
     )
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # storage
     porosity = 0.30
-    sto = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
     # sources
     sourcerecarray = [
         ("CHD-1", "AUX", "CONCENTRATION"),
@@ -334,9 +322,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )

--- a/autotest/test_gwt_lkt03.py
+++ b/autotest/test_gwt_lkt03.py
@@ -50,9 +50,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -134,17 +132,11 @@ def build_models(idx, test):
     con_data = []
     # con_data=(ifno,iconn,(cellid),claktype,bedleak,belev,telev,connlen,connwidth )
     # lake 1
-    con_data.append(
-        (0, 0, (0, 0, 2), "VERTICAL", DNODATA, 10, 10, connlen, connwidth)
-    )
+    con_data.append((0, 0, (0, 0, 2), "VERTICAL", DNODATA, 10, 10, connlen, connwidth))
     # lake 2
-    con_data.append(
-        (1, 0, (0, 0, 3), "VERTICAL", DNODATA, 10, 10, connlen, connwidth)
-    )
+    con_data.append((1, 0, (0, 0, 3), "VERTICAL", DNODATA, 10, 10, connlen, connwidth))
     # lake 3
-    con_data.append(
-        (2, 0, (0, 0, 4), "VERTICAL", DNODATA, 10, 10, connlen, connwidth)
-    )
+    con_data.append((2, 0, (0, 0, 4), "VERTICAL", DNODATA, 10, 10, connlen, connwidth))
 
     p_data = [
         (0, "RAINFALL", 0.1),

--- a/autotest/test_gwt_lkt04.py
+++ b/autotest/test_gwt_lkt04.py
@@ -54,9 +54,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=test.workspace
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -140,9 +138,7 @@ def build_models(idx, test):
     con_data.append(
         (0, 1, (0, 0, 3), "HORIZONTAL", DNODATA, 10, 10, connlen, connwidth)
     )
-    con_data.append(
-        (0, 2, (0, 0, 2), "VERTICAL", DNODATA, 10, 10, connlen, connwidth)
-    )
+    con_data.append((0, 2, (0, 0, 2), "VERTICAL", DNODATA, 10, 10, connlen, connwidth))
     p_data = [
         (0, "STATUS", "ACTIVE"),
         (0, "STAGE", -0.4),
@@ -240,15 +236,11 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # storage
     porosity = 0.30
-    sto = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
     # sources
     sourcerecarray = [
         ("CHD-1", "AUX", "CONCENTRATION"),
@@ -312,9 +304,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[
             ("CONCENTRATION", "ALL"),
@@ -365,9 +355,7 @@ def eval_csv_information(testsim):
     for pd in result:
         if abs(pd) > atol:
             success = False
-            print(
-                f"Lake transport package balance error ({pd}) > tolerance ({atol})"
-            )
+            print(f"Lake transport package balance error ({pd}) > tolerance ({atol})")
 
     assert success, "One or more errors encountered in budget checks"
 
@@ -408,9 +396,7 @@ def check_output(idx, test):
     cobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")
     caq = cobj.get_alldata()
     answer = np.zeros(5)
-    assert np.allclose(
-        caq[-1].flatten(), answer
-    ), f"{caq[-1].flatten()} {answer}"
+    assert np.allclose(caq[-1].flatten(), answer), f"{caq[-1].flatten()} {answer}"
 
     # lkt observation results
     fpth = os.path.join(test.workspace, gwtname + ".lkt.obs.csv")

--- a/autotest/test_gwt_moc3d01.py
+++ b/autotest/test_gwt_moc3d01.py
@@ -57,9 +57,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -251,9 +249,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -276,9 +272,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         station = [(0, 0, 0), (0, 40, 0), (0, 110, 0)]
         tssim = cobj.get_ts(station)[::10]
     except:

--- a/autotest/test_gwt_moc3d01_zod.py
+++ b/autotest/test_gwt_moc3d01_zod.py
@@ -64,9 +64,7 @@ def build_models(idx, test):
         # continue_=True,
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -280,9 +278,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -370,9 +366,7 @@ def check_output(idx, test):
     # get mobile domain concentration object
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         station = [(0, 0, 0), (0, 40, 0), (0, 110, 0)]
         tssim = cobj.get_ts(station)
     except:

--- a/autotest/test_gwt_moc3d02.py
+++ b/autotest/test_gwt_moc3d02.py
@@ -49,9 +49,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -220,9 +218,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -245,9 +241,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         times = cobj.get_times()
         t = times[-1]
         csim = cobj.get_data(totim=t)

--- a/autotest/test_gwt_moc3d03.py
+++ b/autotest/test_gwt_moc3d03.py
@@ -48,9 +48,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -214,9 +212,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -239,9 +235,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         times = cobj.get_times()
         t = times[-1]
         csim = cobj.get_data(totim=t)

--- a/autotest/test_gwt_mst01.py
+++ b/autotest/test_gwt_mst01.py
@@ -41,9 +41,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -175,14 +173,10 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=1.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # mass storage and transfer
-    mst = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=sy[idx], filename=f"{gwtname}.mst"
-    )
+    mst = flopy.mf6.ModflowGwtmst(gwt, porosity=sy[idx], filename=f"{gwtname}.mst")
 
     # sources
     sourcerecarray = [("WEL-1", "AUX", "CONCENTRATION")]
@@ -195,9 +189,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -224,9 +216,9 @@ def check_output(idx, test):
 
     # end of stress period 1
     cres1 = np.ones((nlay, nrow, ncol), float)
-    assert np.allclose(cres1, conc1), (
-        "simulated concentrations do not match " "with known solution."
-    )
+    assert np.allclose(
+        cres1, conc1
+    ), "simulated concentrations do not match with known solution."
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwt_mst02.py
+++ b/autotest/test_gwt_mst02.py
@@ -80,9 +80,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -128,9 +126,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{gwfname}.ic")
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk)
 
     # chd files
     chddict = {0: [[(0, 0, 0), 1.0]]}
@@ -210,9 +206,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.bud",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -236,9 +230,7 @@ def check_output(idx, test):
     # Check aqueous concentrations
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         ts = cobj.get_ts([(0, 0, 0), (0, 0, 1)])
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_mst03.py
+++ b/autotest/test_gwt_mst03.py
@@ -45,9 +45,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -173,14 +171,10 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=100.0)
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # mass storage and transfer
-    mst = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=sy[idx], filename=f"{gwtname}.mst"
-    )
+    mst = flopy.mf6.ModflowGwtmst(gwt, porosity=sy[idx], filename=f"{gwtname}.mst")
 
     # sources
     sourcerecarray = [("WEL-1", "AUX", "CONCENTRATION")]
@@ -193,9 +187,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )

--- a/autotest/test_gwt_mst04_noadv.py
+++ b/autotest/test_gwt_mst04_noadv.py
@@ -39,9 +39,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwt model
     gwtname = "gwt_" + name
@@ -88,18 +86,14 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # mass storage and transfer
-    mst = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=0.1, zero_order_decay=True, decay=-1.0
-    )
+    mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1, zero_order_decay=True, decay=-1.0)
 
     # output control
     oc = flopy.mf6.ModflowGwtoc(
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )

--- a/autotest/test_gwt_mst05.py
+++ b/autotest/test_gwt_mst05.py
@@ -144,9 +144,7 @@ def build_models(idx, test):
         ]
     )
     wel = [
-        np.array(
-            [(0 + 1, 0 + 1, inflow_rate, source_concentration)], dtype=dt
-        ),
+        np.array([(0 + 1, 0 + 1, inflow_rate, source_concentration)], dtype=dt),
         np.array([(0 + 1, 0 + 1, inflow_rate, 0.0)], dtype=dt),
     ]
     chd = np.array([(ncol - 1 + 1, ncol - 1 + 1, -inflow_rate, 0.0)], dtype=dt)
@@ -159,9 +157,7 @@ def build_models(idx, test):
             ("SATURATION", np.float64),
         ]
     )
-    sat = np.array(
-        [(i, i, 0.0, 1.0) for i in range(nlay * nrow * ncol)], dtype=dt
-    )
+    sat = np.array([(i, i, 0.0, 1.0) for i in range(nlay * nrow * ncol)], dtype=dt)
 
     fname = os.path.join(ws, "mybudget.bud")
     with open(fname, "wb") as fbin:
@@ -239,9 +235,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -270,9 +264,7 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_gwt_mst06_noadv.py
+++ b/autotest/test_gwt_mst06_noadv.py
@@ -40,9 +40,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwt model
     gwtname = "gwt_" + name
@@ -89,9 +87,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=8.0, filename=f"{gwtname}.ic")
 
     # mass storage and transfer
-    mst = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=0.1, zero_order_decay=True, decay=1.0
-    )
+    mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1, zero_order_decay=True, decay=1.0)
 
     srcs = {0: [[(0, 0, 0), 0.00]]}
     src = flopy.mf6.ModflowGwtsrc(
@@ -107,9 +103,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.bud",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -128,9 +122,8 @@ def check_output(idx, test):
     # The answer
     # print(conc[:, 1])
     cres = np.array([7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0, 0.0, 0.0])
-    msg = (
-        "simulated concentrations do not match with known "
-        "solution. {} {}".format(conc[:, 1], cres)
+    msg = "simulated concentrations do not match with known solution. {} {}".format(
+        conc[:, 1], cres
     )
     assert np.allclose(cres, conc[:, 1]), msg
 
@@ -154,9 +147,8 @@ def check_output(idx, test):
         0.0,
         0.0,
     ]
-    msg = (
-        "simulated decay rates do not match with known "
-        "solution. {} {}".format(decay_rate, decay_rate_answer)
+    msg = "simulated decay rates do not match with known solution. {} {}".format(
+        decay_rate, decay_rate_answer
     )
     assert np.allclose(decay_rate, decay_rate_answer), msg
 

--- a/autotest/test_gwt_mt3dms_p01.py
+++ b/autotest/test_gwt_mt3dms_p01.py
@@ -222,18 +222,14 @@ def p01mf6(
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
     ws = model_ws
-    sim = flopy.mf6.MFSimulation(
-        sim_name=name, version="mf6", exe_name=exe, sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=name, version="mf6", exe_name=exe, sim_ws=ws)
     from flopy.mf6.mfbase import VerbosityLevel
 
     sim.simulation_data.verbosity_level = VerbosityLevel.quiet
     sim.name_file.memory_print_option = "all"
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -362,9 +358,7 @@ def p01mf6(
         scheme = "TVD"
     else:
         raise Exception()
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme=scheme, filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme=scheme, filename=f"{gwtname}.adv")
 
     # dispersion
     dsp = flopy.mf6.ModflowGwtdsp(gwt, xt3d_off=True, alh=al, ath1=0.1)
@@ -436,9 +430,7 @@ def p01mf6(
         gwt,
         budget_filerecord=f"{gwtname}.bud",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -462,9 +454,7 @@ def p01mf6(
 
     # load concentrations
     fname = os.path.join(model_ws, gwtname + ".ucn")
-    ucnobj = flopy.utils.HeadFile(
-        fname, precision="double", text="CONCENTRATION"
-    )
+    ucnobj = flopy.utils.HeadFile(fname, precision="double", text="CONCENTRATION")
     times = ucnobj.get_times()
     conc = ucnobj.get_alldata()
 

--- a/autotest/test_gwt_mvt01.py
+++ b/autotest/test_gwt_mvt01.py
@@ -55,9 +55,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -152,12 +150,8 @@ def build_models(idx, test):
     connlen = connwidth = delr / 2.0
     con_data = []
     # con_data=(ifno,iconn,(cellid),claktype,bedleak,belev,telev,connlen,connwidth )
-    con_data.append(
-        (0, 0, (0, 0, 0), "VERTICAL", 0.0, 0, 0, connlen, connwidth)
-    )
-    con_data.append(
-        (1, 0, (0, 0, ncol - 1), "VERTICAL", 0.0, 0, 0, connlen, connwidth)
-    )
+    con_data.append((0, 0, (0, 0, 0), "VERTICAL", 0.0, 0, 0, connlen, connwidth))
+    con_data.append((1, 0, (0, 0, ncol - 1), "VERTICAL", 0.0, 0, 0, connlen, connwidth))
     p_data = [
         (0, "STATUS", "CONSTANT"),
         (0, "STAGE", 1.0),
@@ -345,15 +339,11 @@ def build_models(idx, test):
     )
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # storage
     porosity = 1.0
-    sto = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
     # sources
     sourcerecarray = [
         ("CHD-1", "AUX", "CONCENTRATION"),
@@ -463,9 +453,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -511,9 +499,7 @@ def check_output(idx, test):
     # compare observation concs with binary file concs
     for i in range(7):
         oname = f"SFT{i + 1}CONC"
-        assert np.allclose(
-            tc[oname][-1], csft[i]
-        ), f"{tc[oname][-1]} {csft[i]}"
+        assert np.allclose(tc[oname][-1], csft[i]), f"{tc[oname][-1]} {csft[i]}"
 
     # load the sft budget file
     fname = gwtname + ".sft.bud"
@@ -537,9 +523,7 @@ def check_output(idx, test):
     )
     names = list(bud_lst)
     d0 = budl.get_budget(names=names)[0]
-    errmsg = (
-        f"SFR-1_OUT NOT EQUAL LAK-1_IN\n{d0['SFR-1_OUT']}\n{d0['LAK-1_IN']}"
-    )
+    errmsg = f"SFR-1_OUT NOT EQUAL LAK-1_IN\n{d0['SFR-1_OUT']}\n{d0['LAK-1_IN']}"
     assert np.allclose(d0["SFR-1_OUT"], d0["LAK-1_IN"])
 
 

--- a/autotest/test_gwt_mvt02.py
+++ b/autotest/test_gwt_mvt02.py
@@ -57,9 +57,7 @@ def build_models(idx, test):
         memory_print_option=["ALL"],
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -289,15 +287,11 @@ def build_models(idx, test):
         ic = flopy.mf6.ModflowGwtic(gwt, strt=10.0, filename=f"{gwtname}.ic")
 
         # advection
-        adv = flopy.mf6.ModflowGwtadv(
-            gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-        )
+        adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
         # storage
         porosity = 1.0
-        sto = flopy.mf6.ModflowGwtmst(
-            gwt, porosity=porosity, filename=f"{gwtname}.sto"
-        )
+        sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
         # sources
         sourcerecarray = [
             ("WEL-1", "AUX", "CONCENTRATION"),
@@ -434,9 +428,7 @@ def check_output(idx, test):
     # compare observation concs with binary file concs
     for i in range(7):
         oname = f"SFT{i + 1}CONC"
-        assert np.allclose(
-            tc[oname][-1], csft[i]
-        ), f"{tc[oname][-1]} {csft[i]}"
+        assert np.allclose(tc[oname][-1], csft[i]), f"{tc[oname][-1]} {csft[i]}"
 
     simres = tc["SFT1CONC"]
     answer = [

--- a/autotest/test_gwt_mvt02fmi.py
+++ b/autotest/test_gwt_mvt02fmi.py
@@ -48,9 +48,7 @@ def run_flow_model(dir, exe):
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=wsf, exe_name=exe)
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -254,9 +252,7 @@ def run_transport_model(dir, exe):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwt = flopy.mf6.ModflowGwt(
         sim,
@@ -296,15 +292,11 @@ def run_transport_model(dir, exe):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=10.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # storage
     porosity = 1.0
-    sto = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
     # sources
     sourcerecarray = [
         ("WEL-1", "AUX", "CONCENTRATION"),
@@ -380,9 +372,7 @@ def run_transport_model(dir, exe):
         budget_filerecord=f"{gwtname}.bud",
         budgetcsv_filerecord=f"{gwtname}.bud.csv",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -431,9 +421,7 @@ def run_transport_model(dir, exe):
     # compare observation concs with binary file concs
     for i in range(7):
         oname = f"SFT{i+1}CONC"
-        assert np.allclose(
-            tc[oname][-1], csft[i]
-        ), f"{tc[oname][-1]} {csft[i]}"
+        assert np.allclose(tc[oname][-1], csft[i]), f"{tc[oname][-1]} {csft[i]}"
 
     simres = tc["SFT1CONC"]
     answer = [

--- a/autotest/test_gwt_mwt01.py
+++ b/autotest/test_gwt_mwt01.py
@@ -53,9 +53,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -202,15 +200,11 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # storage
     porosity = 0.30
-    sto = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
     # sources
     sourcerecarray = [
         ("CHD-1", "AUX", "CONCENTRATION"),
@@ -244,9 +238,7 @@ def build_models(idx, test):
     obs1 = []
     for icv in range(ncv):
         for iconn in range(nconn):
-            obs1.append(
-                (f"mwt{icv + 1}x{iconn + 1}", obstype, icv + 1, iconn + 1)
-            )
+            obs1.append((f"mwt{icv + 1}x{iconn + 1}", obstype, icv + 1, iconn + 1))
     obs2 = [(f"bmwt{i + 1}", obstype, f"mymwt{i + 1}") for i in range(ncv)]
     mwt_obs[fname] = obs1 + obs2
 
@@ -285,9 +277,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[
             ("CONCENTRATION", "ALL"),
@@ -330,9 +320,7 @@ def check_obs(sim):
         conc_ra = gwt.mwt.obs.output.obs(f=csvfile).data
         success = True
         if ".concentration.csv" in csvfile:
-            print(
-                "Comparing binary concentrations with observed well concentrations."
-            )
+            print("Comparing binary concentrations with observed well concentrations.")
             is_same = np.allclose(conc_ra["BMWT1"], conc_mwt1)
             if not is_same:
                 success = False
@@ -343,9 +331,7 @@ def check_obs(sim):
         # check boundname observations with numeric ID observations
         for icv in range(1):
             # print(f"  Checking reach {imwt + 1}")
-            is_same = np.allclose(
-                conc_ra[f"MWT{icv + 1}"], conc_ra[f"BMWT{icv + 1}"]
-            )
+            is_same = np.allclose(conc_ra[f"MWT{icv + 1}"], conc_ra[f"BMWT{icv + 1}"])
             if not is_same:
                 success = False
                 for t, x, y in zip(

--- a/autotest/test_gwt_mwt02.py
+++ b/autotest/test_gwt_mwt02.py
@@ -44,9 +44,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -249,9 +247,7 @@ def build_models(idx, test):
         ic = flopy.mf6.ModflowGwtic(gwt, strt=0.000, filename=f"{gwtname}.ic")
 
         # advection
-        adv = flopy.mf6.ModflowGwtadv(
-            gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-        )
+        adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
         # dispersion
         diffc = 0.0
@@ -266,9 +262,7 @@ def build_models(idx, test):
 
         # storage
         porosity = 0.30
-        sto = flopy.mf6.ModflowGwtmst(
-            gwt, porosity=porosity, filename=f"{gwtname}.sto"
-        )
+        sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
 
         mwt_obs = {
             (gwtname + ".mwt.obs.csv",): [
@@ -402,9 +396,7 @@ def make_plot(sim):
 
     fname = gwtname + ".ucn"
     fname = os.path.join(ws, fname)
-    cobj = flopy.utils.HeadFile(
-        fname, text="CONCENTRATION"
-    )  # , precision='double')
+    cobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")  # , precision='double')
     conc = cobj.get_data()
 
     import matplotlib.pyplot as plt

--- a/autotest/test_gwt_obs01.py
+++ b/autotest/test_gwt_obs01.py
@@ -48,9 +48,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -181,9 +179,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme=scheme[idx], filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme=scheme[idx], filename=f"{gwtname}.adv")
 
     # mass storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
@@ -199,9 +195,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )

--- a/autotest/test_gwt_prudic2004t2.py
+++ b/autotest/test_gwt_prudic2004t2.py
@@ -40,9 +40,7 @@ def build_models(idx, test):
     # order to speed up this autotest
     tdis_rc = [(1.0, 1, 1.0), (365.25 * 25, 25, 1.0)]
     nper = len(tdis_rc)
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname)
 
@@ -121,18 +119,14 @@ def build_models(idx, test):
         gwf,
         budget_filerecord=f"{gwfname}.bud",
         head_filerecord=f"{gwfname}.hds",
-        headprintrecord=[
-            ("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        headprintrecord=[("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
     )
 
     rch_on = True
     if rch_on:
-        rch = flopy.mf6.ModflowGwfrcha(
-            gwf, recharge={0: 4.79e-3}, pname="RCH-1"
-        )
+        rch = flopy.mf6.ModflowGwfrcha(gwf, recharge={0: 4.79e-3}, pname="RCH-1")
 
     chdlist = []
     fname = str(model_path / "chd.dat")
@@ -150,9 +144,7 @@ def build_models(idx, test):
                     float(hd),
                 ]
             )
-    chd = flopy.mf6.ModflowGwfchd(
-        gwf, stress_period_data=chdlist, pname="CHD-1"
-    )
+    chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chdlist, pname="CHD-1")
 
     rivlist = []
     fname = str(model_path / "riv.dat")
@@ -447,9 +439,7 @@ def build_models(idx, test):
             if obstype == "TO-MVR":
                 ncv = 1
             obs1 = [(f"lkt{i + 1}", obstype, i + 1) for i in range(ncv)]
-            obs2 = [
-                (f"blkt{i + 1}", obstype, f"mylake{i + 1}") for i in range(ncv)
-            ]
+            obs2 = [(f"blkt{i + 1}", obstype, f"mylake{i + 1}") for i in range(ncv)]
             lkt_obs[fname] = obs1 + obs2
 
             # add LKT specific obs
@@ -464,9 +454,7 @@ def build_models(idx, test):
                 (f"lkt{2}-{iconn + 1}", obstype, 2, iconn + 1)
                 for iconn in range(nconn[1])  # lake 2
             ]
-            obs2 = [
-                (f"blkt{i + 1}", obstype, f"mylake{i + 1}") for i in range(ncv)
-            ]
+            obs2 = [(f"blkt{i + 1}", obstype, f"mylake{i + 1}") for i in range(ncv)]
             lkt_obs[fname] = obs1 + obs2
 
         lkt_obs["digits"] = 15
@@ -513,9 +501,7 @@ def build_models(idx, test):
             "EXT-OUTFLOW",
         ]:
             fname = f"{gwtname}.sft.obs.{obstype.lower()}.csv"
-            obs1 = [
-                (f"sft{i + 1}", obstype, i + 1) for i in range(sfrpd.shape[0])
-            ]
+            obs1 = [(f"sft{i + 1}", obstype, i + 1) for i in range(sfrpd.shape[0])]
             obs2 = [
                 (f"bsft{i + 1}", obstype, f"myreach{i + 1}")
                 for i in range(sfrpd.shape[0])
@@ -529,12 +515,9 @@ def build_models(idx, test):
             for id2 in reach_connections:
                 id2 = abs(id2)
                 if id1 != id2:
-                    obs1.append(
-                        (f"sft{id1 + 1}x{id2 + 1}", obstype, id1 + 1, id2 + 1)
-                    )
+                    obs1.append((f"sft{id1 + 1}x{id2 + 1}", obstype, id1 + 1, id2 + 1))
         obs2 = [
-            (f"bsft{i + 1}", obstype, f"myreach{i + 1}")
-            for i in range(sfrpd.shape[0])
+            (f"bsft{i + 1}", obstype, f"myreach{i + 1}") for i in range(sfrpd.shape[0])
         ]
         sft_obs[fname] = obs1 + obs2
 
@@ -780,17 +763,13 @@ def check_obs(sim):
     for ilake in [0, 1]:
         connection_sum = np.zeros(ntimes)
         for column_name in conc_ra.dtype.names:
-            if f"LKT{ilake + 1}" in column_name and column_name.startswith(
-                "LKT"
-            ):
+            if f"LKT{ilake + 1}" in column_name and column_name.startswith("LKT"):
                 connection_sum += conc_ra[column_name]
         is_same = np.allclose(connection_sum, conc_ra[f"BLKT{ilake + 1}"])
         if not is_same:
             success = False
             print(f"Problem with Lake {ilake + 1}")
-            for itime, (cs, blkt) in enumerate(
-                zip(connection_sum, conc_ra["BLKT1"])
-            ):
+            for itime, (cs, blkt) in enumerate(zip(connection_sum, conc_ra["BLKT1"])):
                 print(itime, cs, blkt)
 
     assert success, "One or more LKT obs checks did not pass"
@@ -833,18 +812,14 @@ def check_output(idx, test):
 
     fname = gwtname + ".lkt.bin"
     fname = os.path.join(ws, fname)
-    bobj = flopy.utils.HeadFile(
-        fname, precision="double", text="concentration"
-    )
+    bobj = flopy.utils.HeadFile(fname, precision="double", text="concentration")
     lkaconc = bobj.get_alldata()[:, 0, 0, :]
     times = bobj.times
     bobj.file.close()
 
     fname = gwtname + ".sft.bin"
     fname = os.path.join(ws, fname)
-    bobj = flopy.utils.HeadFile(
-        fname, precision="double", text="concentration"
-    )
+    bobj = flopy.utils.HeadFile(fname, precision="double", text="concentration")
     sfaconc = bobj.get_alldata()[:, 0, 0, :]
     times = bobj.times
     bobj.file.close()

--- a/autotest/test_gwt_prudic2004t2fmi.py
+++ b/autotest/test_gwt_prudic2004t2fmi.py
@@ -34,9 +34,7 @@ def run_flow_model(dir, exe):
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=wsf, exe_name=exe)
     tdis_rc = [(1.0, 1, 1.0), (365.25 * 25, 1, 1.0)]
     nper = len(tdis_rc)
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True)
 
@@ -104,18 +102,14 @@ def run_flow_model(dir, exe):
         gwf,
         budget_filerecord=f"{gwfname}.bud",
         head_filerecord=f"{gwfname}.hds",
-        headprintrecord=[
-            ("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        headprintrecord=[("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
     )
 
     rch_on = True
     if rch_on:
-        rch = flopy.mf6.ModflowGwfrcha(
-            gwf, recharge={0: 4.79e-3}, pname="RCH-1"
-        )
+        rch = flopy.mf6.ModflowGwfrcha(gwf, recharge={0: 4.79e-3}, pname="RCH-1")
 
     chdlist = []
     fname = os.path.join(model_path, "chd.dat")
@@ -133,9 +127,7 @@ def run_flow_model(dir, exe):
                     float(hd),
                 ]
             )
-    chd = flopy.mf6.ModflowGwfchd(
-        gwf, stress_period_data=chdlist, pname="CHD-1"
-    )
+    chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chdlist, pname="CHD-1")
 
     rivlist = []
     fname = os.path.join(model_path, "riv.dat")
@@ -392,9 +384,7 @@ def run_flow_model(dir, exe):
         fname = os.path.join(wsf, fname)
         lkstage = None
         if os.path.isfile(fname):
-            lksobj = flopy.utils.HeadFile(
-                fname, precision="double", text="stage"
-            )
+            lksobj = flopy.utils.HeadFile(fname, precision="double", text="stage")
             lkstage = lksobj.get_data().flatten()
             lksobj.file.close()
 
@@ -403,9 +393,7 @@ def run_flow_model(dir, exe):
         fname = os.path.join(wsf, fname)
         sfstage = None
         if os.path.isfile(fname):
-            bobj = flopy.utils.HeadFile(
-                fname, precision="double", text="stage"
-            )
+            bobj = flopy.utils.HeadFile(fname, precision="double", text="stage")
             sfstage = bobj.get_data().flatten()
             bobj.file.close()
 
@@ -445,9 +433,7 @@ def run_transport_model(dir, exe):
 
     tdis_rc = [(1.0, 1, 1.0), (365.25 * 25, 25, 1.0)]
     nper = len(tdis_rc)
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwt = flopy.mf6.ModflowGwt(sim, modelname=gwtname)
 
@@ -615,18 +601,14 @@ def run_transport_model(dir, exe):
 
     fname = gwtname + ".lkt.bin"
     fname = os.path.join(wst, fname)
-    bobj = flopy.utils.HeadFile(
-        fname, precision="double", text="concentration"
-    )
+    bobj = flopy.utils.HeadFile(fname, precision="double", text="concentration")
     lkaconc = bobj.get_alldata()[:, 0, 0, :]
     times = bobj.times
     bobj.file.close()
 
     fname = gwtname + ".sft.bin"
     fname = os.path.join(wst, fname)
-    bobj = flopy.utils.HeadFile(
-        fname, precision="double", text="concentration"
-    )
+    bobj = flopy.utils.HeadFile(fname, precision="double", text="concentration")
     sfaconc = bobj.get_alldata()[:, 0, 0, :]
     times = bobj.times
     bobj.file.close()
@@ -750,15 +732,11 @@ def run_transport_model(dir, exe):
     # Compare the budget terms from the list file and the budgetcsvfile
     fname = f"{gwtname}.bud.csv"
     fname = os.path.join(wst, fname)
-    csvra = np.genfromtxt(
-        fname, dtype=None, names=True, delimiter=",", deletechars=""
-    )
+    csvra = np.genfromtxt(fname, dtype=None, names=True, delimiter=",", deletechars="")
 
     fname = f"{gwtname}.lst"
     fname = os.path.join(wst, fname)
-    lst = flopy.utils.Mf6ListBudget(
-        fname, budgetkey="MASS BUDGET FOR ENTIRE MODEL"
-    )
+    lst = flopy.utils.Mf6ListBudget(fname, budgetkey="MASS BUDGET FOR ENTIRE MODEL")
     lstra = lst.get_incremental()
 
     # list file has additional terms, so need to pluck out the following for

--- a/autotest/test_gwt_prudic2004t2fmiats.py
+++ b/autotest/test_gwt_prudic2004t2fmiats.py
@@ -39,9 +39,7 @@ def run_flow_model(dir, exe):
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=wsf, exe_name=exe)
     tdis_rc = [(1.0, 1, 1.0), (365.25 * 25, 1, 1.0)]
     nper = len(tdis_rc)
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True)
 
@@ -109,18 +107,14 @@ def run_flow_model(dir, exe):
         gwf,
         budget_filerecord=f"{gwfname}.bud",
         head_filerecord=f"{gwfname}.hds",
-        headprintrecord=[
-            ("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        headprintrecord=[("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
     )
 
     rch_on = True
     if rch_on:
-        rch = flopy.mf6.ModflowGwfrcha(
-            gwf, recharge={0: 4.79e-3}, pname="RCH-1"
-        )
+        rch = flopy.mf6.ModflowGwfrcha(gwf, recharge={0: 4.79e-3}, pname="RCH-1")
 
     chdlist = []
     fname = os.path.join(model_path, "chd.dat")
@@ -138,9 +132,7 @@ def run_flow_model(dir, exe):
                     float(hd),
                 ]
             )
-    chd = flopy.mf6.ModflowGwfchd(
-        gwf, stress_period_data=chdlist, pname="CHD-1"
-    )
+    chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chdlist, pname="CHD-1")
 
     rivlist = []
     fname = os.path.join(model_path, "riv.dat")
@@ -388,9 +380,7 @@ def run_flow_model(dir, exe):
         fname = os.path.join(wsf, fname)
         lkstage = None
         if os.path.isfile(fname):
-            lksobj = flopy.utils.HeadFile(
-                fname, precision="double", text="stage"
-            )
+            lksobj = flopy.utils.HeadFile(fname, precision="double", text="stage")
             lkstage = lksobj.get_data().flatten()
             lksobj.file.close()
 
@@ -399,9 +389,7 @@ def run_flow_model(dir, exe):
         fname = os.path.join(wsf, fname)
         sfstage = None
         if os.path.isfile(fname):
-            bobj = flopy.utils.HeadFile(
-                fname, precision="double", text="stage"
-            )
+            bobj = flopy.utils.HeadFile(fname, precision="double", text="stage")
             sfstage = bobj.get_data().flatten()
             bobj.file.close()
 
@@ -629,18 +617,14 @@ def run_transport_model(dir, exe):
 
     fname = gwtname + ".lkt.bin"
     fname = os.path.join(wst, fname)
-    bobj = flopy.utils.HeadFile(
-        fname, precision="double", text="concentration"
-    )
+    bobj = flopy.utils.HeadFile(fname, precision="double", text="concentration")
     lkaconc = bobj.get_alldata()[:, 0, 0, :]
     times = bobj.times
     bobj.file.close()
 
     fname = gwtname + ".sft.bin"
     fname = os.path.join(wst, fname)
-    bobj = flopy.utils.HeadFile(
-        fname, precision="double", text="concentration"
-    )
+    bobj = flopy.utils.HeadFile(fname, precision="double", text="concentration")
     sfaconc = bobj.get_alldata()[:, 0, 0, :]
     times = bobj.times
     bobj.file.close()
@@ -845,9 +829,7 @@ def run_transport_model(dir, exe):
             all_found = False
             print(f"text not found in mfsim.lst: {stxt}")
         print(msg)
-    assert (
-        all_found
-    ), "One or more required text strings not found in mfsim.lst"
+    assert all_found, "One or more required text strings not found in mfsim.lst"
 
 
 @pytest.mark.slow

--- a/autotest/test_gwt_prudic2004t2gwtgwt.py
+++ b/autotest/test_gwt_prudic2004t2gwtgwt.py
@@ -236,9 +236,7 @@ def build_models(idx, test):
     return sim, regression
 
 
-def sfr_packagedata_to_list(
-    fname, gwf, boundnames=False, convert_to_zero_base=True
-):
+def sfr_packagedata_to_list(fname, gwf, boundnames=False, convert_to_zero_base=True):
     dt = flopy.mf6.ModflowGwfsfr.packagedata.dtype(
         gwf, cellid_expanded=True, boundnames=boundnames, timeseries=False
     )
@@ -265,9 +263,7 @@ def sfr_connectiondata_to_list(fname, convert_to_zero_base=True):
     with open(fname) as f:
         cd_list = [[int(i) for i in s.strip().split()] for s in f.readlines()]
     if convert_to_zero_base:
-        cd_list = [
-            [np.sign(irch) * (abs(irch) - 1) for irch in l] for l in cd_list
-        ]
+        cd_list = [[np.sign(irch) * (abs(irch) - 1) for irch in l] for l in cd_list]
     return cd_list
 
 
@@ -325,17 +321,13 @@ def build_gwfgwt_combo(
         gwf,
         budget_filerecord=f"{gwfname}.bud",
         head_filerecord=f"{gwfname}.hds",
-        headprintrecord=[
-            ("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        headprintrecord=[("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
     )
 
     if rch_on:
-        rch = flopy.mf6.ModflowGwfrcha(
-            gwf, recharge={0: 4.79e-3}, pname="RCH-1"
-        )
+        rch = flopy.mf6.ModflowGwfrcha(gwf, recharge={0: 4.79e-3}, pname="RCH-1")
 
     if icombo == 1:
         fname = "chd_north.dat"
@@ -349,9 +341,7 @@ def build_gwfgwt_combo(
         if len(ll) == 4:
             k, i, j, hd = ll
             chdlist.append([int(k) - 1, int(i) - 1, int(j) - 1, float(hd)])
-    chd = flopy.mf6.ModflowGwfchd(
-        gwf, stress_period_data=chdlist, pname="CHD-1"
-    )
+    chd = flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chdlist, pname="CHD-1")
 
     if sfr_on:
         if icombo == 1:
@@ -737,19 +727,13 @@ def make_concentration_vs_time(sim, ws, ans_lak1, ans_sfr3, ans_sfr4):
         times = np.array(times) / 365.0
         if lkaconc is not None:
             plt.plot(times, lkaconc[:, 0], "b-", label="Lake 1")
-            plt.plot(
-                times, ans_lak1, ls="none", marker="o", mfc="none", mec="b"
-            )
+            plt.plot(times, ans_lak1, ls="none", marker="o", mfc="none", mec="b")
         if sft3outflowconc is not None:
             plt.plot(times, sft3outflowconc, "r-", label="Stream segment 3")
-            plt.plot(
-                times, ans_sfr3, ls="none", marker="o", mfc="none", mec="r"
-            )
+            plt.plot(times, ans_sfr3, ls="none", marker="o", mfc="none", mec="r")
         if sft4outflowconc is not None:
             plt.plot(times, sft4outflowconc, "g-", label="Stream segment 4")
-            plt.plot(
-                times, ans_sfr4, ls="none", marker="o", mfc="none", mec="g"
-            )
+            plt.plot(times, ans_sfr4, ls="none", marker="o", mfc="none", mec="g")
         plt.legend()
         plt.ylim(0, 50)
         plt.xlim(0, 25)
@@ -798,9 +782,7 @@ def make_head_map(sim, ws):
         pmv.plot_array(lakibd, masked_values=[0], alpha=0.2)
         pmv.plot_ibound(idomain)
         pmv.plot_bc(name="CHD-1", color="blue")
-        cs = pmv.contour_array(
-            head_global, levels=levels, masked_values=[1.0e30]
-        )
+        cs = pmv.contour_array(head_global, levels=levels, masked_values=[1.0e30])
         ax.clabel(cs, cs.levels[::5], fmt="%1.0f", colors="b")
         ax.set_title(f"Model layer {ilay + 1}")
 

--- a/autotest/test_gwt_sft01.py
+++ b/autotest/test_gwt_sft01.py
@@ -55,9 +55,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -268,15 +266,11 @@ def build_models(idx, test):
     )
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # storage
     porosity = 1.0
-    sto = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
     # sources
     sourcerecarray = [
         ("CHD-1", "AUX", "CONCENTRATION"),
@@ -347,9 +341,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -395,9 +387,7 @@ def check_output(idx, test):
     # compare observation concs with binary file concs
     for i in range(7):
         oname = f"SFT{i + 1}CONC"
-        assert np.allclose(
-            tc[oname][-1], csft[i]
-        ), f"{tc[oname][-1]} {csft[i]}"
+        assert np.allclose(tc[oname][-1], csft[i]), f"{tc[oname][-1]} {csft[i]}"
 
     # load the sft budget file
     fname = gwtname + ".sft.bud"

--- a/autotest/test_gwt_sft01gwtgwt.py
+++ b/autotest/test_gwt_sft01gwtgwt.py
@@ -176,9 +176,7 @@ def build_models(idx, test):
     if across_model_mvr_on:
         maxmvr, maxpackages = 1, 2
         mvrpack_sim = [["flow1", "sfr-1"], ["flow2", "sfr-1"]]
-        mvrspd = [
-            ["flow1", "sfr-1", ncol - 1, "flow2", "sfr-1", 0, "FACTOR", 1.00]
-        ]
+        mvrspd = [["flow1", "sfr-1", ncol - 1, "flow2", "sfr-1", 0, "FACTOR", 1.00]]
         gwfgwf.mvr.initialize(
             modelnames=True,
             maxmvr=maxmvr,
@@ -459,9 +457,7 @@ def build_gwfgwt_combo(sim, gwfname, gwtname, icombo):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )

--- a/autotest/test_gwt_sft_inactive01.py
+++ b/autotest/test_gwt_sft_inactive01.py
@@ -185,20 +185,14 @@ def set_connectiondata(n, lay, top, left, right, bottom):
     if top:
         jas.append(n - ncol)
         ihc.append(0)  # ihc = 0 for vertical connection
-        cl12.append(
-            cl12_val
-        )  # half the cell thickness or a vertical connection
-        hwva.append(
-            delr * delc
-        )  # for vertical connection, area is 1.0m x 1.0m
+        cl12.append(cl12_val)  # half the cell thickness or a vertical connection
+        hwva.append(delr * delc)  # for vertical connection, area is 1.0m x 1.0m
         angldeg.append(0.0)  # placeholder only for vertical connections
 
     if left:
         jas.append(n - 1)  # left
         ihc.append(1)  # ihc = 1 for horizontal connection
-        cl12.append(
-            delc / 2
-        )  # half the cell width along a horizontal connection
+        cl12.append(delc / 2)  # half the cell width along a horizontal connection
         hwva.append(
             delr
         )  # for horizontal connection, value of hwva is width along a row
@@ -209,9 +203,7 @@ def set_connectiondata(n, lay, top, left, right, bottom):
     if right:
         jas.append(n + 1)  # right
         ihc.append(1)  # ihc = 1 for horizontal connection
-        cl12.append(
-            delc / 2
-        )  # half the cell width along a horizontal connection
+        cl12.append(delc / 2)  # half the cell width along a horizontal connection
         hwva.append(
             delc
         )  # for horizontal connection, value of hwva is width along a row
@@ -222,12 +214,8 @@ def set_connectiondata(n, lay, top, left, right, bottom):
     if bottom:
         jas.append(n + ncol)  # below
         ihc.append(0)  # ihc = 0 for vertical connection
-        cl12.append(
-            cl12_val
-        )  # half the cell thickness or a vertical connection
-        hwva.append(
-            delr * delc
-        )  # for vertical connection, value of hwva is area
+        cl12.append(cl12_val)  # half the cell thickness or a vertical connection
+        hwva.append(delr * delc)  # for vertical connection, value of hwva is area
         angldeg.append(0.0)  # placeholder only for vertical connections
 
     return jas, ihc, cl12, hwva, angldeg
@@ -397,9 +385,7 @@ def build_models(idx, test):
     )
 
     # Instantiate time discretization package
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # Instantiate flow model
     gwf = flopy.mf6.ModflowGwf(
@@ -631,9 +617,7 @@ def build_models(idx, test):
         ("WEL-left", "AUX", "CONCENTRATION"),
         ("WEL-right", "AUX", "CONCENTRATION"),
     ]
-    flopy.mf6.ModflowGwtssm(
-        gwt, sources=sourcerecarray, filename=f"{gwtname}.ssm"
-    )
+    flopy.mf6.ModflowGwtssm(gwt, sources=sourcerecarray, filename=f"{gwtname}.ssm")
 
     # Instantiate streamflow transport package
     sftpackagedata = []
@@ -663,9 +647,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )

--- a/autotest/test_gwt_src01.py
+++ b/autotest/test_gwt_src01.py
@@ -53,9 +53,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -170,9 +168,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # dispersion
     xt3d_off = not xt3d[idx]
@@ -218,9 +214,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )

--- a/autotest/test_gwt_ssm01fmi.py
+++ b/autotest/test_gwt_ssm01fmi.py
@@ -30,9 +30,7 @@ def run_flow_model(dir, exe):
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=wsf, exe_name=exe)
     tdis_rc = [(100.0, 1, 1.0), (100.0, 1, 1.0)]
     nper = len(tdis_rc)
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True)
 
@@ -97,18 +95,14 @@ def run_flow_model(dir, exe):
         gwf,
         budget_filerecord=f"{gwfname}.bud",
         head_filerecord=f"{gwfname}.hds",
-        headprintrecord=[
-            ("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        headprintrecord=[("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
     )
 
     rch_on = False
     if rch_on:
-        rch = flopy.mf6.ModflowGwfrcha(
-            gwf, recharge={0: 4.79e-3}, pname="RCH-1"
-        )
+        rch = flopy.mf6.ModflowGwfrcha(gwf, recharge={0: 4.79e-3}, pname="RCH-1")
 
     # wel
     wellist = []
@@ -183,9 +177,7 @@ def run_transport_model(dir, exe):
 
     tdis_rc = [(100.0, 10, 1.0), (100.0, 10, 1.0)]
     nper = len(tdis_rc)
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwt = flopy.mf6.ModflowGwt(sim, modelname=gwtname)
 
@@ -230,15 +222,9 @@ def run_transport_model(dir, exe):
     # Create the ssm sources block information
     sourcerecarray = []
     # sourcerecarray += [("WEL-1", "AUX", "CONCENTRATION")]
-    sourcerecarray += [
-        (f"GHB-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2, 3]
-    ]
-    sourcerecarray += [
-        (f"RIV-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2]
-    ]
-    sourcerecarray += [
-        (f"DRN-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2]
-    ]
+    sourcerecarray += [(f"GHB-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2, 3]]
+    sourcerecarray += [(f"RIV-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2]]
+    sourcerecarray += [(f"DRN-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2]]
 
     fileinput = [
         ("WEL-1", f"{gwtname}.wel1.spc"),
@@ -258,9 +244,7 @@ def run_transport_model(dir, exe):
         ("GWFHEAD", "../flow/flow.hds", None),
         ("GWFBUDGET", "../flow/flow.bud", None),
     ]
-    fmi = flopy.mf6.ModflowGwtfmi(
-        gwt, packagedata=pd, flow_imbalance_correction=True
-    )
+    fmi = flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd, flow_imbalance_correction=True)
 
     oc = flopy.mf6.ModflowGwtoc(
         gwt,
@@ -282,9 +266,7 @@ def run_transport_model(dir, exe):
     # ensure budget table can be parsed
     fname = gwtname + ".lst"
     fname = os.path.join(wst, fname)
-    budl = flopy.utils.Mf6ListBudget(
-        fname, budgetkey="MASS BUDGET FOR ENTIRE MODEL"
-    )
+    budl = flopy.utils.Mf6ListBudget(fname, budgetkey="MASS BUDGET FOR ENTIRE MODEL")
     d0 = budl.get_budget()[0]
 
     # Load the csv representation of the budget

--- a/autotest/test_gwt_ssm02.py
+++ b/autotest/test_gwt_ssm02.py
@@ -47,9 +47,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -176,9 +174,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=100.0)
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # mass storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=sy[idx])
@@ -195,9 +191,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )

--- a/autotest/test_gwt_ssm03.py
+++ b/autotest/test_gwt_ssm03.py
@@ -42,9 +42,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -192,9 +190,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )

--- a/autotest/test_gwt_ssm04.py
+++ b/autotest/test_gwt_ssm04.py
@@ -58,9 +58,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -213,9 +211,7 @@ def build_models(idx, test):
         time_series_namerecord=time_series_namerecord,
         interpolation_methodrecord=interpolation_methodrecord,
     )
-    np.savetxt(
-        os.path.join(ws, f"{gwfname}.rch4.tas.dat"), recharge_rate, fmt="%7.1f"
-    )
+    np.savetxt(os.path.join(ws, f"{gwfname}.rch4.tas.dat"), recharge_rate, fmt="%7.1f")
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(
@@ -382,9 +378,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )

--- a/autotest/test_gwt_ssm04fmi.py
+++ b/autotest/test_gwt_ssm04fmi.py
@@ -61,9 +61,7 @@ def run_flow_model(dir, exe):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -259,9 +257,7 @@ def run_transport_model(dir, exe):
         tdis_rc.append((perlen[i], nstp[i], tsmult[i]))
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwt model
     gwt = flopy.mf6.ModflowGwt(sim, modelname=gwtname)
@@ -409,9 +405,7 @@ def run_transport_model(dir, exe):
             time_series_namerecord=time_series_namerecord,
             interpolation_methodrecord=interpolation_methodrecord,
         )
-        recharge_concentration = (
-            np.arange(nrow * ncol).reshape((nrow, ncol)) + 1
-        )
+        recharge_concentration = np.arange(nrow * ncol).reshape((nrow, ncol)) + 1
         np.savetxt(
             os.path.join(wst, f"{gwtname}.rch4.spc.tas.dat"),
             recharge_concentration,
@@ -423,9 +417,7 @@ def run_transport_model(dir, exe):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -449,9 +441,7 @@ def run_transport_model(dir, exe):
         ("GWFHEAD", "../flow/flow.hds", None),
         ("GWFBUDGET", "../flow/flow.bud", None),
     ]
-    fmi = flopy.mf6.ModflowGwtfmi(
-        gwt, packagedata=pd, flow_imbalance_correction=True
-    )
+    fmi = flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd, flow_imbalance_correction=True)
 
     sim.write_simulation()
     success, buff = sim.run_simulation(silent=False)

--- a/autotest/test_gwt_ssm05.py
+++ b/autotest/test_gwt_ssm05.py
@@ -52,9 +52,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -201,9 +199,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )

--- a/autotest/test_gwt_ssm06.py
+++ b/autotest/test_gwt_ssm06.py
@@ -46,9 +46,7 @@ def run_flw_and_trnprt_models(dir, exe):
     sim = flopy.mf6.MFSimulation(sim_name=testgroup, sim_ws=ws, exe_name=exe)
     tdis_rc = [(100.0, 10, 1.0), (100.0, 10, 1.0)]
     nper = len(tdis_rc)
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True)
 
@@ -111,9 +109,7 @@ def run_flw_and_trnprt_models(dir, exe):
         gwf,
         budget_filerecord=f"{gwfname}.bud",
         head_filerecord=f"{gwfname}.hds",
-        headprintrecord=[
-            ("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        headprintrecord=[("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
     )
@@ -204,9 +200,7 @@ def run_flw_and_trnprt_models(dir, exe):
     static_mvrperioddata = []
     wel_idx = 0
     for wl in np.arange(2):  # There are only a maximum of 2 wells
-        static_mvrperioddata.append(
-            ("WEL-1", wel_idx, "SFR-1", 0, "FACTOR", 1.0)
-        )
+        static_mvrperioddata.append(("WEL-1", wel_idx, "SFR-1", 0, "FACTOR", 1.0))
         wel_idx += 1
 
     mvrspd = {0: static_mvrperioddata}
@@ -268,12 +262,8 @@ def run_flw_and_trnprt_models(dir, exe):
     # Create the ssm sources block information
     sourcerecarray = []
     # sourcerecarray += [("WEL-1", "AUX", "CONCENTRATION")]
-    sourcerecarray += [
-        (f"GHB-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2, 3]
-    ]
-    sourcerecarray += [
-        (f"DRN-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2]
-    ]
+    sourcerecarray += [(f"GHB-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2, 3]]
+    sourcerecarray += [(f"DRN-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2]]
     sourcerecarray += [(f"WEL-{i+1}", "AUX", "CONCENTRATION") for i in [0]]
     ssm = flopy.mf6.ModflowGwtssm(
         gwt,
@@ -335,9 +325,7 @@ def run_flw_and_trnprt_models(dir, exe):
     # ensure budget table can be parsed
     fname = gwtname + ".lst"
     fname = os.path.join(ws, fname)
-    budl = flopy.utils.Mf6ListBudget(
-        fname, budgetkey="MASS BUDGET FOR ENTIRE MODEL"
-    )
+    budl = flopy.utils.Mf6ListBudget(fname, budgetkey="MASS BUDGET FOR ENTIRE MODEL")
     d0 = budl.get_budget()[0]
 
     # Load the csv representation of the budget

--- a/autotest/test_gwt_ssm06fmi.py
+++ b/autotest/test_gwt_ssm06fmi.py
@@ -53,9 +53,7 @@ def run_flow_model(dir, exe):
     sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=wsf, exe_name=exe)
     tdis_rc = [(100.0, 1, 1.0), (100.0, 1, 1.0)]
     nper = len(tdis_rc)
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True)
 
@@ -120,18 +118,14 @@ def run_flow_model(dir, exe):
         gwf,
         budget_filerecord=f"{gwfname}.bud",
         head_filerecord=f"{gwfname}.hds",
-        headprintrecord=[
-            ("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        headprintrecord=[("COLUMNS", ncol, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
     )
 
     rch_on = False
     if rch_on:
-        rch = flopy.mf6.ModflowGwfrcha(
-            gwf, recharge={0: 4.79e-3}, pname="RCH-1"
-        )
+        rch = flopy.mf6.ModflowGwfrcha(gwf, recharge={0: 4.79e-3}, pname="RCH-1")
 
     # wel
     wellist = []
@@ -219,9 +213,7 @@ def run_flow_model(dir, exe):
     static_mvrperioddata = []
     wel_idx = 0
     for wl in np.arange(2):  # There are only a maximum of 2 wells
-        static_mvrperioddata.append(
-            ("WEL-1", wel_idx, "SFR-1", 0, "FACTOR", 1.0)
-        )
+        static_mvrperioddata.append(("WEL-1", wel_idx, "SFR-1", 0, "FACTOR", 1.0))
         wel_idx += 1
 
     mvrspd = {0: static_mvrperioddata}
@@ -256,9 +248,7 @@ def run_transport_model(dir, exe):
 
     tdis_rc = [(100.0, 10, 1.0), (100.0, 10, 1.0)]
     nper = len(tdis_rc)
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     gwt = flopy.mf6.ModflowGwt(sim, modelname=gwtname)
 
@@ -303,16 +293,10 @@ def run_transport_model(dir, exe):
     # Create the ssm sources block information
     sourcerecarray = []
     sourcerecarray += [("WEL-1", "AUX", "CONCENTRATION")]
-    sourcerecarray += [
-        (f"GHB-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2, 3]
-    ]
-    sourcerecarray += [
-        (f"DRN-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2]
-    ]
+    sourcerecarray += [(f"GHB-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2, 3]]
+    sourcerecarray += [(f"DRN-{i+1}", "AUX", "CONCENTRATION") for i in [0, 1, 2]]
 
-    ssm = flopy.mf6.ModflowGwtssm(
-        gwt, print_flows=True, sources=sourcerecarray
-    )
+    ssm = flopy.mf6.ModflowGwtssm(gwt, print_flows=True, sources=sourcerecarray)
 
     pd = [
         ("GWFHEAD", "../flow/flow.hds", None),
@@ -320,9 +304,7 @@ def run_transport_model(dir, exe):
         ("GWFMOVER", "../flow/flow.mvr.bud", None),
         ("SFR-1", "../flow/flow.sfr.bud", None),
     ]
-    fmi = flopy.mf6.ModflowGwtfmi(
-        gwt, packagedata=pd, flow_imbalance_correction=True
-    )
+    fmi = flopy.mf6.ModflowGwtfmi(gwt, packagedata=pd, flow_imbalance_correction=True)
 
     sftpkdat = []
     for irno in range(len(sfrcells)):
@@ -368,9 +350,7 @@ def run_transport_model(dir, exe):
     # ensure budget table can be parsed
     fname = gwtname + ".lst"
     fname = os.path.join(wst, fname)
-    budl = flopy.utils.Mf6ListBudget(
-        fname, budgetkey="MASS BUDGET FOR ENTIRE MODEL"
-    )
+    budl = flopy.utils.Mf6ListBudget(fname, budgetkey="MASS BUDGET FOR ENTIRE MODEL")
     d0 = budl.get_budget()[0]
 
     # Load the csv representation of the budget for confirming that the model ran

--- a/autotest/test_gwt_subset.py
+++ b/autotest/test_gwt_subset.py
@@ -133,9 +133,7 @@ def get_gwt_model(sim, gwtname, gwtpath, modelshape):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
     )
@@ -156,9 +154,7 @@ def build_models(idx, test):
 
     # build MODFLOW 6 files
     ws = test.workspace
-    sim = flopy.mf6.MFSimulation(
-        sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws
-    )
+    sim = flopy.mf6.MFSimulation(sim_name=ws, version="mf6", exe_name="mf6", sim_ws=ws)
     # create tdis package
     tdis = flopy.mf6.ModflowTdis(
         sim, time_units="DAYS", nper=nper, perioddata=tdis_rc, pname="sim.tdis"
@@ -262,18 +258,14 @@ def check_output(idx, test):
 
     fpth = os.path.join(test.workspace, gwtname, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'
 
     # this simply checks if the solute from the right at t = 0
     # has arrived all the way on the left at t = t_end:
-    assert conc[0, 0, 0] == pytest.approx(
-        1.0
-    ), "concentration should be close to 1.0"
+    assert conc[0, 0, 0] == pytest.approx(1.0), "concentration should be close to 1.0"
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))

--- a/autotest/test_gwt_uzt01.py
+++ b/autotest/test_gwt_uzt01.py
@@ -55,9 +55,7 @@ def build_models(idx, test):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -106,9 +104,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # node property flow
-    npf = flopy.mf6.ModflowGwfnpf(
-        gwf, save_flows=False, icelltype=laytyp, k=hk
-    )
+    npf = flopy.mf6.ModflowGwfnpf(gwf, save_flows=False, icelltype=laytyp, k=hk)
     # storage
     sto = flopy.mf6.ModflowGwfsto(
         gwf,
@@ -135,8 +131,7 @@ def build_models(idx, test):
     # note: for specifying lake number, use fortran indexing!
     uzf_obs = {
         gwfname + ".uzf.obs.csv": [
-            (f"wc{k + 1}", "water-content", k + 1, 0.5 * delv)
-            for k in range(nlay)
+            (f"wc{k + 1}", "water-content", k + 1, 0.5 * delv) for k in range(nlay)
         ]
     }
 
@@ -219,9 +214,7 @@ def build_models(idx, test):
     obs_lst.append(["obs1", "head", (0, 0, 0)])
     obs_lst.append(["obs2", "head", (1, 0, 0)])
     obs_dict = {f"{gwfname}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     # create gwt model
     gwtname = "gwt_" + name
@@ -265,15 +258,11 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="UPSTREAM", filename=f"{gwtname}.adv")
 
     # storage
     porosity = sy
-    sto = flopy.mf6.ModflowGwtmst(
-        gwt, porosity=porosity, filename=f"{gwtname}.sto"
-    )
+    sto = flopy.mf6.ModflowGwtmst(gwt, porosity=porosity, filename=f"{gwtname}.sto")
     # sources
     sourcerecarray = [
         (),
@@ -346,9 +335,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.bud",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[
             ("CONCENTRATION", "ALL"),
             ("BUDGET", "ALL"),
@@ -438,9 +425,7 @@ def check_obs(sim):
             # print(f"  Checking control volume {icv + 1}")
 
             if ".concentration.csv" in csvfile:
-                is_same = np.allclose(
-                    conc_ra[f"BUZT{icv + 1}"], conc_uzt[:, icv]
-                )
+                is_same = np.allclose(conc_ra[f"BUZT{icv + 1}"], conc_uzt[:, icv])
                 if not is_same:
                     success = False
                     print(
@@ -448,9 +433,7 @@ def check_obs(sim):
                     )
                     print(conc_ra["BUZT1"], conc_uzt)
 
-            is_same = np.allclose(
-                conc_ra[f"UZT{icv + 1}"], conc_ra[f"BUZT{icv + 1}"]
-            )
+            is_same = np.allclose(conc_ra[f"UZT{icv + 1}"], conc_ra[f"BUZT{icv + 1}"])
             if not is_same:
                 success = False
                 for t, x, y in zip(
@@ -527,9 +510,7 @@ def check_output(idx, test):
     bobj = flopy.utils.CellBudgetFile(bpth, precision="double")
     uzet = bobj.get_data(text="UZET")
     uz_answer = [-0.432] + 14 * [0.0]
-    for uz in uzet[
-        100:
-    ]:  # Need to look later in simulation when ET demand is met
+    for uz in uzet[100:]:  # Need to look later in simulation when ET demand is met
         msg = f"unsat ET not correct.  Found {uz['q']}.  Should be {uz_answer}"
         assert np.allclose(uz["q"], uz_answer), msg
 

--- a/autotest/test_gwt_uztmvt2x2.py
+++ b/autotest/test_gwt_uztmvt2x2.py
@@ -52,9 +52,7 @@ from framework import TestFramework
 scheme = "UPSTREAM"
 # scheme = "TVD"
 
-cases = [
-    "uztmvt"
-]  # 2-cell model, horizontally connected with staggered alignment
+cases = ["uztmvt"]  # 2-cell model, horizontally connected with staggered alignment
 
 nrow = 2
 ncol = 2
@@ -233,9 +231,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 time discretization
-    flopy.mf6.ModflowTdis(
-        sim, nper=nper, perioddata=tdis_rc, time_units=time_units
-    )
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
 
     # Instantiating MODFLOW 6 groundwater flow model
     gwf = flopy.mf6.ModflowGwf(
@@ -391,9 +387,7 @@ def build_models(idx, test):
     # ----------------------------------------------------
     # Instantiating MODFLOW 6 GWT model
     # ----------------------------------------------------
-    gwt = flopy.mf6.ModflowGwt(
-        sim, modelname=gwtname, model_nam_file=f"{gwtname}.nam"
-    )
+    gwt = flopy.mf6.ModflowGwt(sim, modelname=gwtname, model_nam_file=f"{gwtname}.nam")
     gwt.name_file.save_flows = True
     imsgwt = flopy.mf6.ModflowIms(
         sim,
@@ -429,9 +423,7 @@ def build_models(idx, test):
     )
 
     # Instantiating MODFLOW 6 transport initial concentrations
-    flopy.mf6.ModflowGwtic(
-        gwt, strt=strt_conc, pname="IC-1", filename=f"{gwtname}.ic"
-    )
+    flopy.mf6.ModflowGwtic(gwt, strt=strt_conc, pname="IC-1", filename=f"{gwtname}.ic")
 
     # Instantiating MODFLOW 6 transport advection package
     flopy.mf6.ModflowGwtadv(
@@ -506,17 +498,13 @@ def build_models(idx, test):
         pname="OC-2",
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
 
     sourcerecarray = [[]]
-    flopy.mf6.ModflowGwessm(
-        gwt, sources=sourcerecarray, filename=f"{gwtname}.ssm"
-    )
+    flopy.mf6.ModflowGwessm(gwt, sources=sourcerecarray, filename=f"{gwtname}.ssm")
 
     # Instantiating MODFLOW 6 flow-transport exchange mechanism
     flopy.mf6.ModflowGwfgwt(
@@ -581,9 +569,7 @@ def check_output(idx, test):
                 continue
             else:
                 for z in np.arange(len(mvrdat[x + 1][y])):
-                    assert np.isclose(
-                        abs(mvrdat[x + 1][y][z][-1]), x + 1.0
-                    ), msg0
+                    assert np.isclose(abs(mvrdat[x + 1][y][z][-1]), x + 1.0), msg0
 
     # Transport mover (MVT) amounts are known quantities
     msg1 = "Rejected infiltration transfer mass amount not as expected"

--- a/autotest/test_gwt_zb01.py
+++ b/autotest/test_gwt_zb01.py
@@ -60,9 +60,7 @@ def build_models(idx, test):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwfname = "gwf_" + name
@@ -209,9 +207,7 @@ def build_models(idx, test):
     ic = flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
 
     # advection
-    adv = flopy.mf6.ModflowGwtadv(
-        gwt, scheme="upstream", filename=f"{gwtname}.adv"
-    )
+    adv = flopy.mf6.ModflowGwtadv(gwt, scheme="upstream", filename=f"{gwtname}.adv")
 
     # mass storage and transfer
     mst = flopy.mf6.ModflowGwtmst(gwt, porosity=0.1)
@@ -227,9 +223,7 @@ def build_models(idx, test):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "LAST"), ("BUDGET", "LAST")],
     )
@@ -384,9 +378,7 @@ def check_output(idx, test):
     for i, (key0, key) in enumerate(zip(zone_lst, bud_lst)):
         diffzb[:, i] = zbsum[key0] - d[key]
     diffzbmax = np.abs(diffzb).max()
-    msg += (
-        f"\nmaximum absolute zonebudget-cell by cell difference ({diffzbmax}) "
-    )
+    msg += f"\nmaximum absolute zonebudget-cell by cell difference ({diffzbmax}) "
 
     # write summary
     with open(ws / f"{os.path.basename(test.name)}.zbud.cmp.out", "w") as f:

--- a/autotest/test_gwtgwt_oldexg.py
+++ b/autotest/test_gwtgwt_oldexg.py
@@ -105,9 +105,7 @@ def get_model(idx, dir):
         sim_name=name, version="mf6", exe_name="mf6", sim_ws=dir
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -399,9 +397,7 @@ def add_gwtrefmodel(sim):
         gwt,
         budget_filerecord=f"{mname_gwtref}.cbc",
         concentration_filerecord=f"{mname_gwtref}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -452,9 +448,7 @@ def add_gwtleftmodel(sim):
         gwt,
         budget_filerecord=f"{mname_gwtleft}.cbc",
         concentration_filerecord=f"{mname_gwtleft}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )
@@ -508,9 +502,7 @@ def add_gwtrightmodel(sim):
         gwt,
         budget_filerecord=f"{mname_gwtright}.cbc",
         concentration_filerecord=f"{mname_gwtright}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
     )

--- a/autotest/test_largetestmodels.py
+++ b/autotest/test_largetestmodels.py
@@ -31,9 +31,7 @@ def test_model(
     model_name = model_path.name
     excluded = model_name in excluded_models
     compare = (
-        get_mf6_comparison(model_path)
-        if original_regression
-        else "mf6_regression"
+        get_mf6_comparison(model_path) if original_regression else "mf6_regression"
     )
     dev_only = "dev" in model_name and "not developmode" in markers
     if excluded or dev_only:
@@ -54,9 +52,7 @@ def test_model(
     if compare == "mf6_regression":
         copytree(function_tmpdir, function_tmpdir / compare)
     else:
-        setup_mf6_comparison(
-            model_path, function_tmpdir, compare, overwrite=True
-        )
+        setup_mf6_comparison(model_path, function_tmpdir, compare, overwrite=True)
 
     # run the test
     test.run()

--- a/autotest/test_netcdf_gwe_cnd.py
+++ b/autotest/test_netcdf_gwe_cnd.py
@@ -134,9 +134,7 @@ def check_output(idx, test, export, gridded_input):
     fpth = os.path.join(test.workspace, f"{gwename}.ucn")
     try:
         # load temperatures
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="TEMPERATURE"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="TEMPERATURE")
         conc1 = cobj.get_alldata()
     except:
         assert False, f'could not load concentration data from "{fpth}"'

--- a/autotest/test_netcdf_gwf_disv.py
+++ b/autotest/test_netcdf_gwf_disv.py
@@ -51,9 +51,7 @@ def build_models(idx, test, export, gridded_input):
     name = cases[idx]
 
     # netcdf config
-    ncf = flopy.mf6.ModflowUtlncf(
-        gwf.disv, ogc_wkt=wkt, filename=f"{name}.disv.ncf"
-    )
+    ncf = flopy.mf6.ModflowUtlncf(gwf.disv, ogc_wkt=wkt, filename=f"{name}.disv.ncf")
 
     # output control
     oc = flopy.mf6.ModflowGwfoc(
@@ -188,9 +186,7 @@ def check_output(idx, test, export, gridded_input):
             for l in range(nlay):
                 assert np.allclose(
                     np.array(rec[l]).flatten(),
-                    xds[f"head_l{l+1}"][timestep, :]
-                    .fillna(1.00000000e30)
-                    .data,
+                    xds[f"head_l{l+1}"][timestep, :].fillna(1.00000000e30).data,
                 ), f"NetCDF-Headfile comparison failure in timestep {timestep+1}"
             timestep += 1
 

--- a/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
+++ b/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
@@ -189,9 +189,7 @@ def check_output(idx, test, export, gridded_input):
                     assert np.allclose(
                         np.array(rec[l]).flatten(),
                         # xds[f"head_l{l+1}"][timestep, :].data,
-                        xds[f"head_l{l+1}"][timestep, :]
-                        .fillna(1.00000000e30)
-                        .data,
+                        xds[f"head_l{l+1}"][timestep, :].fillna(1.00000000e30).data,
                     ), f"NetCDF-temperature comparison failure in timestep {timestep+1}"
                 timestep += 1
             elif export == "structured":

--- a/autotest/test_netcdf_gwf_rch03.py
+++ b/autotest/test_netcdf_gwf_rch03.py
@@ -171,9 +171,7 @@ def check_output(idx, test, export, gridded_input):
                 for l in range(nlay):
                     assert np.allclose(
                         np.array(rec[l]).flatten(),
-                        xds[f"head_l{l+1}"][timestep, :]
-                        .fillna(1.00000000e30)
-                        .data,
+                        xds[f"head_l{l+1}"][timestep, :].fillna(1.00000000e30).data,
                     ), f"NetCDF-temperature comparison failure in timestep {timestep+1}"
                 timestep += 1
             elif export == "structured":

--- a/autotest/test_netcdf_gwf_sto01.py
+++ b/autotest/test_netcdf_gwf_sto01.py
@@ -160,9 +160,7 @@ def check_output(idx, test, export, gridded_input):
     elif export == "structured":
         xds = xa.open_dataset(nc_fpth)
 
-    hds_fpth = os.path.join(
-        test.workspace, f"{os.path.basename(test.name)}.hds"
-    )
+    hds_fpth = os.path.join(test.workspace, f"{os.path.basename(test.name)}.hds")
     hds = flopy.utils.HeadFile(hds_fpth, precision="double")
 
     gwf = test.sims[0].gwf[0]

--- a/autotest/test_netcdf_gwf_vsc03_sfr.py
+++ b/autotest/test_netcdf_gwf_vsc03_sfr.py
@@ -195,9 +195,7 @@ def check_output(idx, test, export, gridded_input):
                     assert np.allclose(
                         np.array(rec[l]).flatten(),
                         # xds[f"head_l{l+1}"][timestep, :].data,
-                        xds[f"head_l{l+1}"][timestep, :]
-                        .fillna(1.00000000e30)
-                        .data,
+                        xds[f"head_l{l+1}"][timestep, :].fillna(1.00000000e30).data,
                     ), f"NetCDF-temperature comparison failure in timestep {timestep+1}"
                 timestep += 1
             elif export == "structured":

--- a/autotest/test_netcdf_gwt_dsp01.py
+++ b/autotest/test_netcdf_gwt_dsp01.py
@@ -38,9 +38,7 @@ def build_models(idx, test, export, gridded_input):
         gwt,
         budget_filerecord=f"{gwtname}.cbc",
         concentration_filerecord=f"{gwtname}.ucn",
-        concentrationprintrecord=[
-            ("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")
-        ],
+        concentrationprintrecord=[("COLUMNS", 10, "WIDTH", 15, "DIGITS", 6, "GENERAL")],
         saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
         printrecord=[("CONCENTRATION", "ALL"), ("BUDGET", "LAST")],
     )
@@ -132,9 +130,7 @@ def check_output(idx, test, export, gridded_input):
 
     fpth = os.path.join(test.workspace, f"{gwtname}.ucn")
     try:
-        cobj = flopy.utils.HeadFile(
-            fpth, precision="double", text="CONCENTRATION"
-        )
+        cobj = flopy.utils.HeadFile(fpth, precision="double", text="CONCENTRATION")
         conc = cobj.get_data()
     except:
         assert False, f'could not load data from "{fpth}"'

--- a/autotest/test_netcdf_gwt_prudic2004t2.py
+++ b/autotest/test_netcdf_gwt_prudic2004t2.py
@@ -155,9 +155,7 @@ def check_output(idx, test, export, gridded_input):
                 assert np.allclose(
                     # np.array(rec).flatten(),
                     np.array(rec),
-                    xds["concentration"][timestep, :]
-                    .fillna(1.00000000e30)
-                    .data,
+                    xds["concentration"][timestep, :].fillna(1.00000000e30).data,
                 ), f"NetCDF-concentration comparison failure in timestep {timestep+1}"
                 timestep += 1
 

--- a/autotest/test_olf_dis.py
+++ b/autotest/test_olf_dis.py
@@ -234,9 +234,7 @@ def check_grb_dis2d(fpth):
     assert np.allclose(
         grb.bot.reshape((nrow, ncol)), np.zeros((nrow, ncol))
     ), "grb botm not correct"
-    assert (
-        grb.ia.shape[0] == grb.ncells + 1
-    ), "ia in grb file is not correct size"
+    assert grb.ia.shape[0] == grb.ncells + 1, "ia in grb file is not correct size"
     assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
     assert np.allclose(
         grb.idomain.reshape((nrow, ncol)), idomain
@@ -263,21 +261,13 @@ def check_grb_disv2d(fpth):
         np.linspace(dx / 2, ncol * dx - dx / 2, ncol),
         np.linspace(dx * nrow - dx / 2.0, dx / 2, nrow),
     )
-    assert np.allclose(
-        grb._datadict["CELLX"], cellx.flatten()
-    ), "cellx is not right"
-    assert np.allclose(
-        grb._datadict["CELLY"], celly.flatten()
-    ), "celly is not right"
-    assert (
-        grb._datadict["IAVERT"].shape[0] == ncpl + 1
-    ), "iavert size not right"
+    assert np.allclose(grb._datadict["CELLX"], cellx.flatten()), "cellx is not right"
+    assert np.allclose(grb._datadict["CELLY"], celly.flatten()), "celly is not right"
+    assert grb._datadict["IAVERT"].shape[0] == ncpl + 1, "iavert size not right"
     assert (
         grb._datadict["IAVERT"][-1] - 1 == grb._datadict["JAVERT"].shape[0]
     ), "javert size not right"
-    assert (
-        grb.ia.shape[0] == grb.ncells + 1
-    ), "ia in grb file is not correct size"
+    assert grb.ia.shape[0] == grb.ncells + 1, "ia in grb file is not correct size"
     assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
     assert np.allclose(
         grb.idomain.reshape((ncpl,)), idomain.reshape((ncpl,))

--- a/autotest/test_par_gwf01.py
+++ b/autotest/test_par_gwf01.py
@@ -73,9 +73,7 @@ def get_model(idx, dir):
         sim_ws=dir,
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -92,9 +90,7 @@ def get_model(idx, dir):
 
     # submodel on the left:
     left_chd = [
-        [(ilay, irow, 0), h_left]
-        for irow in range(nrow)
-        for ilay in range(nlay)
+        [(ilay, irow, 0), h_left] for irow in range(nrow) for ilay in range(nlay)
     ]
     chd_spd_left = {0: left_chd}
 
@@ -210,12 +206,8 @@ def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{name_right}.hds")
     hds = flopy.utils.HeadFile(fpth)
     heads_right = hds.get_data().flatten()
-    np.testing.assert_array_almost_equal(
-        heads_left[0:5], [1.0, 2.0, 3.0, 4.0, 5.0]
-    )
-    np.testing.assert_array_almost_equal(
-        heads_right[0:5], [6.0, 7.0, 8.0, 9.0, 10.0]
-    )
+    np.testing.assert_array_almost_equal(heads_left[0:5], [1.0, 2.0, 3.0, 4.0, 5.0])
+    np.testing.assert_array_almost_equal(heads_right[0:5], [6.0, 7.0, 8.0, 9.0, 10.0])
 
 
 @pytest.mark.parallel

--- a/autotest/test_par_gwf02.py
+++ b/autotest/test_par_gwf02.py
@@ -71,9 +71,7 @@ def get_simulation(idx, ws):
         sim_ws=ws,
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_par_gwf03.py
+++ b/autotest/test_par_gwf03.py
@@ -61,9 +61,7 @@ def get_simulation(idx, ws):
         sim_ws=ws,
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -94,9 +92,7 @@ def get_simulation(idx, ws):
         for iy in range(nr_models_y - 1):
             name_south = get_model_name(ix, iy)
             name_north = get_model_name(ix, iy + 1)
-            add_exchange_south_north(
-                sim, name_south, name_north, nlay, nrow, ncol
-            )
+            add_exchange_south_north(sim, name_south, name_north, nlay, nrow, ncol)
 
     return sim
 

--- a/autotest/test_par_gwf04.py
+++ b/autotest/test_par_gwf04.py
@@ -73,9 +73,7 @@ def get_simulation(idx, ws):
         sim_ws=ws,
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,

--- a/autotest/test_par_gwf_disu.py
+++ b/autotest/test_par_gwf_disu.py
@@ -97,9 +97,7 @@ def get_model(idx, dir):
         sim_ws=dir,
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -228,12 +226,8 @@ def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{name_right}.hds")
     hds = flopy.utils.HeadFile(fpth)
     heads_right = hds.get_data().flatten()
-    np.testing.assert_array_almost_equal(
-        heads_left[0:5], [1.0, 2.0, 3.0, 4.0, 5.0]
-    )
-    np.testing.assert_array_almost_equal(
-        heads_right[0:5], [6.0, 7.0, 8.0, 9.0, 10.0]
-    )
+    np.testing.assert_array_almost_equal(heads_left[0:5], [1.0, 2.0, 3.0, 4.0, 5.0])
+    np.testing.assert_array_almost_equal(heads_right[0:5], [6.0, 7.0, 8.0, 9.0, 10.0])
 
 
 @pytest.mark.parallel

--- a/autotest/test_par_gwf_splitter01.py
+++ b/autotest/test_par_gwf_splitter01.py
@@ -59,9 +59,7 @@ def get_model(idx, test):
         sim_ws=test.workspace,
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -78,9 +76,7 @@ def get_model(idx, test):
 
     # left CHD:
     left_chd = [
-        [(ilay, irow, 0), h_left]
-        for irow in range(nrow)
-        for ilay in range(nlay)
+        [(ilay, irow, 0), h_left] for irow in range(nrow) for ilay in range(nlay)
     ]
 
     # right CHD:
@@ -153,9 +149,7 @@ def check_output(idx, test):
 
     # define reference result:
     def exact(x):
-        return h_left + (h_right - h_left) * (x - 0.5 * delr) / (
-            (ncol - 1) * delr
-        )
+        return h_left + (h_right - h_left) * (x - 0.5 * delr) / ((ncol - 1) * delr)
 
     # load the finished sim:
     sim = flopy.mf6.MFSimulation.load(sim_ws=test.workspace)

--- a/autotest/test_par_hpc01.py
+++ b/autotest/test_par_hpc01.py
@@ -85,9 +85,7 @@ def get_simulation(idx, ws):
 
     hpc = flopy.mf6.ModflowUtlhpc(sim, partitions=partitions)
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -265,9 +263,7 @@ def check_output(idx, test):
                 if success_msg in line:
                     success = True
                     break
-            assert (
-                success
-            ), f"Model {model_id} not created on target process {rank}"
+            assert success, f"Model {model_id} not created on target process {rank}"
     elif ncpus == 1:
         list_file = pl.Path(test.workspace, "mfsim.lst")
         for name, rank in partitions:
@@ -278,9 +274,7 @@ def check_output(idx, test):
                 if success_msg in line:
                     success = True
                     break
-            assert (
-                success
-            ), f"Model {model_id} not created on target process {rank}"
+            assert success, f"Model {model_id} not created on target process {rank}"
 
 
 @pytest.mark.parallel

--- a/autotest/test_par_petsc01.py
+++ b/autotest/test_par_petsc01.py
@@ -73,9 +73,7 @@ def get_model(idx, dir):
         sim_ws=dir,
     )
 
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -92,9 +90,7 @@ def get_model(idx, dir):
 
     # submodel on the left:
     left_chd = [
-        [(ilay, irow, 0), h_left]
-        for irow in range(nrow)
-        for ilay in range(nlay)
+        [(ilay, irow, 0), h_left] for irow in range(nrow) for ilay in range(nlay)
     ]
     chd_spd_left = {0: left_chd}
 
@@ -221,12 +217,8 @@ def check_output(idx, test):
     fpth = os.path.join(test.workspace, f"{name_right}.hds")
     hds = flopy.utils.HeadFile(fpth)
     heads_right = hds.get_data().flatten()
-    np.testing.assert_array_almost_equal(
-        heads_left[0:5], [1.0, 2.0, 3.0, 4.0, 5.0]
-    )
-    np.testing.assert_array_almost_equal(
-        heads_right[0:5], [6.0, 7.0, 8.0, 9.0, 10.0]
-    )
+    np.testing.assert_array_almost_equal(heads_left[0:5], [1.0, 2.0, 3.0, 4.0, 5.0])
+    np.testing.assert_array_almost_equal(heads_right[0:5], [6.0, 7.0, 8.0, 9.0, 10.0])
 
 
 @pytest.mark.parallel

--- a/autotest/test_prt_budget.py
+++ b/autotest/test_prt_budget.py
@@ -161,9 +161,7 @@ def build_mp7_sim(name, ws, mp7, gwf):
 
 
 def build_models(idx, test):
-    gwf_sim = HorizontalCase.get_gwf_sim(
-        test.name, test.workspace, test.targets["mf6"]
-    )
+    gwf_sim = HorizontalCase.get_gwf_sim(test.name, test.workspace, test.targets["mf6"])
     prt_sim = build_prt_sim(
         test.name, test.workspace, test.workspace / "prt", test.targets["mf6"]
     )
@@ -261,8 +259,7 @@ def check_output(idx, test):
     ]:
         check_track_data(
             track_bin=prt_ws / prt_track_file,
-            track_hdr=prt_ws
-            / Path(prt_track_file.replace(".trk", ".trk.hdr")),
+            track_hdr=prt_ws / Path(prt_track_file.replace(".trk", ".trk.hdr")),
             track_csv=track_csv,
         )
 

--- a/autotest/test_prt_disv1.py
+++ b/autotest/test_prt_disv1.py
@@ -95,9 +95,7 @@ def build_gwf_sim(idx, ws, mf6):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create gwf model
     gwf = flopy.mf6.ModflowGwf(
@@ -165,9 +163,7 @@ def build_gwf_sim(idx, ws, mf6):
             obs_lst.append(["obs_" + str(i + 1), "head", (k, i)])
 
     obs_dict = {f"{gwf_name}.obs.csv": obs_lst}
-    obs = flopy.mf6.ModflowUtlobs(
-        gwf, pname="head_obs", digits=20, continuous=obs_dict
-    )
+    obs = flopy.mf6.ModflowUtlobs(gwf, pname="head_obs", digits=20, continuous=obs_dict)
 
     return sim
 
@@ -183,9 +179,7 @@ def build_prt_sim(idx, gwf_ws, prt_ws, mf6):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create prt model
     prt_name = f"{cases[idx]}_prt"
@@ -332,9 +326,7 @@ def plot_output(name, gwf, head, spdis, mf6_pls, mp7_pls, fpath):
     pmv.plot_vector(*spdis, normalize=True, color="white")
 
     # plot labeled nodes and vertices
-    plot_nodes_and_vertices(
-        gwf, gwf.modelgrid, None, gwf.modelgrid.ncpl, ax[0]
-    )
+    plot_nodes_and_vertices(gwf, gwf.modelgrid, None, gwf.modelgrid.ncpl, ax[0])
     mf6_plines = mf6_pls.groupby(["iprp", "irpt", "trelease"])
     for ipl, ((iprp, irpt, trelease), pl) in enumerate(mf6_plines):
         pl.plot(

--- a/autotest/test_prt_drape.py
+++ b/autotest/test_prt_drape.py
@@ -45,10 +45,7 @@ releasepts = [
     # particle index, k, i, j, x, y, z
     [i, 0, 0, 1, float(f"1.{i + 1}"), float(f"0.{i + 1}"), 75]
     for i in range(5)
-] + [
-    [i, 0, 0, 3, float(f"3.{i + 1}"), float(f"0.{i + 1}"), 75]
-    for i in range(5, 9)
-]
+] + [[i, 0, 0, 3, float(f"3.{i + 1}"), float(f"0.{i + 1}"), 75] for i in range(5, 9)]
 
 
 def build_gwf_sim(name, ws, mf6):
@@ -60,9 +57,7 @@ def build_gwf_sim(name, ws, mf6):
         sim_name=gwf_name, version="mf6", exe_name=mf6, sim_ws=ws
     )
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # set ims csv files
     csv0 = f"{gwf_name}.outer.ims.csv"
@@ -154,9 +149,7 @@ def build_prt_sim(name, gwf_ws, prt_ws, mf6):
     )
 
     # create tdis package
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", nper=nper, perioddata=tdis_rc
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", nper=nper, perioddata=tdis_rc)
 
     # create prt model
     prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name)
@@ -276,8 +269,7 @@ def check_output(idx, test):
     ]:
         check_track_data(
             track_bin=prt_ws / prt_track_file,
-            track_hdr=prt_ws
-            / Path(prt_track_file.replace(".trk", ".trk.hdr")),
+            track_hdr=prt_ws / Path(prt_track_file.replace(".trk", ".trk.hdr")),
             track_csv=track_csv,
         )
 

--- a/autotest/test_prt_exg.py
+++ b/autotest/test_prt_exg.py
@@ -41,9 +41,7 @@ def get_model_name(idx, mdl):
 def build_mf6_sim(idx, test):
     # create simulation
     name = cases[idx]
-    sim = FlopyReadmeCase.get_gwf_sim(
-        name, test.workspace, test.targets["mf6"]
-    )
+    sim = FlopyReadmeCase.get_gwf_sim(name, test.workspace, test.targets["mf6"])
 
     # create prt model
     prt_name = get_model_name(idx, "prt")
@@ -59,9 +57,7 @@ def build_mf6_sim(idx, test):
     )
 
     # create mip package
-    flopy.mf6.ModflowPrtmip(
-        prt, pname="mip", porosity=FlopyReadmeCase.porosity
-    )
+    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=FlopyReadmeCase.porosity)
 
     # create prp package
     rpts = (
@@ -163,9 +159,7 @@ def build_models(idx, test):
     mf6sim = build_mf6_sim(idx, test)
     gwf_name = get_model_name(idx, "gwf")
     gwf = mf6sim.get_model(gwf_name)
-    mp7sim = build_mp7_sim(
-        idx, test.workspace / "mp7", test.targets["mp7"], gwf
-    )
+    mp7sim = build_mp7_sim(idx, test.workspace / "mp7", test.targets["mp7"], gwf)
     return mf6sim, mp7sim
 
 
@@ -224,9 +218,7 @@ def check_output(idx, test):
     # check boundname values
     if "bnms" in name:
         # boundnames should be release point numbers (so pandas parses them as ints)
-        assert np.array_equal(
-            mf6_pls["name"].to_numpy(), mf6_pls["irpt"].to_numpy()
-        )
+        assert np.array_equal(mf6_pls["name"].to_numpy(), mf6_pls["irpt"].to_numpy())
     else:
         # no boundnames given so check for defaults
         assert pd.isna(mf6_pls["name"]).all()

--- a/autotest/test_prt_fmi.py
+++ b/autotest/test_prt_fmi.py
@@ -90,22 +90,16 @@ def build_prt_sim(name, gwf_ws, prt_ws, mf6):
     )
 
     # create mip package
-    flopy.mf6.ModflowPrtmip(
-        prt, pname="mip", porosity=FlopyReadmeCase.porosity
-    )
+    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=FlopyReadmeCase.porosity)
 
     # convert mp7 to prt release points and check against expectation
     partdata = get_partdata(prt.modelgrid, FlopyReadmeCase.releasepts_mp7)
     coords = partdata.to_coords(prt.modelgrid)
     if "bprp" in name:
         # bad cell indices!
-        releasepts = [
-            (i, 0, 1, 1, c[0], c[1], c[2]) for i, c in enumerate(coords)
-        ]
+        releasepts = [(i, 0, 1, 1, c[0], c[1], c[2]) for i, c in enumerate(coords)]
     else:
-        releasepts = [
-            (i, 0, 0, 0, c[0], c[1], c[2]) for i, c in enumerate(coords)
-        ]
+        releasepts = [(i, 0, 0, 0, c[0], c[1], c[2]) for i, c in enumerate(coords)]
         assert np.allclose(FlopyReadmeCase.releasepts_prt, releasepts)
 
     # create prp package
@@ -291,8 +285,7 @@ def check_output(idx, test):
     ]:
         check_track_data(
             track_bin=prt_ws / prt_track_file,
-            track_hdr=prt_ws
-            / Path(prt_track_file.replace(".trk", ".trk.hdr")),
+            track_hdr=prt_ws / Path(prt_track_file.replace(".trk", ".trk.hdr")),
             track_csv=track_csv,
         )
 

--- a/autotest/test_prt_libmf6_budget.py
+++ b/autotest/test_prt_libmf6_budget.py
@@ -24,9 +24,7 @@ def build_models(idx, test):
     ws = test.workspace
     name = cases[idx]
 
-    gwf_sim = HorizontalCase.get_gwf_sim(
-        test.name, test.workspace, test.targets["mf6"]
-    )
+    gwf_sim = HorizontalCase.get_gwf_sim(test.name, test.workspace, test.targets["mf6"])
     prt_sim = build_prt_sim(
         test.name,
         test.workspace,

--- a/autotest/test_prt_quad_refinement.py
+++ b/autotest/test_prt_quad_refinement.py
@@ -74,9 +74,7 @@ def get_gridprops(test, **kwargs):
 
     # add polygon for each refinement level
     polygon = [[(300, 300), (300, 700), (700, 700), (700, 300), (300, 300)]]
-    g.add_refinement_features(
-        [polygon], "polygon", refinement_levels, range(nlay)
-    )
+    g.add_refinement_features([polygon], "polygon", refinement_levels, range(nlay))
     g.build(verbose=False)
     return g.get_gridprops_disv()
 
@@ -100,9 +98,7 @@ def build_mf6_sim(idx, test, **kwargs):
     )
 
     # create gwf model
-    gwf = flopy.mf6.ModflowGwf(
-        sim, modelname=gwf_name, model_nam_file=gwf_name
-    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwf_name, model_nam_file=gwf_name)
     gwf.name_file.save_flows = True
     disv = flopy.mf6.ModflowGwfdisv(
         gwf,
@@ -136,9 +132,7 @@ def build_mf6_sim(idx, test, **kwargs):
     # create prt model
     prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name)
     flopy.mf6.ModflowGwfdisv(prt, length_units="FEET", **gridprops)
-    flopy.mf6.ModflowPrtmip(
-        prt, pname="mip", porosity=FlopyReadmeCase.porosity
-    )
+    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=FlopyReadmeCase.porosity)
     rpts = [(50, 950), (45, 945), (55, 955)]
     rpts = [
         [i, 0, prt.modelgrid.intersect(x, y), x, y, 5.0]
@@ -280,9 +274,7 @@ def check_output(idx, test, snapshot):
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.parametrize("levels", [1, 2])
 @pytest.mark.parametrize("method", ["pollock", "ternary"])
-def test_mf6model(
-    idx, name, function_tmpdir, targets, levels, method, array_snapshot
-):
+def test_mf6model(idx, name, function_tmpdir, targets, levels, method, array_snapshot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,

--- a/autotest/test_prt_release_timing.py
+++ b/autotest/test_prt_release_timing.py
@@ -116,9 +116,7 @@ def build_prt_sim(name, gwf_ws, prt_ws, mf6):
     )
 
     # create mip package
-    flopy.mf6.ModflowPrtmip(
-        prt, pname="mip", porosity=FlopyReadmeCase.porosity
-    )
+    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=FlopyReadmeCase.porosity)
 
     # convert mp7 particledata to prt release points
     partdata = get_partdata(prt.modelgrid, FlopyReadmeCase.releasepts_mp7)
@@ -395,8 +393,7 @@ def check_output(test, snapshot):
     ]:
         check_track_data(
             track_bin=prt_ws / prt_track_file,
-            track_hdr=prt_ws
-            / Path(prt_track_file.replace(".trk", ".trk.hdr")),
+            track_hdr=prt_ws / Path(prt_track_file.replace(".trk", ".trk.hdr")),
             track_csv=track_csv,
         )
 
@@ -419,9 +416,7 @@ def check_output(test, snapshot):
         )
 
     # compare pathlines with snapshot
-    assert snapshot == mf6_pls.drop("name", axis=1).round(3).to_records(
-        index=False
-    )
+    assert snapshot == mf6_pls.drop("name", axis=1).round(3).to_records(index=False)
 
     # convert mf6 pathlines to mp7 format
     mf6_pls = to_mp7_pathlines(mf6_pls)

--- a/autotest/test_prt_stop_zones.py
+++ b/autotest/test_prt_stop_zones.py
@@ -61,10 +61,7 @@ def build_gwf_sim(name, ws, mf6):
     nlay = int(name[-1])
     botm = [FlopyReadmeCase.top - (k + 1) for k in range(nlay)]
     botm_data = np.array(
-        [
-            list(repeat(b, FlopyReadmeCase.nrow * FlopyReadmeCase.ncol))
-            for b in botm
-        ]
+        [list(repeat(b, FlopyReadmeCase.nrow * FlopyReadmeCase.ncol)) for b in botm]
     ).reshape((nlay, FlopyReadmeCase.nrow, FlopyReadmeCase.ncol))
     dis.nlay = nlay
     dis.botm.set_data(botm_data)
@@ -217,9 +214,7 @@ def build_models(idx, test):
     prt_sim = build_prt_sim(
         test.name, test.workspace, test.workspace / "prt", test.targets["mf6"]
     )
-    mp7_sim = build_mp7_sim(
-        test.name, test.workspace / "mp7", test.targets["mp7"], gwf
-    )
+    mp7_sim = build_mp7_sim(test.name, test.workspace / "mp7", test.targets["mp7"], gwf)
     return gwf_sim, prt_sim, mp7_sim
 
 
@@ -388,9 +383,7 @@ def check_output(idx, test):
         k, i, j = mg.intersect(x, y, z)
         nn = mg.get_node([k, i, j]) + 1
         neighbors = mg.neighbors(nn)
-        assert np.isclose(nn, icell, atol=1) or any(
-            (nn - 1) == n for n in neighbors
-        )
+        assert np.isclose(nn, icell, atol=1) or any((nn - 1) == n for n in neighbors)
 
     # convert mf6 pathlines to mp7 format
     mf6_pls = to_mp7_pathlines(mf6_pls)

--- a/autotest/test_prt_ternary_methods.py
+++ b/autotest/test_prt_ternary_methods.py
@@ -44,9 +44,7 @@ methods = [
 ]
 
 
-def build_prt_sim(
-    idx, name, gwf_ws, prt_ws, targets, exit_solve_tolerance=1e-5
-):
+def build_prt_sim(idx, name, gwf_ws, prt_ws, targets, exit_solve_tolerance=1e-5):
     prt_ws = Path(prt_ws)
     gwfname = get_model_name(name, "gwf")
     prtname = get_model_name(name, "prt")
@@ -54,9 +52,7 @@ def build_prt_sim(
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name=targets["mf6"], sim_ws=prt_ws
     )
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", perioddata=[[1.0, 1, 1.0]]
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", perioddata=[[1.0, 1, 1.0]])
     prt = flopy.mf6.ModflowPrt(sim, modelname=prtname)
     tri = get_tri(prt_ws / "grid", targets)
     cell2d = tri.get_cell2d()
@@ -124,9 +120,7 @@ def build_prt_sim(
 
 
 def build_models(idx, test, exit_solve_tolerance=1e-7):
-    gwf_sim = build_gwf_sim(
-        test.name, test.workspace, test.targets, ["left", "botm"]
-    )
+    gwf_sim = build_gwf_sim(test.name, test.workspace, test.targets, ["left", "botm"])
     prt_sim = build_prt_sim(
         idx,
         test.name,
@@ -235,11 +229,7 @@ def check_output(idx, test, snapshot):
     prt_name = get_model_name(name, "prt")
     prt_track_csv_file = f"{prt_name}.prp.trk.csv"
     pls = pd.read_csv(prt_ws / prt_track_csv_file, na_filter=False)
-    endpts = (
-        pls.sort_values("t")
-        .groupby(["imdl", "iprp", "irpt", "trelease"])
-        .tail(1)
-    )
+    endpts = pls.sort_values("t").groupby(["imdl", "iprp", "irpt", "trelease"]).tail(1)
 
     # check pathline shape and endpoints
     assert pls.shape == (116, 16)
@@ -249,20 +239,14 @@ def check_output(idx, test, snapshot):
     # plot results if enabled
     plot = False
     if plot:
-        plot_output(
-            name, gwf, head, (qx, qy), pls, fpath=prt_ws / f"{name}.png"
-        )
+        plot_output(name, gwf, head, (qx, qy), pls, fpath=prt_ws / f"{name}.png")
 
     # check pathlines against snapshot
-    assert snapshot == pls.drop("name", axis=1).round(3).to_records(
-        index=False
-    )
+    assert snapshot == pls.drop("name", axis=1).round(3).to_records(index=False)
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(
-    idx, name, function_tmpdir, targets, benchmark, array_snapshot
-):
+def test_mf6model(idx, name, function_tmpdir, targets, benchmark, array_snapshot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,

--- a/autotest/test_prt_track_events.py
+++ b/autotest/test_prt_track_events.py
@@ -130,9 +130,7 @@ def build_prt_sim(name, gwf_ws, prt_ws, mf6):
     )
 
     # create mip package
-    flopy.mf6.ModflowPrtmip(
-        prt, pname="mip", porosity=FlopyReadmeCase.porosity
-    )
+    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=FlopyReadmeCase.porosity)
 
     # create a prp package for groups a and b
     prps = [
@@ -309,9 +307,7 @@ def build_models(idx, test):
         test.name, test.workspace, test.workspace / "prt", test.targets["mf6"]
     )
     # build mp7 model
-    mp7_sim = build_mp7_sim(
-        test.name, test.workspace / "mp7", test.targets["mp7"], gwf
-    )
+    mp7_sim = build_mp7_sim(test.name, test.workspace / "mp7", test.targets["mp7"], gwf)
     return gwf_sim, prt_sim, mp7_sim
 
 
@@ -375,9 +371,7 @@ def check_output(idx, test):
     if "trts" in name or "open" in name:
         expected_len += 5324
     if "mult" in name:
-        expected_len += 2 * (
-            len(releasepts_prt["a"]) + len(releasepts_prt["b"])
-        )
+        expected_len += 2 * (len(releasepts_prt["a"]) + len(releasepts_prt["b"]))
     assert len(mf6_pls) == expected_len
 
     # make sure mf6 pathline data have correct
@@ -389,12 +383,8 @@ def check_output(idx, test):
 
     if len(mf6_pls) > 0:
         assert all_equal(mf6_pls["imdl"], 1)
-        assert set(mf6_pls[mf6_pls["iprp"] == 1]["irpt"].unique()) == set(
-            range(1, 5)
-        )
-        assert set(mf6_pls[mf6_pls["iprp"] == 2]["irpt"].unique()) == set(
-            range(1, 6)
-        )
+        assert set(mf6_pls[mf6_pls["iprp"] == 1]["irpt"].unique()) == set(range(1, 5))
+        assert set(mf6_pls[mf6_pls["iprp"] == 2]["irpt"].unique()) == set(range(1, 6))
 
     # check budget data were written to mf6 prt list file
     check_budget_data(

--- a/autotest/test_prt_triangle.py
+++ b/autotest/test_prt_triangle.py
@@ -143,9 +143,7 @@ def build_prt_sim(idx, name, gwf_ws, prt_ws, targets):
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name=targets["mf6"], sim_ws=prt_ws
     )
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", perioddata=[[1.0, 1, 1.0]]
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", perioddata=[[1.0, 1, 1.0]])
     prt = flopy.mf6.ModflowPrt(sim, modelname=prtname)
     tri = get_tri(prt_ws / "grid", targets)
     cell2d = tri.get_cell2d()
@@ -278,9 +276,7 @@ def check_output(idx, test, snapshot):
     endpts = pls[pls.ireason == 3]  # termination
 
     # check termination points against snapshot
-    assert snapshot == endpts.drop("name", axis=1).round(3).to_records(
-        index=False
-    )
+    assert snapshot == endpts.drop("name", axis=1).round(3).to_records(index=False)
 
     plot_debug = False
     if plot_debug:

--- a/autotest/test_prt_voronoi1.py
+++ b/autotest/test_prt_voronoi1.py
@@ -102,9 +102,7 @@ def build_gwf_sim(name, ws, targets):
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name=targets["mf6"], sim_ws=ws
     )
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", perioddata=[[1.0, 1, 1.0]]
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", perioddata=[[1.0, 1, 1.0]])
     gwf = flopy.mf6.ModflowGwf(sim, modelname=gwf_name, save_flows=True)
     ims = flopy.mf6.ModflowIms(
         sim,
@@ -118,9 +116,7 @@ def build_gwf_sim(name, ws, targets):
     )
     if "wel" in name:
         # k, j, q
-        wells = [
-            (0, c, 0.5 * (-1 if "welp" in name else 1)) for c in well_cells
-        ]
+        wells = [(0, c, 0.5 * (-1 if "welp" in name else 1)) for c in well_cells]
         wel = flopy.mf6.ModflowGwfwel(
             gwf,
             maxbound=len(wells),
@@ -190,9 +186,7 @@ def build_prt_sim(idx, name, gwf_ws, prt_ws, targets, cell_ids):
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name=targets["mf6"], sim_ws=prt_ws
     )
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", perioddata=[[1.0, 1, 1.0]]
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", perioddata=[[1.0, 1, 1.0]])
     prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name)
     disv = flopy.mf6.ModflowGwfdisv(
         prt, nlay=nlay, **grid.get_disv_gridprops(), top=top, botm=botm
@@ -349,9 +343,7 @@ def plot_output(name, gwf, head, spdis, pls, fpath):
     def get_meshes(model, pathlines):
         vtk = Vtk(model=model, binary=False, smooth=False)
         vtk.add_model(model)
-        vtk.add_pathline_points(
-            to_mp7_pathlines(pathlines.to_records(index=False))
-        )
+        vtk.add_pathline_points(to_mp7_pathlines(pathlines.to_records(index=False)))
         grid_mesh, path_mesh = vtk.to_pyvista()
         grid_mesh.rotate_x(-100, point=axes.origin, inplace=True)
         grid_mesh.rotate_z(90, point=axes.origin, inplace=True)
@@ -399,24 +391,18 @@ def check_output(idx, test, snapshot):
     # have moved vertically. round for cross-platform error.
     # skip macos-14 in CI because grid is slightly different
     if not (is_in_ci() and system() == "Darwin" and processor() == "arm"):
-        assert snapshot == endpts.drop("name", axis=1).round(1).to_records(
-            index=False
-        )
+        assert snapshot == endpts.drop("name", axis=1).round(1).to_records(index=False)
 
     # plot results if enabled
     plot = False
     if plot:
-        plot_output(
-            name, gwf, head, (qx, qy), pls, fpath=prt_ws / f"{name}.png"
-        )
+        plot_output(name, gwf, head, (qx, qy), pls, fpath=prt_ws / f"{name}.png")
 
 
 @requires_pkg("syrupy")
 @pytest.mark.slow
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(
-    idx, name, function_tmpdir, targets, benchmark, array_snapshot
-):
+def test_mf6model(idx, name, function_tmpdir, targets, benchmark, array_snapshot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,

--- a/autotest/test_prt_voronoi2.py
+++ b/autotest/test_prt_voronoi2.py
@@ -139,21 +139,15 @@ def build_prt_sim(name, gwf_ws, prt_ws, targets, cell_ids):
     sim = flopy.mf6.MFSimulation(
         sim_name=name, version="mf6", exe_name=targets["mf6"], sim_ws=prt_ws
     )
-    tdis = flopy.mf6.ModflowTdis(
-        sim, time_units="DAYS", perioddata=[[1.0, 1, 1.0]]
-    )
+    tdis = flopy.mf6.ModflowTdis(sim, time_units="DAYS", perioddata=[[1.0, 1, 1.0]])
     prt = flopy.mf6.ModflowPrt(sim, modelname=prt_name)
     disv = flopy.mf6.ModflowGwfdisv(
         prt, nlay=nlay, **grid.get_disv_gridprops(), top=top, botm=botm
     )
     flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=porosity)
 
-    sddata = flopy.modpath.CellDataType(
-        columncelldivisions=1, rowcelldivisions=1
-    )
-    data = flopy.modpath.NodeParticleData(
-        subdivisiondata=sddata, nodes=[release_cells]
-    )
+    sddata = flopy.modpath.CellDataType(columncelldivisions=1, rowcelldivisions=1)
+    data = flopy.modpath.NodeParticleData(subdivisiondata=sddata, nodes=[release_cells])
     prpdata = list(data.to_prp(prt.modelgrid))
     prp_track_file = f"{prt_name}.prp.trk"
     prp_track_csv_file = f"{prt_name}.prp.trk.csv"
@@ -198,9 +192,7 @@ def build_prt_sim(name, gwf_ws, prt_ws, targets, cell_ids):
 
 
 def build_models(idx, test):
-    gwf_sim, gwf_cell_ids = build_gwf_sim(
-        test.name, test.workspace, test.targets
-    )
+    gwf_sim, gwf_cell_ids = build_gwf_sim(test.name, test.workspace, test.targets)
     gwt_sim, gwt_cell_ids = build_gwt_sim(
         test.name, test.workspace, test.workspace / "gwt", test.targets
     )
@@ -248,9 +240,7 @@ def check_output(idx, test):
         # plt.clabel(headctr)
         # plt.colorbar(headmesh, shrink=0.25, ax=ax, label="Head", location="right")
         concmesh = pmv.plot_array(conc, cmap="jet")
-        concctr = pmv.contour_array(
-            conc, levels=(0.0001, 0.001, 0.01, 0.1), colors="y"
-        )
+        concctr = pmv.contour_array(conc, levels=(0.0001, 0.001, 0.01, 0.1), colors="y")
         plt.clabel(concctr)
         plt.colorbar(
             concmesh,
@@ -301,9 +291,7 @@ def check_output(idx, test):
         def get_meshes(model, pathlines):
             vtk = Vtk(model=model, binary=False, smooth=False)
             vtk.add_model(model)
-            vtk.add_pathline_points(
-                to_mp7_pathlines(pathlines.to_records(index=False))
-            )
+            vtk.add_pathline_points(to_mp7_pathlines(pathlines.to_records(index=False)))
             grid_mesh, path_mesh = vtk.to_pyvista()
             grid_mesh.rotate_x(-100, point=axes.origin, inplace=True)
             grid_mesh.rotate_z(90, point=axes.origin, inplace=True)

--- a/autotest/test_prt_weak_sinks.py
+++ b/autotest/test_prt_weak_sinks.py
@@ -86,9 +86,7 @@ def build_prt_sim(name, gwf_ws, prt_ws, mf6):
     )
 
     # create mip package
-    flopy.mf6.ModflowPrtmip(
-        prt, pname="mip", porosity=FlopyReadmeCase.porosity
-    )
+    flopy.mf6.ModflowPrtmip(prt, pname="mip", porosity=FlopyReadmeCase.porosity)
 
     # create prp package
     flopy.mf6.ModflowPrtprp(
@@ -202,9 +200,7 @@ def build_models(idx, test):
     )
 
     # build mp7 model
-    mp7_sim = build_mp7_sim(
-        test.name, test.workspace / "mp7", test.targets["mp7"], gwf
-    )
+    mp7_sim = build_mp7_sim(test.name, test.workspace / "mp7", test.targets["mp7"], gwf)
     return gwf_sim, prt_sim, mp7_sim
 
 

--- a/autotest/test_testmodels_mf5to6.py
+++ b/autotest/test_testmodels_mf5to6.py
@@ -97,9 +97,7 @@ def test_model(
     if compare == "mf6_regression":
         copytree(mf5to6_workspace, mf6_workspace / compare)
     else:
-        setup_mf6_comparison(
-            mf5to6_workspace, mf6_workspace, compare, overwrite=True
-        )
+        setup_mf6_comparison(mf5to6_workspace, mf6_workspace, compare, overwrite=True)
 
     # run the test
     test.run()

--- a/autotest/test_testmodels_mf6.py
+++ b/autotest/test_testmodels_mf6.py
@@ -41,9 +41,7 @@ def test_model(
     model_name = model_path.name
     excluded = model_name in excluded_models
     compare = (
-        get_mf6_comparison(model_path)
-        if original_regression
-        else "mf6_regression"
+        get_mf6_comparison(model_path) if original_regression else "mf6_regression"
     )
     dev_only = "dev" in model_name and "not developmode" in markers
     if excluded or dev_only:
@@ -64,9 +62,7 @@ def test_model(
     if compare == "mf6_regression":
         copytree(function_tmpdir, function_tmpdir / compare)
     else:
-        setup_mf6_comparison(
-            model_path, function_tmpdir, compare, overwrite=True
-        )
+        setup_mf6_comparison(model_path, function_tmpdir, compare, overwrite=True)
 
     # run the test
     test.run()

--- a/autotest/update_flopy.py
+++ b/autotest/update_flopy.py
@@ -18,9 +18,7 @@ print(f"flopy is installed in {fpy_path}")
 def test_delete_mf6():
     pth = os.path.join(fpy_path, "mf6", "modflow")
     files = [
-        entry
-        for entry in os.listdir(pth)
-        if os.path.isfile(os.path.join(pth, entry))
+        entry for entry in os.listdir(pth) if os.path.isfile(os.path.join(pth, entry))
     ]
     delete_files(files, pth, exclude="mfsimulation.py")
 
@@ -29,9 +27,7 @@ def test_delete_mf6():
 def test_delete_dfn():
     pth = os.path.join(fpy_path, "mf6", "data", "dfn")
     files = [
-        entry
-        for entry in os.listdir(pth)
-        if os.path.isfile(os.path.join(pth, entry))
+        entry for entry in os.listdir(pth) if os.path.isfile(os.path.join(pth, entry))
     ]
     delete_files(files, pth, exclude="flopy.dfn")
 
@@ -40,9 +36,7 @@ def test_delete_dfn():
 @pytest.mark.parametrize("path", [dfn_path])
 def test_copy_dfn(path):
     files = [
-        entry
-        for entry in os.listdir(path)
-        if os.path.isfile(os.path.join(path, entry))
+        entry for entry in os.listdir(path) if os.path.isfile(os.path.join(path, entry))
     ]
     pth1 = os.path.join(fpy_path, "mf6", "data", "dfn")
     for fn in files:
@@ -85,9 +79,7 @@ def test_create_packages():
 def list_files(pth, exts=["py"]):
     print(f"\nLIST OF FILES IN {pth}")
     files = [
-        entry
-        for entry in os.listdir(pth)
-        if os.path.isfile(os.path.join(pth, entry))
+        entry for entry in os.listdir(pth) if os.path.isfile(os.path.join(pth, entry))
     ]
     idx = 0
     for fn in files:
@@ -120,9 +112,7 @@ def delete_files(files, pth, allow_failure=False, exclude=None):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("Update flopy from DFN files")
-    parser.add_argument(
-        "-p", "--path", help="path to DFN files", default=str(dfn_path)
-    )
+    parser.add_argument("-p", "--path", help="path to DFN files", default=str(dfn_path))
     args = parser.parse_args()
 
     path = Path(args.path).expanduser().resolve()

--- a/distribution/benchmark.py
+++ b/distribution/benchmark.py
@@ -121,9 +121,7 @@ def revert_files(app, example):
                     with open(fpth, "w") as f:
                         for line in lines:
                             if replace[0] in line.lower():
-                                line = line.lower().replace(
-                                    replace[0], replace[1]
-                                )
+                                line = line.lower().replace(replace[0], replace[1])
                             f.write(line)
 
 
@@ -179,9 +177,7 @@ def run_function(id, app, example):
     )
 
 
-def run_model(
-    current_app: PathLike, previous_app: PathLike, model_path: PathLike
-):
+def run_model(current_app: PathLike, previous_app: PathLike, model_path: PathLike):
     current_app = Path(current_app).expanduser().absolute()
     previous_app = Path(previous_app).expanduser().absolute()
     model_path = Path(model_path).expanduser().absolute()
@@ -314,9 +310,7 @@ def write_results(
         line += f"| Current Version {current_v} "
         line += f"| Previous Version {previous_v} "
         line += "| Percent difference |\n"
-        line += (
-            "| :---------- | :----------: | :----------: | :----------: |\n"
-        )
+        line += "| :---------- | :----------: | :----------: | :----------: |\n"
         f.write(line)
 
         # write benchmark data
@@ -350,9 +344,7 @@ def run_benchmarks(
     output_path = Path(output_path).expanduser().absolute()
 
     example_dirs = get_model_paths(examples_path, excluded=excluded)
-    assert any(
-        example_dirs
-    ), "No example model paths found, have models been built?"
+    assert any(example_dirs), "No example model paths found, have models been built?"
 
     # results_path = output_path / _markdown_file_name
     # if results_path.is_file():
@@ -373,9 +365,7 @@ def run_benchmarks(
 
     if not previous_exe.is_file():
         version, download_path = download_previous_version(output_path)
-        print(
-            f"Rebuilding latest MODFLOW 6 release {version} in development mode"
-        )
+        print(f"Rebuilding latest MODFLOW 6 release {version} in development mode")
         meson_build(
             project_path=download_path,
             build_path=build_path,
@@ -472,19 +462,13 @@ if __name__ == "__main__":
     build_path = Path(args.build_path)
     current_bin_path = Path(args.current_bin_path)
     previous_bin_path = Path(args.previous_bin_path)
-    output_path = (
-        Path(args.output_path) if args.output_path else Path(os.getcwd())
-    )
+    output_path = Path(args.output_path) if args.output_path else Path(os.getcwd())
     examples_repo_path = (
-        Path(args.examples_repo_path)
-        if args.examples_repo_path
-        else EXAMPLES_REPO_PATH
+        Path(args.examples_repo_path) if args.examples_repo_path else EXAMPLES_REPO_PATH
     )
 
     output_path.mkdir(parents=True, exist_ok=True)
-    assert (
-        examples_repo_path.is_dir()
-    ), f"Examples repo not found: {examples_repo_path}"
+    assert examples_repo_path.is_dir(), f"Examples repo not found: {examples_repo_path}"
 
     run_benchmarks(
         build_path=build_path,

--- a/distribution/build_dist.py
+++ b/distribution/build_dist.py
@@ -30,9 +30,7 @@ DEFAULT_MODELS = ["gwf", "gwt", "gwe", "prt", "swf"]
 # OS-specific extensions
 SYSTEM = platform.system()
 EXE_EXT = ".exe" if SYSTEM == "Windows" else ""
-LIB_EXT = (
-    ".dll" if SYSTEM == "Windows" else ".so" if SYSTEM == "Linux" else ".dylib"
-)
+LIB_EXT = ".dll" if SYSTEM == "Windows" else ".so" if SYSTEM == "Linux" else ".dylib"
 SCR_EXT = ".bat" if SYSTEM == "Windows" else ".sh"
 MF6_EXE = f"mf6{EXE_EXT}"
 
@@ -117,18 +115,12 @@ def setup_examples(
     examples_path = Path(examples_path).expanduser().absolute()
 
     # find and download example models distribution from latest examples release
-    latest = get_release(
-        "MODFLOW-USGS/modflow6-examples", tag="latest", verbose=True
-    )
+    latest = get_release("MODFLOW-USGS/modflow6-examples", tag="latest", verbose=True)
     assets = latest["assets"]
     print(f"Found {len(assets)} assets from the latest examples release:")
     pprint([a["name"] for a in assets])
-    asset = next(
-        iter([a for a in assets if a["name"].endswith("examples.zip")]), None
-    )
-    download_and_unzip(
-        asset["browser_download_url"], examples_path, verbose=True
-    )
+    asset = next(iter([a for a in assets if a["name"].endswith("examples.zip")]), None)
+    download_and_unzip(asset["browser_download_url"], examples_path, verbose=True)
 
     # filter examples for models selected for release
     # and omit any excluded models
@@ -159,9 +151,7 @@ def setup_examples(
                 f.write(runbatloc + "\n")
                 if SYSTEM == "Windows":
                     f.write("echo." + "\n")
-                    f.write(
-                        "echo Run complete.  Press any key to continue" + "\n"
-                    )
+                    f.write("echo Run complete.  Press any key to continue" + "\n")
                     f.write("pause>nul" + "\n")
 
             if SYSTEM != "Windows":
@@ -195,9 +185,7 @@ def setup_examples(
                 print(f"Execute permission set for {script_path}")
 
 
-def build_programs_meson(
-    build_path: PathLike, bin_path: PathLike, force: bool = False
-):
+def build_programs_meson(build_path: PathLike, bin_path: PathLike, force: bool = False):
     build_path = Path(build_path).expanduser().absolute()
     bin_path = Path(bin_path).expanduser().absolute()
 
@@ -283,9 +271,7 @@ def test_build_makefiles(tmp_path):
     assert (tmp_path / "make" / "makefile").is_file()
     assert (tmp_path / "make" / "makedefaults").is_file()
     assert (tmp_path / "utils" / "zonebudget" / "make" / "makefile").is_file()
-    assert (
-        tmp_path / "utils" / "zonebudget" / "make" / "makedefaults"
-    ).is_file()
+    assert (tmp_path / "utils" / "zonebudget" / "make" / "makedefaults").is_file()
     assert (tmp_path / "utils" / "mf5to6" / "make" / "makefile").is_file()
     assert (tmp_path / "utils" / "mf5to6" / "make" / "makedefaults").is_file()
 

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -65,9 +65,7 @@ DEFAULT_MODELS = ["gwf", "gwt", "gwe", "prt", "swf"]
 # OS-specific extensions
 SYSTEM = platform.system()
 EXE_EXT = ".exe" if SYSTEM == "Windows" else ""
-LIB_EXT = (
-    ".dll" if SYSTEM == "Windows" else ".so" if SYSTEM == "Linux" else ".dylib"
-)
+LIB_EXT = ".dll" if SYSTEM == "Windows" else ".so" if SYSTEM == "Linux" else ".dylib"
 
 # publications included in full dist docs
 PUB_URLS = [
@@ -88,9 +86,7 @@ def download_benchmarks(
 
     output_path = Path(output_path).expanduser().absolute()
     name = "run-time-comparison"  # todo make configurable
-    repo = (
-        f"{repo_owner}/modflow6"  # todo make configurable, add pytest/cli args
-    )
+    repo = f"{repo_owner}/modflow6"  # todo make configurable, add pytest/cli args
     artifacts = list_artifacts(repo, name=name, verbose=verbose)
     artifacts = sorted(
         artifacts,
@@ -100,16 +96,13 @@ def download_benchmarks(
     artifacts = [
         a
         for a in artifacts
-        if a["workflow_run"]["head_branch"]
-        == "develop"  # todo make configurable
+        if a["workflow_run"]["head_branch"] == "develop"  # todo make configurable
     ]
     most_recent = next(iter(artifacts), None)
     print(f"Found most recent benchmarks (artifact {most_recent['id']})")
     if most_recent:
         print(f"Downloading benchmarks (artifact {most_recent['id']})")
-        download_artifact(
-            repo, id=most_recent["id"], path=output_path, verbose=verbose
-        )
+        download_artifact(repo, id=most_recent["id"], path=output_path, verbose=verbose)
         print(f"Downloaded benchmarks to {output_path}")
         path = output_path / f"{name}.md"
         assert path.is_file()
@@ -149,9 +142,7 @@ def build_benchmark_tex(
 
     # download benchmark artifacts if any exist on GitHub
     if not benchmarks_path.is_file():
-        benchmarks_path = download_benchmarks(
-            BENCHMARKS_PATH, repo_owner=repo_owner
-        )
+        benchmarks_path = download_benchmarks(BENCHMARKS_PATH, repo_owner=repo_owner)
 
     # run benchmarks again if no benchmarks found on GitHub or overwrite requested
     if force or not benchmarks_path.is_file():
@@ -212,9 +203,7 @@ def build_deprecations_tex(force: bool = False):
     else:
         tex_path.unlink(missing_ok=True)
         with set_dir(RELEASE_NOTES_PATH):
-            out, err, ret = run_py_script(
-                "mk_deprecations.py", md_path, verbose=True
-            )
+            out, err, ret = run_py_script("mk_deprecations.py", md_path, verbose=True)
             assert not ret, out + err
 
     # check deprecations files exist
@@ -375,9 +364,7 @@ def build_pdfs(
                     buff = out + err
                     assert not ret, buff
                     if first:
-                        out, err, ret = run_cmd(
-                            "bibtex", tex_path.stem + ".aux"
-                        )
+                        out, err, ret = run_cmd("bibtex", tex_path.stem + ".aux")
                         buff = out + err
                         assert not ret or "I found no" in buff, buff
                         first = False
@@ -391,9 +378,7 @@ def build_pdfs(
         else:
             print(f"{tgt_path} already exists, nothing to do")
 
-        assert (
-            tgt_path.is_file()
-        ), f"Failed to build {tgt_path} from {tex_path}"
+        assert tgt_path.is_file(), f"Failed to build {tgt_path} from {tex_path}"
         assert tgt_path not in built_paths, f"Duplicate target: {tgt_path}"
         built_paths.add(tgt_path)
 
@@ -455,21 +440,15 @@ def build_documentation(
 
     if full:
         # convert benchmarks to LaTex, running them first if necessary
-        build_benchmark_tex(
-            output_path=output_path, force=force, repo_owner=repo_owner
-        )
+        build_benchmark_tex(output_path=output_path, force=force, repo_owner=repo_owner)
 
         # download example docs
         pdf_name = "mf6examples.pdf"
         if force or not (output_path / pdf_name).is_file():
             latest = get_release(f"{repo_owner}/modflow6-examples", "latest")
             assets = latest["assets"]
-            asset = next(
-                iter([a for a in assets if a["name"] == pdf_name]), None
-            )
-            download_and_unzip(
-                asset["browser_download_url"], output_path, verbose=True
-            )
+            asset = next(iter([a for a in assets if a["name"] == pdf_name]), None)
+            download_and_unzip(asset["browser_download_url"], output_path, verbose=True)
 
         # download publications
         for url in PUB_URLS:

--- a/distribution/build_makefiles.py
+++ b/distribution/build_makefiles.py
@@ -19,9 +19,7 @@ FC_REASON = "make must be used with gfortran"
 
 
 def run_makefile(target):
-    assert Path(
-        "makefile"
-    ).is_file(), f"makefile does not exist in {os.getcwd()}"
+    assert Path("makefile").is_file(), f"makefile does not exist in {os.getcwd()}"
 
     base_target = os.path.basename(target)
     base_message = (
@@ -39,9 +37,7 @@ def run_makefile(target):
     return_code = os.system(f"make FC={environ.get('FC', 'gfortran')}")
 
     assert return_code == 0, f"could not make '{base_target}'." + base_message
-    assert os.path.isfile(target), (
-        f"{base_target} does not exist." + base_message
-    )
+    assert os.path.isfile(target), f"{base_target} does not exist." + base_message
 
 
 def build_mf6_makefile():

--- a/distribution/check_dist.py
+++ b/distribution/check_dist.py
@@ -11,9 +11,7 @@ from modflow_devtools.misc import run_cmd
 # OS-specific extensions
 SYSTEM = platform.system()
 EXE_EXT = ".exe" if SYSTEM == "Windows" else ""
-LIB_EXT = (
-    ".dll" if SYSTEM == "Windows" else ".so" if SYSTEM == "Linux" else ".dylib"
-)
+LIB_EXT = ".dll" if SYSTEM == "Windows" else ".so" if SYSTEM == "Linux" else ".dylib"
 SCR_EXT = ".bat" if SYSTEM == "Windows" else ".sh"
 
 # fortran compiler
@@ -115,24 +113,14 @@ def test_makefiles(dist_dir_path, full):
 
     assert (dist_dir_path / "make" / "makefile").is_file()
     assert (dist_dir_path / "make" / "makedefaults").is_file()
-    assert (
-        dist_dir_path / "utils" / "zonebudget" / "make" / "makefile"
-    ).is_file()
-    assert (
-        dist_dir_path / "utils" / "zonebudget" / "make" / "makedefaults"
-    ).is_file()
+    assert (dist_dir_path / "utils" / "zonebudget" / "make" / "makefile").is_file()
+    assert (dist_dir_path / "utils" / "zonebudget" / "make" / "makedefaults").is_file()
     assert (dist_dir_path / "utils" / "mf5to6" / "make" / "makefile").is_file()
-    assert (
-        dist_dir_path / "utils" / "mf5to6" / "make" / "makedefaults"
-    ).is_file()
+    assert (dist_dir_path / "utils" / "mf5to6" / "make" / "makedefaults").is_file()
 
     # makefiles can't be used on Windows with ifort compiler
     if SYSTEM != "Windows" or FC != "ifort":
-        print(
-            subprocess.check_output(
-                "make", cwd=dist_dir_path / "make", shell=True
-            )
-        )
+        print(subprocess.check_output("make", cwd=dist_dir_path / "make", shell=True))
         print(
             subprocess.check_output(
                 "make",
@@ -196,9 +184,7 @@ def test_examples(dist_dir_path, full):
 
     # print examples found
     example_paths = [
-        p
-        for p in examples_path.glob("*")
-        if p.is_dir() and p.stem.startswith("ex")
+        p for p in examples_path.glob("*") if p.is_dir() and p.stem.startswith("ex")
     ]
     assert any(example_paths)
     print(f"{len(example_paths)} example models found:")

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -122,11 +122,7 @@ def get_disclaimer(approved: bool = False, formatted: bool = False) -> str:
     if approved:
         return _approved_fmtdisclaimer if formatted else _approved_disclaimer
     else:
-        return (
-            _preliminary_fmtdisclaimer
-            if formatted
-            else _preliminary_disclaimer
-        )
+        return _preliminary_fmtdisclaimer if formatted else _preliminary_disclaimer
 
 
 def get_software_citation(
@@ -181,19 +177,13 @@ def update_version_txt_and_py(version: Version, timestamp: datetime):
         f.write(str(version))
     log_update(version_file_path, version)
 
-    py_path = (
-        project_root_path
-        / "doc"
-        / version_file_path.name.replace(".txt", ".py")
-    )
+    py_path = project_root_path / "doc" / version_file_path.name.replace(".txt", ".py")
     with open(py_path, "w") as f:
         f.write(
             f"# {project_name} version file automatically "
             + f"created using...{os.path.basename(__file__)}\n"
         )
-        f.write(
-            "# created on..." + f"{timestamp.strftime('%B %d, %Y %H:%M:%S')}\n"
-        )
+        f.write("# created on..." + f"{timestamp.strftime('%B %d, %Y %H:%M:%S')}\n")
         f.write(f'__version__ = "{version}"\n')
     log_update(py_path, version)
 
@@ -215,9 +205,7 @@ def update_version_tex(version: Version, timestamp: datetime):
         line = "\\newcommand{\\modflowversion}{mf" + str(version) + "}"
         f.write(f"{line}\n")
         line = (
-            "\\newcommand{\\modflowdate}{"
-            + f"{timestamp.strftime('%B %d, %Y')}"
-            + "}"
+            "\\newcommand{\\modflowdate}{" + f"{timestamp.strftime('%B %d, %Y')}" + "}"
         )
         f.write(f"{line}\n")
         line = (
@@ -258,10 +246,7 @@ def update_version_f90(
                     + f"IDEVELOPMODE = {1 if developmode else 0}"
                 )
             elif ":: VERSIONNUMBER =" in line:
-                line = (
-                    line.rpartition("::")[0]
-                    + f":: VERSIONNUMBER = '{version_num}'"
-                )
+                line = line.rpartition("::")[0] + f":: VERSIONNUMBER = '{version_num}'"
             elif ":: VERSIONTAG =" in line:
                 fmat_tstmp = timestamp.strftime("%m/%d/%Y")
                 label_clause = version_label if version_label else ""
@@ -318,9 +303,7 @@ def update_citation_cff(version: Version, timestamp: datetime):
     log_update(path, version)
 
 
-def update_codejson(
-    version: Version, timestamp: datetime, approved: bool = False
-):
+def update_codejson(version: Version, timestamp: datetime, approved: bool = False):
     path = project_root_path / "code.json"
     with open(path, "r") as f:
         data = json.load(f, object_pairs_hook=OrderedDict)
@@ -436,25 +419,17 @@ def test_update_version(version, approved, developmode):
             assert updated == _current_version
 
         # check IDEVELOPMODE was set correctly
-        version_f90_path = (
-            project_root_path / "src" / "Utilities" / "version.f90"
-        )
+        version_f90_path = project_root_path / "src" / "Utilities" / "version.f90"
         lines = version_f90_path.read_text().splitlines()
         assert any(
-            f"IDEVELOPMODE = {1 if developmode else 0}" in line
-            for line in lines
+            f"IDEVELOPMODE = {1 if developmode else 0}" in line for line in lines
         )
 
         # check disclaimer has appropriate language
         disclaimer_path = project_root_path / "DISCLAIMER.md"
         disclaimer = disclaimer_path.read_text().splitlines()
-        assert (
-            any(("approved for release") in line for line in lines) == approved
-        )
-        assert (
-            any(("preliminary or provisional") in line for line in lines)
-            != approved
-        )
+        assert any(("approved for release") in line for line in lines) == approved
+        assert any(("preliminary or provisional") in line for line in lines) != approved
 
         # check readme has appropriate language
         readme_path = project_root_path / "README.md"

--- a/distribution/utils.py
+++ b/distribution/utils.py
@@ -14,11 +14,7 @@ def get_project_root_path():
 
 
 def get_modified_time(path: Path) -> float:
-    return (
-        path.stat().st_mtime
-        if path.is_file()
-        else datetime.today().timestamp()
-    )
+    return path.stat().st_mtime if path.is_file() else datetime.today().timestamp()
 
 
 def glob(

--- a/doc/ReleaseNotes/mk_deprecations.py
+++ b/doc/ReleaseNotes/mk_deprecations.py
@@ -66,8 +66,6 @@ if __name__ == "__main__":
                     skipline = False
         ftex.write(footer)
         ftex.close()
-        print(
-            f"Created LaTex file {fnametex} from markdown deprecations file {fpath}"
-        )
+        print(f"Created LaTex file {fnametex} from markdown deprecations file {fpath}")
     else:
         warn(f"Deprecations not found: {fpath}")

--- a/doc/mf6io/mf6ivar/mem_allocate.py
+++ b/doc/mf6io/mf6ivar/mem_allocate.py
@@ -113,9 +113,7 @@ def write_md(memvar_list, fmd):
             varname,
             dims,
         ) = l
-        write_md_record(
-            fmd, source_name, current_module, typename, varname, dims
-        )
+        write_md_record(fmd, source_name, current_module, typename, varname, dims)
     return
 
 
@@ -156,9 +154,7 @@ def write_tex_header(f):
         "\\caption{List of variables stored in memory manager } \\tabularnewline \n\n"
     )
     f.write("\\hline\n\\hline\n")
-    f.write(
-        "\\textbf{Class.Variable} & \\textbf{Name} & \\textbf{Dimensions} \\\\\n"
-    )
+    f.write("\\textbf{Class.Variable} & \\textbf{Name} & \\textbf{Dimensions} \\\\\n")
     f.write("\\hline\n\\endfirsthead\n\n\n")
 
     f.write("\captionsetup{textformat=simple}\n")
@@ -168,16 +164,12 @@ def write_tex_header(f):
     )
 
     f.write("\n\\hline\n\\hline\n")
-    f.write(
-        "\\textbf{Class.Variable} & \\textbf{Name} & \\textbf{Dimensions} \\\\\n"
-    )
+    f.write("\\textbf{Class.Variable} & \\textbf{Name} & \\textbf{Dimensions} \\\\\n")
     f.write("\\hline\n\\endhead\n\n\\hline\n\\endfoot\n\n\n")
 
 
 def write_tex_footer(f):
-    f.write(
-        "\n\n\\hline\n\\end{longtable}\n\\label{table:blocks}\n\\normalsize\n"
-    )
+    f.write("\n\n\\hline\n\\end{longtable}\n\\label{table:blocks}\n\\normalsize\n")
     f.close()
     return
 

--- a/doc/mf6io/mf6ivar/mf6ivar.py
+++ b/doc/mf6io/mf6ivar/mf6ivar.py
@@ -153,9 +153,7 @@ def parse_mf6var_file(fname):
                 else:
                     key = name
                 if key in vardict:
-                    raise ValueError(
-                        f"Variable already exists in dictionary: {k}"
-                    )
+                    raise ValueError(f"Variable already exists in dictionary: {k}")
                 vardict[key] = vd
             vd = {}
             continue
@@ -170,9 +168,7 @@ def parse_mf6var_file(fname):
             istart = line.index(" ")
             v = line[istart:].strip()
             if k in vd:
-                raise ValueError(
-                    f"Attribute already exists in dictionary: {k}"
-                )
+                raise ValueError(f"Attribute already exists in dictionary: {k}")
             vd[k] = v
 
     if len(vd) > 0:
@@ -276,9 +272,7 @@ def block_entry(varname, block, vardict, prefix="  "):
     return s
 
 
-def write_block(
-    vardict, block, blk_var_list, varexcludeprefix=None, indent=None
-):
+def write_block(vardict, block, blk_var_list, varexcludeprefix=None, indent=None):
     prepend = "" if indent is None else indent * " "
     s = prepend + f"BEGIN {block.upper()}"
     for variable in blk_var_list:
@@ -508,8 +502,7 @@ def get_examples(component):
     files = [
         filename
         for filename in sorted(os.listdir(EXAMPLES_DIR_PATH))
-        if component.lower() in filename.lower()
-        and "-obs" not in filename.lower()
+        if component.lower() in filename.lower() and "-obs" not in filename.lower()
     ]
     s = ""
     for idx, filename in enumerate(files):
@@ -560,12 +553,8 @@ def get_obs_table(component):
     s = ""
     if files:
         s += "#### Available Observation Types\n\n"
-        s += (
-            "| Stress Package | Observation Type | ID1 | ID2 | Description |\n"
-        )
-        s += (
-            "|----------------|------------------|-----|-----|-------------|\n"
-        )
+        s += "| Stress Package | Observation Type | ID1 | ID2 | Description |\n"
+        s += "|----------------|------------------|-----|-----|-------------|\n"
     for filename in files:
         fpth = os.path.join(COMMON_DIR_PATH, filename)
         with open(fpth, "r") as f:
@@ -665,9 +654,7 @@ def write_appendix(blocks):
             f.write(s)
             lastftype = ftype
 
-        f.write(
-            "\n\n\\hline\n\\end{longtable}\n\\label{table:blocks}\n\\normalsize\n"
-        )
+        f.write("\n\n\\hline\n\\end{longtable}\n\\label{table:blocks}\n\\normalsize\n")
 
 
 def get_dfn_files(models):
@@ -725,23 +712,21 @@ def write_variables():
                 allblocks.append(b)
 
             # go through each block and write information
-            desc = "% DO NOT MODIFY THIS FILE DIRECTLY.  IT IS CREATED BY mf6ivar.py \n\n"
+            desc = (
+                "% DO NOT MODIFY THIS FILE DIRECTLY.  IT IS CREATED BY mf6ivar.py \n\n"
+            )
             for b in blocks:
                 blk_var_list = []
 
                 # Write the name of the block to the latex file
                 desc += f"\\item \\textbf{'{Block: ' + b.upper() + '}'}\n\n"
                 desc += "\\begin{description}\n"
-                desc += write_desc(
-                    vardict, b, blk_var_list, varexcludeprefix="dev_"
-                )
+                desc += write_desc(vardict, b, blk_var_list, varexcludeprefix="dev_")
                 desc += "\\end{description}\n"
 
                 with open(TEX_DIR_PATH / f"{fpath.stem}-{b}.dat", "w") as f:
                     s = (
-                        write_block(
-                            vardict, b, blk_var_list, varexcludeprefix="dev_"
-                        )
+                        write_block(vardict, b, blk_var_list, varexcludeprefix="dev_")
                         + "\n"
                     )
                     f.write(s)

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-line-length = 79
+line-length = 88
 target-version = "py37"
 include = [
     ".doc/**/*.py",

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -35,9 +35,7 @@ class Dfn2F90:
         self._subpackage = []
         self._verbose = verbose
 
-        self.component, self.subcomponent = self._dfnfspec.stem.upper().split(
-            "-"
-        )
+        self.component, self.subcomponent = self._dfnfspec.stem.upper().split("-")
 
         print(f"\nprocessing dfn => {self._dfnfspec}")
         self._set_var_d()
@@ -55,9 +53,7 @@ class Dfn2F90:
     def write_f90(self, ofspec=None):
         with open(ofspec, "w") as f:
             # file header
-            f.write(
-                self._source_file_header(self.component, self.subcomponent)
-            )
+            f.write(self._source_file_header(self.component, self.subcomponent))
 
             # found type
             f.write(
@@ -97,73 +93,44 @@ class Dfn2F90:
             # params
             if len(self._param_varnames):
                 f.write(self._param_str)
+                f.write(self._source_params_header(self.component, self.subcomponent))
+                f.write("    " + ", &\n    ".join(self._param_varnames) + " &\n")
                 f.write(
-                    self._source_params_header(
-                        self.component, self.subcomponent
-                    )
-                )
-                f.write(
-                    "    " + ", &\n    ".join(self._param_varnames) + " &\n"
-                )
-                f.write(
-                    self._source_list_footer(self.component, self.subcomponent)
-                    + "\n"
+                    self._source_list_footer(self.component, self.subcomponent) + "\n"
                 )
             else:
-                f.write(
-                    self._source_params_header(
-                        self.component, self.subcomponent
-                    )
-                )
+                f.write(self._source_params_header(self.component, self.subcomponent))
                 f.write(self._param_str.rsplit(",", 1)[0] + " &\n")
                 f.write(
-                    self._source_list_footer(self.component, self.subcomponent)
-                    + "\n"
+                    self._source_list_footer(self.component, self.subcomponent) + "\n"
                 )
 
             # aggregate types
             if len(self._aggregate_varnames):
                 f.write(self._aggregate_str)
                 f.write(
-                    self._source_aggregates_header(
-                        self.component, self.subcomponent
-                    )
+                    self._source_aggregates_header(self.component, self.subcomponent)
                 )
+                f.write("    " + ", &\n    ".join(self._aggregate_varnames) + " &\n")
                 f.write(
-                    "    "
-                    + ", &\n    ".join(self._aggregate_varnames)
-                    + " &\n"
-                )
-                f.write(
-                    self._source_list_footer(self.component, self.subcomponent)
-                    + "\n"
+                    self._source_list_footer(self.component, self.subcomponent) + "\n"
                 )
             else:
                 f.write(
-                    self._source_aggregates_header(
-                        self.component, self.subcomponent
-                    )
+                    self._source_aggregates_header(self.component, self.subcomponent)
                 )
                 f.write(self._aggregate_str.rsplit(",", 1)[0] + " &\n")
                 f.write(
-                    self._source_list_footer(self.component, self.subcomponent)
-                    + "\n"
+                    self._source_list_footer(self.component, self.subcomponent) + "\n"
                 )
 
             # blocks
-            f.write(
-                self._source_blocks_header(self.component, self.subcomponent)
-            )
+            f.write(self._source_blocks_header(self.component, self.subcomponent))
             f.write(self._block_str.rsplit(",", 1)[0] + " &\n")
-            f.write(
-                self._source_list_footer(self.component, self.subcomponent)
-                + "\n"
-            )
+            f.write(self._source_list_footer(self.component, self.subcomponent) + "\n")
 
             # file footer
-            f.write(
-                self._source_file_footer(self.component, self.subcomponent)
-            )
+            f.write(self._source_file_footer(self.component, self.subcomponent))
 
     def get_blocknames(self):
         blocknames = []
@@ -221,9 +188,7 @@ class Dfn2F90:
                 istart = line.index(" ")
                 v = line[istart:].strip()
                 if k in vd:
-                    raise Exception(
-                        "Attribute already exists in dictionary: " + k
-                    )
+                    raise Exception("Attribute already exists in dictionary: " + k)
                 vd[k] = v
 
         if len(vd) > 0:
@@ -234,9 +199,7 @@ class Dfn2F90:
             else:
                 key = name
             if name in vardict:
-                raise Exception(
-                    "Variable already exists in dictionary: " + name
-                )
+                raise Exception("Variable already exists in dictionary: " + name)
             vardict[key] = vd
 
         self._var_d = vardict
@@ -415,11 +378,7 @@ class Dfn2F90:
 
             if t == "DOUBLE PRECISION":
                 t = "DOUBLE"
-            if (
-                shape != ""
-                and not aggregate_t
-                and (t == "DOUBLE" or t == "INTEGER")
-            ):
+            if shape != "" and not aggregate_t and (t == "DOUBLE" or t == "INTEGER"):
                 t = f"{t}{ndim}D"
 
             longname = ""
@@ -621,12 +580,7 @@ class IdmDfnSelector:
 
     def _write_selectors(self):
         for c in self._d:
-            ofspec = (
-                SRC_PATH
-                / "Idm"
-                / "selector"
-                / f"Idm{c.title()}DfnSelector.f90"
-            )
+            ofspec = SRC_PATH / "Idm" / "selector" / f"Idm{c.title()}DfnSelector.f90"
             with open(ofspec, "w") as fh:
                 self._write_selector_decl(fh, component=c, sc_list=self._d[c])
                 self._write_selector_helpers(fh)
@@ -653,9 +607,7 @@ class IdmDfnSelector:
                 )
                 self._write_selector_multi(fh, component=c, sc_list=self._d[c])
                 self._write_selector_sub(fh, component=c, sc_list=self._d[c])
-                self._write_selector_integration(
-                    fh, component=c, sc_list=self._d[c]
-                )
+                self._write_selector_integration(fh, component=c, sc_list=self._d[c])
                 fh.write(f"end module Idm{c.title()}DfnSelectorModule\n")
 
     def _write_selector_decl(self, fh=None, component=None, sc_list=None):
@@ -815,9 +767,7 @@ class IdmDfnSelector:
 
         fh.write(s)
 
-    def _write_selector_integration(
-        self, fh=None, component=None, sc_list=None
-    ):
+    def _write_selector_integration(self, fh=None, component=None, sc_list=None):
         c = component
 
         s = (
@@ -1000,7 +950,7 @@ class IdmDfnSelector:
         )
 
         for c in dfn_d:
-            s += f"    case ('{c}')\n" f"      integrated = .true.\n"
+            s += f"    case ('{c}')\n      integrated = .true.\n"
 
         s += (
             "    case default\n"
@@ -1059,11 +1009,7 @@ if __name__ == "__main__":
     if dfn.suffix.lower() in [".txt"]:
         dfns = open(dfn, "r").readlines()
         dfns = [l.strip() for l in dfns]
-        dfns = [
-            l
-            for l in dfns
-            if not l.startswith("#") and l.lower().endswith(".dfn")
-        ]
+        dfns = [l for l in dfns if not l.startswith("#") and l.lower().endswith(".dfn")]
         if dfn == DEFAULT_DFNS_PATH:
             dfns = [DFN_PATH / p for p in dfns]
     elif dfn.suffix.lower() in [".yml", ".yaml"]:


### PR DESCRIPTION
This PR reformats Python code with a maximum line length of 88 characters to better represent the code. Note that a related repo [MODFLOW-USGS/modflow6-examples](https://github.com/MODFLOW-USGS/modflow6-examples) already uses the default line length of 88.

See https://github.com/modflowpy/flopy/pull/2362 for a related PR with rational and discussion.

This PR was automated using these Ruff commands (including quick fixes to [ISC001](https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/)):
```bash
ruff format
ruff check --select ISC001 --fix
ruff format
```