### PR TITLE
chore: add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,38 @@
+# apply fprettify formatting (#956)
+41e98a24cec6d3607138558fa538621191260efa
+
+# apply fprettify formatting (#957)
+c033fc85713770ace7d51f3c382257bc90d9932f
+
+# apply fprettify formatting (#960)
+571dcfd5cd439ba7129ed86b6e54e6e0c7340d35
+
+# apply fprettify formatting (#961)
+cc444d0364f97e47c965b91efd6b480d66ea2105
+
+# apply fprettify formatting (#963)
+04e82dd660541b3fa61b9cfe3343a827698f113a
+
+# apply fprettify formatting (#969)
+b063109202645a13a2f6d8b9799048c304e525d9
+
+# apply fprettify formatting (#974)
+9514eb46c14f0d4f4860fbfb0eb96c2606ac597f
+
+# apply fprettify formatting (#975)
+c3f415362edd6a8e033204967281fd10061dacf8
+
+# apply fprettify formatting (#980)
+ff1f8e596680ce1a5bdad589b80b2746bc6dca55
+
+# apply fprettify formatting (#984)
+d56a12e0db8ff9d052b7ef9d7157506528e1a70e
+
+# apply fprettify formatting (#985)
+9f7c07aea29d55f9c0ef2a61f62bc15d45321695
+
+# run ruff lint and format on python files in repo (#1936)
+9d55d586439b832c33feb196718a6122973dc6aa
+
+# reformat Python code with line length = 88 (#2056)
+f6c3a55ea72065ba1ce8540d1fd3c051696df1f1

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -82,6 +82,12 @@ Some additional, optional tools are also discussed below.
 [Git](https://git-scm.com) and/or the **GitHub app** (for [Mac](https://mac.github.com) or [Windows](https://windows.github.com)).
 [GitHub's Guide to Installing Git](https://help.github.com/articles/set-up-git) is a good source of information.
 
+Optionally, the [`git blame`](https://git-scm.com/docs/git-blame) tool can be configured to work locally using:
+
+```shell
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ### Python
 
 Python 3.9+ is required to run MODFLOW 6 tests and in some cases to build MODFLOW 6. Information on installing the python environment is given in the [Installing Python environment](#install-the-python-environment) section. The MODFLOW 6 python environment should be installed after [locally cloning the repository](#get-the-modflow-6-repository).


### PR DESCRIPTION
This PR attempts to clear some "noise" when using GitHub's "blame view" UI tool to see changes in code history for individual files.

These commits are chosen as they are mostly style-related changes rather than code refactors (minor refactors are OK):

- 41e98a24cec6d3607138558fa538621191260efa
- c033fc85713770ace7d51f3c382257bc90d9932f
- 571dcfd5cd439ba7129ed86b6e54e6e0c7340d35
- cc444d0364f97e47c965b91efd6b480d66ea2105
- 04e82dd660541b3fa61b9cfe3343a827698f113a
- b063109202645a13a2f6d8b9799048c304e525d9
- 9514eb46c14f0d4f4860fbfb0eb96c2606ac597f
- c3f415362edd6a8e033204967281fd10061dacf8
- ff1f8e596680ce1a5bdad589b80b2746bc6dca55
- d56a12e0db8ff9d052b7ef9d7157506528e1a70e
- 9f7c07aea29d55f9c0ef2a61f62bc15d45321695
- 9d55d586439b832c33feb196718a6122973dc6aa
- f6c3a55ea72065ba1ce8540d1fd3c051696df1f1

A note is added to DEVELOPER.md optionally configure `git blame`. Nothing else is needed for GitHub, which automatically uses the file.