### PR TITLE
chore: add codespell configuration, check python source files

### DIFF
--- a/.codespell.ignore
+++ b/.codespell.ignore
@@ -1,4 +1,4 @@
-alph
+Alph
 wel
 nam
 gage
@@ -7,10 +7,11 @@ delt
 lke
 ist
 inout
+fo
+nd
 ot
-initialx
-initialy
-initialz
+initialY
+localy
 iterm
 dum
 shft
@@ -19,3 +20,5 @@ thi
 thckstrt
 rin
 checkin
+exchng
+welp

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = *.pdf,*.grb,*.bib,*.bst,./src/Utilities/Libraries/*,./utils/mf5to6/*
+ignore-words = .codespell.ignore

--- a/.github/common/check_spelling.py
+++ b/.github/common/check_spelling.py
@@ -14,11 +14,7 @@ PROJ_ROOT = Path(__file__).parents[2]
 excludedirs = [
     PROJ_ROOT / ".pixi",
     PROJ_ROOT / "autotest" / ".pytest_cache",
-    PROJ_ROOT / "src" / "Utilities" / "Libraries" / "blas",
-    PROJ_ROOT / "src" / "Utilities" / "Libraries" / "daglib",
-    PROJ_ROOT / "src" / "Utilities" / "Libraries" / "rcm",
-    PROJ_ROOT / "src" / "Utilities" / "Libraries" / "sparsekit",
-    PROJ_ROOT / "src" / "Utilities" / "Libraries" / "sparskit2",
+    PROJ_ROOT / "src" / "Utilities" / "Libraries",
     PROJ_ROOT / "srcbmi" / "latex",
     PROJ_ROOT / "utils" / "mf5to6",
 ]
@@ -27,7 +23,7 @@ excludedirs = [
 excludefiles = []
 
 # commands
-codespell = "codespell --ignore-words=.codespell.ignore"
+codespell_cmds = ["codespell", "--ignore-words=.codespell.ignore"]
 
 
 def excluded(path) -> bool:
@@ -46,10 +42,12 @@ def check_spelling(path, lock, checks, failures, write_changes=False, verbose=Fa
     if verbose:
         print(f"Checking spelling: {path}")
 
-    wc = "-w" if write_changes else ""
-    cmd = f"{codespell} {wc} {path}"
-    result = run(cmd, capture_output=True, shell=True)
-    if result.stdout or result.stderr:
+    cmds = codespell_cmds.copy()
+    if write_changes:
+        cmds.append("-w")
+    cmds.append(path)
+    result = run(cmds, capture_output=True)
+    if result.returncode != 0:
         failures.put(path)
 
     with lock:
@@ -71,7 +69,7 @@ def report(checks, failures, duration: float) -> bool:
         print(f"{hr}\n{stats}")
         while True:
             try:
-                print(f"{codespell} {pop(failures)}")
+                print(f"{' '.join(codespell_cmds)} {pop(failures)}")
             except Empty:
                 break
 
@@ -93,7 +91,7 @@ if __name__ == "__main__":
         "--extension",
         help="file extensions to check",
         action="append",
-        default=[".[fF]9[05]", ".dfn", ".tex", ".md"],
+        default=[".[fF]9[05]", ".dfn", ".tex", ".md", ".py"],
     )
     parser.add_argument(
         "-w",

--- a/.github/common/check_spelling.py
+++ b/.github/common/check_spelling.py
@@ -23,7 +23,7 @@ excludedirs = [
 excludefiles = []
 
 # commands
-codespell_cmds = ["codespell", "--ignore-words=.codespell.ignore"]
+codespell_cmds = ["codespell"]
 
 
 def excluded(path) -> bool:

--- a/autotest/test_chf_dis.py
+++ b/autotest/test_chf_dis.py
@@ -177,7 +177,7 @@ def check_grb_disv1d(fpth):
         grb._datadict["IAVERT"][-1] - 1 == grb._datadict["JAVERT"].shape[0]
     ), "javert size not right"
     assert grb.ia.shape[0] == grb.ncells + 1, "ia in grb file is not correct size"
-    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
+    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not correct size"
     assert np.allclose(
         grb.idomain.reshape((nodes,)), idomain.reshape((nodes,))
     ), "grb idomain not correct"

--- a/autotest/test_chf_dis_fdc.py
+++ b/autotest/test_chf_dis_fdc.py
@@ -183,7 +183,7 @@ def check_grb_disv1d(fpth):
         grb._datadict["IAVERT"][-1] - 1 == grb._datadict["JAVERT"].shape[0]
     ), "javert size not right"
     assert grb.ia.shape[0] == grb.ncells + 1, "ia in grb file is not correct size"
-    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
+    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not correct size"
     assert np.allclose(
         grb.idomain.reshape((nodes,)), idomain.reshape((nodes,))
     ), "grb idomain not correct"

--- a/autotest/test_gwe_drycell_cnd4.py
+++ b/autotest/test_gwe_drycell_cnd4.py
@@ -500,7 +500,7 @@ def check_output(idx, test):
     )
     temp_diff = np.diff(temp_nwt.squeeze(), axis=0)
 
-    # Because of the time discretization scheme, need to check each cell in two chuncks
+    # Because of the time discretization scheme, need to check each cell in two chunks
     # Cell ID: (0, 0, 0)
     assert isMonotonic(temp_diff[:, 0, 0][::-1][0:10]), msg2
     assert isMonotonic(temp_diff[:, 0, 0][::-1][10:-1]), msg2

--- a/autotest/test_gwe_esl02.py
+++ b/autotest/test_gwe_esl02.py
@@ -339,8 +339,7 @@ def check_output(idx, test):
         "Grid cell temperatures do not reflect the expected difference"
         "in stress period "
     )
-    ans = ncol[idx]
-    assert np.isclose(np.sum(temps[-1]), ans), msg0 + str(index)
+    assert np.isclose(np.sum(temps[-1]), ncol[idx]), msg0 + str(index)
 
 
 # - No need to change any code below

--- a/autotest/test_gwe_split_analyt.py
+++ b/autotest/test_gwe_split_analyt.py
@@ -154,7 +154,7 @@ def calc_ener_input(primer_val):
     return ener_add_rate
 
 
-# Instatiate model to compare against analytical solution
+# Instantiate model to compare against analytical solution
 def assemble_half_model(sim, gwfname, gwfpath, side="right"):
     # Create GWF model
     gwf = flopy.mf6.MFModel(

--- a/autotest/test_gwf_csub_sub01_adjmat.py
+++ b/autotest/test_gwf_csub_sub01_adjmat.py
@@ -305,7 +305,7 @@ def check_output(idx, test):
         calci["THICK"] += calc["THICK"]
         calci["THETA"] += calc["THICK"] * calc["THETA"]
 
-    # finialize weighted theta and
+    # finalize weighted theta and
     calci["THETA"] /= calci["THICK"]
     for key in calci.dtype.names:
         diff = calci[key] - ovalsi[key]

--- a/autotest/test_gwt_sft_inactive01.py
+++ b/autotest/test_gwt_sft_inactive01.py
@@ -1,6 +1,6 @@
 """
 A test of the keyword NONE for <cellid> in the package data block.
-In essense, this tests inactivation of cells which if active, would be connected
+In essence, this tests inactivation of cells which if active, would be connected
 to SFR reaches during a simulation. Additionally, this uses a DISU grid.  The
 test was developed based on a user having memory access violations for a real-
 world model that included DISU and SFR reaches where cells did not exist.
@@ -169,7 +169,7 @@ def buildout_vertex_locations():
 
 
 def set_connectiondata(n, lay, top, left, right, bottom):
-    # Instatiate empty lists
+    # Instantiate empty lists
     jas = [n]
     ihc = [lay]
     cl12 = [n]
@@ -445,7 +445,7 @@ def build_models(idx, test):
         transient={0: True},
     )
 
-    # Instantiate the intial conditions
+    # Instantiate the initial conditions
     flopy.mf6.ModflowGwfic(gwf, strt=strt)
 
     # Instantiate constant heads for keeping the heads from rising
@@ -672,7 +672,7 @@ def check_output(idx, test):
         "therefore inactive."
     )
     msg1 = (
-        "There seems to be mis-alignment in the flow/transport results "
+        "There seems to be misalignment in the flow/transport results "
         "when some of the GWF cells are inactive but overlain with SFR "
         "reaches"
     )

--- a/autotest/test_olf_dis.py
+++ b/autotest/test_olf_dis.py
@@ -235,7 +235,7 @@ def check_grb_dis2d(fpth):
         grb.bot.reshape((nrow, ncol)), np.zeros((nrow, ncol))
     ), "grb botm not correct"
     assert grb.ia.shape[0] == grb.ncells + 1, "ia in grb file is not correct size"
-    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
+    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not correct size"
     assert np.allclose(
         grb.idomain.reshape((nrow, ncol)), idomain
     ), "grb idomain not correct"
@@ -268,7 +268,7 @@ def check_grb_disv2d(fpth):
         grb._datadict["IAVERT"][-1] - 1 == grb._datadict["JAVERT"].shape[0]
     ), "javert size not right"
     assert grb.ia.shape[0] == grb.ncells + 1, "ia in grb file is not correct size"
-    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not corect size"
+    assert grb.ja.shape[0] == grb.nja, "ja in grb file is not correct size"
     assert np.allclose(
         grb.idomain.reshape((ncpl,)), idomain.reshape((ncpl,))
     ), "grb idomain not correct"


### PR DESCRIPTION
This PR has two primary aims:

1. Add a codespell configuration, so that users can type `codespell` to check everything and show suggested changes. This takes 1.5 seconds on my laptop.
2. `python3 .github/common/check_spelling.py` now checks Python source files. This takes 12.5 seconds on the same laptop.

Other changes:

- Fix a small handful of typos from Python source files.
- Expand the list of ignored words. Some case-sensitive ignores are enforced, others that don't raise errors are removed.
- Improve use of [`subprocess.run()`](https://docs.python.org/3/library/subprocess.html#subprocess.run) usage in  `check_spelling.py`