### PR TITLE
ci(macos): switch macos-12 -> 13, trim compiler compat test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,16 +198,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-12
+          # intel mac, release mode
+          - os: macos-13
             debug: false
+          # arm mac, release mode
           - os: macos-14
             debug: false
+          # arm mac, debug mode
           - os: macos-14
             debug: true
+          # ubuntu, release mode
           - os: ubuntu-22.04
             debug: false
+          # ubuntu, debug mode
           - os: ubuntu-22.04
             debug: true
+          # windows, release mode
           - os: windows-2022
             debug: false
     defaults:
@@ -251,7 +257,7 @@ jobs:
         run: pixi run install
 
       - name: Set LDFLAGS (macOS)
-        if: matrix.os == 'macos-14'
+        if: runner.os == 'macOS'
         run: |
           os_ver=$(sw_vers -productVersion | cut -d'.' -f1)
           if (( "$os_ver" > 12 )); then
@@ -372,7 +378,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-13, windows-2022]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -15,30 +15,19 @@ jobs:
         # combinations from https://github.com/fortran-lang/setup-fortran#runner-compatibility
         include:
           # gfortran
-          - {os: ubuntu-20.04, compiler: gcc, version: 11}
           - {os: ubuntu-22.04, compiler: gcc, version: 11}
           - {os: ubuntu-22.04, compiler: gcc, version: 12}
           - {os: ubuntu-22.04, compiler: gcc, version: 13}
-          - {os: macos-11, compiler: gcc, version: 11}
-          - {os: macos-11, compiler: gcc, version: 12}
-          - {os: macos-11, compiler: gcc, version: 13}
-          - {os: macos-12, compiler: gcc, version: 11}
-          - {os: macos-12, compiler: gcc, version: 12}
-          - {os: macos-12, compiler: gcc, version: 13}
-          - {os: windows-2019, compiler: gcc, version: 11}
-          - {os: windows-2019, compiler: gcc, version: 12}
-          - {os: windows-2019, compiler: gcc, version: 13}
+          - {os: macos-13, compiler: gcc, version: 11}
+          - {os: macos-13, compiler: gcc, version: 12}
+          - {os: macos-13, compiler: gcc, version: 13}
+          - {os: macos-14, compiler: gcc, version: 11}
+          - {os: macos-14, compiler: gcc, version: 12}
+          - {os: macos-14, compiler: gcc, version: 13}
           - {os: windows-2022, compiler: gcc, version: 11}
           - {os: windows-2022, compiler: gcc, version: 12}
           - {os: windows-2022, compiler: gcc, version: 13}
           # ifx
-          - {os: ubuntu-20.04, compiler: intel, version: 2024.1}
-          - {os: ubuntu-20.04, compiler: intel, version: "2024.0"}
-          - {os: ubuntu-20.04, compiler: intel, version: 2023.2}
-          - {os: ubuntu-20.04, compiler: intel, version: 2023.1}
-          - {os: ubuntu-20.04, compiler: intel, version: "2023.0"}
-          - {os: ubuntu-20.04, compiler: intel, version: 2022.2.1}
-          - {os: ubuntu-20.04, compiler: intel, version: 2022.2}
           - {os: ubuntu-22.04, compiler: intel, version: 2024.1}
           - {os: ubuntu-22.04, compiler: intel, version: "2024.0"}
           - {os: ubuntu-22.04, compiler: intel, version: 2023.2}
@@ -46,13 +35,6 @@ jobs:
           - {os: ubuntu-22.04, compiler: intel, version: "2023.0"}
           - {os: ubuntu-22.04, compiler: intel, version: 2022.2.1}
           - {os: ubuntu-22.04, compiler: intel, version: 2022.2}
-          # no ifx on mac
-          - {os: windows-2019, compiler: intel, version: 2024.1}
-          - {os: windows-2019, compiler: intel, version: "2024.0"}
-          - {os: windows-2019, compiler: intel, version: 2023.2}
-          - {os: windows-2019, compiler: intel, version: 2023.1}
-          - {os: windows-2019, compiler: intel, version: "2023.0"}
-          - {os: windows-2019, compiler: intel, version: 2022.2}
           - {os: windows-2022, compiler: intel, version: 2024.1}
           - {os: windows-2022, compiler: intel, version: "2024.0"}
           - {os: windows-2022, compiler: intel, version: 2023.2}
@@ -60,16 +42,6 @@ jobs:
           - {os: windows-2022, compiler: intel, version: "2023.0"}
           - {os: windows-2022, compiler: intel, version: 2022.2}
           # ifort
-          - {os: ubuntu-20.04, compiler: intel-classic, version: "2021.10"}
-          - {os: ubuntu-20.04, compiler: intel-classic, version: 2021.9}
-          - {os: ubuntu-20.04, compiler: intel-classic, version: 2021.8}
-          - {os: ubuntu-20.04, compiler: intel-classic, version: 2021.7}
-          - {os: ubuntu-20.04, compiler: intel-classic, version: 2021.6}
-          - {os: ubuntu-20.04, compiler: intel-classic, version: 2021.5}
-          - {os: ubuntu-20.04, compiler: intel-classic, version: 2021.4}
-          - {os: ubuntu-20.04, compiler: intel-classic, version: 2021.3}
-          - {os: ubuntu-20.04, compiler: intel-classic, version: 2021.2}
-          - {os: ubuntu-20.04, compiler: intel-classic, version: 2021.1}
           - {os: ubuntu-22.04, compiler: intel-classic, version: "2021.10"}
           - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.9}
           - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.8}
@@ -80,31 +52,16 @@ jobs:
           - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.3}
           - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.2}
           - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.1}
-          - {os: macos-11, compiler: intel-classic, version: "2021.10"}
-          - {os: macos-11, compiler: intel-classic, version: 2021.9}
-          - {os: macos-11, compiler: intel-classic, version: 2021.8}
-          - {os: macos-11, compiler: intel-classic, version: 2021.7}
-          - {os: macos-11, compiler: intel-classic, version: 2021.6}
-          - {os: macos-11, compiler: intel-classic, version: 2021.5}
-          - {os: macos-11, compiler: intel-classic, version: 2021.4}
-          - {os: macos-11, compiler: intel-classic, version: 2021.3}
-          - {os: macos-11, compiler: intel-classic, version: 2021.2}
-          - {os: macos-11, compiler: intel-classic, version: 2021.1}
-          - {os: macos-12, compiler: intel-classic, version: "2021.10"}
-          - {os: macos-12, compiler: intel-classic, version: 2021.9}
-          - {os: macos-12, compiler: intel-classic, version: 2021.8}
-          - {os: macos-12, compiler: intel-classic, version: 2021.7}
-          - {os: macos-12, compiler: intel-classic, version: 2021.6}
-          - {os: macos-12, compiler: intel-classic, version: 2021.5}
-          - {os: macos-12, compiler: intel-classic, version: 2021.4}
-          - {os: macos-12, compiler: intel-classic, version: 2021.3}
-          - {os: macos-12, compiler: intel-classic, version: 2021.2}
-          - {os: macos-12, compiler: intel-classic, version: 2021.1}
-          - {os: windows-2019, compiler: intel-classic, version: "2021.10"}
-          - {os: windows-2019, compiler: intel-classic, version: 2021.9}
-          - {os: windows-2019, compiler: intel-classic, version: 2021.8}
-          - {os: windows-2019, compiler: intel-classic, version: 2021.7}
-          - {os: windows-2019, compiler: intel-classic, version: 2021.6}
+          - {os: macos-13, compiler: intel-classic, version: "2021.10"}
+          - {os: macos-13, compiler: intel-classic, version: 2021.9}
+          - {os: macos-13, compiler: intel-classic, version: 2021.8}
+          - {os: macos-13, compiler: intel-classic, version: 2021.7}
+          - {os: macos-13, compiler: intel-classic, version: 2021.6}
+          - {os: macos-13, compiler: intel-classic, version: 2021.5}
+          - {os: macos-13, compiler: intel-classic, version: 2021.4}
+          - {os: macos-13, compiler: intel-classic, version: 2021.3}
+          - {os: macos-13, compiler: intel-classic, version: 2021.2}
+          - {os: macos-13, compiler: intel-classic, version: 2021.1}
           - {os: windows-2022, compiler: intel-classic, version: "2021.10"}
           - {os: windows-2022, compiler: intel-classic, version: 2021.9}
           - {os: windows-2022, compiler: intel-classic, version: 2021.8}


### PR DESCRIPTION
Carved out of #2054. The `macos-12` runner will be deprecated soon and has started seeing warning outages. Also shrink the test matrix for the compiler compatibility tests to include only the latest of each platform.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Removed checklist items not relevant to this pull request