### PR TITLE
fix(urword): increase number of characters for integers and floats

### DIFF
--- a/autotest/TestInputOutput.f90
+++ b/autotest/TestInputOutput.f90
@@ -1,7 +1,8 @@
 module TestInputOutput
   use testdrive, only: error_type, unittest_type, new_unittest, check
+  use KindModule, only: I4B, DP
   use ConstantsModule, only: LINELENGTH
-  ! use InputOutputModule, only: ???
+  use InputOutputModule, only: urword
   implicit none
   private
   public :: collect_inputoutput
@@ -10,7 +11,81 @@ contains
 
   subroutine collect_inputoutput(testsuite)
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
-    allocate (testsuite(0))
+    testsuite = [ &
+                new_unittest("urword", test_urword) &
+                ]
   end subroutine collect_inputoutput
+
+  subroutine test_urword(error)
+    type(error_type), allocatable, intent(out) :: error
+    character(len=LINELENGTH) :: line
+    integer(I4B) :: icol
+    integer(I4B) :: istart
+    integer(I4B) :: istop
+    integer(I4B) :: ncode
+    integer(I4B) :: n
+    integer(I4B) :: iout
+    integer(I4B) :: in
+    real(DP) :: r
+
+    ! parse integer
+    line = "77"
+    icol = 1
+    ncode = 2
+    call URWORD(line, icol, istart, istop, ncode, n, r, iout, in)
+    call check(error, n == 77)
+    if (allocated(error)) return
+
+    ! parse float
+    line = "1.0"
+    icol = 1
+    ncode = 3
+    call URWORD(line, icol, istart, istop, ncode, n, r, iout, in)
+    call check(error, r == 1.D0)
+    if (allocated(error)) return
+
+    ! parse string
+    line = "mymodel"
+    icol = 1
+    ncode = 0
+    call URWORD(line, icol, istart, istop, ncode, n, r, iout, in)
+    call check(error, line(istart:istop) == "mymodel")
+    if (allocated(error)) return
+
+    ! parse string and convert to caps
+    line = "mymodel"
+    icol = 1
+    ncode = 1
+    call URWORD(line, icol, istart, istop, ncode, n, r, iout, in)
+    call check(error, line(istart:istop) == "MYMODEL")
+    if (allocated(error)) return
+
+    ! parse float with more than 30 characters
+    line = "1000000000000000000000000000000000000000"
+    icol = 1
+    ncode = 3
+    call URWORD(line, icol, istart, istop, ncode, n, r, iout, in)
+    call check(error, r == 1D39)
+    if (allocated(error)) return
+
+    ! parse empty line into a zero float value
+    line = "       "
+    icol = 1
+    ncode = 3
+    r = -999.D0
+    call URWORD(line, icol, istart, istop, ncode, n, r, iout, in)
+    call check(error, r == 0.D0)
+    if (allocated(error)) return
+
+    ! parse empty line into a zero integer value
+    line = "       "
+    icol = 1
+    ncode = 2
+    n = -999
+    call URWORD(line, icol, istart, istop, ncode, n, r, iout, in)
+    call check(error, n == 0)
+    if (allocated(error)) return
+
+  end subroutine test_urword
 
 end module TestInputOutput

--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -47,6 +47,7 @@
 		\item The GWF-GWF Exchange has been fixed to support the configuration of the Mover package (MVR) also in cases where the number of exchanges equals zero (NEXG = 0). In earlier versions this has caused MODFLOW to terminate with an error.
 		\item A PRT bug was fixed in which array-based input read from the RCH (recharge) or EVT (evapotranspiration) packages could fail to be processed correctly by the PRT FMI (flow model interface) package, causing a crash.
 		\item When the SQUARE\_GWET option was invoked in the UZF options block, evapotranspiration from the water table (GWET) was calculated incorrectly.  Instead of acting as a sink, the calculated evapotranspiration flux was added as a source of water.  The applied fix ensures that groundwater evapotranspiration is removed from the water table and as a result the GWET values are accumulated as outflows in the budget table.
+		\item The number of characters used to represent integers and floating point numbers in MODFLOW input files was restricted to 30.  The program was modified to accept any number of characters provided the number is valid.  This may be useful for parameter estimation programs that use character substitution to create new input files.
 	%	\item xxx
 
 	\end{itemize}

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -502,8 +502,15 @@ contains
 100 if (ncode == 2 .or. ncode == 3) then
       l = istop - istart + 1
       if (l < 1) go to 200
-      if (ncode == 2) read (line(istart:istop), *, err=200) n
-      if (ncode == 3) read (line(istart:istop), *, err=200) r
+      if (istart > linlen) then
+        ! support legacy urword behavior to return a zero value when
+        ! no more data is on the line
+        if (ncode == 2) n = 0
+        if (ncode == 3) r = DZERO
+      else
+        if (ncode == 2) read (line(istart:istop), *, err=200) n
+        if (ncode == 3) read (line(istart:istop), *, err=200) r
+      end if
     end if
     return
     !

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -415,7 +415,6 @@ contains
     integer(I4B), intent(in) :: in !< input file unit number
     ! -- local
     character(len=20) string
-    character(len=30) rw
     character(len=1) tab
     character(len=1) charend
     character(len=200) :: msg
@@ -501,12 +500,10 @@ contains
     !
     ! -- Convert word to a number if requested.
 100 if (ncode == 2 .or. ncode == 3) then
-      rw = ' '
-      l = 30 - istop + istart
+      l = istop - istart + 1
       if (l < 1) go to 200
-      rw(l:30) = line(istart:istop)
-      if (ncode == 2) read (rw, '(i30)', err=200) n
-      if (ncode == 3) read (rw, '(f30.0)', err=200) r
+      if (ncode == 2) read (line(istart:istop), *, err=200) n
+      if (ncode == 3) read (line(istart:istop), *, err=200) r
     end if
     return
     !


### PR DESCRIPTION
There was a 30 character limit hardwired into urword.  This seemed arbitrary and could cause problems for programs like PEST as described in #1638.  This PR relieves this restriction and instead defers to the Fortran casting from a string to an integer to determine if there is a problem.

Simple fix is to change from

```
100 if (ncode == 2 .or. ncode == 3) then
      rw = ' '
      l = 30 - istop + istart
      if (l < 1) go to 200
      rw(l:30) = line(istart:istop)
      if (ncode == 2) read (rw, '(i30)', err=200) n
      if (ncode == 3) read (rw, '(f30.0)', err=200) r
    end if
    return
```
to 

```
100 if (ncode == 2 .or. ncode == 3) then
      l = istop - istart + 1
      if (l < 1) go to 200
      if (istart > linlen) then
        ! support legacy urword behavior to return a zero value when
        ! no more data is on the line
        if (ncode == 2) n = 0
        if (ncode == 3) r = DZERO
      else
        if (ncode == 2) read (line(istart:istop), *, err=200) n
        if (ncode == 3) read (line(istart:istop), *, err=200) r
      end if
    end if
    return
```

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Close #1638 
- [x] Added new test or modified an existing test
- [x] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).