### PR TITLE
feat(io): add wrapper routine with check around getunit

### DIFF
--- a/src/Model/GroundWaterFlow/gwf-lak.f90
+++ b/src/Model/GroundWaterFlow/gwf-lak.f90
@@ -3093,7 +3093,7 @@ contains
     use ConstantsModule, only: MAXCHARLEN, DZERO, MNORMAL
     use OpenSpecModule, only: access, form
     use SimModule, only: store_error
-    use InputOutputModule, only: urword, getunit, check_assign_unit, openfile
+    use InputOutputModule, only: urword, getunit, assign_iounit, openfile
     ! -- dummy
     class(LakType), intent(inout) :: this
     character(len=*), intent(inout) :: option
@@ -3140,7 +3140,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
+        call assign_iounit(this%ibudgetout, this%inunit, "BUDGET fileout")
         call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE', mode_opt=MNORMAL)
         write (this%iout, fmtlakbin) 'BUDGET', trim(adjustl(fname)), &
@@ -3152,7 +3152,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
+        call assign_iounit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
         call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                       filstat_opt='REPLACE')
         write (this%iout, fmtlakbin) 'BUDGET CSV', trim(adjustl(fname)), &

--- a/src/Model/GroundWaterFlow/gwf-lak.f90
+++ b/src/Model/GroundWaterFlow/gwf-lak.f90
@@ -3093,7 +3093,7 @@ contains
     use ConstantsModule, only: MAXCHARLEN, DZERO, MNORMAL
     use OpenSpecModule, only: access, form
     use SimModule, only: store_error
-    use InputOutputModule, only: urword, getunit, openfile
+    use InputOutputModule, only: urword, getunit, check_assign_unit, openfile
     ! -- dummy
     class(LakType), intent(inout) :: this
     character(len=*), intent(inout) :: option
@@ -3140,7 +3140,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%ibudgetout = getunit()
+        call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
         call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE', mode_opt=MNORMAL)
         write (this%iout, fmtlakbin) 'BUDGET', trim(adjustl(fname)), &
@@ -3152,7 +3152,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%ibudcsv = getunit()
+        call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
         call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                       filstat_opt='REPLACE')
         write (this%iout, fmtlakbin) 'BUDGET CSV', trim(adjustl(fname)), &

--- a/src/Model/GroundWaterFlow/gwf-maw.f90
+++ b/src/Model/GroundWaterFlow/gwf-maw.f90
@@ -1645,7 +1645,7 @@ contains
   subroutine maw_read_options(this, option, found)
     use ConstantsModule, only: MAXCHARLEN, DZERO, MNORMAL
     use OpenSpecModule, only: access, form
-    use InputOutputModule, only: urword, check_assign_unit, openfile
+    use InputOutputModule, only: urword, assign_iounit, openfile
     ! -- dummy
     class(MawType), intent(inout) :: this
     character(len=*), intent(inout) :: option
@@ -1674,7 +1674,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%iheadout, this%inunit, "HEAD fileout")
+        call assign_iounit(this%iheadout, this%inunit, "HEAD fileout")
         call openfile(this%iheadout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE', mode_opt=MNORMAL)
         write (this%iout, fmtmawbin) 'HEAD', trim(adjustl(fname)), &
@@ -1687,7 +1687,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
+        call assign_iounit(this%ibudgetout, this%inunit, "BUDGET fileout")
         call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE', mode_opt=MNORMAL)
         write (this%iout, fmtmawbin) 'BUDGET', trim(adjustl(fname)), &
@@ -1700,7 +1700,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
+        call assign_iounit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
         call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                       filstat_opt='REPLACE')
         write (this%iout, fmtmawbin) 'BUDGET CSV', trim(adjustl(fname)), &

--- a/src/Model/GroundWaterFlow/gwf-maw.f90
+++ b/src/Model/GroundWaterFlow/gwf-maw.f90
@@ -1645,7 +1645,7 @@ contains
   subroutine maw_read_options(this, option, found)
     use ConstantsModule, only: MAXCHARLEN, DZERO, MNORMAL
     use OpenSpecModule, only: access, form
-    use InputOutputModule, only: urword, getunit, openfile
+    use InputOutputModule, only: urword, check_assign_unit, openfile
     ! -- dummy
     class(MawType), intent(inout) :: this
     character(len=*), intent(inout) :: option
@@ -1674,7 +1674,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%iheadout = getunit()
+        call check_assign_unit(this%iheadout, this%inunit, "HEAD fileout")
         call openfile(this%iheadout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE', mode_opt=MNORMAL)
         write (this%iout, fmtmawbin) 'HEAD', trim(adjustl(fname)), &
@@ -1687,7 +1687,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%ibudgetout = getunit()
+        call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
         call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE', mode_opt=MNORMAL)
         write (this%iout, fmtmawbin) 'BUDGET', trim(adjustl(fname)), &
@@ -1700,7 +1700,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%ibudcsv = getunit()
+        call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
         call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                       filstat_opt='REPLACE')
         write (this%iout, fmtmawbin) 'BUDGET CSV', trim(adjustl(fname)), &

--- a/src/Model/GroundWaterFlow/gwf-mvr.f90
+++ b/src/Model/GroundWaterFlow/gwf-mvr.f90
@@ -688,7 +688,7 @@ contains
     use ConstantsModule, only: LINELENGTH, DZERO, DONE
     use OpenSpecModule, only: access, form
     use SimModule, only: store_error, store_error_unit
-    use InputOutputModule, only: urword, getunit, openfile
+    use InputOutputModule, only: urword, check_assign_unit, openfile
     ! -- dummy
     class(GwfMvrType) :: this
     ! -- local
@@ -718,7 +718,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            this%ibudgetout = getunit()
+            call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
             call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                           form, access, 'REPLACE')
             write (this%iout, fmtmvrbin) 'BUDGET', trim(adjustl(fname)), &
@@ -732,7 +732,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            this%ibudcsv = getunit()
+            call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
             call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                           filstat_opt='REPLACE')
             write (this%iout, fmtmvrbin) 'BUDGET CSV', trim(adjustl(fname)), &

--- a/src/Model/GroundWaterFlow/gwf-mvr.f90
+++ b/src/Model/GroundWaterFlow/gwf-mvr.f90
@@ -688,7 +688,7 @@ contains
     use ConstantsModule, only: LINELENGTH, DZERO, DONE
     use OpenSpecModule, only: access, form
     use SimModule, only: store_error, store_error_unit
-    use InputOutputModule, only: urword, check_assign_unit, openfile
+    use InputOutputModule, only: urword, assign_iounit, openfile
     ! -- dummy
     class(GwfMvrType) :: this
     ! -- local
@@ -718,7 +718,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
+            call assign_iounit(this%ibudgetout, this%inunit, "BUDGET fileout")
             call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                           form, access, 'REPLACE')
             write (this%iout, fmtmvrbin) 'BUDGET', trim(adjustl(fname)), &
@@ -732,7 +732,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
+            call assign_iounit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
             call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                           filstat_opt='REPLACE')
             write (this%iout, fmtmvrbin) 'BUDGET CSV', trim(adjustl(fname)), &

--- a/src/Model/GroundWaterFlow/gwf-sfr.f90
+++ b/src/Model/GroundWaterFlow/gwf-sfr.f90
@@ -707,7 +707,7 @@ contains
   subroutine sfr_options(this, option, found)
     ! -- modules
     use OpenSpecModule, only: access, form
-    use InputOutputModule, only: getunit, check_assign_unit, openfile
+    use InputOutputModule, only: getunit, assign_iounit, openfile
     ! -- dummy variables
     class(SfrType), intent(inout) :: this !< SfrType object
     character(len=*), intent(inout) :: option !< option keyword string
@@ -761,7 +761,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
+        call assign_iounit(this%ibudgetout, this%inunit, "BUDGET fileout")
         call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE', MNORMAL)
         write (this%iout, fmtsfrbin) &
@@ -774,7 +774,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
+        call assign_iounit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
         call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                       filstat_opt='REPLACE')
         write (this%iout, fmtsfrbin) &

--- a/src/Model/GroundWaterFlow/gwf-sfr.f90
+++ b/src/Model/GroundWaterFlow/gwf-sfr.f90
@@ -707,7 +707,7 @@ contains
   subroutine sfr_options(this, option, found)
     ! -- modules
     use OpenSpecModule, only: access, form
-    use InputOutputModule, only: getunit, openfile
+    use InputOutputModule, only: getunit, check_assign_unit, openfile
     ! -- dummy variables
     class(SfrType), intent(inout) :: this !< SfrType object
     character(len=*), intent(inout) :: option !< option keyword string
@@ -761,7 +761,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%ibudgetout = getunit()
+        call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
         call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE', MNORMAL)
         write (this%iout, fmtsfrbin) &
@@ -774,7 +774,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%ibudcsv = getunit()
+        call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
         call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                       filstat_opt='REPLACE')
         write (this%iout, fmtsfrbin) &

--- a/src/Model/GroundWaterFlow/gwf-uzf.f90
+++ b/src/Model/GroundWaterFlow/gwf-uzf.f90
@@ -376,7 +376,7 @@ contains
     use ConstantsModule, only: DZERO, MNORMAL
     use OpenSpecModule, only: access, form
     use SimModule, only: store_error
-    use InputOutputModule, only: urword, getunit, check_assign_unit, openfile
+    use InputOutputModule, only: urword, getunit, assign_iounit, openfile
     implicit none
     ! -- dummy
     class(uzftype), intent(inout) :: this
@@ -432,7 +432,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
+        call assign_iounit(this%ibudgetout, this%inunit, "BUDGET fileout")
         call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE', mode_opt=MNORMAL)
         write (this%iout, fmtuzfbin) 'BUDGET', trim(adjustl(fname)), &
@@ -444,7 +444,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
+        call assign_iounit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
         call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                       filstat_opt='REPLACE')
         write (this%iout, fmtuzfbin) 'BUDGET CSV', trim(adjustl(fname)), &

--- a/src/Model/GroundWaterFlow/gwf-uzf.f90
+++ b/src/Model/GroundWaterFlow/gwf-uzf.f90
@@ -376,7 +376,7 @@ contains
     use ConstantsModule, only: DZERO, MNORMAL
     use OpenSpecModule, only: access, form
     use SimModule, only: store_error
-    use InputOutputModule, only: urword, getunit, openfile
+    use InputOutputModule, only: urword, getunit, check_assign_unit, openfile
     implicit none
     ! -- dummy
     class(uzftype), intent(inout) :: this
@@ -432,7 +432,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%ibudgetout = getunit()
+        call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
         call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE', mode_opt=MNORMAL)
         write (this%iout, fmtuzfbin) 'BUDGET', trim(adjustl(fname)), &
@@ -444,7 +444,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%ibudcsv = getunit()
+        call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
         call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                       filstat_opt='REPLACE')
         write (this%iout, fmtuzfbin) 'BUDGET CSV', trim(adjustl(fname)), &

--- a/src/Model/GroundWaterTransport/gwt-ist.f90
+++ b/src/Model/GroundWaterTransport/gwt-ist.f90
@@ -975,7 +975,7 @@ contains
     use ConstantsModule, only: LINELENGTH, MNORMAL
     use SimModule, only: store_error
     use OpenSpecModule, only: access, form
-    use InputOutputModule, only: getunit, check_assign_unit, openfile
+    use InputOutputModule, only: getunit, assign_iounit, openfile
     ! -- dummy
     class(GwtIstType), intent(inout) :: this !< GwtIstType object
     ! -- local
@@ -1027,7 +1027,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
+            call assign_iounit(this%ibudgetout, this%inunit, "BUDGET fileout")
             call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                           form, access, 'REPLACE', mode_opt=MNORMAL)
             write (this%iout, fmtistbin) 'BUDGET', trim(adjustl(fname)), &
@@ -1041,7 +1041,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
+            call assign_iounit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
             call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                           filstat_opt='REPLACE')
             write (this%iout, fmtistbin) 'BUDGET CSV', trim(adjustl(fname)), &

--- a/src/Model/GroundWaterTransport/gwt-ist.f90
+++ b/src/Model/GroundWaterTransport/gwt-ist.f90
@@ -975,7 +975,7 @@ contains
     use ConstantsModule, only: LINELENGTH, MNORMAL
     use SimModule, only: store_error
     use OpenSpecModule, only: access, form
-    use InputOutputModule, only: getunit, openfile
+    use InputOutputModule, only: getunit, check_assign_unit, openfile
     ! -- dummy
     class(GwtIstType), intent(inout) :: this !< GwtIstType object
     ! -- local
@@ -1027,7 +1027,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            this%ibudgetout = getunit()
+            call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
             call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                           form, access, 'REPLACE', mode_opt=MNORMAL)
             write (this%iout, fmtistbin) 'BUDGET', trim(adjustl(fname)), &
@@ -1041,7 +1041,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            this%ibudcsv = getunit()
+            call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
             call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                           filstat_opt='REPLACE')
             write (this%iout, fmtistbin) 'BUDGET CSV', trim(adjustl(fname)), &

--- a/src/Model/TransportModel/tsp-apt.f90
+++ b/src/Model/TransportModel/tsp-apt.f90
@@ -1307,7 +1307,7 @@ contains
   subroutine apt_options(this, option, found)
     use ConstantsModule, only: MAXCHARLEN, DZERO
     use OpenSpecModule, only: access, form
-    use InputOutputModule, only: urword, getunit, check_assign_unit, openfile
+    use InputOutputModule, only: urword, getunit, assign_iounit, openfile
     ! -- dummy
     class(TspAptType), intent(inout) :: this
     character(len=*), intent(inout) :: option
@@ -1365,7 +1365,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
+        call assign_iounit(this%ibudgetout, this%inunit, "BUDGET fileout")
         call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE')
         write (this%iout, fmtaptbin) trim(adjustl(this%text)), 'BUDGET', &
@@ -1377,7 +1377,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
+        call assign_iounit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
         call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                       filstat_opt='REPLACE')
         write (this%iout, fmtaptbin) trim(adjustl(this%text)), 'BUDGET CSV', &

--- a/src/Model/TransportModel/tsp-apt.f90
+++ b/src/Model/TransportModel/tsp-apt.f90
@@ -1307,7 +1307,7 @@ contains
   subroutine apt_options(this, option, found)
     use ConstantsModule, only: MAXCHARLEN, DZERO
     use OpenSpecModule, only: access, form
-    use InputOutputModule, only: urword, getunit, openfile
+    use InputOutputModule, only: urword, getunit, check_assign_unit, openfile
     ! -- dummy
     class(TspAptType), intent(inout) :: this
     character(len=*), intent(inout) :: option
@@ -1365,7 +1365,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%ibudgetout = getunit()
+        call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
         call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                       form, access, 'REPLACE')
         write (this%iout, fmtaptbin) trim(adjustl(this%text)), 'BUDGET', &
@@ -1377,7 +1377,7 @@ contains
       call this%parser%GetStringCaps(keyword)
       if (keyword == 'FILEOUT') then
         call this%parser%GetString(fname)
-        this%ibudcsv = getunit()
+        call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
         call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                       filstat_opt='REPLACE')
         write (this%iout, fmtaptbin) trim(adjustl(this%text)), 'BUDGET CSV', &

--- a/src/Model/TransportModel/tsp-mvt.f90
+++ b/src/Model/TransportModel/tsp-mvt.f90
@@ -570,7 +570,7 @@ contains
   subroutine read_options(this)
     ! -- modules
     use OpenSpecModule, only: access, form
-    use InputOutputModule, only: getunit, openfile
+    use InputOutputModule, only: check_assign_unit, openfile
     ! -- dummy
     class(TspMvtType) :: this
     ! -- local
@@ -611,7 +611,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            this%ibudgetout = getunit()
+            call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
             call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                           form, access, 'REPLACE')
             write (this%iout, fmtflow) 'MVT', 'BUDGET', trim(adjustl(fname)), &
@@ -624,7 +624,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            this%ibudcsv = getunit()
+            call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
             call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                           filstat_opt='REPLACE')
             write (this%iout, fmtflow) 'MVT', 'BUDGET CSV', &

--- a/src/Model/TransportModel/tsp-mvt.f90
+++ b/src/Model/TransportModel/tsp-mvt.f90
@@ -570,7 +570,7 @@ contains
   subroutine read_options(this)
     ! -- modules
     use OpenSpecModule, only: access, form
-    use InputOutputModule, only: check_assign_unit, openfile
+    use InputOutputModule, only: assign_iounit, openfile
     ! -- dummy
     class(TspMvtType) :: this
     ! -- local
@@ -611,7 +611,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            call check_assign_unit(this%ibudgetout, this%inunit, "BUDGET fileout")
+            call assign_iounit(this%ibudgetout, this%inunit, "BUDGET fileout")
             call openfile(this%ibudgetout, this%iout, fname, 'DATA(BINARY)', &
                           form, access, 'REPLACE')
             write (this%iout, fmtflow) 'MVT', 'BUDGET', trim(adjustl(fname)), &
@@ -624,7 +624,7 @@ contains
           call this%parser%GetStringCaps(keyword)
           if (keyword == 'FILEOUT') then
             call this%parser%GetString(fname)
-            call check_assign_unit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
+            call assign_iounit(this%ibudcsv, this%inunit, "BUDGETCSV fileout")
             call openfile(this%ibudcsv, this%iout, fname, 'CSV', &
                           filstat_opt='REPLACE')
             write (this%iout, fmtflow) 'MVT', 'BUDGET CSV', &

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -17,7 +17,7 @@ module InputOutputModule
             linear_interpolate, lowcase, read_line, GetFileFromPath, &
             extract_idnum_or_bndname, urdaux, print_format, BuildFixedFormat, &
             BuildFloatFormat, BuildIntFormat, fseek_stream, get_nwords, &
-            u9rdcom, append_processor_id
+            u9rdcom, append_processor_id, check_assign_unit
 
 contains
 
@@ -178,6 +178,27 @@ contains
     call freeunitnumber(iunit)
     getunit = iunit
   end function getunit
+
+  !> @ brief check assign unit
+  !!
+  !!  Generic method to verify that an integer variable for storing
+  !!  a file io unit number is unassigned.  Assumes unit number is
+  !!  unassigned and initialized if less than or equal to 0.  Assigns
+  !!  a valid number if unassigned, otherwise throws an error and exits.
+  !!
+  !<
+  subroutine check_assign_unit(iounit, errunit, description)
+    integer(I4B), intent(inout) :: iounit !< iounit to assign
+    integer(I4B), intent(in) :: errunit !< input file inunit for error assignment
+    character(len=*), intent(in) :: description !< usage description for iounit
+    if (iounit > 0) then
+      write (errmsg, '(a,1x,i0)') &
+        trim(description)//' already assigned at unit: ', iounit
+      call store_error(errmsg)
+      call store_error_unit(errunit)
+    end if
+    iounit = getunit()
+  end subroutine check_assign_unit
 
   !> @brief Convert to upper case
   !!

--- a/src/Utilities/InputOutput.f90
+++ b/src/Utilities/InputOutput.f90
@@ -17,7 +17,7 @@ module InputOutputModule
             linear_interpolate, lowcase, read_line, GetFileFromPath, &
             extract_idnum_or_bndname, urdaux, print_format, BuildFixedFormat, &
             BuildFloatFormat, BuildIntFormat, fseek_stream, get_nwords, &
-            u9rdcom, append_processor_id, check_assign_unit
+            u9rdcom, append_processor_id, assign_iounit
 
 contains
 
@@ -179,16 +179,14 @@ contains
     getunit = iunit
   end function getunit
 
-  !> @ brief check assign unit
+  !> @ brief assign io unit number
   !!
-  !!  Generic method to verify that an integer variable for storing
-  !!  a file io unit number is unassigned.  Assumes unit number is
-  !!  unassigned and initialized if less than or equal to 0.  Assigns
-  !!  a valid number if unassigned, otherwise throws an error and exits.
-  !!
+  !!  Generic method to assign io unit number to unassigned integer
+  !!  variable (initialized less than or equal to 0).  Assigns a valid
+  !!  number if unassigned, otherwise sets a terminating error.
   !<
-  subroutine check_assign_unit(iounit, errunit, description)
-    integer(I4B), intent(inout) :: iounit !< iounit to assign
+  subroutine assign_iounit(iounit, errunit, description)
+    integer(I4B), intent(inout) :: iounit !< iounit variable
     integer(I4B), intent(in) :: errunit !< input file inunit for error assignment
     character(len=*), intent(in) :: description !< usage description for iounit
     if (iounit > 0) then
@@ -198,7 +196,7 @@ contains
       call store_error_unit(errunit)
     end if
     iounit = getunit()
-  end subroutine check_assign_unit
+  end subroutine assign_iounit
 
   !> @brief Convert to upper case
   !!


### PR DESCRIPTION
Add InputOutput GetUnit() wrapper:
  - throw error if provided integer has valid assigned i/o unit number (>0)
  - assign a valid unit number if provided integer in initialized state (<=0) 
  - #1786 

Checklist of items for pull request
- [X] Replaced section above with description of pull request
- [X] Referenced issue or pull request #1786
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Added doxygen comments to new and modified procedures
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).