### PR TITLE
fix(obs): terminate with error if obs name not unique within CONTINUOUS block

### DIFF
--- a/autotest/test_gwt_sft_inactive01.py
+++ b/autotest/test_gwt_sft_inactive01.py
@@ -501,16 +501,16 @@ def build_models(idx, test):
 
     sfr_obs = {
         f"{name}.sfr.obs.csv": [
-            ("gwf", "sfr", (0,)),
-            ("outflow", "ext-inflow", (0,)),
-            ("depth", "depth", (0,)),
-            ("gwf", "sfr", (6,)),
-            ("depth", "depth", (6,)),
-            ("gwf", "sfr", (7,)),
-            ("depth", "depth", (7,)),
-            ("gwf", "sfr", (14,)),
-            ("outflow", "ext-outflow", (14,)),
-            ("depth", "depth", (14,)),
+            ("gwf0", "sfr", (0,)),
+            ("outflow0", "ext-inflow", (0,)),
+            ("depth0", "depth", (0,)),
+            ("gwf6", "sfr", (6,)),
+            ("depth6", "depth", (6,)),
+            ("gwf7", "sfr", (7,)),
+            ("depth7", "depth", (7,)),
+            ("gwf14", "sfr", (14,)),
+            ("outflow14", "ext-outflow", (14,)),
+            ("depth14", "depth", (14,)),
         ],
         "filename": name + ".sfr.obs",
     }

--- a/src/Utilities/Observation/Obs.f90
+++ b/src/Utilities/Observation/Obs.f90
@@ -1039,9 +1039,9 @@ contains
 
           ! check and make sure obsname is unique
           if (this%is_duplicate(obsrv)) then
-            errmsg = 'Observation name has already been specified: ' // &
-              trim(obsrv%Name) // '.  Check for duplicate observation names &
-              &within a block and make sure name are unique.'
+            errmsg = 'Observation name has already been specified: '// &
+              trim(obsrv%Name)//'.  Check for duplicate observation names &
+              &within a block and make sure names are unique.'
             call store_error(errmsg)
           end if
 


### PR DESCRIPTION
Prior to this PR, observation names did not need to be unique within a CONTINUOUS block.  Output in this case would be confusing.  This PR checks for duplicate observation names within an input block and terminates with an error if a duplicate is found.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Close issue #122 
- [x] Referenced issue or pull request #122
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).