### PR TITLE
ci(plot): add plot option to conftest

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -100,6 +100,11 @@ def original_regression(request) -> bool:
     return request.config.getoption("--original-regression")
 
 
+@pytest.fixture
+def plot(request) -> bool:
+    return request.config.getoption("--plot")
+
+
 @pytest.fixture(scope="session")
 def markers(pytestconfig) -> str:
     return pytestconfig.getoption("-m")
@@ -123,6 +128,12 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="include netcdf test cases",
+    )
+    parser.addoption(
+        "--plot",
+        action="store_true",
+        default=False,
+        help="make plots of model output",
     )
 
 

--- a/autotest/framework.py
+++ b/autotest/framework.py
@@ -224,6 +224,7 @@ class TestFramework:
         api_func: Optional[Callable] = None,
         build: Optional[Callable] = None,
         check: Optional[Callable] = None,
+        plot: Optional[Callable] = None,
         compare: Optional[str] = "auto",
         parallel=False,
         ncpus=1,
@@ -244,6 +245,7 @@ class TestFramework:
         self.targets = targets
         self.build = build
         self.check = check
+        self.plot = plot
         self.parallel = parallel
         self.ncpus = [ncpus] if isinstance(ncpus, int) else ncpus
         self.api_func = api_func
@@ -753,3 +755,9 @@ class TestFramework:
             if self.verbose:
                 print("Checking outputs")
             self.check(self)
+
+        # plot results, if enabled
+        if self.plot:
+            if self.verbose:
+                print("Plotting outputs")
+            self.plot(self)

--- a/autotest/test_chf_dfw_loop.py
+++ b/autotest/test_chf_dfw_loop.py
@@ -323,7 +323,6 @@ def build_models(idx, test):
 
 
 def plot_output(idx, test):
-
     import matplotlib.pyplot as plt
 
     name = test.name
@@ -481,7 +480,6 @@ def plot_output(idx, test):
 
 
 def check_output(idx, test):
-
     # read the observation output
     name = cases[idx]
     fpth = test.workspace / f"{name}.obs.csv"


### PR DESCRIPTION
Many of the autotest scripts have code for plotting results.  This PR establishes a convention for passing in a --plot command line option to pytest, which will cause a `plot_output()` function to be called.  

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).