### PR TITLE
ci(plotting): update autotests with plots to use new pytest --plot hook

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -785,7 +785,7 @@ The framework has three hooks:
 
 - `build`: construct one or more MF6 simulations and/or non-MF6 models with FloPy
 - `check`: evaluate simulation/model output
-- `plot`: evaluate simulation/model output
+- `plot`: make one or more plots of simulation/model output
 
 A test script conventionally contains one or more test cases, fed to the test function as `idx, name` pairs. `idx` can be used to index parameter values or expected results for a specific test case. The test case `name` is useful for model/subdirectory naming, etc.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -763,23 +763,29 @@ def check_output(idx, test):
   e = expected[idx]
   ...
 
+def plot_output(idx, test):
+  import matplotlib.pyplot as plt
+  ...
+
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
         compare=None,
     )
     test.run()
 ```
 
-The framework has two hooks:
+The framework has three hooks:
 
 - `build`: construct one or more MF6 simulations and/or non-MF6 models with FloPy
 - `check`: evaluate simulation/model output
+- `plot`: evaluate simulation/model output
 
 A test script conventionally contains one or more test cases, fed to the test function as `idx, name` pairs. `idx` can be used to index parameter values or expected results for a specific test case. The test case `name` is useful for model/subdirectory naming, etc.
 

--- a/autotest/test_chf_dfw_beg2022.py
+++ b/autotest/test_chf_dfw_beg2022.py
@@ -174,8 +174,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def make_plot(test, mfsim):
-    print("making plots...")
+def plot_output(idx, test):
     import matplotlib.pyplot as plt
 
     hecras = data_path / "hecras0125.csv.cmp"
@@ -251,10 +250,6 @@ def check_output(idx, test):
     # get MFSimulation from test
     sim = test.sims[0]
 
-    makeplot = False
-    if makeplot:
-        make_plot(test, sim)
-
     # assign name
     name = "chfmodel"
 
@@ -304,12 +299,13 @@ def check_output(idx, test):
 
 @pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
         targets=targets,
     )
     test.run()

--- a/autotest/test_chf_dfw_swrt2.py
+++ b/autotest/test_chf_dfw_swrt2.py
@@ -165,7 +165,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def make_plot(test, mfsim):
+def plot_output(idx, test):
     print("making plots...")
     import matplotlib.pyplot as plt
 
@@ -203,10 +203,6 @@ def check_output(idx, test):
     ws = test.workspace
     mfsim = flopy.mf6.MFSimulation.load(sim_ws=ws)
 
-    makeplot = False
-    if makeplot:
-        make_plot(test, mfsim)
-
     # read binary stage file
     fpth = test.workspace / f"{chfname}.stage"
     sobj = flopy.utils.HeadFile(fpth, precision="double", text="STAGE")
@@ -243,12 +239,13 @@ def check_output(idx, test):
 
 @pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
         targets=targets,
     )
     test.run()

--- a/autotest/test_chf_dfw_swrt2b.py
+++ b/autotest/test_chf_dfw_swrt2b.py
@@ -169,8 +169,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def make_plot(test, mfsim):
-    print("making plots...")
+def plot_output(idx, test):
     import matplotlib.pyplot as plt
 
     fpth = test.workspace / "chf_model.obs.csv"
@@ -207,10 +206,6 @@ def check_output(idx, test):
     ws = test.workspace
     mfsim = flopy.mf6.MFSimulation.load(sim_ws=ws)
 
-    makeplot = False
-    if makeplot:
-        make_plot(test, mfsim)
-
     # read binary stage file
     fpth = test.workspace / f"{chfname}.stage"
     sobj = flopy.utils.HeadFile(fpth, precision="double", text="STAGE")
@@ -229,12 +224,13 @@ def check_output(idx, test):
 
 @pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
         targets=targets,
     )
     test.run()

--- a/autotest/test_chf_dis.py
+++ b/autotest/test_chf_dis.py
@@ -139,13 +139,16 @@ def add_chf_model_disv1d(sim):
     return
 
 
-def make_plot(test, mfsim, stage, idx):
-    print("making plots...")
+def plot_output(idx, test):
     import matplotlib.pyplot as plt
 
+    mfsim = test.sims[0]
     chf = mfsim.chf[0]
+
+    stage = chf.output.stage().get_data().reshape((nodes,))
+
     pmv = flopy.plot.PlotMapView(model=chf)
-    pmv.plot_array(stage, masked_values=[3e30])
+    pmv.plot_array(stage, masked_values=[3e30])  # not working yet
     pmv.plot_grid()
 
     fname = test.workspace / "results.png"
@@ -201,20 +204,16 @@ def check_output(idx, test):
     assert stage[idomain == 1].max() == 1.0, "maximum stage should be 1.0"
     assert stage[idomain == 1].min() == 0.5, "minimum stage should be 0.5"
 
-    makeplot = False
-    if makeplot:
-        # PlotMapView not working yet for disv1d
-        make_plot(test, mfsim, stage.flatten(), idx)
-
 
 @pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
         targets=targets,
     )
     test.run()

--- a/autotest/test_chf_dis_fdc.py
+++ b/autotest/test_chf_dis_fdc.py
@@ -33,7 +33,6 @@ yorigin = 200.0
 angrot = 25.0
 
 idomain = np.ones((nodes,), dtype=int)
-idomain[3:6] = 0
 h0 = 0.5
 h1 = 1.0
 rough = [0.035, 0.35]
@@ -145,11 +144,14 @@ def add_chf_model_disv1d(sim):
     return
 
 
-def make_plot(test, mfsim, stage, idx):
-    print("making plots...")
+def plot_output(idx, test):
     import matplotlib.pyplot as plt
 
+    mfsim = test.sims[0]
     chf = mfsim.chf[0]
+
+    stage = chf.output.stage().get_data().reshape((nodes,))
+
     pmv = flopy.plot.PlotMapView(model=chf)
     pmv.plot_array(stage, masked_values=[3e30])  # not working yet
     pmv.plot_grid()
@@ -241,20 +243,16 @@ def check_output(idx, test):
     print(f"Simulated flow is {flow_sim} cubic meters per seconds")
     assert np.allclose(flow, flow_sim), "known flow and simulated flow not the same"
 
-    makeplot = False
-    if makeplot:
-        # PlotMapView not working yet for disv1d
-        make_plot(test, mfsim, stage.flatten(), idx)
-
 
 @pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
         targets=targets,
     )
     test.run()

--- a/autotest/test_gwt_buy_solute_heat.py
+++ b/autotest/test_gwt_buy_solute_heat.py
@@ -322,36 +322,23 @@ def build_models(idx, test):
     return sim, None
 
 
-def make_plot(sim):
-    print("making plots...")
-    name = sim.name
-    ws = sim.workspace
-    sim = flopy.mf6.MFSimulation.load(sim_ws=ws)
+def plot_output(idx, test):
+    import matplotlib.pyplot as plt
+
+    ws = test.workspace
+    sim = test.sims[0]
     gwfname = "flow"
     gwtsname = "salinity"
     gwthname = "temperature"
     gwf = sim.get_model(gwfname)
     gwts = sim.get_model(gwtsname)
     gwth = sim.get_model(gwthname)
-
-    fname = gwtsname + ".ucn"
-    fname = os.path.join(ws, fname)
-    cobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")  # , precision='double')
-    conc = cobj.get_alldata()
-
-    fname = gwthname + ".ucn"
-    fname = os.path.join(ws, fname)
-    tobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")  # , precision='double')
-    temperature = tobj.get_alldata()
-
-    fname = gwfname + ".buy.bin"
-    fname = os.path.join(ws, fname)
-    dobj = flopy.utils.HeadFile(fname, text="DENSITY")  # , precision='double')
-    dense = dobj.get_alldata()
+    conc = gwts.output.concentration().get_alldata()
+    temperature = gwth.output.concentration().get_alldata()
+    dense = gwf.buy.output.density().get_alldata()
 
     idxtime = -1
-
-    import matplotlib.pyplot as plt
+    alpha = 1.0
 
     fig = plt.figure(figsize=(10, 10))
     nplotrows = 3
@@ -361,7 +348,7 @@ def make_plot(sim):
     pxs.plot_bc(ftype="WEL")
     pxs.plot_bc(ftype="GHB")
     a = conc[idxtime]
-    pa = pxs.plot_array(a, cmap="jet", alpha=0.25)
+    pa = pxs.plot_array(a, cmap="jet", alpha=alpha)
     cs = pxs.contour_array(a, levels=35.0 * np.array([0.01, 0.5, 0.99]), colors="y")
     plt.colorbar(pa, shrink=0.5)
     ax.set_title("SALINITY")
@@ -372,7 +359,7 @@ def make_plot(sim):
     pxs.plot_bc(ftype="WEL")
     pxs.plot_bc(ftype="GHB")
     a = temperature[idxtime]
-    pa = pxs.plot_array(a, cmap="jet", alpha=0.25)
+    pa = pxs.plot_array(a, cmap="jet", alpha=alpha)
     cs = pxs.contour_array(a, levels=5 + 20.0 * np.array([0.01, 0.5, 0.99]), colors="y")
     plt.colorbar(pa, shrink=0.5)
     ax.set_title("TEMPERATURE")
@@ -383,43 +370,31 @@ def make_plot(sim):
     pxs.plot_bc(ftype="WEL")
     pxs.plot_bc(ftype="GHB")
     a = dense[idxtime]
-    pa = pxs.plot_array(a, cmap="jet", alpha=0.25)
+    pa = pxs.plot_array(a, cmap="jet", alpha=alpha)
     # cs = pxs.contour_array(a, levels=5+20.*np.array([0.01, .5, 0.99]),
     #                       colors='y')
     plt.colorbar(pa, shrink=0.5)
     ax.set_title("DENSITY")
 
     plt.draw()
-    fname = os.path.join(ws, gwtsname + ".png")
+    fname = os.path.join(ws, "results.png")
     plt.savefig(fname)
 
     return
 
 
 def check_output(idx, test):
-    makeplot = False
-    if makeplot:
-        make_plot(test)
-
     ws = test.workspace
+    sim = test.sims[0]
     gwfname = "flow"
     gwtsname = "salinity"
     gwthname = "temperature"
-
-    fname = gwfname + ".buy.bin"
-    fname = os.path.join(ws, fname)
-    dobj = flopy.utils.HeadFile(fname, text="DENSITY")  # , precision='double')
-    dense = dobj.get_alldata()
-
-    fname = gwtsname + ".ucn"
-    fname = os.path.join(ws, fname)
-    cobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")  # , precision='double')
-    conc = cobj.get_alldata()
-
-    fname = gwthname + ".ucn"
-    fname = os.path.join(ws, fname)
-    tobj = flopy.utils.HeadFile(fname, text="CONCENTRATION")  # , precision='double')
-    temperature = tobj.get_alldata()
+    gwf = sim.get_model(gwfname)
+    gwts = sim.get_model(gwtsname)
+    gwth = sim.get_model(gwthname)
+    conc = gwts.output.concentration().get_alldata()
+    temperature = gwth.output.concentration().get_alldata()
+    dense = gwf.buy.output.density().get_alldata()
 
     # density is lagged, so use c and t from previous timestep
     c = conc[-2]
@@ -440,14 +415,14 @@ def check_output(idx, test):
         assert False, "density is not correct"
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
     )
     test.run()

--- a/autotest/test_gwt_henry_nr.py
+++ b/autotest/test_gwt_henry_nr.py
@@ -367,16 +367,23 @@ def get_patch_collection(modelgrid, head, conc, cmap="jet", zorder=None):
     return pc
 
 
-def make_plot(sim, headall, concall):
-    print("making plots...")
+def plot_output(idx, test):
+# def make_plot(sim, headall, concall):
+#     print("making plots...")
 
-    name = sim.name
-    ws = sim.workspace
-    sim = flopy.mf6.MFSimulation.load(sim_ws=ws)
+    # name = sim.name
+    # ws = sim.workspace
+    # sim = flopy.mf6.MFSimulation.load(sim_ws=ws)
+
+    ws = test.workspace
+    name = test.name
+    sim = test.sims[0]
     gwfname = "gwf_" + name
     gwtname = "gwt_" + name
     gwf = sim.get_model(gwfname)
     gwt = sim.get_model(gwtname)
+    headall = gwf.output.head().get_alldata()
+    concall = gwt.output.concentration().get_alldata()
 
     import matplotlib.patches
     import matplotlib.pyplot as plt
@@ -456,20 +463,13 @@ def make_plot(sim, headall, concall):
 def check_output(idx, test):
     name = test.name
     ws = test.workspace
+    sim = test.sims[0]
     gwfname = "gwf_" + name
     gwtname = "gwt_" + name
-
-    # load heads
-    fname = os.path.join(ws, gwfname + ".hds")
-    assert os.path.isfile(fname)
-    headobj = flopy.utils.HeadFile(fname, precision="double")
-    head = headobj.get_alldata()
-
-    # load concs
-    fname = os.path.join(ws, gwtname + ".ucn")
-    assert os.path.isfile(fname)
-    concobj = flopy.utils.HeadFile(fname, text="concentration", precision="double")
-    conc = concobj.get_alldata()
+    gwf = sim.get_model(gwfname)
+    gwt = sim.get_model(gwtname)
+    headobj = gwf.output.head()
+    concobj = gwt.output.concentration()
 
     # extract 10 simulated heads and concs for cell (0, 0, 20)
     hsim = headobj.get_ts((0, 0, 20))[::125, 1]
@@ -509,20 +509,16 @@ def check_output(idx, test):
     errmsg = f"concs not right for cell (0, 0, 20):\n{csim}\n{cans}"
     assert np.allclose(hsim, hans, atol=1.0e-3), errmsg
 
-    makeplot = False
-    if makeplot:
-        make_plot(test, head, conc)
-        assert False
-
 
 @pytest.mark.slow
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
     )
     test.run()

--- a/autotest/test_gwt_henry_nr.py
+++ b/autotest/test_gwt_henry_nr.py
@@ -368,13 +368,6 @@ def get_patch_collection(modelgrid, head, conc, cmap="jet", zorder=None):
 
 
 def plot_output(idx, test):
-# def make_plot(sim, headall, concall):
-#     print("making plots...")
-
-    # name = sim.name
-    # ws = sim.workspace
-    # sim = flopy.mf6.MFSimulation.load(sim_ws=ws)
-
     ws = test.workspace
     name = test.name
     sim = test.sims[0]

--- a/autotest/test_gwt_ist02.py
+++ b/autotest/test_gwt_ist02.py
@@ -311,10 +311,9 @@ def build_models(idx, test):
     return sim, None
 
 
-def make_plot(sim):
-    print("making plots...")
-    name = sim.name
-    ws = sim.workspace
+def plot_output(idx, test):
+    name = test.name
+    ws = test.workspace
     sim = flopy.mf6.MFSimulation.load(sim_ws=ws)
     gwfname = "gwf_" + name
     gwtname = "gwt_" + name
@@ -339,10 +338,6 @@ def make_plot(sim):
 
 
 def check_output(idx, test):
-    makeplot = False
-    if makeplot:
-        make_plot(test)
-
     name = test.name
     gwtname = "gwt_" + name
     gwfname = "gwf_" + name
@@ -368,12 +363,13 @@ def check_output(idx, test):
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
     )
     test.run()

--- a/autotest/test_gwt_ist03.py
+++ b/autotest/test_gwt_ist03.py
@@ -261,10 +261,10 @@ def build_models(idx, test):
     return sim, None
 
 
-def make_plot(sim, plot_title):
-    print("making plots...")
-    name = sim.name
-    ws = sim.workspace
+def plot_output(idx, test):
+    plot_title = sorption_idx[idx]
+    name = test.name
+    ws = test.workspace
     sim = flopy.mf6.MFSimulation.load(sim_ws=ws)
     gwfname = "gwf_" + name
     gwtname = "gwt_" + name
@@ -310,11 +310,6 @@ def check_output(idx, test):
     sorption = sorption_idx[idx]
     distcoef = distcoef_idx[idx]
     sp2 = sp2_idx[idx]
-
-    makeplot = False
-    if makeplot:
-        plot_title = sorption
-        make_plot(test, plot_title)
 
     name = test.name
     gwtname = "gwt_" + name
@@ -367,12 +362,13 @@ def check_output(idx, test):
 
 
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
     )
     test.run()

--- a/autotest/test_gwt_mwt02.py
+++ b/autotest/test_gwt_mwt02.py
@@ -371,10 +371,9 @@ def build_models(idx, test):
     return sim, None
 
 
-def make_plot(sim):
-    print("making plots...")
-    name = sim.name
-    ws = sim.workspace
+def plot_output(idx, test):
+    name = test.name
+    ws = test.workspace
     sim = flopy.mf6.MFSimulation.load(sim_ws=ws)
     gwfname = "gwf_" + name
     gwtname = "gwt_" + name
@@ -406,10 +405,6 @@ def make_plot(sim):
 
 
 def check_output(idx, test):
-    makeplot = False
-    if makeplot:
-        make_plot(test)
-
     # ensure concentrations were saved
     name = cases[idx]
     gwtname = "gwt_" + name
@@ -452,12 +447,13 @@ def check_output(idx, test):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
     )
     test.run()

--- a/autotest/test_gwt_prudic2004t2.py
+++ b/autotest/test_gwt_prudic2004t2.py
@@ -7,7 +7,6 @@ through the system.
 """
 
 import os
-import sys
 
 import flopy
 import numpy as np
@@ -777,8 +776,6 @@ def plot_output(idx, test):
 
 
 def check_output(idx, test):
-
-    # ensure concentrations were saved
     ws = test.workspace
     name = test.name
     gwtname = "gwt_" + name

--- a/autotest/test_gwt_prudic2004t2.py
+++ b/autotest/test_gwt_prudic2004t2.py
@@ -771,15 +771,12 @@ def check_obs(sim):
     assert success, "One or more SFT-LKT obs checks did not pass"
 
 
-def check_output(idx, test):
-    makeplot = False
-    for arg in sys.argv:
-        if arg.lower() == "--makeplot":
-            makeplot = True
+def plot_output(idx, test):
+    make_concentration_vs_time(test)
+    make_concentration_map(test)
 
-    if makeplot:
-        make_concentration_vs_time(test)
-        make_concentration_map(test)
+
+def check_output(idx, test):
 
     # ensure concentrations were saved
     ws = test.workspace
@@ -919,12 +916,13 @@ def check_output(idx, test):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
     )
     test.run()

--- a/autotest/test_gwt_prudic2004t2gwtgwt.py
+++ b/autotest/test_gwt_prudic2004t2gwtgwt.py
@@ -7,7 +7,6 @@ through the system.
 """
 
 import os
-import sys
 
 import flopy
 import numpy as np
@@ -863,7 +862,6 @@ def plot_output(idx, test):
 
 
 def check_output(idx, test):
-
     ans_lak1, ans_sfr3, ans_sfr4 = get_answers()
     ws = test.workspace
     sim = flopy.mf6.MFSimulation.load(sim_ws=ws, strict=False)

--- a/autotest/test_gwt_prudic2004t2gwtgwt.py
+++ b/autotest/test_gwt_prudic2004t2gwtgwt.py
@@ -841,7 +841,7 @@ def make_concentration_map(sim, ws):
     plt.savefig(fname)
 
 
-def check_output(idx, test):
+def get_answers():
     # these answer files are results from autotest/prudic2004test2
     fname = os.path.join(model_path, "result_conc_lak1.txt")
     ans_lak1 = np.loadtxt(fname)
@@ -849,39 +849,38 @@ def check_output(idx, test):
     ans_sfr3 = np.loadtxt(fname)
     fname = os.path.join(model_path, "result_conc_sfr4.txt")
     ans_sfr4 = np.loadtxt(fname)
+    return ans_lak1, ans_sfr3, ans_sfr4
 
-    makeplot = False
-    for arg in sys.argv:
-        if arg.lower() == "--makeplot":
-            makeplot = True
 
+def plot_output(idx, test):
     ws = test.workspace
-    simfp = flopy.mf6.MFSimulation.load(sim_ws=ws, strict=False)
+    simfp = test.sims[0]
+    ans_lak1, ans_sfr3, ans_sfr4 = get_answers()
+    make_head_map(simfp, ws)
+    if transport_on:
+        make_concentration_vs_time(simfp, ws, ans_lak1, ans_sfr3, ans_sfr4)
+        make_concentration_map(simfp, ws)
 
-    if makeplot:
-        make_head_map(simfp, ws)
-        if transport_on:
-            make_concentration_vs_time(simfp, ws, ans_lak1, ans_sfr3, ans_sfr4)
-            make_concentration_map(simfp, ws)
 
-    # ensure concentrations were saved
+def check_output(idx, test):
+
+    ans_lak1, ans_sfr3, ans_sfr4 = get_answers()
     ws = test.workspace
-    gwfname = gwfnames[0]
-    gwtname = gwtnames[0]
+    sim = flopy.mf6.MFSimulation.load(sim_ws=ws, strict=False)
 
     lkaconc = None
     if lkt_on and transport_on:
-        gwt = simfp.get_model(gwtnames[0])
-        bobj = gwt.lkt.output.concentration()
-        lkaconc = bobj.get_alldata()[:, 0, 0, :]
-        times = bobj.times
-        bobj.file.close()
+        gwt = sim.get_model(gwtnames[0])
+        cobj = gwt.lkt.output.concentration()
+        lkaconc = cobj.get_alldata()[:, 0, 0, :]
+        times = cobj.times
+        cobj.file.close()
 
     sft3outflowconc = None
     sft4outflowconc = None
     if sft_on and transport_on:
         # get southern model
-        gwt = simfp.get_model(gwtnames[1])
+        gwt = sim.get_model(gwtnames[1])
         sftpack = gwt.get_package("sft-3")
         times = sftpack.output.concentration().times
         conc = sftpack.output.concentration().get_alldata()[:, 0, 0, :]
@@ -918,12 +917,13 @@ def check_output(idx, test):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         targets=targets,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
     )
     test.run()

--- a/autotest/test_olf_dis.py
+++ b/autotest/test_olf_dis.py
@@ -206,11 +206,14 @@ def add_olf_model_disv2d(sim):
     return
 
 
-def make_plot(test, mfsim, stage, idx):
-    print("making plots...")
+def plot_output(idx, test):
     import matplotlib.pyplot as plt
 
+    mfsim = test.sims[0]
     olf = mfsim.olf[0]
+
+    stage = olf.output.stage().get_data()
+
     pmv = flopy.plot.PlotMapView(model=olf)
     pmv.plot_array(stage, masked_values=[3e30])
     pmv.plot_grid()
@@ -299,19 +302,16 @@ def check_output(idx, test):
     assert stage[idomain == 1].max() == 1.0, "maximum stage should be 1.0"
     assert stage[idomain == 1].min() == 0.5, "minimum stage should be 0.5"
 
-    makeplot = False
-    if makeplot:
-        make_plot(test, mfsim, stage.flatten(), idx)
-
 
 @pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
         targets=targets,
     )
     test.run()

--- a/autotest/test_olf_vcatch.py
+++ b/autotest/test_olf_vcatch.py
@@ -203,8 +203,7 @@ def build_models(idx, test):
     return sim, None
 
 
-def make_plot(test, mfsim):
-    print("making plots...")
+def plot_output(idx, test):
     import matplotlib.pyplot as plt
 
     fpth = test.workspace / "olf_model.zdg.obs.csv"
@@ -239,10 +238,6 @@ def check_output(idx, test):
     olfname = "olf_model"
     ws = test.workspace
     mfsim = flopy.mf6.MFSimulation.load(sim_ws=ws)
-
-    makeplot = False
-    if makeplot:
-        make_plot(test, mfsim)
 
     # read the binary grid file
     fpth = test.workspace / f"{olfname}.dis2d.grb"
@@ -292,12 +287,13 @@ def check_output(idx, test):
 
 @pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
-def test_mf6model(idx, name, function_tmpdir, targets):
+def test_mf6model(idx, name, function_tmpdir, targets, plot):
     test = TestFramework(
         name=name,
         workspace=function_tmpdir,
         build=lambda t: build_models(idx, t),
         check=lambda t: check_output(idx, t),
+        plot=lambda t: plot_output(idx, t) if plot else None,
         targets=targets,
     )
     test.run()


### PR DESCRIPTION
Some autotests have plotting routines.  This PR modifies them to use a consistent format that works with the new pytest --plot hook.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #2087 
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Updated developer.md
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).