### PR TITLE
fix(gwe-esl): src/esl typo in mf6io guide

### DIFF
--- a/doc/mf6io/gwe/esl.tex
+++ b/doc/mf6io/gwe/esl.tex
@@ -1,4 +1,4 @@
-Input to the Energy Source Loading (ESL) Package is read from the file that has type ``ESL6'' in the Name File.  Any number of SRC Packages can be specified for a single groundwater energy transport model.
+Input to the Energy Source Loading (ESL) Package is read from the file that has type ``ESL6'' in the Name File.  Any number of ESL Packages can be specified for a single groundwater energy transport model.
 
 \vspace{5mm}
 \subsubsection{Structure of Blocks}


### PR DESCRIPTION
patching up a small typo in the ESL section of the mf6io guide

- [x] Referenced issue or pull request #1493 
- [x] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
