### PR TITLE
refactor(netcdf): replace export_netcdf input tag with type specific fileout tags

### DIFF
--- a/autotest/test_netcdf_gwe_cnd.py
+++ b/autotest/test_netcdf_gwe_cnd.py
@@ -32,12 +32,16 @@ def build_models(idx, test, export, gridded_input):
     sim, dummy = build(idx, test)
     sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwe = sim.gwe[0]
-    gwe.name_file.export_netcdf = export
     gwe.dis.export_array_netcdf = True
     gwe.ic.export_array_netcdf = True
     gwe.cnd.export_array_netcdf = True
 
     name = "gwe-" + cases[idx]
+
+    if export == "ugrid":
+        gwe.name_file.nc_mesh2d_filerecord = f"{name}.nc"
+    elif export == "structured":
+        gwe.name_file.nc_structured_filerecord = f"{name}.nc"
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -59,10 +63,15 @@ def check_output(idx, test, export, gridded_input):
         nc_fname = f"{name}.{export}.nc"
         os.rename(test.workspace / input_fname, test.workspace / nc_fname)
 
+        if export == "ugrid":
+            fileout_tag = "NETCDF_MESH2D"
+        elif export == "structured":
+            fileout_tag = "NETCDF_STRUCTURED"
+
         with open(test.workspace / f"{name}.nam", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_FLOWS\n")
-            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  {fileout_tag}  FILEOUT  {name}.nc\n")
             f.write(f"  NETCDF  FILEIN {name}.{export}.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")

--- a/autotest/test_netcdf_gwf_disv.py
+++ b/autotest/test_netcdf_gwf_disv.py
@@ -43,12 +43,14 @@ def build_models(idx, test, export, gridded_input):
     sim, dummy = build(idx, test)
     sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwf = sim.gwf[0]
-    gwf.name_file.export_netcdf = export
     gwf.disv.export_array_netcdf = True
     gwf.ic.export_array_netcdf = True
     gwf.npf.export_array_netcdf = True
 
     name = cases[idx]
+
+    if export == "ugrid":
+        gwf.name_file.nc_mesh2d_filerecord = f"{name}.nc"
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(gwf.disv, ogc_wkt=wkt, filename=f"{name}.disv.ncf")
@@ -76,9 +78,12 @@ def check_output(idx, test, export, gridded_input):
         nc_fname = f"{name}.{export}.nc"
         os.rename(test.workspace / input_fname, test.workspace / nc_fname)
 
+        if export == "ugrid":
+            fileout_tag = "NETCDF_MESH2D"
+
         with open(test.workspace / f"{name}.nam", "w") as f:
             f.write("BEGIN options\n")
-            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  {fileout_tag}  FILEOUT  {name}.nc\n")
             f.write(f"  NETCDF  FILEIN {name}.{export}.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")

--- a/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
+++ b/autotest/test_netcdf_gwf_lak_wetlakbedarea02.py
@@ -32,7 +32,6 @@ def build_models(idx, test, export, gridded_input):
     sim, dummy = build(idx, test)
     sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwf = sim.gwf[0]
-    gwf.name_file.export_netcdf = export
     gwf.dis.export_array_netcdf = True
     gwf.ic.export_array_netcdf = True
     gwf.npf.export_array_netcdf = True
@@ -41,6 +40,11 @@ def build_models(idx, test, export, gridded_input):
 
     name = cases[idx]
     gwfname = "gwf-" + name
+
+    if export == "ugrid":
+        gwf.name_file.nc_mesh2d_filerecord = f"{gwfname}.nc"
+    elif export == "structured":
+        gwf.name_file.nc_structured_filerecord = f"{gwfname}.nc"
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -63,11 +67,16 @@ def check_output(idx, test, export, gridded_input):
         nc_fname = f"{gwfname}.{export}.nc"
         os.rename(test.workspace / input_fname, test.workspace / nc_fname)
 
+        if export == "ugrid":
+            fileout_tag = "NETCDF_MESH2D"
+        elif export == "structured":
+            fileout_tag = "NETCDF_STRUCTURED"
+
         with open(test.workspace / f"{gwfname}.nam", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_FLOWS\n")
             f.write("  NEWTON\n")
-            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  {fileout_tag}  FILEOUT  {gwfname}.nc\n")
             f.write(f"  NETCDF  FILEIN {gwfname}.{export}.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")

--- a/autotest/test_netcdf_gwf_rch01.py
+++ b/autotest/test_netcdf_gwf_rch01.py
@@ -32,13 +32,17 @@ def build_models(idx, test, export, gridded_input):
     sim, dummy = build(idx, test)
     sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwf = sim.gwf[0]
-    gwf.name_file.export_netcdf = export
     gwf.dis.export_array_netcdf = True
     gwf.ic.export_array_netcdf = True
     gwf.npf.export_array_netcdf = True
     gwf.rch.export_array_netcdf = True
 
     name = "rch"
+
+    if export == "ugrid":
+        gwf.name_file.nc_mesh2d_filerecord = f"{name}.nc"
+    elif export == "structured":
+        gwf.name_file.nc_structured_filerecord = f"{name}.nc"
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -60,10 +64,15 @@ def check_output(idx, test, export, gridded_input):
         nc_fname = f"{name}.{export}.nc"
         os.rename(test.workspace / input_fname, test.workspace / nc_fname)
 
+        if export == "ugrid":
+            fileout_tag = "NETCDF_MESH2D"
+        elif export == "structured":
+            fileout_tag = "NETCDF_STRUCTURED"
+
         with open(test.workspace / f"{name}.nam", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_FLOWS\n")
-            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  {fileout_tag}  FILEOUT  {name}.nc\n")
             f.write(f"  NETCDF  FILEIN {name}.{export}.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")

--- a/autotest/test_netcdf_gwf_rch03.py
+++ b/autotest/test_netcdf_gwf_rch03.py
@@ -32,15 +32,18 @@ def build_models(idx, test, export, gridded_input):
     sim, dummy = build(idx, test)
     sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwf = sim.gwf[0]
-    gwf.name_file.export_netcdf = export
     gwf.dis.export_array_netcdf = True
     gwf.ic.export_array_netcdf = True
     gwf.npf.export_array_netcdf = True
     gwf.rch.export_array_netcdf = True
-    print(gwf.rch)
 
     # name = "gwf-" + cases[idx]
     name = "rch"
+
+    if export == "ugrid":
+        gwf.name_file.nc_mesh2d_filerecord = f"{name}.nc"
+    elif export == "structured":
+        gwf.name_file.nc_structured_filerecord = f"{name}.nc"
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -62,10 +65,15 @@ def check_output(idx, test, export, gridded_input):
         nc_fname = f"{name}.{export}.nc"
         os.rename(test.workspace / input_fname, test.workspace / nc_fname)
 
+        if export == "ugrid":
+            fileout_tag = "NETCDF_MESH2D"
+        elif export == "structured":
+            fileout_tag = "NETCDF_STRUCTURED"
+
         with open(test.workspace / f"{name}.nam", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_FLOWS\n")
-            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  {fileout_tag}  FILEOUT  {name}.nc\n")
             f.write(f"  NETCDF  FILEIN {name}.{export}.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")

--- a/autotest/test_netcdf_gwf_sto01.py
+++ b/autotest/test_netcdf_gwf_sto01.py
@@ -43,13 +43,17 @@ def build_models(idx, test, export, gridded_input):
     sim, dummy = build(idx, test)
     sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwf = sim.gwf[0]
-    gwf.name_file.export_netcdf = export
     gwf.dis.export_array_netcdf = True
     gwf.ic.export_array_netcdf = True
     gwf.npf.export_array_netcdf = True
     gwf.sto.export_array_netcdf = True
 
     name = cases[idx]
+
+    if export == "ugrid":
+        gwf.name_file.nc_mesh2d_filerecord = f"{name}.nc"
+    elif export == "structured":
+        gwf.name_file.nc_structured_filerecord = f"{name}.nc"
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -70,11 +74,16 @@ def check_output(idx, test, export, gridded_input):
         nc_fname = f"gwf_sto01.{export}.nc"
         os.rename(test.workspace / input_fname, test.workspace / nc_fname)
 
+        if export == "ugrid":
+            fileout_tag = "NETCDF_MESH2D"
+        elif export == "structured":
+            fileout_tag = "NETCDF_STRUCTURED"
+
         with open(test.workspace / "gwf_sto01.nam", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_FLOWS\n")
             f.write("  NEWTON\n")
-            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  {fileout_tag}  FILEOUT  gwf_sto01.nc\n")
             f.write(f"  NETCDF  FILEIN gwf_sto01.{export}.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")

--- a/autotest/test_netcdf_gwf_vsc03_sfr.py
+++ b/autotest/test_netcdf_gwf_vsc03_sfr.py
@@ -32,7 +32,6 @@ def build_models(idx, test, export, gridded_input):
     sim, dummy = build(idx, test)
     sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwf = sim.gwf[0]
-    gwf.name_file.export_netcdf = export
     gwf.dis.export_array_netcdf = True
     gwf.ic.export_array_netcdf = True
     gwf.npf.export_array_netcdf = True
@@ -42,6 +41,11 @@ def build_models(idx, test, export, gridded_input):
     assert gwf.sto
 
     name = "gwf-" + cases[idx]
+
+    if export == "ugrid":
+        gwf.name_file.nc_mesh2d_filerecord = f"{name}.nc"
+    elif export == "structured":
+        gwf.name_file.nc_structured_filerecord = f"{name}.nc"
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -63,11 +67,16 @@ def check_output(idx, test, export, gridded_input):
         nc_fname = f"{name}.{export}.nc"
         os.rename(test.workspace / input_fname, test.workspace / nc_fname)
 
+        if export == "ugrid":
+            fileout_tag = "NETCDF_MESH2D"
+        elif export == "structured":
+            fileout_tag = "NETCDF_STRUCTURED"
+
         with open(test.workspace / f"{name}.nam", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_FLOWS\n")
             f.write("  NEWTON\n")
-            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  {fileout_tag}  FILEOUT  {name}.nc\n")
             f.write(f"  NETCDF  FILEIN {name}.{export}.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")

--- a/autotest/test_netcdf_gwt_dsp01.py
+++ b/autotest/test_netcdf_gwt_dsp01.py
@@ -20,13 +20,17 @@ def build_models(idx, test, export, gridded_input):
     sim, dummy = build(idx, test)
     sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwt = sim.gwt[0]
-    gwt.name_file.export_netcdf = export
     gwt.dis.export_array_netcdf = True
     gwt.ic.export_array_netcdf = True
     gwt.dsp.export_array_netcdf = True
 
     # output control
     gwtname = "gwt_" + cases[idx]
+
+    if export == "ugrid":
+        gwt.name_file.nc_mesh2d_filerecord = f"{gwtname}.nc"
+    elif export == "structured":
+        gwt.name_file.nc_structured_filerecord = f"{gwtname}.nc"
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -58,10 +62,15 @@ def check_output(idx, test, export, gridded_input):
         nc_fname = f"{gwtname}.{export}.nc"
         os.rename(test.workspace / input_fname, test.workspace / nc_fname)
 
+        if export == "ugrid":
+            fileout_tag = "NETCDF_MESH2D"
+        elif export == "structured":
+            fileout_tag = "NETCDF_STRUCTURED"
+
         with open(test.workspace / f"{gwtname}.nam", "w") as f:
             f.write("BEGIN options\n")
             f.write("  SAVE_FLOWS\n")
-            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  {fileout_tag}  FILEOUT  {gwtname}.nc\n")
             f.write(f"  NETCDF  FILEIN {gwtname}.{export}.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")

--- a/autotest/test_netcdf_gwt_prudic2004t2.py
+++ b/autotest/test_netcdf_gwt_prudic2004t2.py
@@ -20,13 +20,17 @@ def build_models(idx, test, export, gridded_input):
     sim, dummy = build(idx, test)
     sim.tdis.start_date_time = "2041-01-01T00:00:00-05:00"
     gwt = sim.gwt[0]
-    gwt.name_file.export_netcdf = export
     gwt.dis.export_array_netcdf = True
     gwt.ic.export_array_netcdf = True
     gwt.dsp.export_array_netcdf = True
 
     name = cases[idx]
     gwtname = "gwt_" + name
+
+    if export == "ugrid":
+        gwt.name_file.nc_mesh2d_filerecord = f"{gwtname}.nc"
+    elif export == "structured":
+        gwt.name_file.nc_structured_filerecord = f"{gwtname}.nc"
 
     # netcdf config
     ncf = flopy.mf6.ModflowUtlncf(
@@ -49,9 +53,14 @@ def check_output(idx, test, export, gridded_input):
         nc_fname = f"{gwtname}.{export}.nc"
         os.rename(test.workspace / input_fname, test.workspace / nc_fname)
 
+        if export == "ugrid":
+            fileout_tag = "NETCDF_MESH2D"
+        elif export == "structured":
+            fileout_tag = "NETCDF_STRUCTURED"
+
         with open(test.workspace / f"{gwtname}.nam", "w") as f:
             f.write("BEGIN options\n")
-            f.write(f"  EXPORT_NETCDF {export}\n")
+            f.write(f"  {fileout_tag}  FILEOUT  {gwtname}.nc\n")
             f.write(f"  NETCDF  FILEIN {gwtname}.{export}.nc\n")
             f.write("END options\n\n")
             f.write("BEGIN packages\n")

--- a/doc/mf6io/mf6ivar/dfn/gwe-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-nam.dfn
@@ -34,13 +34,87 @@ longname save flows for all packages to budget file
 description REPLACE save_flows {'{#1}': 'all model package'}
 
 block options
-name export_netcdf
-type string
+name nc_mesh2d_filerecord
+type record netcdf_mesh2d fileout ncmesh2dfile
+shape
 reader urword
+tagged true
 optional true
-mf6internal export_netcdf
-longname export model output netcdf file.
-description keyword that specifies timeseries data for the dependent variable should be written to a model output netcdf file.  ``STRUCTURED'' or ``MESH'' (ugrid based export) values are supported.
+longname
+description netcdf layered mesh fileout record.
+mf6internal ncmesh2drec
+
+block options
+name netcdf_mesh2d
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname budget keyword
+description keyword to specify that record corresponds to a layered mesh netcdf file.
+extended true
+
+block options
+name nc_structured_filerecord
+type record netcdf_structured fileout ncstructfile
+shape
+reader urword
+tagged true
+optional true
+longname
+description netcdf structured fileout record.
+mf6internal ncstructrec
+
+block options
+name netcdf_structured
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname budget keyword
+description keyword to specify that record corresponds to a structured netcdf file.
+mf6internal netcdf_struct
+extended true
+
+block options
+name fileout
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name ncmesh2dfile
+type string
+preserve_case true
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the netcdf ugrid layered mesh output file.
+extended true
+
+block options
+name ncstructfile
+type string
+preserve_case true
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the netcdf structured output file.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwf-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwf-nam.dfn
@@ -59,13 +59,87 @@ longname keyword to activate Newton-Raphson UNDER_RELAXATION option
 description keyword that indicates whether the groundwater head in a cell will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\_RELAXATION is not applied.
 
 block options
-name export_netcdf
-type string
+name nc_mesh2d_filerecord
+type record netcdf_mesh2d fileout ncmesh2dfile
+shape
 reader urword
+tagged true
 optional true
-mf6internal export_netcdf
-longname export model output netcdf file.
-description keyword that specifies timeseries data for the dependent variable should be written to a model output netcdf file.  ``STRUCTURED'' or ``MESH'' (ugrid based export) values are supported.
+longname
+description netcdf layered mesh fileout record.
+mf6internal ncmesh2drec
+
+block options
+name netcdf_mesh2d
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname budget keyword
+description keyword to specify that record corresponds to a layered mesh netcdf file. 
+extended true
+
+block options
+name nc_structured_filerecord
+type record netcdf_structured fileout ncstructfile
+shape
+reader urword
+tagged true
+optional true
+longname
+description netcdf structured fileout record.
+mf6internal ncstructrec
+
+block options
+name netcdf_structured
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname budget keyword
+description keyword to specify that record corresponds to a structured netcdf file.
+mf6internal netcdf_struct
+extended true
+
+block options
+name fileout
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name ncmesh2dfile
+type string
+preserve_case true
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the netcdf ugrid layered mesh output file.
+extended true
+
+block options
+name ncstructfile
+type string
+preserve_case true
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the netcdf structured output file.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/dfn/gwt-nam.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-nam.dfn
@@ -34,13 +34,87 @@ longname save flows for all packages to budget file
 description REPLACE save_flows {'{#1}': 'all model package'}
 
 block options
-name export_netcdf
-type string
+name nc_mesh2d_filerecord
+type record netcdf_mesh2d fileout ncmesh2dfile
+shape
 reader urword
+tagged true
 optional true
-mf6internal export_netcdf
-longname export model output netcdf file.
-description keyword that specifies timeseries data for the dependent variable should be written to a model output netcdf file.  ``STRUCTURED'' or ``MESH'' (ugrid based export) values are supported.
+longname
+description netcdf layered mesh fileout record.
+mf6internal ncmesh2drec
+
+block options
+name netcdf_mesh2d
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname budget keyword
+description keyword to specify that record corresponds to a layered mesh netcdf file.
+extended true
+
+block options
+name nc_structured_filerecord
+type record netcdf_structured fileout ncstructfile
+shape
+reader urword
+tagged true
+optional true
+longname
+description netcdf structured fileout record.
+mf6internal ncstructrec
+
+block options
+name netcdf_structured
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname budget keyword
+description keyword to specify that record corresponds to a structured netcdf file.
+mf6internal netcdf_struct
+extended true
+
+block options
+name fileout
+type keyword
+shape
+in_record true
+reader urword
+tagged true
+optional false
+longname file keyword
+description keyword to specify that an output filename is expected next.
+
+block options
+name ncmesh2dfile
+type string
+preserve_case true
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the netcdf ugrid layered mesh output file.
+extended true
+
+block options
+name ncstructfile
+type string
+preserve_case true
+shape
+in_record true
+reader urword
+tagged false
+optional false
+longname file keyword
+description name of the netcdf structured output file.
 extended true
 
 block options

--- a/doc/mf6io/mf6ivar/examples/netcdf-nam-example.dat
+++ b/doc/mf6io/mf6ivar/examples/netcdf-nam-example.dat
@@ -1,6 +1,6 @@
 # GWF Model input name file
 BEGIN options
-  EXPORT_NETCDF MESH # configure mesh type model NetCDF timeseries export
+  NETCDF_MESH2D FILEOUT gwf.nc # configure mesh type model NetCDF timeseries export
   NETCDF FILEIN gwf.in.nc # configure model NetCDF griddata input file
 END options
 

--- a/src/Idm/gwe-namidm.f90
+++ b/src/Idm/gwe-namidm.f90
@@ -16,7 +16,13 @@ module GweNamInputModule
     logical :: print_input = .false.
     logical :: print_flows = .false.
     logical :: save_flows = .false.
-    logical :: export_netcdf = .false.
+    logical :: ncmesh2drec = .false.
+    logical :: netcdf_mesh2d = .false.
+    logical :: ncstructrec = .false.
+    logical :: netcdf_struct = .false.
+    logical :: fileout = .false.
+    logical :: ncmesh2dfile = .false.
+    logical :: ncstructfile = .false.
     logical :: nc_filerecord = .false.
     logical :: netcdf = .false.
     logical :: filein = .false.
@@ -107,19 +113,127 @@ module GweNamInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    gwenam_export_netcdf = InputParamDefinitionType &
+    gwenam_ncmesh2drec = InputParamDefinitionType &
     ( &
     'GWE', & ! component
     'NAM', & ! subcomponent
     'OPTIONS', & ! block
-    'EXPORT_NETCDF', & ! tag name
-    'EXPORT_NETCDF', & ! fortran variable
-    'STRING', & ! type
+    'NC_MESH2D_FILERECORD', & ! tag name
+    'NCMESH2DREC', & ! fortran variable
+    'RECORD NETCDF_MESH2D FILEOUT NCMESH2DFILE', & ! type
     '', & ! shape
-    'export model output netcdf file.', & ! longname
+    '', & ! longname
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwenam_netcdf_mesh2d = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NETCDF_MESH2D', & ! tag name
+    'NETCDF_MESH2D', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'budget keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwenam_ncstructrec = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NC_STRUCTURED_FILERECORD', & ! tag name
+    'NCSTRUCTREC', & ! fortran variable
+    'RECORD NETCDF_STRUCTURED FILEOUT NCSTRUCTFILE', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwenam_netcdf_struct = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NETCDF_STRUCTURED', & ! tag name
+    'NETCDF_STRUCT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'budget keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwenam_fileout = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwenam_ncmesh2dfile = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NCMESH2DFILE', & ! tag name
+    'NCMESH2DFILE', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwenam_ncstructfile = InputParamDefinitionType &
+    ( &
+    'GWE', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NCSTRUCTFILE', & ! tag name
+    'NCSTRUCTFILE', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -257,7 +371,13 @@ module GweNamInputModule
     gwenam_print_input, &
     gwenam_print_flows, &
     gwenam_save_flows, &
-    gwenam_export_netcdf, &
+    gwenam_ncmesh2drec, &
+    gwenam_netcdf_mesh2d, &
+    gwenam_ncstructrec, &
+    gwenam_netcdf_struct, &
+    gwenam_fileout, &
+    gwenam_ncmesh2dfile, &
+    gwenam_ncstructfile, &
     gwenam_nc_filerecord, &
     gwenam_netcdf, &
     gwenam_filein, &

--- a/src/Idm/gwf-namidm.f90
+++ b/src/Idm/gwf-namidm.f90
@@ -19,7 +19,13 @@ module GwfNamInputModule
     logical :: newtonoptions = .false.
     logical :: newton = .false.
     logical :: under_relaxation = .false.
-    logical :: export_netcdf = .false.
+    logical :: ncmesh2drec = .false.
+    logical :: netcdf_mesh2d = .false.
+    logical :: ncstructrec = .false.
+    logical :: netcdf_struct = .false.
+    logical :: fileout = .false.
+    logical :: ncmesh2dfile = .false.
+    logical :: ncstructfile = .false.
     logical :: nc_filerecord = .false.
     logical :: netcdf = .false.
     logical :: filein = .false.
@@ -164,19 +170,127 @@ module GwfNamInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    gwfnam_export_netcdf = InputParamDefinitionType &
+    gwfnam_ncmesh2drec = InputParamDefinitionType &
     ( &
     'GWF', & ! component
     'NAM', & ! subcomponent
     'OPTIONS', & ! block
-    'EXPORT_NETCDF', & ! tag name
-    'EXPORT_NETCDF', & ! fortran variable
-    'STRING', & ! type
+    'NC_MESH2D_FILERECORD', & ! tag name
+    'NCMESH2DREC', & ! fortran variable
+    'RECORD NETCDF_MESH2D FILEOUT NCMESH2DFILE', & ! type
     '', & ! shape
-    'export model output netcdf file.', & ! longname
+    '', & ! longname
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfnam_netcdf_mesh2d = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NETCDF_MESH2D', & ! tag name
+    'NETCDF_MESH2D', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'budget keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfnam_ncstructrec = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NC_STRUCTURED_FILERECORD', & ! tag name
+    'NCSTRUCTREC', & ! fortran variable
+    'RECORD NETCDF_STRUCTURED FILEOUT NCSTRUCTFILE', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfnam_netcdf_struct = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NETCDF_STRUCTURED', & ! tag name
+    'NETCDF_STRUCT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'budget keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfnam_fileout = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfnam_ncmesh2dfile = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NCMESH2DFILE', & ! tag name
+    'NCMESH2DFILE', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwfnam_ncstructfile = InputParamDefinitionType &
+    ( &
+    'GWF', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NCSTRUCTFILE', & ! tag name
+    'NCSTRUCTFILE', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -317,7 +431,13 @@ module GwfNamInputModule
     gwfnam_newtonoptions, &
     gwfnam_newton, &
     gwfnam_under_relaxation, &
-    gwfnam_export_netcdf, &
+    gwfnam_ncmesh2drec, &
+    gwfnam_netcdf_mesh2d, &
+    gwfnam_ncstructrec, &
+    gwfnam_netcdf_struct, &
+    gwfnam_fileout, &
+    gwfnam_ncmesh2dfile, &
+    gwfnam_ncstructfile, &
     gwfnam_nc_filerecord, &
     gwfnam_netcdf, &
     gwfnam_filein, &

--- a/src/Idm/gwt-namidm.f90
+++ b/src/Idm/gwt-namidm.f90
@@ -16,7 +16,13 @@ module GwtNamInputModule
     logical :: print_input = .false.
     logical :: print_flows = .false.
     logical :: save_flows = .false.
-    logical :: export_netcdf = .false.
+    logical :: ncmesh2drec = .false.
+    logical :: netcdf_mesh2d = .false.
+    logical :: ncstructrec = .false.
+    logical :: netcdf_struct = .false.
+    logical :: fileout = .false.
+    logical :: ncmesh2dfile = .false.
+    logical :: ncstructfile = .false.
     logical :: nc_filerecord = .false.
     logical :: netcdf = .false.
     logical :: filein = .false.
@@ -107,19 +113,127 @@ module GwtNamInputModule
     )
 
   type(InputParamDefinitionType), parameter :: &
-    gwtnam_export_netcdf = InputParamDefinitionType &
+    gwtnam_ncmesh2drec = InputParamDefinitionType &
     ( &
     'GWT', & ! component
     'NAM', & ! subcomponent
     'OPTIONS', & ! block
-    'EXPORT_NETCDF', & ! tag name
-    'EXPORT_NETCDF', & ! fortran variable
-    'STRING', & ! type
+    'NC_MESH2D_FILERECORD', & ! tag name
+    'NCMESH2DREC', & ! fortran variable
+    'RECORD NETCDF_MESH2D FILEOUT NCMESH2DFILE', & ! type
     '', & ! shape
-    'export model output netcdf file.', & ! longname
+    '', & ! longname
     .false., & ! required
     .false., & ! multi-record
     .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtnam_netcdf_mesh2d = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NETCDF_MESH2D', & ! tag name
+    'NETCDF_MESH2D', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'budget keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtnam_ncstructrec = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NC_STRUCTURED_FILERECORD', & ! tag name
+    'NCSTRUCTREC', & ! fortran variable
+    'RECORD NETCDF_STRUCTURED FILEOUT NCSTRUCTFILE', & ! type
+    '', & ! shape
+    '', & ! longname
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtnam_netcdf_struct = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NETCDF_STRUCTURED', & ! tag name
+    'NETCDF_STRUCT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'budget keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtnam_fileout = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'FILEOUT', & ! tag name
+    'FILEOUT', & ! fortran variable
+    'KEYWORD', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .false., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtnam_ncmesh2dfile = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NCMESH2DFILE', & ! tag name
+    'NCMESH2DFILE', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
+    .false., & ! layered
+    .false. & ! timeseries
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    gwtnam_ncstructfile = InputParamDefinitionType &
+    ( &
+    'GWT', & ! component
+    'NAM', & ! subcomponent
+    'OPTIONS', & ! block
+    'NCSTRUCTFILE', & ! tag name
+    'NCSTRUCTFILE', & ! fortran variable
+    'STRING', & ! type
+    '', & ! shape
+    'file keyword', & ! longname
+    .true., & ! required
+    .true., & ! multi-record
+    .true., & ! preserve case
     .false., & ! layered
     .false. & ! timeseries
     )
@@ -257,7 +371,13 @@ module GwtNamInputModule
     gwtnam_print_input, &
     gwtnam_print_flows, &
     gwtnam_save_flows, &
-    gwtnam_export_netcdf, &
+    gwtnam_ncmesh2drec, &
+    gwtnam_netcdf_mesh2d, &
+    gwtnam_ncstructrec, &
+    gwtnam_netcdf_struct, &
+    gwtnam_fileout, &
+    gwtnam_ncmesh2dfile, &
+    gwtnam_ncstructfile, &
     gwtnam_nc_filerecord, &
     gwtnam_netcdf, &
     gwtnam_filein, &

--- a/src/Idm/utl-ncfidm.f90
+++ b/src/Idm/utl-ncfidm.f90
@@ -118,7 +118,7 @@ module UtlNcfInputModule
     'CHUNKING', & ! fortran variable
     'KEYWORD', & ! type
     '', & ! shape
-    'keyword when defining ugrid chunking parameters', & ! longname
+    'keyword when defining chunking parameters', & ! longname
     .true., & ! required
     .true., & ! multi-record
     .false., & ! preserve case
@@ -154,7 +154,7 @@ module UtlNcfInputModule
     'CHUNK_FACE', & ! fortran variable
     'INTEGER', & ! type
     '', & ! shape
-    'chunking parameter for the ugrid face dimension', & ! longname
+    'chunking parameter for the mesh face dimension', & ! longname
     .false., & ! required
     .true., & ! multi-record
     .false., & ! preserve case

--- a/src/Utilities/Export/DisNCMesh.f90
+++ b/src/Utilities/Export/DisNCMesh.f90
@@ -49,13 +49,14 @@ contains
 
   !> @brief netcdf export dis init
   !<
-  subroutine dis_export_init(this, modelname, modeltype, modelfname, disenum, &
-                             nctype, iout)
+  subroutine dis_export_init(this, modelname, modeltype, modelfname, nc_fname, &
+                             disenum, nctype, iout)
     use ArrayHandlersModule, only: expandarray
     class(Mesh2dDisExportType), intent(inout) :: this
     character(len=*), intent(in) :: modelname
     character(len=*), intent(in) :: modeltype
     character(len=*), intent(in) :: modelfname
+    character(len=*), intent(in) :: nc_fname
     integer(I4B), intent(in) :: disenum
     integer(I4B), intent(in) :: nctype
     integer(I4B), intent(in) :: iout
@@ -67,7 +68,8 @@ contains
     allocate (this%var_ids%dependent(this%nlay))
 
     ! initialize base class
-    call this%mesh_init(modelname, modeltype, modelfname, disenum, nctype, iout)
+    call this%mesh_init(modelname, modeltype, modelfname, nc_fname, disenum, &
+                        nctype, iout)
   end subroutine dis_export_init
 
   !> @brief netcdf export dis destroy

--- a/src/Utilities/Export/DisNCStructured.f90
+++ b/src/Utilities/Export/DisNCStructured.f90
@@ -90,14 +90,15 @@ contains
 
   !> @brief netcdf export dis init
   !<
-  subroutine dis_export_init(this, modelname, modeltype, modelfname, disenum, &
-                             nctype, iout)
+  subroutine dis_export_init(this, modelname, modeltype, modelfname, nc_fname, &
+                             disenum, nctype, iout)
     use MemoryManagerModule, only: get_isize
     use MemoryManagerExtModule, only: mem_set_value
     class(DisNCStructuredType), intent(inout) :: this
     character(len=*), intent(in) :: modelname
     character(len=*), intent(in) :: modeltype
     character(len=*), intent(in) :: modelfname
+    character(len=*), intent(in) :: nc_fname
     integer(I4B), intent(in) :: disenum
     integer(I4B), intent(in) :: nctype
     integer(I4B), intent(in) :: iout
@@ -124,8 +125,8 @@ contains
     this%latlon = .false.
 
     ! initialize base class
-    call this%NCModelExportType%init(modelname, modeltype, modelfname, disenum, &
-                                     nctype, iout)
+    call this%NCModelExportType%init(modelname, modeltype, modelfname, nc_fname, &
+                                     disenum, nctype, iout)
     ! update values from input context
     if (this%ncf_mempath /= '') then
       call mem_set_value(this%chunk_z, 'CHUNK_Z', this%ncf_mempath, found)

--- a/src/Utilities/Export/DisvNCMesh.f90
+++ b/src/Utilities/Export/DisvNCMesh.f90
@@ -47,13 +47,14 @@ contains
 
   !> @brief netcdf export disv init
   !<
-  subroutine disv_export_init(this, modelname, modeltype, modelfname, disenum, &
-                              nctype, iout)
+  subroutine disv_export_init(this, modelname, modeltype, modelfname, nc_fname, &
+                              disenum, nctype, iout)
     use ArrayHandlersModule, only: expandarray
     class(Mesh2dDisvExportType), intent(inout) :: this
     character(len=*), intent(in) :: modelname
     character(len=*), intent(in) :: modeltype
     character(len=*), intent(in) :: modelfname
+    character(len=*), intent(in) :: nc_fname
     integer(I4B), intent(in) :: disenum
     integer(I4B), intent(in) :: nctype
     integer(I4B), intent(in) :: iout
@@ -65,7 +66,8 @@ contains
     allocate (this%var_ids%dependent(this%nlay))
 
     ! initialize base class
-    call this%mesh_init(modelname, modeltype, modelfname, disenum, nctype, iout)
+    call this%mesh_init(modelname, modeltype, modelfname, nc_fname, disenum, &
+                        nctype, iout)
   end subroutine disv_export_init
 
   !> @brief netcdf export disv destroy

--- a/src/Utilities/Export/MeshNCModel.f90
+++ b/src/Utilities/Export/MeshNCModel.f90
@@ -95,21 +95,22 @@ contains
 
   !> @brief initialize
   !<
-  subroutine mesh_init(this, modelname, modeltype, modelfname, disenum, &
-                       nctype, iout)
+  subroutine mesh_init(this, modelname, modeltype, modelfname, nc_fname, &
+                       disenum, nctype, iout)
     use MemoryManagerExtModule, only: mem_set_value
     class(MeshModelType), intent(inout) :: this
     character(len=*), intent(in) :: modelname
     character(len=*), intent(in) :: modeltype
     character(len=*), intent(in) :: modelfname
+    character(len=*), intent(in) :: nc_fname
     integer(I4B), intent(in) :: disenum
     integer(I4B), intent(in) :: nctype
     integer(I4B), intent(in) :: iout
     logical(LGP) :: found
 
     ! initialize base class
-    call this%NCModelExportType%init(modelname, modeltype, modelfname, disenum, &
-                                     nctype, iout)
+    call this%NCModelExportType%init(modelname, modeltype, modelfname, nc_fname, &
+                                     disenum, nctype, iout)
 
     ! allocate and initialize
     allocate (this%chunk_face)

--- a/src/Utilities/Export/NCExportCreate.f90
+++ b/src/Utilities/Export/NCExportCreate.f90
@@ -28,7 +28,7 @@ contains
   !> @brief create model netcdf export type
   !!
   subroutine create_nc_export(export_model, num_model)
-    use NCModelExportModule, only: NETCDF_UGRID, NETCDF_STRUCTURED
+    use NCModelExportModule, only: NETCDF_MESH2D, NETCDF_STRUCTURED
     use MeshDisModelModule, only: Mesh2dDisExportType
     use MeshDisvModelModule, only: Mesh2dDisvExportType
     use DisNCStructuredModule, only: DisNCStructuredType
@@ -43,7 +43,7 @@ contains
     select case (export_model%disenum)
     case (DIS)
       ! allocate nc structured grid export object
-      if (export_model%nctype == NETCDF_UGRID) then
+      if (export_model%nctype == NETCDF_MESH2D) then
         ! allocate nc structured grid export object
         allocate (ugrid_dis)
 
@@ -60,8 +60,9 @@ contains
 
         ! initialize export object
         call ugrid_dis%init(export_model%modelname, export_model%modeltype, &
-                            export_model%modelfname, export_model%disenum, &
-                            NETCDF_UGRID, export_model%iout)
+                            export_model%modelfname, export_model%nc_fname, &
+                            export_model%disenum, NETCDF_MESH2D, &
+                            export_model%iout)
 
         ! define export object
         call ugrid_dis%df()
@@ -85,8 +86,9 @@ contains
 
         ! initialize export object
         call structured_dis%init(export_model%modelname, export_model%modeltype, &
-                                 export_model%modelfname, export_model%disenum, &
-                                 NETCDF_STRUCTURED, export_model%iout)
+                                 export_model%modelfname, export_model%nc_fname, &
+                                 export_model%disenum, NETCDF_STRUCTURED, &
+                                 export_model%iout)
 
         ! define export object
         call structured_dis%df()
@@ -95,7 +97,7 @@ contains
         export_model%nc_export => structured_dis
       end if
     case (DISV)
-      if (export_model%nctype == NETCDF_UGRID) then
+      if (export_model%nctype == NETCDF_MESH2D) then
         ! allocate nc structured grid export object
         allocate (ugrid_disv)
 
@@ -112,8 +114,9 @@ contains
 
         ! initialize export object
         call ugrid_disv%init(export_model%modelname, export_model%modeltype, &
-                             export_model%modelfname, export_model%disenum, &
-                             NETCDF_UGRID, export_model%iout)
+                             export_model%modelfname, export_model%nc_fname, &
+                             export_model%disenum, NETCDF_MESH2D, &
+                             export_model%iout)
 
         ! define export object
         call ugrid_disv%df()

--- a/src/Utilities/Idm/SourceLoad.F90
+++ b/src/Utilities/Idm/SourceLoad.F90
@@ -309,8 +309,8 @@ contains
       call nc_export_create()
 #else
       write (errmsg, '(a)') &
-        'Model namefile EXPORT_NETCDF option configured but NetCDF libraries are &
-        &not available.'
+        'Model namefile NETCDF_STUCTURED or NETCDF_MESH2D option configured &
+        &but NetCDF libraries are not available.'
       call store_error(errmsg, .true.)
 #endif
     end if


### PR DESCRIPTION
GWF, GWT and GWE name files to this point have supported the ```EXPORT_NETCDF``` tag which takes an argument for the NetCDF export type, ```mesh``` or ```structured```.  This change replaces ```EXPORT_NETCDF``` with the fileout tags ```NETCDF_STRUCTURED``` and ```NETCDF_MESH2D```, and allows the user to specify the NetCDF output filename.  

For example:
```
NETCDF_MESH2D  FILEOUT  gwf_sto01.nc
```

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Added new test or modified an existing test
- [X] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).