### PR TITLE
fix(mf6io): cleanup description of EVAPORATION keyword in SFE and LKE

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwe-lke.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-lke.dfn
@@ -415,7 +415,7 @@ in_record true
 reader urword
 time_series true
 longname evaporation temperature
-description real or character value that defines the temperature of evaporated water $(e.g., ^{\circ}C or ^{\circ}F)$ for the reach. If this temperature value is larger than the simulated temperature in the reach, then the evaporated water will be removed at the same temperature as the reach.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.
+description use of the EVAPORATION keyword is allowed in the LKE package; however, the specified value is not currently used in LKE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.
 
 
 block period

--- a/doc/mf6io/mf6ivar/dfn/gwe-sfe.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-sfe.dfn
@@ -415,7 +415,7 @@ in_record true
 reader urword
 time_series true
 longname evaporation temperature
-description real or character value that defines the temperature of evaporated water $(e.g., ^{\circ}C or ^{\circ}F)$ for the reach. If this temperature value is larger than the simulated temperature in the reach, then the evaporated water will be removed at the same temperature as the reach.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.
+description use of the EVAPORATION keyword is allowed in the SFE package; however, the specified value is not currently used in SFE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.
 
 block period
 name runoff


### PR DESCRIPTION
The description for the `EVAPORATION` keyword in SFE and LKE was leftover from using the SFT and LKT .dfn files as a launch point for the SFE and LKE .dfn files.  The effects of evaporation in a GWT vs GWE are fundamentally different and the description should reflect this.

- [x] Replaced section above with description of pull request
- [x] Relates to pull request #2100 
- [x] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)