### PR TITLE
chore: mark developmode tests

### DIFF
--- a/autotest/test_gwe_bad_input.py
+++ b/autotest/test_gwe_bad_input.py
@@ -480,7 +480,7 @@ def check_output(idx, test):
         print(msg1)
 
 
-# - No need to change any code below
+@pytest.mark.developmode
 @pytest.mark.parametrize(
     "idx, name",
     list(enumerate(cases)),

--- a/autotest/test_prt_quad_refinement.py
+++ b/autotest/test_prt_quad_refinement.py
@@ -282,6 +282,7 @@ def plot_output(idx, test):
     plt.savefig(gwf_ws / f"test_{name}.png")
 
 
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 @pytest.mark.parametrize("levels", [1, 2])
 @pytest.mark.parametrize("method", ["pollock", "ternary"])

--- a/autotest/test_prt_ternary_methods.py
+++ b/autotest/test_prt_ternary_methods.py
@@ -252,6 +252,7 @@ def check_output(idx, test, snapshot):
     assert snapshot == pls.drop("name", axis=1).round(3).to_records(index=False)
 
 
+@pytest.mark.developmode
 @pytest.mark.parametrize("idx, name", enumerate(cases))
 def test_mf6model(idx, name, function_tmpdir, targets, benchmark, array_snapshot, plot):
     test = TestFramework(


### PR DESCRIPTION
We missed a few tests that should only run in develop mode (`IDEVELOPMODE = 1`). It's making the release build fail.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Removed checklist items not relevant to this pull request