### PR TITLE
fix(prt): avoid fpes, patch centroid calculation

### DIFF
--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -89,7 +89,6 @@ module ParticleModule
     ! state
     integer(I4B), dimension(:, :), pointer, public, contiguous :: idomain !< array of indices for domains in the tracking domain hierarchy
     integer(I4B), dimension(:, :), pointer, public, contiguous :: iboundary !< array of indices for tracking domain boundaries
-    integer(I4B), dimension(:), pointer, public, contiguous :: icp !< previous cell number (reduced)
     integer(I4B), dimension(:), pointer, public, contiguous :: icu !< cell number (user)
     integer(I4B), dimension(:), pointer, public, contiguous :: ilay !< layer
     integer(I4B), dimension(:), pointer, public, contiguous :: izone !< current zone number
@@ -133,7 +132,6 @@ contains
     call mem_allocate(this%irpt, np, 'PLIRPT', mempath)
     call mem_allocate(this%iprp, np, 'PLIPRP', mempath)
     call mem_allocate(this%name, LENBOUNDNAME, np, 'PLNAME', mempath)
-    call mem_allocate(this%icp, np, 'PLICP', mempath)
     call mem_allocate(this%icu, np, 'PLICU', mempath)
     call mem_allocate(this%ilay, np, 'PLILAY', mempath)
     call mem_allocate(this%izone, np, 'PLIZONE', mempath)
@@ -165,7 +163,6 @@ contains
     call mem_deallocate(this%iprp, 'PLIPRP', mempath)
     call mem_deallocate(this%irpt, 'PLIRPT', mempath)
     call mem_deallocate(this%name, 'PLNAME', mempath)
-    call mem_deallocate(this%icp, 'PLICP', mempath)
     call mem_deallocate(this%icu, 'PLICU', mempath)
     call mem_deallocate(this%ilay, 'PLILAY', mempath)
     call mem_deallocate(this%izone, 'PLIZONE', mempath)
@@ -200,7 +197,6 @@ contains
     call mem_reallocate(this%iprp, np, 'PLIPRP', mempath)
     call mem_reallocate(this%irpt, np, 'PLIRPT', mempath)
     call mem_reallocate(this%name, LENBOUNDNAME, np, 'PLNAME', mempath)
-    call mem_reallocate(this%icp, np, 'PLICP', mempath)
     call mem_reallocate(this%icu, np, 'PLICU', mempath)
     call mem_reallocate(this%ilay, np, 'PLILAY', mempath)
     call mem_reallocate(this%izone, np, 'PLIZONE', mempath)
@@ -244,7 +240,7 @@ contains
     this%istopweaksink = store%istopweaksink(ip)
     this%istopzone = store%istopzone(ip)
     this%idrymeth = store%idrymeth(ip)
-    this%icp = store%icp(ip)
+    this%icp = 0
     this%icu = store%icu(ip)
     this%ilay = store%ilay(ip)
     this%izone = store%izone(ip)
@@ -281,7 +277,6 @@ contains
     this%istopweaksink(ip) = particle%istopweaksink
     this%istopzone(ip) = particle%istopzone
     this%idrymeth(ip) = particle%idrymeth
-    this%icp(ip) = particle%icp
     this%icu(ip) = particle%icu
     this%ilay(ip) = particle%ilay
     this%izone(ip) = particle%izone


### PR DESCRIPTION
Fix several related issues that can occur with the generalized tracking method on vertex grids.

1. The polygon centroid formula used when dividing cells into subcells can fail due to floating (im)precision when the vertex coordinates are all large and near to one another, i.e. big grids with really small cells. One option is to do a point-in-polygon check on the result of the centroid calculation and use a simple geometric mean if it fails, but the check is not cheap. Another option is to always use the geo mean instead of the polygon centroid &mdash; to guarantee that this is safe we will need to check that the cell vertices don't "wrap around" or contain duplicates I think. In the meantime this PR aims for an 80/20 solution and uses the geometric mean if the cell has 3 vertices, otherwise the full formula. This avoids the error in the common case that the very small cell is a triangle.

2. The tracking routine could encounter floating point exceptions due to a failure to terminate particles in subcells with no exit face.

3. Avoid floating point exceptions due to log of a negative number in the subroutine to calculate travel time to exit. This is done by taking the absolute value of the argument to `log`. Is this safe? I think so because the direction of travel is determined elsewhere.

___

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).