### PR TITLE
fix(prt): skip release times falling outside tdis

### DIFF
--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -20,7 +20,7 @@
 \textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
 \underline{BASIC FUNCTIONALITY}
 \begin{itemize}
-	\item The PRT model previously allowed particles to be released at any time. Release times falling outside the bounds of the simulation's time discretization could produce undefined behavior. Any release times falling outside the bounds of TDIS will now be skipped with a warning message. 
+	\item The PRT model previously allowed particles to be released at any time. Release times falling outside the bounds of the simulation's time discretization could produce undefined behavior. Any release times occurring before the simulation begins (i.e. negative times) will now be skipped with a warning message. If EXTEND\_TRACKING is not enabled, the same goes for release times occurring after the end of the simulation. If EXTEND\_TRACKING is enabled, release times after the end of the simulation are allowed.
 \end{itemize}
 
 %\underline{INTERNAL FLOW PACKAGES}

--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -17,13 +17,11 @@
 %	\item xxx
 %\end{itemize}
 
-%\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
-%\underline{BASIC FUNCTIONALITY}
-%\begin{itemize}
-%	\item xxx
-%	\item xxx
-%	\item xxx
-%\end{itemize}
+\textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
+\underline{BASIC FUNCTIONALITY}
+\begin{itemize}
+	\item The PRT model previously allowed particles to be released at any time. Release times falling outside the bounds of the simulation's time discretization could produce undefined behavior. Any release times falling outside the bounds of TDIS will now be skipped with a warning message. 
+\end{itemize}
 
 %\underline{INTERNAL FLOW PACKAGES}
 %\begin{itemize}

--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -20,7 +20,7 @@
 \textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
 \underline{BASIC FUNCTIONALITY}
 \begin{itemize}
-	\item The PRT model previously allowed particles to be released at any time. Release times falling outside the bounds of the simulation's time discretization could produce undefined behavior. Any release times occurring before the simulation begins (i.e. negative times) will now be skipped with a warning message. If EXTEND\_TRACKING is not enabled, the same goes for release times occurring after the end of the simulation. If EXTEND\_TRACKING is enabled, release times after the end of the simulation are allowed.
+	\item The PRT model previously allowed particles to be released at any time. Release times falling outside the bounds of the simulation's time discretization could produce undefined behavior. Any release times occurring before the simulation begins (i.e. negative times) will now be skipped with a warning message. If EXTEND\_TRACKING is not enabled, release times occurring after the end of the simulation will now be skipped with a warning message as well. If EXTEND\_TRACKING is enabled, release times after the end of the simulation are allowed.
 \end{itemize}
 
 %\underline{INTERNAL FLOW PACKAGES}

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -134,7 +134,7 @@ type double precision
 reader urword
 optional true
 longname stop time
-description real value defining the maximum simulation time to which particles in the package can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when simulation time STOPTIME is reached.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTIME.  If the last stress period in the simulation consists of a single time step, it is assumed to be a steady-state stress period, and its ending time will not limit the simulation time to which particles can be tracked.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached.
+description real value defining the maximum simulation time to which particles in the package can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when simulation time STOPTIME is reached.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTIME.  If the EXTEND\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached.
 
 block options
 name stoptraveltime

--- a/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
+++ b/doc/mf6io/mf6ivar/dfn/prt-prp.dfn
@@ -142,7 +142,7 @@ type double precision
 reader urword
 optional true
 longname stop travel time
-description real value defining the maximum travel time over which particles in the model can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when their travel time reaches STOPTRAVELTIME.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTRAVELTIME.  If the last stress period in the simulation consists of a single time step, it is assumed to be a steady-state stress period, and its ending time will not limit the travel time over which particles can be tracked.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached.
+description real value defining the maximum travel time over which particles in the model can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when their travel time reaches STOPTRAVELTIME.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTRAVELTIME.  If the EXTEND\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached.
 
 block options
 name stop_at_weak_sink

--- a/src/Model/ModelUtilities/ReleaseSchedule.f90
+++ b/src/Model/ModelUtilities/ReleaseSchedule.f90
@@ -7,8 +7,6 @@ module ReleaseScheduleModule
   use MathUtilModule, only: is_close
   use TimeSelectModule, only: TimeSelectType
   use TimeStepSelectModule, only: TimeStepSelectType
-  use SimModule, only: store_error, store_warning
-  use SimVariablesModule, only: errmsg, warnmsg
 
   implicit none
   private
@@ -110,7 +108,7 @@ contains
   !! This routine is idempotent.
   !<
   subroutine advance(this, lines)
-    use TdisModule, only: totimc, kstp, endofperiod, totalsimtime
+    use TdisModule, only: totimc, kstp, endofperiod
     class(ReleaseScheduleType), intent(inout) :: this
     character(len=LINELENGTH), intent(in), optional :: lines(:)
     integer(I4B) :: it, i
@@ -145,24 +143,10 @@ contains
     end if
 
     ! Schedule explicitly specified release times, up
-    ! to the configured tolerance of coincidence. Any
-    ! release times falling outside tdis' bounds will
-    ! be omitted; particle releases may only occur in
-    ! the simulation's time window.
+    ! to the configured tolerance of coincidence
     if (this%time_select%any()) then
       do it = this%time_select%selection(1), this%time_select%selection(2)
         trelease = this%time_select%times(it)
-
-        ! Skip the release time if..
-        ! ..it falls before the simulation start time
-        if (trelease < DZERO .or. trelease > totalsimtime) then
-          write (warnmsg, '(a,g0,a)') &
-            'Warning: release time (t=', trelease, ') is outside tdis'
-          call store_warning(warnmsg)
-          cycle
-        end if
-
-        ! ..or it's too close to the previous time
         if (tprevious >= DZERO .and. is_close( &
             tprevious, &
             trelease, &

--- a/src/Model/ParticleTracking/prt-prp.f90
+++ b/src/Model/ParticleTracking/prt-prp.f90
@@ -351,14 +351,14 @@ contains
         ! starts, or if no `extend_tracking`, after it ends.
         if (t < DZERO) then
           write (warnmsg, '(a,g0,a)') &
-            'Warning: Skipping negative release time (t=', t, ').'
+            'Skipping negative release time (t=', t, ').'
           call store_warning(warnmsg)
           cycle
         else if (t > totalsimtime .and. this%iextend == 0) then
           write (warnmsg, '(a,g0,a)') &
-            'Warning: Skipping release time falling after the end &
-            &of the simulation (t=', t, '). Enable EXTEND_TRACKING &
-            &to release particles after the simulation end time.'
+            'Skipping release time falling after the end of the &
+            &simulation (t=', t, '). Enable EXTEND_TRACKING to &
+            &release particles after the simulation end time.'
           call store_warning(warnmsg)
           cycle
         end if


### PR DESCRIPTION
Mentioned in the discussion in #2125, skip release times before simulation start, and after simulation end if no extended tracking.

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Referenced issue or pull request #2125
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request