### PR TITLE
fix(prt): don't reset transform in subcell rect method

### DIFF
--- a/src/Solution/ParticleTracker/CellDefn.f90
+++ b/src/Solution/ParticleTracker/CellDefn.f90
@@ -1,7 +1,5 @@
 module CellDefnModule
   use KindModule, only: DP, I4B, LGP
-  use ConstantsModule, only: DZERO
-  use MathUtilModule, only: is_close
   implicit none
 
   private

--- a/src/Solution/ParticleTracker/Method.f90
+++ b/src/Solution/ParticleTracker/Method.f90
@@ -134,9 +134,8 @@ contains
       ! otherwise pass the particle to the next subdomain.
       ! if that leaves it on a boundary, stop advancing.
       call this%pass(particle)
-      if (particle%iboundary(nextlevel - 1) .ne. 0) then
+      if (particle%iboundary(nextlevel - 1) .ne. 0) &
         advancing = .false.
-      end if
     end if
   end subroutine try_pass
 

--- a/src/Solution/ParticleTracker/MethodSubcellPollock.f90
+++ b/src/Solution/ParticleTracker/MethodSubcellPollock.f90
@@ -73,7 +73,6 @@ contains
       call particle%transform(xOrigin, yOrigin)
       call this%track_subcell(subcell, particle, tmax)
       call particle%transform(xOrigin, yOrigin, invert=.true.)
-      call particle%reset_transform()
     end select
   end subroutine apply_msp
 


### PR DESCRIPTION
#2066 introduced a bug where particle coordinates were prematurely transformed back from cell-local coords to model coords. This produced incorrect particle positions within quad-refined cells and cells adjacent to a quad-refined cell.

See e.g. https://modflow6-examples.readthedocs.io/en/master/_notebooks/ex-prt-mp7-p04.html.