### PR TITLE
fix(MemoryHelper.f90) Added optional checks

### DIFF
--- a/src/Utilities/Memory/MemoryHelper.f90
+++ b/src/Utilities/Memory/MemoryHelper.f90
@@ -29,7 +29,7 @@ contains
     if (present(subcomponent)) then
       call mem_check_length(subcomponent, LENCOMPONENTNAME, "package")
     end if
-    
+
     if (present(context)) then
       call mem_check_length(context, LENCONTEXTNAME, "context")
     end if

--- a/src/Utilities/Memory/MemoryHelper.f90
+++ b/src/Utilities/Memory/MemoryHelper.f90
@@ -25,8 +25,14 @@ contains
     character(len=LENMEMPATH) :: memory_path !< the memory path
 
     call mem_check_length(component, LENCOMPONENTNAME, "solution/model/exchange")
-    call mem_check_length(subcomponent, LENCOMPONENTNAME, "package")
-    call mem_check_length(context, LENCONTEXTNAME, "context")
+
+    if (present(subcomponent)) then
+      call mem_check_length(subcomponent, LENCOMPONENTNAME, "package")
+    end if
+    
+    if (present(context)) then
+      call mem_check_length(context, LENCONTEXTNAME, "context")
+    end if
 
     memory_path = trim(component)
 


### PR DESCRIPTION
Fixes crash that occurred when compiled with flang-new 19.1.1 on windows

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).