### PR TITLE
Replace the recursive clear_nodes method by a do while loop

### DIFF
--- a/src/Utilities/KeyValueList.f90
+++ b/src/Utilities/KeyValueList.f90
@@ -103,32 +103,41 @@ contains
   subroutine clear(this)
     class(KeyValueListType) :: this
 
-    if (associated(this%first)) call clear_node(this%first)
+    call clear_nodes(this%first)
+
     this%first => null()
     this%last => null()
     this%cnt = 0
 
   end subroutine
 
-  !> @brief Clears the node
+  !> @brief Clears the node and all subsequent nodes
   !!
-  !! Recursive method that clears the next node before clearing itself
   !<
-  recursive subroutine clear_node(node)
+  subroutine clear_nodes(node)
+    type(KeyValueNodeType), pointer :: node
+    type(KeyValueNodeType), pointer :: next
+
+    do while (associated(node))
+      next => node%next
+
+      call clear_node(node)
+      deallocate (node)
+
+      node => next
+    end do
+
+  end subroutine clear_nodes
+
+  subroutine clear_node(node)
     type(KeyValueNodeType), pointer :: node
 
-    if (associated(node)) then
-      call clear_node(node%next)
+    deallocate (node%key)
 
-      deallocate (node%key)
+    nullify (node%key)
+    nullify (node%value)
+    nullify (node%next)
 
-      nullify (node%key)
-      nullify (node%value)
-      nullify (node%next)
-
-      deallocate (node)
-    end if
-
-  end subroutine clear_node
+  end subroutine
 
 end module KeyValueListModule

--- a/src/Utilities/KeyValueList.f90
+++ b/src/Utilities/KeyValueList.f90
@@ -129,6 +129,9 @@ contains
 
   end subroutine clear_nodes
 
+  !> @brief Clears a single node
+  !!
+  !<
   subroutine clear_node(node)
     type(KeyValueNodeType), pointer :: node
 


### PR DESCRIPTION
In the KeyValueList there is the clear_node method that recursively calls itself until the entire list is cleared.
This works find for small lists, however for large lists this may cause issues. The reason being that each recursive call creates a new call stack which can eventually lead to a segmentation error.

In this PR the recursive method is replaced by a do while loop which mitigates this issues

Checklist of items for pull request

- [ ] Replaced section above with description of pull request
- [ ] Closed issue #xxxx
- [ ] Referenced issue or pull request #xxxx
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).