### PR TITLE
ci(release): don't download benchmark artifacts in build_docs.py

### DIFF
--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -14,13 +14,12 @@ from warnings import warn
 
 import pytest
 from benchmark import run_benchmarks
-from flaky import flaky
 from modflow_devtools.build import meson_build
 from modflow_devtools.download import (
     download_and_unzip,
     get_release,
 )
-from modflow_devtools.markers import no_parallel, requires_exe, requires_github
+from modflow_devtools.markers import no_parallel, requires_exe
 from modflow_devtools.misc import run_cmd, run_py_script, set_dir
 
 from utils import assert_match, convert_line_endings, get_project_root_path, glob, match

--- a/distribution/build_docs.py
+++ b/distribution/build_docs.py
@@ -106,20 +106,6 @@ def build_benchmark_tex(
         assert (RELEASE_NOTES_PATH / f"{benchmarks_path.stem}.tex").is_file()
 
 
-@flaky
-@no_parallel
-@requires_github
-def test_build_benchmark_tex(tmp_path):
-    benchmarks_path = BENCHMARKS_PATH / "run-time-comparison.md"
-    tex_path = DISTRIBUTION_PATH / f"{benchmarks_path.stem}.tex"
-
-    try:
-        build_benchmark_tex(tmp_path)
-        assert benchmarks_path.is_file()
-    finally:
-        tex_path.unlink(missing_ok=True)
-
-
 def build_deprecations_tex(force: bool = False):
     """Build LaTeX files for the deprecations table to go into the release notes."""
 


### PR DESCRIPTION
We could just do this in the release.yml workflow with `actions/download-artifact`, now that v4 supports downloads from arbitrary workflow runs. But we probably want to run fresh benchmarks at release time.

Also remove some awkward tests for things that get exercised nightly in the release workflow anyway.