### PR TITLE
fix(exg-gwf*): check for equal idomain 

### DIFF
--- a/autotest/test_prt_exg.py
+++ b/autotest/test_prt_exg.py
@@ -59,9 +59,12 @@ def build_mf6_sim(idx, test):
         (FlopyReadmeCase.nlay, FlopyReadmeCase.nrow, FlopyReadmeCase.ncol)
     )
     if "idm" in name:
+        # add an inactive cell to
+        # tracking model idomain
         idomain[-1, -1, -1] = 0
     if "idmn" in name:
-        # TODO alter flow model's idomain
+        # add a (different) inactive
+        # cell to flow model idomain
         gwf_idomain = idomain.copy()
         gwf_idomain[-1, -1, -1] = 1
         gwf_idomain[0, 0, 0] = 0

--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -20,6 +20,7 @@
 \textbf{\underline{BUG FIXES AND OTHER CHANGES TO EXISTING FUNCTIONALITY}} \\
 \underline{BASIC FUNCTIONALITY}
 \begin{itemize}
+	\item Previously, GWF Model exchanges with other model types (GWT, GWE, PRT) verified that the flow model and the coupled model had the same number of active nodes, but did not check that the models' IDOMAIN arrays selected precisely the same set. Exchanges will now check that model IDOMAIN arrays are identical.
 	\item A regression was recently introduced into the PRT model's generalized tracking method, in which a coordinate transformation was carried out prematurely. This could result in incorrect particle positions in and near quad-refined cells. This bug has been fixed.
 	\item The PRT model previously allowed particles to be released at any time. Release times falling outside the bounds of the simulation's time discretization could produce undefined behavior. Any release times occurring before the simulation begins (i.e. negative times) will now be skipped with a warning message. If EXTEND\_TRACKING is not enabled, release times occurring after the end of the simulation will now be skipped with a warning message as well. If EXTEND\_TRACKING is enabled, release times after the end of the simulation are allowed.
 \end{itemize}

--- a/src/Model/ModelUtilities/FlowModelInterface.f90
+++ b/src/Model/ModelUtilities/FlowModelInterface.f90
@@ -23,7 +23,7 @@ module FlowModelInterfaceModule
     logical, pointer :: flows_from_file => null() !< if .false., then flows come from GWF through GWF-Model exg
     type(ListType), pointer :: gwfbndlist => null() !< list of gwf stress packages
     integer(I4B), pointer :: iflowsupdated => null() !< flows were updated for this time step
-    integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !< pointer to model ibound
+    integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !< pointer to Model ibound
     real(DP), dimension(:), pointer, contiguous :: gwfflowja => null() !< pointer to the GWF flowja array
     real(DP), dimension(:, :), pointer, contiguous :: gwfspdis => null() !< pointer to npf specific discharge array
     real(DP), dimension(:), pointer, contiguous :: gwfhead => null() !< pointer to the GWF head array

--- a/src/Model/ModelUtilities/FlowModelInterface.f90
+++ b/src/Model/ModelUtilities/FlowModelInterface.f90
@@ -23,7 +23,7 @@ module FlowModelInterfaceModule
     logical, pointer :: flows_from_file => null() !< if .false., then flows come from GWF through GWF-Model exg
     type(ListType), pointer :: gwfbndlist => null() !< list of gwf stress packages
     integer(I4B), pointer :: iflowsupdated => null() !< flows were updated for this time step
-    integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !< pointer to Model ibound
+    integer(I4B), dimension(:), pointer, contiguous :: ibound => null() !< pointer to model ibound
     real(DP), dimension(:), pointer, contiguous :: gwfflowja => null() !< pointer to the GWF flowja array
     real(DP), dimension(:, :), pointer, contiguous :: gwfspdis => null() !< pointer to npf specific discharge array
     real(DP), dimension(:), pointer, contiguous :: gwfhead => null() !< pointer to the GWF head array


### PR DESCRIPTION
Check that models connected to a flow model by an exchange have an idomain identical to the flow model's idomain. This is an easy error to make, and (up to now) hard to detect.

I only added a test for PRT for now. The logic is identical in GWT and GWE. I wondered if there are suitable autotests for those models to add a test case to? Or maybe this behavior should have its own autotest?

#2144 facilitates adding the same check for flow model interface. I figure that can be done in a separate PR since it probably deserves a separate release note?

___
Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Added new test or modified an existing test
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Added doxygen comments to new and modified procedures
- [x] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [x] Removed checklist items not relevant to this pull request