### PR TITLE
docs(prt-fmi): clarify only required when post-processing

### DIFF
--- a/autotest/test_prt_exg.py
+++ b/autotest/test_prt_exg.py
@@ -108,15 +108,17 @@ def build_mf6_sim(idx, test):
         trackcsv_filerecord=[prt_track_csv_file],
     )
 
-    # create a flow model interface
-    # todo Mike Fienen's report (crash when FMI created but not needed)
-    # flopy.mf6.ModflowPrtfmi(
-    #     prt,
-    #     packagedata=[
-    #         ("GWFHEAD", gwf_head_file),
-    #         ("GWFBUDGET", gwf_budget_file),
-    #     ],
-    # )
+    # create a flow model interface. should be ignored.
+    # Mike Fienen reported that an early version of PRT
+    # crashed if FMI is provided when using an exchange.
+    flopy.mf6.ModflowPrtfmi(
+        prt,
+        packagedata=[
+            # garbage paths
+            ("GWFHEAD", "heads.hds"),
+            ("GWFBUDGET", "budget.cbc"),
+        ],
+    )
 
     # create exchange
     gwf_name = get_model_name(idx, "gwf")

--- a/doc/mf6io/gwe/fmi.tex
+++ b/doc/mf6io/gwe/fmi.tex
@@ -1,6 +1,6 @@
-Flow Model Interface (FMI) Package information is read from the file that is specified by ``FMI6'' as the file type.  The FMI Package is optional, but if provided, only one FMI Package can be specified for a GWE model.
+Flow Model Interface (FMI) Package information is read from the file that is specified by ``FMI6'' as the file type.  The FMI Package file is required only if the GWE Model is running in a separate simulation from a previously run GWF Model. If the GWE Model is coupled to a GWF Model by an exchange, the FMI Package file is not required. Only one FMI Package can be specified for a GWE model.
 
-For most simulations, the GWE Model needs groundwater flows for every cell in the model grid, for all boundary conditions, and for other terms, such as the flow of water in or out of storage.  The FMI Package is the interface between the GWE Model and simulated groundwater flows provided by a corresponding GWF Model that is running concurrently within the simulation or from binary budget files that were created from a previous GWF model run.  The following are several different FMI simulation cases:
+The GWE Model needs groundwater flows for model grid cells, for boundary conditions, and for other terms, such as the flow of water in or out of storage.  The FMI Package is the interface between the GWE Model and simulated groundwater flows provided by a corresponding GWF Model that is running concurrently within the simulation or from binary budget files that were created from a previous GWF model run.  The following are several different FMI simulation cases:
 
 \begin{itemize}
 

--- a/doc/mf6io/gwt/fmi.tex
+++ b/doc/mf6io/gwt/fmi.tex
@@ -1,6 +1,6 @@
-Flow Model Interface (FMI) Package information is read from the file that is specified by ``FMI6'' as the file type.  The FMI Package is optional, but if provided, only one FMI Package can be specified for a GWT model.
+Flow Model Interface (FMI) Package information is read from the file that is specified by ``FMI6'' as the file type. The FMI Package file is required only if the GWT Model is running in a separate simulation from a previously run GWF Model. If the GWT Model is coupled to a GWF Model by an exchange, the FMI Package file is not required. Only one FMI Package can be specified for a GWT model.
 
-For most simulations, the GWT Model needs groundwater flows for every cell in the model grid, for all boundary conditions, and for other terms, such as the flow of water in or out of storage.  The FMI Package is the interface between the GWT Model and simulated groundwater flows provided by a corresponding GWF Model that is running concurrently within the simulation or from binary budget files that were created from a previous GWF model run.  The following are several different FMI simulation cases:
+The GWT Model needs groundwater flows for model grid cells, for boundary conditions, and for other terms, such as the flow of water in or out of storage.  The FMI Package is the interface between the GWT Model and simulated groundwater flows provided by a corresponding GWF Model that is running concurrently within the simulation or from binary budget files that were created from a previous GWF model run.  The following are several different FMI simulation cases:
 
 \begin{itemize}
 

--- a/doc/mf6io/prt/fmi.tex
+++ b/doc/mf6io/prt/fmi.tex
@@ -1,6 +1,6 @@
-Flow Model Interface (FMI) Package information is read from the file that is specified by ``FMI6'' as the file type.  The FMI Package is required, and only one FMI Package can be specified for a PRT model.
+Flow Model Interface (FMI) Package information is read from the file that is specified by ``FMI6'' as the file type.  The FMI Package file is required only if the PRT Model is running in a separate simulation from a previously run GWF Model. If the PRT Model is coupled to a GWF Model by an exchange, the FMI Package file is not required. Only one FMI Package can be specified for a PRT model.
 
-For most simulations, the PRT Model needs groundwater flows for every cell in the model grid, for all boundary conditions, and for other terms, such as the flow of water in or out of storage.  The FMI Package is the interface between the PRT Model and simulated groundwater flows provided by a corresponding GWF Model that is running concurrently within the simulation or from binary budget files that were created from a previous GWF model run.  The following are several different FMI simulation cases:
+The PRT Model needs groundwater flows for model grid cells, for boundary conditions, and for other terms, such as the flow of water in or out of storage.  The FMI Package is the interface between the PRT Model and simulated groundwater flows provided by a corresponding GWF Model that is running concurrently within the simulation or from binary budget files that were created from a previous GWF model run.  The following are several different FMI simulation cases:
 
 \begin{itemize}
 


### PR DESCRIPTION
The first paragraph in the prt fmi section could be read to indicate that the fmi file is always required. Add some clarification. Also update a test to make sure the head/budget file paths provided via fmi are ignored when the simulation uses an exchange