### PR TITLE
fix(gwe-est): add support for energy decay in the solid phase

### DIFF
--- a/autotest/test_gwe_decay01.py
+++ b/autotest/test_gwe_decay01.py
@@ -128,6 +128,13 @@ def build_models(idx, test):
 
 def check_output(idx, test):
     print("evaluating results...")
+    msg = (
+        "Differences detected between the simulated results for zeroth-order "
+        "energy decay and the expected solution for decay specified in "
+    )
+    msg0 = msg + "the aqueous phase."
+    msg1 = msg + "the solid phase."
+    msg2 = msg + "both the aqueous and solid phases."
 
     # read transport results from GWE model
     name = cases[idx]
@@ -152,13 +159,13 @@ def check_output(idx, test):
     print("temperature evaluation: " + str(temp_analy_w))
 
     if "aqe" in name:
-        assert temp_ts[-1, 1] == temp_analy_w[-1]
+        assert np.isclose(temp_ts[-1, 1], temp_analy_w[-1], atol=1e-10), msg0
 
     if "sld" in name:
-        assert temp_ts[-1, 1] == temp_analy_s[-1]
+        assert np.isclose(temp_ts[-1, 1], temp_analy_s[-1], atol=1e-10), msg1
 
     if "both" in name:
-        assert temp_ts[-1, 1] == temp_analy_ws[-1]
+        assert np.isclose(temp_ts[-1, 1], temp_analy_ws[-1], atol=1e-10), msg2
 
 
 # - No need to change any code below

--- a/autotest/test_gwe_decay01.py
+++ b/autotest/test_gwe_decay01.py
@@ -1,0 +1,177 @@
+"""
+Test problem for decay of energy in EST package of GWE.  Uses a single-cell
+model.  Test contributed by Cas Neyens.
+"""
+
+# Imports
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+# Base simulation and model name and workspace
+
+cases = ["decay-aqe", "decay-sld", "decay-both"]
+
+# Model units
+length_units = "meters"
+time_units = "seconds"
+
+rho_w = 1000  # kg/m^3
+rho_s = 2500  # kg/m^3
+n = 0.2  # -
+gamma_w = -1000  # J/s/m^3, arbitrary value for zero-order aqueous heat production
+gamma_s = -0.1  # J/s/kg, arbitrary value for zero-order solid heat production
+c_w = 4000  # J/kg/degC
+c_s = 1000  # J/kg/decC
+T0 = 0  # degC
+
+nrow = 1
+ncol = 1
+nlay = 1
+delr = 1  # m
+delc = 1  # m
+top = 1  # m
+botm = 0  # m
+
+perlen = 86400  # s
+nstp = 20
+
+parameters = {
+    # aqueous
+    "decay-aqe": {
+        "zero_order_decay_water": True,
+        "zero_order_decay_solid": False,
+        "decay_water": gamma_w,
+        "decay_solid": gamma_s,
+    },
+    # solid
+    "decay-sld": {
+        "zero_order_decay_water": False,
+        "zero_order_decay_solid": True,
+        "decay_water": gamma_w,
+        "decay_solid": gamma_s,
+    },
+    # combined
+    "decay-both": {
+        "zero_order_decay_water": True,
+        "zero_order_decay_solid": True,
+        "decay_water": gamma_w,
+        "decay_solid": gamma_s,
+    },
+}
+
+
+def temp_z_decay(t, rho_w, rho_s, c_w, c_s, gamma_w, gamma_s, n, T0):
+    t = np.atleast_1d(t)
+    coeff = (-gamma_w * n - gamma_s * (1 - n) * rho_s) / (
+        rho_w * c_w * n + rho_s * c_s * (1 - n)
+    )
+    return coeff * t + T0
+
+
+def build_models(idx, test):
+    # Base MF6 GWF model type
+    ws = test.workspace
+    name = cases[idx]
+    gwename = "gwe-" + name
+
+    decay_kwargs = parameters[name]
+
+    print(f"Building MF6 model...{name}")
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name="heat",
+        sim_ws=ws,
+        exe_name="mf6",
+        version="mf6",
+    )
+    tdis = flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(perlen, nstp, 1.0)])
+    ims = flopy.mf6.ModflowIms(
+        sim, complexity="SIMPLE", inner_dvclose=0.001
+    )  # T can not become negative in this model
+
+    gwe = flopy.mf6.ModflowGwe(
+        sim,
+        modelname=gwename,
+        save_flows=True,
+        model_nam_file=f"{gwename}.nam",
+    )
+    dis = flopy.mf6.ModflowGwedis(
+        gwe, nrow=nrow, ncol=ncol, nlay=nlay, delr=delr, delc=delc, top=top, botm=botm
+    )
+    ic = flopy.mf6.ModflowGweic(gwe, strt=T0)
+    est = flopy.mf6.ModflowGweest(
+        gwe,
+        zero_order_decay_water=decay_kwargs["zero_order_decay_water"],
+        zero_order_decay_solid=decay_kwargs["zero_order_decay_solid"],
+        density_water=rho_w,
+        density_solid=rho_s,
+        heat_capacity_water=c_w,
+        heat_capacity_solid=c_s,
+        porosity=n,
+        decay_water=decay_kwargs["decay_water"],
+        decay_solid=decay_kwargs["decay_solid"],
+    )
+
+    oc = flopy.mf6.ModflowGweoc(
+        gwe,
+        budget_filerecord=f"{gwe.name}.bud",
+        temperature_filerecord=f"{gwe.name}.ucn",
+        printrecord=[("BUDGET", "ALL"), ("TEMPERATURE", "ALL")],
+        saverecord=[("BUDGET", "ALL"), ("TEMPERATURE", "ALL")],
+    )
+
+    return sim, None
+
+
+def check_output(idx, test):
+    print("evaluating results...")
+
+    # read transport results from GWE model
+    name = cases[idx]
+    gwename = "gwe-" + name
+
+    # Get the MF6 temperature output
+    sim = test.sims[0]
+    gwe = sim.get_model(gwename)
+    temp_ts = gwe.output.temperature().get_ts((0, 0, 0))
+    t = temp_ts[:, 0]
+
+    temp_analy_w = temp_z_decay(
+        t, rho_w, rho_s, c_w, c_s, gamma_w, 0, n, T0
+    )  # aqueous decay only
+    temp_analy_s = temp_z_decay(
+        t, rho_w, rho_s, c_w, c_s, 0, gamma_s, n, T0
+    )  # aqueous decay only
+    temp_analy_ws = temp_z_decay(
+        t, rho_w, rho_s, c_w, c_s, gamma_w, gamma_s, n, T0
+    )  # aqueous + solid decay
+
+    print("temperature evaluation: " + str(temp_analy_w))
+
+    if "aqe" in name:
+        assert temp_ts[-1, 1] == temp_analy_w[-1]
+
+    if "sld" in name:
+        assert temp_ts[-1, 1] == temp_analy_s[-1]
+
+    if "both" in name:
+        assert temp_ts[-1, 1] == temp_analy_ws[-1]
+
+
+# - No need to change any code below
+@pytest.mark.parametrize(
+    "idx, name",
+    list(enumerate(cases)),
+)
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+    )
+    test.run()

--- a/autotest/test_gwe_decay02.py
+++ b/autotest/test_gwe_decay02.py
@@ -59,7 +59,7 @@ def add_gwe(sim, gwename, add_esl=False):
 
         esl_amt = n * gamma_w + (1 - n) * gamma_s * rho_s
         esl_spd = {
-            0: [[(0, 0, 0), abs(esl_amt)]],
+            0: [[(0, 0, 0), -esl_amt]],
         }
         esl = flopy.mf6.ModflowGweesl(
             gwe,

--- a/autotest/test_gwe_decay02.py
+++ b/autotest/test_gwe_decay02.py
@@ -57,8 +57,9 @@ def add_gwe(sim, gwename, add_esl=False):
         zero_order_decay_water = False
         zero_order_decay_solid = False
 
+        esl_amt = n * gamma_w + (1 - n) * gamma_s * rho_s
         esl_spd = {
-            0: [[(0, 0, 0), 400]],
+            0: [[(0, 0, 0), abs(esl_amt)]],
         }
         esl = flopy.mf6.ModflowGweesl(
             gwe,

--- a/autotest/test_gwe_decay02.py
+++ b/autotest/test_gwe_decay02.py
@@ -1,0 +1,162 @@
+"""
+Test problem for decay of energy in EST package of GWE.  Compares energy loss
+to that of an ESL boundary
+"""
+
+# Imports
+
+import flopy
+import numpy as np
+import pytest
+from framework import TestFramework
+
+# Base simulation and model name and workspace
+
+cases = ["decay"]
+
+# Model units
+length_units = "meters"
+time_units = "seconds"
+
+rho_w = 1000  # kg/m^3
+rho_s = 2500  # kg/m^3
+n = 0.2  # -
+gamma_w = -1000  # J/s/m^3, arbitrary value for zero-order aqueous heat production
+gamma_s = -0.1  # J/s/kg, arbitrary value for zero-order solid heat production
+c_w = 4000  # J/kg/degC
+c_s = 1000  # J/kg/decC
+T0 = 0  # degC
+
+nrow = 1
+ncol = 1
+nlay = 1
+delr = 1  # m
+delc = 1  # m
+top = 1  # m
+botm = 0  # m
+
+perlen = 86400  # s
+nstp = 20
+
+
+def add_gwe(sim, gwename, add_esl=False):
+    gwe = flopy.mf6.ModflowGwe(
+        sim,
+        modelname=gwename,
+        save_flows=True,
+        model_nam_file=f"{gwename}.nam",
+    )
+    dis = flopy.mf6.ModflowGwedis(
+        gwe, nrow=nrow, ncol=ncol, nlay=nlay, delr=delr, delc=delc, top=top, botm=botm
+    )
+    ic = flopy.mf6.ModflowGweic(gwe, strt=T0)
+    if not add_esl:
+        zero_order_decay_water = True
+        zero_order_decay_solid = True
+    else:
+        zero_order_decay_water = False
+        zero_order_decay_solid = False
+
+        esl_spd = {
+            0: [[(0, 0, 0), 400]],
+        }
+        esl = flopy.mf6.ModflowGweesl(
+            gwe,
+            stress_period_data=esl_spd,
+            pname="ESL",
+            filename=f"{gwename}.esl",
+        )
+
+    est = flopy.mf6.ModflowGweest(
+        gwe,
+        zero_order_decay_water=zero_order_decay_water,
+        zero_order_decay_solid=zero_order_decay_solid,
+        density_water=rho_w,
+        density_solid=rho_s,
+        heat_capacity_water=c_w,
+        heat_capacity_solid=c_s,
+        porosity=n,
+        decay_water=gamma_w,
+        decay_solid=gamma_s,
+    )
+
+    oc = flopy.mf6.ModflowGweoc(
+        gwe,
+        budget_filerecord=f"{gwe.name}.bud",
+        temperature_filerecord=f"{gwe.name}.ucn",
+        printrecord=[("BUDGET", "ALL"), ("TEMPERATURE", "ALL")],
+        saverecord=[("BUDGET", "ALL"), ("TEMPERATURE", "ALL")],
+    )
+
+    return sim
+
+
+def build_models(idx, test):
+    # Base MF6 GWF model type
+    ws = test.workspace
+    name = cases[idx]
+    gwename = "gwe-" + name
+
+    print(f"Building MF6 model...{name}")
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name="heat",
+        sim_ws=ws,
+        exe_name="mf6",
+        version="mf6",
+    )
+    tdis = flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(perlen, nstp, 1.0)])
+    ims = flopy.mf6.ModflowIms(
+        sim, complexity="SIMPLE", inner_dvclose=0.001
+    )  # T can not become negative in this model
+
+    # add first GWE model
+    sim = add_gwe(sim, gwename + "-1", add_esl=False)
+    # add second GWE model
+    sim = add_gwe(sim, gwename + "-2", add_esl=True)
+
+    return sim, None
+
+
+def check_output(idx, test):
+    print("evaluating results...")
+    ws = test.workspace
+
+    msg = (
+        "Differences detected between the simulated results for zeroth-order "
+        "energy decay and the ESL Package.  The respective approaches are "
+        "expected to give the same answer."
+    )
+
+    # read transport results from GWE model
+    name = cases[idx]
+    gwename1 = "gwe-" + name + "-1"
+    gwename2 = "gwe-" + name + "-2"
+
+    # Get the MF6 temperature output
+    sim = test.sims[0]
+    gwe1 = sim.get_model(gwename1)
+    temp_ts1 = gwe1.output.temperature().get_ts((0, 0, 0))
+    t1 = temp_ts1[:, 0]
+
+    gwe2 = sim.get_model(gwename2)
+    temp_ts2 = gwe2.output.temperature().get_ts((0, 0, 0))
+    t2 = temp_ts2[:, 0]
+
+    assert np.isclose(temp_ts1[-1, 1], temp_ts2[-1, 1], atol=1e-10), msg
+
+
+# - No need to change any code below
+@pytest.mark.parametrize(
+    "idx, name",
+    list(enumerate(cases)),
+)
+def test_mf6model(idx, name, function_tmpdir, targets):
+    test = TestFramework(
+        name=name,
+        workspace=function_tmpdir,
+        targets=targets,
+        build=lambda t: build_models(idx, t),
+        check=lambda t: check_output(idx, t),
+    )
+    test.run()

--- a/doc/ReleaseNotes/develop.tex
+++ b/doc/ReleaseNotes/develop.tex
@@ -25,6 +25,7 @@
 	\item A regression was recently introduced into the PRT model's generalized tracking method, in which a coordinate transformation was carried out prematurely. This could result in incorrect particle positions in and near quad-refined cells. This bug has been fixed.
 	\item The PRT model previously allowed particles to be released at any time. Release times falling outside the bounds of the simulation's time discretization could produce undefined behavior. Any release times occurring before the simulation begins (i.e. negative times) will now be skipped with a warning message. If EXTEND\_TRACKING is not enabled, release times occurring after the end of the simulation will now be skipped with a warning message as well. If EXTEND\_TRACKING is enabled, release times after the end of the simulation are allowed.
 	\item A profiling module is added for more enhanced performance diagnostics of the program. It can be activated through the PROFILE\_OPTION in the simulation name file.
+	\item Energy decay in the solid phase was added to the EST Package.  This capability is described in the Supplemental Technical Information document, but no actual support was provided in the source code.  Users can now specify distinct zeroth-order decay rates in either the aqueous or solid phases.
 \end{itemize}
 
 \underline{INTERNAL FLOW PACKAGES}

--- a/doc/mf6io/mf6ivar/dfn/gwe-est.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-est.dfn
@@ -14,7 +14,7 @@ type keyword
 reader urword
 optional true
 longname activate zero-order decay in aqueous phase
-description is a text keyword to indicate that zero-order decay will occur in the aqueous phase.  Use of this keyword requires that DECAY_WATER is specified in the GRIDDATA block.
+description is a text keyword to indicate that zero-order decay will occur in the aqueous phase.  Use of this keyword requires that DECAY\_WATER is specified in the GRIDDATA block.
 
 block options
 name zero_order_decay_solid
@@ -22,7 +22,7 @@ type keyword
 reader urword
 optional true
 longname activate zero-order decay in solid phase
-description is a text keyword to indicate that zero-order decay will occur in the solid phase.  Use of this keyword requires that DECAY_SOLID is specified in the GRIDDATA block.
+description is a text keyword to indicate that zero-order decay will occur in the solid phase.  Use of this keyword requires that DECAY\_SOLID is specified in the GRIDDATA block.
 
 block options
 name density_water
@@ -73,7 +73,7 @@ reader readarray
 layered true
 optional true
 longname aqueous phase decay rate coefficient
-description is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of decay for zero-order decay in the aqueous phase is energy per length cubed per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO_ORDER_DECAY_WATER is specified in the options block.
+description is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of decay for zero-order decay in the aqueous phase is energy per length cubed per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\_ORDER\_DECAY\_WATER is specified in the options block.
 
 block griddata
 name decay_solid
@@ -83,7 +83,7 @@ reader readarray
 layered true
 optional true
 longname solid phase decay rate coefficient
-description is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production.  The dimensions of decay for zero-order decay in the solid phase is energy per length cubed per time.  Zero-order decay in the solid phase will have no effect on simulation results unless ZERO_ORDER_DECAY_SOLID is specified in the options block.
+description is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production.  The dimensions of decay for zero-order decay in the solid phase is energy per length cubed per time.  Zero-order decay in the solid phase will have no effect on simulation results unless ZERO\_ORDER\_DECAY\_SOLID is specified in the options block.
 
 block griddata
 name heat_capacity_solid

--- a/doc/mf6io/mf6ivar/dfn/gwe-est.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-est.dfn
@@ -22,7 +22,7 @@ type keyword
 reader urword
 optional true
 longname activate zero-order decay in solid phase
-description is a text keyword to indicate that zero-order decay will occur in the solid phase. That is, decay occurs in the solid and is a rate per mass of solid only, not per volume of aquifer (i.e., grid cell).  Use of this keyword requires that DECAY\_SOLID is specified in the GRIDDATA block.
+description is a text keyword to indicate that zero-order decay will occur in the solid phase. That is, decay occurs in the solid and is a rate per mass (not volume) of solid only.  Use of this keyword requires that DECAY\_SOLID is specified in the GRIDDATA block.
 
 block options
 name density_water
@@ -73,7 +73,7 @@ reader readarray
 layered true
 optional true
 longname aqueous phase decay rate coefficient
-description is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of zero-order decay in the aqueous phase are energy per length cubed per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\_ORDER\_DECAY\_WATER is specified in the options block.
+description is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of zero-order decay in the aqueous phase are energy per length cubed (volume of water) per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\_ORDER\_DECAY\_WATER is specified in the options block.
 
 block griddata
 name decay_solid

--- a/doc/mf6io/mf6ivar/dfn/gwe-est.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-est.dfn
@@ -14,7 +14,7 @@ type keyword
 reader urword
 optional true
 longname activate zero-order decay in aqueous phase
-description is a text keyword to indicate that zero-order decay will occur in the aqueous phase.  Use of this keyword requires that DECAY\_WATER is specified in the GRIDDATA block.
+description is a text keyword to indicate that zero-order decay will occur in the aqueous phase. That is, decay occurs in the water and is a rate per volume of water only, not per volume of aquifer (i.e., grid cell).  Use of this keyword requires that DECAY\_WATER is specified in the GRIDDATA block.
 
 block options
 name zero_order_decay_solid
@@ -22,7 +22,7 @@ type keyword
 reader urword
 optional true
 longname activate zero-order decay in solid phase
-description is a text keyword to indicate that zero-order decay will occur in the solid phase.  Use of this keyword requires that DECAY\_SOLID is specified in the GRIDDATA block.
+description is a text keyword to indicate that zero-order decay will occur in the solid phase. That is, decay occurs in the solid and is a rate per mass of solid only, not per volume of aquifer (i.e., grid cell).  Use of this keyword requires that DECAY\_SOLID is specified in the GRIDDATA block.
 
 block options
 name density_water
@@ -73,7 +73,7 @@ reader readarray
 layered true
 optional true
 longname aqueous phase decay rate coefficient
-description is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of decay for zero-order decay in the aqueous phase is energy per length cubed per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\_ORDER\_DECAY\_WATER is specified in the options block.
+description is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of zero-order decay in the aqueous phase are energy per length cubed per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\_ORDER\_DECAY\_WATER is specified in the options block.
 
 block griddata
 name decay_solid
@@ -83,7 +83,7 @@ reader readarray
 layered true
 optional true
 longname solid phase decay rate coefficient
-description is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production.  The dimensions of decay for zero-order decay in the solid phase is energy per length cubed per time.  Zero-order decay in the solid phase will have no effect on simulation results unless ZERO\_ORDER\_DECAY\_SOLID is specified in the options block.
+description is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production. The dimensions of zero-order decay in the solid phase are energy per mass of solid per time. Zero-order decay in the solid phase will have no effect on simulation results unless ZERO\_ORDER\_DECAY\_SOLID is specified in the options block.
 
 block griddata
 name heat_capacity_solid

--- a/doc/mf6io/mf6ivar/dfn/gwe-est.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwe-est.dfn
@@ -9,12 +9,20 @@ longname save calculated flows to budget file
 description REPLACE save_flows {'{#1}': 'EST'}
 
 block options
-name zero_order_decay
+name zero_order_decay_water
 type keyword
 reader urword
 optional true
-longname activate zero-order decay
-description is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY is specified in the GRIDDATA block.
+longname activate zero-order decay in aqueous phase
+description is a text keyword to indicate that zero-order decay will occur in the aqueous phase.  Use of this keyword requires that DECAY_WATER is specified in the GRIDDATA block.
+
+block options
+name zero_order_decay_solid
+type keyword
+reader urword
+optional true
+longname activate zero-order decay in solid phase
+description is a text keyword to indicate that zero-order decay will occur in the solid phase.  Use of this keyword requires that DECAY_SOLID is specified in the GRIDDATA block.
 
 block options
 name density_water
@@ -58,14 +66,24 @@ longname porosity
 description is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  The GWE model does not support the concept of an immobile domain in the context of heat transport. 
 
 block griddata
-name decay
+name decay_water
 type double precision
 shape (nodes)
 reader readarray
 layered true
 optional true
 longname aqueous phase decay rate coefficient
-description is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of decay for zero-order decay is energy per length cubed per time.  Zero-order decay will have no effect on simulation results unless zero-order decay is specified in the options block.
+description is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of decay for zero-order decay in the aqueous phase is energy per length cubed per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO_ORDER_DECAY_WATER is specified in the options block.
+
+block griddata
+name decay_solid
+type double precision
+shape (nodes)
+reader readarray
+layered true
+optional true
+longname solid phase decay rate coefficient
+description is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production.  The dimensions of decay for zero-order decay in the solid phase is energy per length cubed per time.  Zero-order decay in the solid phase will have no effect on simulation results unless ZERO_ORDER_DECAY_SOLID is specified in the options block.
 
 block griddata
 name heat_capacity_solid

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -48,7 +48,7 @@ module GweEstModule
     !
     ! -- decay
     integer(I4B), pointer :: idcy => null() !< order of decay rate (0:none, 1:first, 2:zero (aqueous and/or solid))
-    integer(I4B), dimension(:), pointer :: idcytype => null() !< decay source (or sink) (0: not specified
+    integer(I4B), pointer :: idcytype => null() !< decay source (or sink) (1: aqueous only, 2: solid only, 3: both phases
     real(DP), dimension(:), pointer, contiguous :: decay_water => null() !< first or zero order decay rate (aqueous)
     real(DP), dimension(:), pointer, contiguous :: decay_solid => null() !< first or zero order decay rate (solid)
     real(DP), dimension(:), pointer, contiguous :: ratedcyw => null() !< rate of decay in aqueous phase
@@ -277,7 +277,8 @@ contains
         hhcof = -this%decay_water(n) * vcell * swtpdt * this%porosity(n) &
                 * this%eqnsclfac
         call matrix_sln%add_value_pos(idxglo(idiag), hhcof)
-      elseif (this%idcy == 2 .and. this%idcytype(1) > 0) then
+      elseif (this%idcy == 2 .and. (this%idcytype == 1 .or. &
+                                    this%idcytype == 3)) then
         !
         ! -- Call function to get zero-order decay rate, which may be changed
         !    from the user-specified rate to prevent negative temperatures     ! Important note: still need to think through negative temps
@@ -335,7 +336,8 @@ contains
       ! -- add sorbed mass decay rate terms to accumulators
       if (this%idcy == 1) then
         ! -- first order decay rate not supported in GWE
-      elseif (this%idcy == 2 .and. this%idcytype(2) > 0) then
+      elseif (this%idcy == 2 .and. (this%idcytype == 2 .or. &
+                                    this%idcytype == 3)) then
         !
         ! -- Call function to get zero-order decay rate for the solid phase,
         !    which may be changed from the user-specified rate to prevent
@@ -369,10 +371,10 @@ contains
     !
     ! -- decay
     if (this%idcy /= 0) then
-      if (this%idcytype(1) > 0) then
+      if (this%idcytype == 1 .or. this%idcytype == 3) then
         call this%est_cq_dcy(nodes, cnew, cold, flowja)
       end if
-      if (this%idcytype(2) > 0) then
+      if (this%idcytype == 2 .or. this%idcytype == 3) then
         call this%est_cq_dcy_solid(nodes, cnew, cold, flowja)
       end if
     end if
@@ -452,8 +454,6 @@ contains
     real(DP) :: vcell
     real(DP) :: decay_rate
     !
-    ! -- initialize
-    !
     ! -- Calculate decay change
     do n = 1, nodes
       !
@@ -472,7 +472,8 @@ contains
       if (this%idcy == 1) then ! Important note: do we need/want first-order decay for temperature???
         hhcof = -this%decay_water(n) * vcell * swtpdt * this%porosity(n) &
                 * this%eqnsclfac
-      elseif (this%idcy == 2 .and. this%idcytype(1) > IZERO) then ! zero order decay aqueous phase
+      elseif (this%idcy == 2 .and. this%idcytype == 1 .or. &
+              this%idcytype == 3) then ! zero order decay aqueous phase
         decay_rate = get_zero_order_decay(this%decay_water(n), &
                                           this%decaylastw(n), 0, cold(n), &
                                           cnew(n), delt)
@@ -526,7 +527,8 @@ contains
       if (this%idcy == 1) then ! Important note: do we need/want first-order decay for temperature???
         hhcof = -this%decay_solid(n) * vcell * (1 - this%porosity(n)) &
                 * this%eqnsclfac
-      elseif (this%idcy == 2 .and. this%idcytype(2) > IZERO) then ! zero order decay in the solid phase
+      elseif (this%idcy == 2 .and. this%idcytype == 2 .or. &
+              this%idcytype == 3) then ! zero order decay in the solid phase
         decay_rate = get_zero_order_decay(this%decay_solid(n), &
                                           this%decaylasts(n), 0, cold(n), &
                                           cnew(n), delt)
@@ -563,13 +565,13 @@ contains
     !
     ! -- dcy
     if (this%idcy /= 0) then
-      if (this%idcytype(1) > IZERO) then
+      if (this%idcytype == 1 .or. this%idcytype == 3) then
         ! -- aqueous phase
         call rate_accumulator(this%ratedcyw, rin, rout)
         call model_budget%addentry(rin, rout, delt, budtxt(2), &
                                    isuppress_output, rowlabel=this%packName)
       end if
-      if (this%idcytype(2) > IZERO) then
+      if (this%idcytype == 2 .or. this%idcytype == 3) then
         ! -- solid phase
         call rate_accumulator(this%ratedcys, rin, rout)
         call model_budget%addentry(rin, rout, delt, budtxt(3), &
@@ -615,13 +617,13 @@ contains
       !
       ! -- dcy
       if (this%idcy /= 0) then
-        if (this%idcytype(1) > IZERO) then
+        if (this%idcytype == 1 .or. this%idcytype == 3) then
           ! -- aqueous phase
           call this%dis%record_array(this%ratedcyw, this%iout, iprint, &
                                      -ibinun, budtxt(2), cdatafmp, nvaluesp, &
                                      nwidthp, editdesc, dinact)
         end if
-        if (this%idcytype(2) > IZERO) then
+        if (this%idcytype == 2 .or. this%idcytype == 3) then
           ! -- solid phase
           call this%dis%record_array(this%ratedcys, this%iout, iprint, &
                                      -ibinun, budtxt(3), cdatafmp, nvaluesp, &
@@ -677,8 +679,6 @@ contains
     use MemoryManagerModule, only: mem_allocate, mem_setptr
     ! -- dummy
     class(GweEstType) :: this !< GweEstType object
-    ! -- local
-    integer(I4B) :: n
     !
     ! -- Allocate scalars in NumericalPackageType
     call this%NumericalPackageType%allocate_scalars()
@@ -688,16 +688,14 @@ contains
     call mem_allocate(this%rhow, 'RHOW', this%memoryPath)
     call mem_allocate(this%latheatvap, 'LATHEATVAP', this%memoryPath)
     call mem_allocate(this%idcy, 'IDCY', this%memoryPath)
-    call mem_allocate(this%idcytype, 2, 'IDCYTYPE', this%memoryPath)
+    call mem_allocate(this%idcytype, 'IDCYTYPE', this%memoryPath)
     !
     ! -- Initialize
     this%cpw = DZERO
     this%rhow = DZERO
     this%latheatvap = DZERO
-    this%idcy = 0
-    do n = 1, 2
-      this%idcytype(n) = IZERO
-    end do
+    this%idcy = IZERO
+    this%idcytype = IZERO
   end subroutine allocate_scalars
 
   !> @ brief Allocate arrays for package
@@ -803,11 +801,19 @@ contains
           write (this%iout, fmtidcy1)
         case ('ZERO_ORDER_DECAY_WATER')
           this%idcy = 2
-          this%idcytype(1) = 1
+          if (this%idcytype > IZERO) then
+            this%idcytype = 3
+          else
+            this%idcytype = 1
+          end if
           write (this%iout, fmtidcy2)
         case ('ZERO_ORDER_DECAY_SOLID')
           this%idcy = 2
-          this%idcytype(2) = 2
+          if (this%idcytype > IZERO) then
+            this%idcytype = 3
+          else
+            this%idcytype = 2
+          end if
           write (this%iout, fmtidcy3)
         case ('HEAT_CAPACITY_WATER')
           this%cpw = this%parser%GetDouble()

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -280,8 +280,6 @@ contains
       elseif (this%idcy == 2 .and. (this%idcysrc == 1 .or. &
                                     this%idcysrc == 3)) then
         !
-        ! -- Call function to get zero-order decay rate, which may be changed
-        !    from the user-specified rate to prevent negative temperatures     ! Important note: still need to think through negative temps
         decay_rate = this%decay_water(n)
         ! -- This term does get divided by eqnsclfac for fc purposes because it
         !    should start out being a rate of energy
@@ -952,16 +950,15 @@ contains
     if (this%idcy > 0) then
       if (.not. lname(2) .and. .not. lname(3)) then
         write (errmsg, '(a)') 'Zero order decay in either the aqueous &
-          &or solid phase is active but zero-order rate coefficients, &
-          &either in the aqueous or solid phase, is not specified.  &
-          &Either DECAY_WATER or DECAY_SOLID must be specified in the &
-          &griddata block.'
+          &or solid phase is active but the corresponding zero-order &
+          &rate coefficient is not specified. Either DECAY_WATER or &
+          &DECAY_SOLID must be specified in the griddata block.'
         call store_error(errmsg)
       end if
     else
       if (lname(2)) then
         write (warnmsg, '(a)') 'Zero order decay in the aqueous phase has &
-          &not been activated but DECAY_WATER has been specified.  Zero &
+          &not been activated but DECAY_WATER has been specified. Zero &
           &order decay in the aqueous phase will have no affect on &
           &simulation results.'
         call store_warning(warnmsg)

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -251,7 +251,7 @@ contains
     integer(I4B), intent(in) :: kiter !< solution outer iteration number
     ! -- local
     integer(I4B) :: n
-    real(DP) :: hhcof, rrhs
+    real(DP) :: rrhs
     real(DP) :: swtpdt
     real(DP) :: vcell
     real(DP) :: decay_rate
@@ -299,7 +299,7 @@ contains
     integer(I4B), intent(in) :: kiter !< solution outer iteration number
     ! -- local
     integer(I4B) :: n
-    real(DP) :: hhcof, rrhs
+    real(DP) :: rrhs
     real(DP) :: vcell
     real(DP) :: decay_rate
     !
@@ -310,7 +310,6 @@ contains
       if (this%ibound(n) <= 0) cycle
       !
       ! -- set variables
-      hhcof = DZERO
       rrhs = DZERO
       vcell = this%dis%area(n) * (this%dis%top(n) - this%dis%bot(n))
       !

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -67,7 +67,7 @@ module GweEstModule
     procedure :: est_ar
     procedure :: est_fc
     procedure :: est_fc_sto
-    procedure :: est_fc_dcy
+    procedure :: est_fc_dcy_water
     procedure :: est_fc_dcy_solid
     procedure :: est_cq
     procedure :: est_cq_sto
@@ -178,8 +178,8 @@ contains
     !
     ! -- decay contribution
     if (this%idcy /= 0) then
-      call this%est_fc_dcy(nodes, cold, cnew, nja, matrix_sln, idxglo, &
-                           rhs, kiter)
+      call this%est_fc_dcy_water(nodes, cold, cnew, nja, matrix_sln, idxglo, &
+                                 rhs, kiter)
       call this%est_fc_dcy_solid(nodes, cold, nja, matrix_sln, idxglo, rhs, &
                                  cnew, kiter)
     end if
@@ -237,8 +237,8 @@ contains
   !!
   !!  Method to calculate and fill decay coefficients for the package.
   !<
-  subroutine est_fc_dcy(this, nodes, cold, cnew, nja, matrix_sln, &
-                        idxglo, rhs, kiter)
+  subroutine est_fc_dcy_water(this, nodes, cold, cnew, nja, matrix_sln, &
+                              idxglo, rhs, kiter)
     ! -- dummy
     class(GweEstType) :: this !< GweEstType object
     integer, intent(in) :: nodes !< number of nodes
@@ -279,7 +279,7 @@ contains
       end if
       !
     end do
-  end subroutine est_fc_dcy
+  end subroutine est_fc_dcy_water
 
   !> @ brief Fill solid decay coefficient method for package
   !!

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -472,8 +472,8 @@ contains
       if (this%idcy == 1) then ! Important note: do we need/want first-order decay for temperature???
         hhcof = -this%decay_water(n) * vcell * swtpdt * this%porosity(n) &
                 * this%eqnsclfac
-      elseif (this%idcy == 2 .and. this%idcysrc == 1 .or. &
-              this%idcysrc == 3) then ! zero order decay aqueous phase
+      elseif (this%idcy == 2 .and. (this%idcysrc == 1 .or. &
+                                    this%idcysrc == 3)) then ! zero order decay aqueous phase
         decay_rate = get_zero_order_decay(this%decay_water(n), &
                                           this%decaylastw(n), 0, cold(n), &
                                           cnew(n), delt)
@@ -527,8 +527,8 @@ contains
       if (this%idcy == 1) then ! Important note: do we need/want first-order decay for temperature???
         hhcof = -this%decay_solid(n) * vcell * (1 - this%porosity(n)) &
                 * this%eqnsclfac
-      elseif (this%idcy == 2 .and. this%idcysrc == 2 .or. &
-              this%idcysrc == 3) then ! zero order decay in the solid phase
+      elseif (this%idcy == 2 .and. (this%idcysrc == 2 .or. &
+                                    this%idcysrc == 3)) then ! zero order decay in the solid phase
         decay_rate = get_zero_order_decay(this%decay_solid(n), &
                                           this%decaylasts(n), 0, cold(n), &
                                           cnew(n), delt)

--- a/src/Model/GroundWaterEnergy/gwe-est.f90
+++ b/src/Model/GroundWaterEnergy/gwe-est.f90
@@ -239,8 +239,6 @@ contains
   !<
   subroutine est_fc_dcy(this, nodes, cold, cnew, nja, matrix_sln, &
                         idxglo, rhs, kiter)
-    ! -- modules
-    use TdisModule, only: delt
     ! -- dummy
     class(GweEstType) :: this !< GweEstType object
     integer, intent(in) :: nodes !< number of nodes
@@ -297,8 +295,6 @@ contains
   !<
   subroutine est_fc_dcy_solid(this, nodes, cold, nja, matrix_sln, idxglo, &
                               rhs, cnew, kiter)
-    ! -- modules
-    use TdisModule, only: delt
     ! -- dummy
     class(GweEstType) :: this !< GwtMstType object
     integer, intent(in) :: nodes !< number of nodes
@@ -432,9 +428,7 @@ contains
   !!
   !!  Method to calculate decay terms for the aqueous phase.
   !<
-  subroutine est_cq_dcy(this, nodes, cnew, cold, flowja) ! Important note: this handles only decay in water; need to add zero-order (but not first-order?) decay in solid
-    ! -- modules
-    use TdisModule, only: delt
+  subroutine est_cq_dcy(this, nodes, cnew, cold, flowja)
     ! -- dummy
     class(GweEstType) :: this !< GweEstType object
     integer(I4B), intent(in) :: nodes !< number of nodes
@@ -483,13 +477,11 @@ contains
     end do
   end subroutine est_cq_dcy
 
-  !> @ brief Calculate decay terms for aqueous phase
+  !> @ brief Calculate decay terms for solid phase
   !!
-  !!  Method to calculate decay terms for the aqueous phase.
+  !!  Method to calculate decay terms for the solid phase.
   !<
-  subroutine est_cq_dcy_solid(this, nodes, cnew, cold, flowja) ! Important note: this handles only decay in solid
-    ! -- modules
-    use TdisModule, only: delt
+  subroutine est_cq_dcy_solid(this, nodes, cnew, cold, flowja)
     ! -- dummy
     class(GweEstType) :: this !< GweEstType object
     integer(I4B), intent(in) :: nodes !< number of nodes

--- a/src/Model/GroundWaterTransport/gwt-mst.f90
+++ b/src/Model/GroundWaterTransport/gwt-mst.f90
@@ -441,7 +441,6 @@ contains
   !> @ brief Fill sorption-decay coefficient method for package
   !!
   !!  Method to calculate and fill sorption-decay coefficients for the package.
-  !!
   !<
   subroutine mst_fc_dcy_srb(this, nodes, cold, nja, matrix_sln, idxglo, &
                             rhs, cnew, kiter)


### PR DESCRIPTION
Support for specifying energy decay in the solid phase was missing despite it being described in the Supplemental Technical Information document.  The best I can figure is that during development it was initially skipped over with the intention of coming back to it - but then was forgotten about. 

- [x] Replaced section above with description of pull request
- [x] Addresses issue #2142 
- [x] Functionality should have been included with pull request #1493 
- [x] Added new test or modified an existing test
- [x] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users