### PR TITLE
Fix str1d deallocation

### DIFF
--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -540,7 +540,7 @@
 			<FileConfiguration Name="Release|Win32" ExcludedFromBuild="true"/></File>
 		<File RelativePath="..\src\Utilities\Matrix\SparseMatrix.f90"/></Filter>
 		<Filter Name="Memory">
-		<File RelativePath="..\src\Utilities\Memory\Memory.f90"/>
+		<File RelativePath="..\src\Utilities\Memory\Memory.F90"/>
 		<File RelativePath="..\src\Utilities\Memory\MemoryContainerIterator.f90"/>
 		<File RelativePath="..\src\Utilities\Memory\MemoryHelper.f90"/>
 		<File RelativePath="..\src\Utilities\Memory\MemoryManager.f90"/>

--- a/src/Utilities/Memory/Memory.F90
+++ b/src/Utilities/Memory/Memory.F90
@@ -142,7 +142,12 @@ contains
 
       call c_f_pointer(cptr, astr1d, [this%isize * this%element_size])
 
+#if __GNUC__ < 13
       if (this%master) deallocate (astr1d)
+#else
+      if (this%master) deallocate (this%astr1d)
+#endif
+
       nullify (this%astr1d)
     end if
 

--- a/src/Utilities/Memory/Memory.F90
+++ b/src/Utilities/Memory/Memory.F90
@@ -142,7 +142,7 @@ contains
 
       call c_f_pointer(cptr, astr1d, [this%isize * this%element_size])
 
-#if __GNUC__ < 13
+#if __GFORTRAN__  &&__GNUC__ < 13
       if (this%master) deallocate (astr1d)
 #else
       if (this%master) deallocate (this%astr1d)

--- a/src/Utilities/Memory/Memory.f90
+++ b/src/Utilities/Memory/Memory.f90
@@ -30,7 +30,7 @@ module MemoryTypeModule
     integer(I4B), pointer :: intsclr => null() !< pointer to the integer
     real(DP), pointer :: dblsclr => null() !< pointer to the double
     ! The 1d character string array is handled differently than the other arrays due to a bug in gfortran 11.3 and 12.1.
-    ! Due to this bug the length of the string is not stored in the array descriptor. With a segementation fault as a result
+    ! Due to this bug the length of the string is not stored in the array descriptor. With a segmentation fault as a result
     ! on deallocation.
     class(*), dimension(:), pointer, contiguous :: astr1d => null() !< pointer to the 1d character string array
     integer(I4B), dimension(:), pointer, contiguous :: aint1d => null() !< pointer to 1d integer array

--- a/src/Utilities/Memory/Memory.f90
+++ b/src/Utilities/Memory/Memory.f90
@@ -29,7 +29,10 @@ module MemoryTypeModule
     logical(LGP), pointer :: logicalsclr => null() !< pointer to the logical
     integer(I4B), pointer :: intsclr => null() !< pointer to the integer
     real(DP), pointer :: dblsclr => null() !< pointer to the double
-    character(len=:), dimension(:), pointer, contiguous :: astr1d => null() !< pointer to the 1d character string array
+    ! The 1d character string array is handled differently than the other arrays due to a bug in gfortran 11.3 and 12.1.
+    ! Due to this bug the length of the string is not stored in the array descriptor. With a segementation fault as a result
+    ! on deallocation.
+    class(*), dimension(:), pointer, contiguous :: astr1d => null() !< pointer to the 1d character string array
     integer(I4B), dimension(:), pointer, contiguous :: aint1d => null() !< pointer to 1d integer array
     integer(I4B), dimension(:, :), pointer, contiguous :: aint2d => null() !< pointer to 2d integer array
     integer(I4B), dimension(:, :, :), pointer, contiguous :: aint3d => null() !< pointer to 3d integer array
@@ -98,8 +101,12 @@ contains
   end function mt_associated
 
   subroutine mt_deallocate(this)
+    use iso_c_binding, only: c_loc, c_ptr, c_null_ptr, c_f_pointer
     class(MemoryType) :: this
     integer(I4B) :: n
+    type(c_ptr) :: astr1d
+
+    character(len=1), dimension(:), pointer :: key
 
     if (associated(this%strsclr)) then
       if (this%master) deallocate (this%strsclr)
@@ -121,8 +128,21 @@ contains
       nullify (this%dblsclr)
     end if
 
+    ! Handle the dealloction of the 1d character string array differently due to a bug in gfortran 11.3 and 12.1
+    ! We use a c_ptr to cast the pointer to a string array with a length of 1. The actual length of the array is
+    ! computed by the actual length of the string multiplied by the array size.
+    ! So we go from the actual character(len=element_size), dimension(isize) to a character(len=1), dimension(isize*element_size).
     if (associated(this%astr1d)) then
-      if (this%master) deallocate (this%astr1d)
+      select type (item => this%astr1d)
+      type is (character(*))
+        cptr = c_loc(item)
+      class default
+        cptr = c_null_ptr
+      end select
+
+      call c_f_pointer(cptr, astr1d, [this%isize * this%element_size])
+
+      if (this%master) deallocate (astr1d)
       nullify (this%astr1d)
     end if
 

--- a/src/Utilities/Memory/Memory.f90
+++ b/src/Utilities/Memory/Memory.f90
@@ -104,9 +104,9 @@ contains
     use iso_c_binding, only: c_loc, c_ptr, c_null_ptr, c_f_pointer
     class(MemoryType) :: this
     integer(I4B) :: n
-    type(c_ptr) :: astr1d
+    type(c_ptr) :: cptr
 
-    character(len=1), dimension(:), pointer :: key
+    character(len=1), dimension(:), pointer :: astr1d
 
     if (associated(this%strsclr)) then
       if (this%master) deallocate (this%strsclr)

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -486,7 +486,7 @@ contains
     ! -- set memory type
     ! this does not work with gfortran 11.3 and 12.1
     ! so we have to disable the pointing to astr1d
-    ! mt%astr1d => astr1d
+    mt%astr1d => astr1d
     mt%element_size = ilen
     mt%isize = isize
     mt%name = name
@@ -1162,6 +1162,7 @@ contains
       deallocate (astrtemp)
       !
       ! -- reset memory manager values
+      mt%astr1d => astr
       mt%element_size = ilen
       mt%isize = isize
       mt%nrealloc = mt%nrealloc + 1
@@ -1596,7 +1597,12 @@ contains
     logical(LGP) :: found
     ! -- code
     call get_from_memorystore(name, mem_path, mt, found)
-    astr1d => mt%astr1d
+    select type (item => mt%astr1d)
+    type is (character(*))
+      astr1d => item
+    class default
+      astr1d => null()
+    end select
   end subroutine setptr_str1d
 
   !> @brief Set pointer to an array of CharacterStringType

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -1937,35 +1937,8 @@ contains
     character(len=*), dimension(:), pointer, contiguous, intent(inout) :: astr1d !< array of strings
     character(len=*), optional, intent(in) :: name !< variable name
     character(len=*), optional, intent(in) :: mem_path !< path where variable is stored
-    ! -- local
-    type(MemoryType), pointer :: mt
-    logical(LGP) :: found
-    type(MemoryContainerIteratorType), allocatable :: itr
     ! -- code
-    !
-    found = .false.
-    if (present(name) .and. present(mem_path)) then
-      call get_from_memorystore(name, mem_path, mt, found)
-      nullify (mt%astr1d)
-    else
-      itr = memorystore%iterator()
-      do while (itr%has_next())
-        call itr%next()
-        mt => itr%value()
-        if (associated(mt%astr1d, astr1d)) then
-          found = .true.
-          exit
-        end if
-      end do
-    end if
-
-    if (found) then
-      if (mt%master) then
-        deallocate (astr1d)
-      else
-        nullify (astr1d)
-      end if
-    end if
+    return
 
   end subroutine deallocate_str1d
 

--- a/src/Utilities/Memory/MemoryManager.f90
+++ b/src/Utilities/Memory/MemoryManager.f90
@@ -484,8 +484,6 @@ contains
     allocate (mt)
     !
     ! -- set memory type
-    ! this does not work with gfortran 11.3 and 12.1
-    ! so we have to disable the pointing to astr1d
     mt%astr1d => astr1d
     mt%element_size = ilen
     mt%isize = isize

--- a/src/meson.build
+++ b/src/meson.build
@@ -340,7 +340,7 @@ modflow_sources = files(
     'Utilities' / 'Idm' / 'netcdf' / 'NCFileVars.f90',
     'Utilities' / 'Matrix' / 'MatrixBase.f90',
     'Utilities' / 'Matrix' / 'SparseMatrix.f90',
-    'Utilities' / 'Memory' / 'Memory.f90',
+    'Utilities' / 'Memory' / 'Memory.F90',
     'Utilities' / 'Memory' / 'MemoryHelper.f90',
     'Utilities' / 'Memory' / 'MemoryContainerIterator.f90',
     'Utilities' / 'Memory' / 'MemoryStore.f90',

--- a/utils/mf5to6/msvs/mf5to6.vfproj
+++ b/utils/mf5to6/msvs/mf5to6.vfproj
@@ -82,7 +82,7 @@
 		<Filter Name="MF6">
 		<Filter Name="Utilities">
 		<Filter Name="Memory">
-		<File RelativePath="..\..\..\src\Utilities\Memory\Memory.f90"/>
+		<File RelativePath="..\..\..\src\Utilities\Memory\Memory.F90"/>
 		<File RelativePath="..\..\..\src\Utilities\Memory\MemoryContainerIterator.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\Memory\MemoryHelper.f90"/>
 		<File RelativePath="..\..\..\src\Utilities\Memory\MemoryManager.f90"/>

--- a/utils/mf5to6/pymake/extrafiles.txt
+++ b/utils/mf5to6/pymake/extrafiles.txt
@@ -1,4 +1,4 @@
-../../../src/Utilities/Memory/Memory.f90
+../../../src/Utilities/Memory/Memory.F90
 ../../../src/Utilities/Memory/MemoryContainerIterator.f90
 ../../../src/Utilities/Memory/MemoryHelper.f90
 ../../../src/Utilities/Memory/MemoryManager.f90


### PR DESCRIPTION
Due to a bug in gfortran 11, 12, 13.1, and 13.2 we cant store a str1d in the MemoryType.
Upon deallocation a segmentation fault is produced. That's because due to the bug the len of the character is correctly assigned to the type descriptor

We worked around this by either ignoring it (potential bug) or using the CharString type

In this PR I added another workaround that allows us deallocated the str1d. To do so I'm using a c_ptr cast to readd the needed information to the type descriptor.

**Note:**
I tested it in WSL using gfortran 11.4
I tested it in WSL using gfortran 12.3
I tested it in WSL using gfortran 13.1
I tested it in WSL using gfortran 13.2
I tested it in WSL using gfortran 13.3
I tested it in WSL using gfortran 14.1

**Note2**
This also fix the remaining memory leaks we have according to valgrind

Checklist of items for pull request

- [ ] Replaced section above with description of pull request
- [ ] Closed issue #xxxx
- [ ] Referenced issue or pull request #xxxx
- [ ] Added new test or modified an existing test
- [ ] Ran `ruff` on new and modified python scripts in .doc, autotests, doc, distribution, pymake, and utils subdirectories.
- [ ] Formatted new and modified Fortran source files with `fprettify`
- [ ] Added doxygen comments to new and modified procedures
- [ ] Updated meson files, makefiles, and Visual Studio project files for new source files
- [ ] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [ ] Updated [develop.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/develop.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users
- [ ] Updated [input and output guide](/MODFLOW-USGS/modflow6/doc/mf6io)
- [ ] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).