### PR TITLE
refactor(get-wetted-station): simplify and speed up calculation

### DIFF
--- a/src/Idm/olf-flwidm.f90
+++ b/src/Idm/olf-flwidm.f90
@@ -320,7 +320,7 @@ module OlfFlwInputModule
     'Q', & ! fortran variable
     'DOUBLE', & ! type
     '', & ! shape
-    'well rate', & ! longname
+    'flow rate', & ! longname
     .true., & ! required
     .true., & ! multi-record
     .false., & ! preserve case

--- a/src/Model/ModelUtilities/SfrCrossSectionUtils.f90
+++ b/src/Model/ModelUtilities/SfrCrossSectionUtils.f90
@@ -529,10 +529,7 @@ contains
     real(DP) :: xlen
     real(DP) :: dlen
     real(DP) :: slope
-    real(DP) :: dx
     real(DP) :: xt
-    real(DP) :: xt0
-    real(DP) :: xt1
     !
     ! -- calculate the minimum and maximum depth
     dmin = min(d0, d1)
@@ -544,27 +541,24 @@ contains
       x1 = x0
       ! -- if d is between dmin and dmax station length is less
       !    than d1 - d0
-    else if (d < dmax) then
+    else if (d >= dmax) then
+      ! x0 and x1 unchanged (full wetted width)
+      continue
+    else
       xlen = x1 - x0
       dlen = d1 - d0
-      if (abs(dlen) > DZERO) then
-        slope = xlen / dlen
-      else
-        slope = DZERO
-      end if
+      ! because of preceding checks
+      ! we know dmin<d<dmax, dmax>dmin, dlen > 0
+      ! no need to check for dlen == 0
+      slope = xlen / dlen
+      xt = x0 + slope * (d - d0)
       if (d0 > d1) then
-        dx = (d - d1) * slope
-        xt = x1 + dx
-        xt0 = xt
-        xt1 = x1
+        ! x1 unchanged
+        x0 = xt
       else
-        dx = (d - d0) * slope
-        xt = x0 + dx
-        xt0 = x0
-        xt1 = xt
+        !x0 unchanged
+        x1 = xt
       end if
-      x0 = xt0
-      x1 = xt1
     end if
   end subroutine get_wetted_station
 

--- a/src/Model/ModelUtilities/SfrCrossSectionUtils.f90
+++ b/src/Model/ModelUtilities/SfrCrossSectionUtils.f90
@@ -535,16 +535,17 @@ contains
     dmin = min(d0, d1)
     dmax = max(d0, d1)
     !
-    ! -- if d is less than or equal to the minimum value the
-    !    station length (xlen) is zero
+    ! -- calculate x0 and x1
     if (d <= dmin) then
+      ! -- if d is less than or equal to the minimum value the
+      !    station length (xlen) is zero
       x1 = x0
-      ! -- if d is between dmin and dmax station length is less
-      !    than d1 - d0
     else if (d >= dmax) then
       ! x0 and x1 unchanged (full wetted width)
       continue
     else
+      ! -- if d is between dmin and dmax, station length is less
+      !    than d1 - d0
       xlen = x1 - x0
       dlen = d1 - d0
       ! because of preceding checks

--- a/src/Model/ModelUtilities/SwfCxsUtils.f90
+++ b/src/Model/ModelUtilities/SwfCxsUtils.f90
@@ -1049,16 +1049,17 @@ contains
     dmin = min(d0, d1)
     dmax = max(d0, d1)
     !
-    ! -- if d is less than or equal to the minimum value the
-    !    station length (xlen) is zero
+    ! -- calculate x0 and x1
     if (d <= dmin) then
+      ! -- if d is less than or equal to the minimum value the
+      !    station length (xlen) is zero
       x1 = x0
-      ! -- if d is between dmin and dmax station length is less
-      !    than d1 - d0
     else if (d >= dmax) then
       ! x0 and x1 unchanged (full wetted width)
       continue
     else
+      ! -- if d is between dmin and dmax, station length is less
+      !    than d1 - d0
       xlen = x1 - x0
       dlen = d1 - d0
       ! because of preceding checks

--- a/src/Model/ModelUtilities/SwfCxsUtils.f90
+++ b/src/Model/ModelUtilities/SwfCxsUtils.f90
@@ -1043,10 +1043,7 @@ contains
     real(DP) :: xlen
     real(DP) :: dlen
     real(DP) :: slope
-    real(DP) :: dx
     real(DP) :: xt
-    real(DP) :: xt0
-    real(DP) :: xt1
     !
     ! -- calculate the minimum and maximum depth
     dmin = min(d0, d1)
@@ -1058,27 +1055,24 @@ contains
       x1 = x0
       ! -- if d is between dmin and dmax station length is less
       !    than d1 - d0
-    else if (d < dmax) then
+    else if (d >= dmax) then
+      ! x0 and x1 unchanged (full wetted width)
+      continue
+    else
       xlen = x1 - x0
       dlen = d1 - d0
-      if (abs(dlen) > DZERO) then
-        slope = xlen / dlen
-      else
-        slope = DZERO
-      end if
+      ! because of preceding checks
+      ! we know dmin<d<dmax, dmax>dmin, dlen > 0
+      ! no need to check for dlen == 0
+      slope = xlen / dlen
+      xt = x0 + slope * (d - d0)
       if (d0 > d1) then
-        dx = (d - d1) * slope
-        xt = x1 + dx
-        xt0 = xt
-        xt1 = x1
+        ! x1 unchanged
+        x0 = xt
       else
-        dx = (d - d0) * slope
-        xt = x0 + dx
-        xt0 = x0
-        xt1 = xt
+        !x0 unchanged
+        x1 = xt
       end if
-      x0 = xt0
-      x1 = xt1
     end if
   end subroutine get_wetted_station
 


### PR DESCRIPTION
The routine for calculating the wetted station length was simplified based on a suggestion by @aprovost-usgs.  The resulting subroutine is shorter and likely slightly faster and will produce the same results.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Formatted new and modified Fortran source files with `fprettify`
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).