### PR TITLE
refactor(makefiles): regenerate makefiles with updated pymake

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: modflow6
 
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 
 dependencies:
   - python>=3.9

--- a/make/makedefaults
+++ b/make/makedefaults
@@ -1,4 +1,4 @@
-# makedefaults created by pymake (version 1.2.10) for the 'mf6' executable.
+# makedefaults created by pymake for the 'mf6' executable.
 
 # determine OS
 ifeq ($(OS), Windows_NT)

--- a/make/makefile
+++ b/make/makefile
@@ -1,51 +1,51 @@
-# makefile created by pymake (version 1.4.0.dev0) for the 'mf6' executable.
+# makefile created by pymake for the 'mf6' executable.
 
 
 include ./makedefaults
 
 # Define the source file directories
 SOURCEDIR1=../src
-SOURCEDIR2=../src/Idm
-SOURCEDIR3=../src/Idm/selector
-SOURCEDIR4=../src/Exchange
-SOURCEDIR5=../src/Distributed
-SOURCEDIR6=../src/Solution
-SOURCEDIR7=../src/Solution/LinearMethods
-SOURCEDIR8=../src/Solution/ParticleTracker
-SOURCEDIR9=../src/Solution/PETSc
-SOURCEDIR10=../src/Timing
-SOURCEDIR11=../src/Utilities
-SOURCEDIR12=../src/Utilities/Idm
-SOURCEDIR13=../src/Utilities/Idm/mf6blockfile
-SOURCEDIR14=../src/Utilities/Idm/netcdf
-SOURCEDIR15=../src/Utilities/TimeSeries
-SOURCEDIR16=../src/Utilities/Memory
-SOURCEDIR17=../src/Utilities/OutputControl
-SOURCEDIR18=../src/Utilities/ArrayRead
-SOURCEDIR19=../src/Utilities/Libraries
-SOURCEDIR20=../src/Utilities/Libraries/rcm
-SOURCEDIR21=../src/Utilities/Libraries/blas
-SOURCEDIR22=../src/Utilities/Libraries/sparskit2
-SOURCEDIR23=../src/Utilities/Libraries/daglib
-SOURCEDIR24=../src/Utilities/Libraries/sparsekit
-SOURCEDIR25=../src/Utilities/Export
-SOURCEDIR26=../src/Utilities/Vector
-SOURCEDIR27=../src/Utilities/Matrix
-SOURCEDIR28=../src/Utilities/Observation
-SOURCEDIR29=../src/Model
-SOURCEDIR30=../src/Model/Connection
-SOURCEDIR31=../src/Model/ChannelFlow
-SOURCEDIR32=../src/Model/OverlandFlow
-SOURCEDIR33=../src/Model/ParticleTracking
-SOURCEDIR34=../src/Model/SurfaceWaterFlow
-SOURCEDIR35=../src/Model/GroundWaterTransport
-SOURCEDIR36=../src/Model/ModelUtilities
-SOURCEDIR37=../src/Model/GroundWaterFlow
-SOURCEDIR38=../src/Model/GroundWaterFlow/submodules
-SOURCEDIR39=../src/Model/Discretization
-SOURCEDIR40=../src/Model/TransportModel
-SOURCEDIR41=../src/Model/Geometry
-SOURCEDIR42=../src/Model/GroundWaterEnergy
+SOURCEDIR2=../src/Distributed
+SOURCEDIR3=../src/Exchange
+SOURCEDIR4=../src/Idm
+SOURCEDIR5=../src/Idm/selector
+SOURCEDIR6=../src/Model
+SOURCEDIR7=../src/Model/ChannelFlow
+SOURCEDIR8=../src/Model/Connection
+SOURCEDIR9=../src/Model/Discretization
+SOURCEDIR10=../src/Model/Geometry
+SOURCEDIR11=../src/Model/GroundWaterEnergy
+SOURCEDIR12=../src/Model/GroundWaterFlow
+SOURCEDIR13=../src/Model/GroundWaterFlow/submodules
+SOURCEDIR14=../src/Model/GroundWaterTransport
+SOURCEDIR15=../src/Model/ModelUtilities
+SOURCEDIR16=../src/Model/OverlandFlow
+SOURCEDIR17=../src/Model/ParticleTracking
+SOURCEDIR18=../src/Model/SurfaceWaterFlow
+SOURCEDIR19=../src/Model/TransportModel
+SOURCEDIR20=../src/Solution
+SOURCEDIR21=../src/Solution/LinearMethods
+SOURCEDIR22=../src/Solution/PETSc
+SOURCEDIR23=../src/Solution/ParticleTracker
+SOURCEDIR24=../src/Timing
+SOURCEDIR25=../src/Utilities
+SOURCEDIR26=../src/Utilities/ArrayRead
+SOURCEDIR27=../src/Utilities/Export
+SOURCEDIR28=../src/Utilities/Idm
+SOURCEDIR29=../src/Utilities/Idm/mf6blockfile
+SOURCEDIR30=../src/Utilities/Idm/netcdf
+SOURCEDIR31=../src/Utilities/Libraries
+SOURCEDIR32=../src/Utilities/Libraries/blas
+SOURCEDIR33=../src/Utilities/Libraries/daglib
+SOURCEDIR34=../src/Utilities/Libraries/rcm
+SOURCEDIR35=../src/Utilities/Libraries/sparsekit
+SOURCEDIR36=../src/Utilities/Libraries/sparskit2
+SOURCEDIR37=../src/Utilities/Matrix
+SOURCEDIR38=../src/Utilities/Memory
+SOURCEDIR39=../src/Utilities/Observation
+SOURCEDIR40=../src/Utilities/OutputControl
+SOURCEDIR41=../src/Utilities/TimeSeries
+SOURCEDIR42=../src/Utilities/Vector
 
 VPATH = \
 ${SOURCEDIR1} \

--- a/utils/mf5to6/make/makedefaults
+++ b/utils/mf5to6/make/makedefaults
@@ -1,4 +1,4 @@
-# makedefaults created by pymake (version 1.2.10) for the 'mf5to6' executable.
+# makedefaults created by pymake for the 'mf5to6' executable.
 
 # determine OS
 ifeq ($(OS), Windows_NT)

--- a/utils/mf5to6/make/makefile
+++ b/utils/mf5to6/make/makefile
@@ -1,14 +1,14 @@
-# makefile created by pymake (version 1.4.0.dev0) for the 'mf5to6' executable.
+# makefile created by pymake for the 'mf5to6' executable.
 
 
 include ./makedefaults
 
 # Define the source file directories
 SOURCEDIR1=../src
-SOURCEDIR2=../src/NWT
-SOURCEDIR3=../src/LGR
-SOURCEDIR4=../src/Preproc
-SOURCEDIR5=../src/MF2005
+SOURCEDIR2=../src/LGR
+SOURCEDIR3=../src/MF2005
+SOURCEDIR4=../src/NWT
+SOURCEDIR5=../src/Preproc
 SOURCEDIR6=../../../src/Utilities/Memory
 SOURCEDIR7=../../../src/Utilities/TimeSeries
 SOURCEDIR8=../../../src/Utilities

--- a/utils/zonebudget/make/makedefaults
+++ b/utils/zonebudget/make/makedefaults
@@ -1,4 +1,4 @@
-# makedefaults created by pymake (version 1.2.10) for the 'zbud6' executable.
+# makedefaults created by pymake for the 'zbud6' executable.
 
 # determine OS
 ifeq ($(OS), Windows_NT)

--- a/utils/zonebudget/make/makefile
+++ b/utils/zonebudget/make/makefile
@@ -1,4 +1,4 @@
-# makefile created by pymake (version 1.4.0.dev0) for the 'zbud6' executable.
+# makefile created by pymake for the 'zbud6' executable.
 
 
 include ./makedefaults


### PR DESCRIPTION
pymake has been updated to reduce unimportant changes. Regenerate makefiles with updated pymake. Also removed defaults channel from `environment.yml` by specifying `nodefaults`.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Updated meson files, makefiles, and Visual Studio project files for new source files
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).