### PR TITLE
doc(v6.6.0.tex): Mention the new VSC and ATES examples included with Ver 6.6.0

### DIFF
--- a/doc/ReleaseNotes/previous/v6.6.0.tex
+++ b/doc/ReleaseNotes/previous/v6.6.0.tex
@@ -17,6 +17,8 @@
     \item A new Toth example was added to show how the classic groundwater problem consisting of local, intermediate, and regional flow paths can be simulated with MODFLOW.
     \item A new Streamflow Routing (SFR) Package example based on the Pinder-Sauer problem \citep{pinder1971numerical} modified by \cite{lal2001modification} was added to demonstrate the capabilities of the kinematic-wave approximation option.
     \item A new Barends example was added to demonstrate the use of the Groundwater Energy (GWE) Model for simulating heat transport in a groundwater reservoir overlain by a low-permeability overburden.
+    \item A new example demonstrating application of the Viscosity (VSC) Package was added.  The example demonstrates differences that may arise in the solute transport solution with and without accounting for the effects of viscosity.
+    \item Another new example for demonstrating GWE capabilities, titled ``Aquifer Thermal Energy Storage'' (ATES) shows thermal energy being added and removed from the middle layer of a three layer system.  Thermal bleeding into the over- and underlying layers is visually depicted.  
 %	\item xxx
 \end{itemize}
 


### PR DESCRIPTION
The aquifer thermal energy storage (ATES) and viscosity (VSC) examples were released in version 6.6.0, but were not mentioned in the release notes.  Retroactively adding them to the version 6.6.0 release notes.  

- [x] Replaced section above with description of pull request
- [x] Related to pull request [#206](https://github.com/MODFLOW-USGS/modflow6-examples/pull/206) and [#209](https://github.com/MODFLOW-USGS/modflow6-examples/pull/209)
- [x] Updated [v6.6.0.tex](/MODFLOW-USGS/modflow6/doc/ReleaseNotes/previous/v6.6.0.tex) with a plain-language description of the bug fix, change, feature; required for changes that may affect users