### PR TITLE
docs(ist): indicate sorption in IST and MST must be same

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/gwt-ist.dfn
+++ b/doc/mf6io/mf6ivar/dfn/gwt-ist.dfn
@@ -92,7 +92,7 @@ valid linear freundlich langmuir
 reader urword
 optional true
 longname activate sorption
-description is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.
+description is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.  The sorption option must be consistent with the sorption option specified in the MST Package or the program will terminate with an error.
 
 block options
 name first_order_decay

--- a/src/Model/GroundWaterTransport/gwt-ist.f90
+++ b/src/Model/GroundWaterTransport/gwt-ist.f90
@@ -201,11 +201,11 @@ contains
         &Packages.')
     end if
     if (this%isrb /= this%mst%isrb) then
-      call store_error('Sorption is active for the IST Package but it is not &
-        &compatible with the sorption option selected for the MST Package.  &
-        &If sorption is active for the IST Package, then the same type of &
-        &sorption (LINEAR, FREUNDLICH, or LANGMUIR) must &
-        &be specified in the options block of the MST Package.')
+      call store_error('SORPTION must be activated consistently between the &
+        &MST and IST Packages.  Activate or deactivate SORPTION for both &
+        &Packages.  If activated, the same type of sorption (LINEAR, &
+        &FREUNDLICH, or LANGMUIR) must be specified in the options block of &
+        &both the MST and IST Packages.')
     end if
     if (count_errors() > 0) then
       call this%parser%StoreErrorUnit()


### PR DESCRIPTION
Indicate sorption option must be same in GWT-MST and GWT-IST Packages.

Checklist of items for pull request

- [x] Replaced section above with description of pull request
- [x] Updated [definition files](/MODFLOW-USGS/modflow6/tree/develop/doc/mf6io/mf6ivar)
- [x] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).