### PR TITLE
fix(utl-hpc.dfn): fix flopy subpackage metadata

### DIFF
--- a/doc/mf6io/mf6ivar/dfn/utl-hpc.dfn
+++ b/doc/mf6io/mf6ivar/dfn/utl-hpc.dfn
@@ -1,5 +1,5 @@
 # --------------------- sim hpc options ---------------------
-# flopy subpackage hpc_filerecord hpc hpc_data hpc
+# flopy subpackage hpc_filerecord hpc hpc_data hpc_data
 # flopy parent_name_type parent_package MFSimulation
 
 block options


### PR DESCRIPTION
I think the final term here should be `hpc_data`, to follow the convention used for other subpackages and produce the generated files as they currently appear in flopy &mdash; at least assuming the same code is to handle all subpackages. Seems like there is inconsistent handling currently, depending whether they are attached to simulation or to a model or package. Which we will need to dig out unless https://github.com/modflowpy/flopy/pull/2333 merges first.