### PR TITLE
ci: fix compiler compatibility workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,11 +259,8 @@ jobs:
       - name: Set LDFLAGS (macOS)
         if: runner.os == 'macOS'
         run: |
-          os_ver=$(sw_vers -productVersion | cut -d'.' -f1)
-          if (( "$os_ver" > 12 )); then
-            ldflags="$LDFLAGS -Wl,-ld_classic"
-            echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
-          fi
+          ldflags="$LDFLAGS -Wl,-ld_classic"
+          echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Build MF6
         working-directory: modflow6

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -29,7 +29,6 @@ jobs:
           - {os: windows-2022, compiler: gcc, version: 11}
           - {os: windows-2022, compiler: gcc, version: 12}
           - {os: windows-2022, compiler: gcc, version: 13}
-          - {os: windows-2022, compiler: gcc, version: 14}
           # ifx
           - {os: ubuntu-22.04, compiler: intel, version: 2025.0}
           - {os: ubuntu-22.04, compiler: intel, version: 2024.1}

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -18,15 +18,18 @@ jobs:
           - {os: ubuntu-22.04, compiler: gcc, version: 11}
           - {os: ubuntu-22.04, compiler: gcc, version: 12}
           - {os: ubuntu-22.04, compiler: gcc, version: 13}
+          - {os: ubuntu-22.04, compiler: gcc, version: 14}
           - {os: macos-13, compiler: gcc, version: 11}
           - {os: macos-13, compiler: gcc, version: 12}
           - {os: macos-13, compiler: gcc, version: 13}
           - {os: macos-14, compiler: gcc, version: 11}
           - {os: macos-14, compiler: gcc, version: 12}
           - {os: macos-14, compiler: gcc, version: 13}
+          - {os: macos-14, compiler: gcc, version: 14}
           - {os: windows-2022, compiler: gcc, version: 11}
           - {os: windows-2022, compiler: gcc, version: 12}
           - {os: windows-2022, compiler: gcc, version: 13}
+          - {os: windows-2022, compiler: gcc, version: 14}
           # ifx
           - {os: ubuntu-22.04, compiler: intel, version: 2025.0}
           - {os: ubuntu-22.04, compiler: intel, version: 2024.1}
@@ -105,6 +108,12 @@ jobs:
       - name: Custom pixi install
         working-directory: modflow6
         run: pixi run install
+
+      - name: Set LDFLAGS (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          ldflags="$LDFLAGS -Wl,-ld_classic"
+          echo "LDFLAGS=$ldflags" >> $GITHUB_ENV
 
       - name: Build modflow6
         working-directory: modflow6


### PR DESCRIPTION
Use LDFLAGS workaround to select classic linker on macOS. Also add gcc14 to test matrix.