### PR TITLE
fix(netcdf): add all models to model inputs list

### DIFF
--- a/src/Utilities/Export/ModelExport.f90
+++ b/src/Utilities/Export/ModelExport.f90
@@ -74,7 +74,7 @@ contains
   !> @brief create export container variable for all local models
   !!
   subroutine modelexports_create(iout)
-    use InputLoadTypeModule, only: input_models
+    use InputLoadTypeModule, only: model_inputs
     use MemoryManagerModule, only: mem_setptr
     use MemoryManagerExtModule, only: mem_set_value
     use MemoryHelperModule, only: create_mem_path
@@ -83,31 +83,31 @@ contains
     use NCModelExportModule, only: NETCDF_MESH2D, NETCDF_STRUCTURED
     use SourceCommonModule, only: file_ext
     integer(I4B), intent(in) :: iout
-    type(ModelDynamicPkgsType), pointer :: input_model
+    type(ModelDynamicPkgsType), pointer :: model_input
     type(ExportModelType), pointer :: export_model
     character(len=LENMEMPATH) :: modelnam_mempath, model_mempath, ext
     integer(I4B), pointer :: disenum
     integer(I4B) :: n
     logical(LGP) :: found
 
-    do n = 1, input_models%Count()
+    do n = 1, model_inputs%Count()
       ! allocate and initialize
       allocate (export_model)
 
       ! set pointer to dynamic input model instance
-      input_model => GetDynamicModelFromList(input_models, n)
+      model_input => GetDynamicModelFromList(model_inputs, n)
 
       ! set input mempaths
       modelnam_mempath = &
-        create_mem_path(component=input_model%modelname, &
+        create_mem_path(component=model_input%modelname, &
                         subcomponent='NAM', context=idm_context)
-      model_mempath = create_mem_path(component=input_model%modelname, &
+      model_mempath = create_mem_path(component=model_input%modelname, &
                                       context=idm_context)
       ! set pointer to dis enum type
       call mem_setptr(disenum, 'DISENUM', model_mempath)
 
       ! initialize model
-      call export_model%init(input_model, disenum, iout)
+      call export_model%init(model_input, disenum, iout)
 
       ! update NetCDF fileout name if provided
       call mem_set_value(export_model%nc_fname, 'NCMESH2DFILE', &

--- a/src/Utilities/Export/ModelExport.f90
+++ b/src/Utilities/Export/ModelExport.f90
@@ -74,7 +74,7 @@ contains
   !> @brief create export container variable for all local models
   !!
   subroutine modelexports_create(iout)
-    use InputLoadTypeModule, only: model_dynamic_pkgs
+    use InputLoadTypeModule, only: input_models
     use MemoryManagerModule, only: mem_setptr
     use MemoryManagerExtModule, only: mem_set_value
     use MemoryHelperModule, only: create_mem_path
@@ -83,31 +83,31 @@ contains
     use NCModelExportModule, only: NETCDF_MESH2D, NETCDF_STRUCTURED
     use SourceCommonModule, only: file_ext
     integer(I4B), intent(in) :: iout
-    type(ModelDynamicPkgsType), pointer :: model_dynamic_input
+    type(ModelDynamicPkgsType), pointer :: input_model
     type(ExportModelType), pointer :: export_model
     character(len=LENMEMPATH) :: modelnam_mempath, model_mempath, ext
     integer(I4B), pointer :: disenum
     integer(I4B) :: n
     logical(LGP) :: found
 
-    do n = 1, model_dynamic_pkgs%Count()
+    do n = 1, input_models%Count()
       ! allocate and initialize
       allocate (export_model)
 
       ! set pointer to dynamic input model instance
-      model_dynamic_input => GetDynamicModelFromList(model_dynamic_pkgs, n)
+      input_model => GetDynamicModelFromList(input_models, n)
 
       ! set input mempaths
       modelnam_mempath = &
-        create_mem_path(component=model_dynamic_input%modelname, &
+        create_mem_path(component=input_model%modelname, &
                         subcomponent='NAM', context=idm_context)
-      model_mempath = create_mem_path(component=model_dynamic_input%modelname, &
+      model_mempath = create_mem_path(component=input_model%modelname, &
                                       context=idm_context)
       ! set pointer to dis enum type
       call mem_setptr(disenum, 'DISENUM', model_mempath)
 
       ! initialize model
-      call export_model%init(model_dynamic_input, disenum, iout)
+      call export_model%init(input_model, disenum, iout)
 
       ! update NetCDF fileout name if provided
       call mem_set_value(export_model%nc_fname, 'NCMESH2DFILE', &

--- a/src/Utilities/Idm/IdmLoad.f90
+++ b/src/Utilities/Idm/IdmLoad.f90
@@ -15,7 +15,7 @@ module IdmLoadModule
   use InputLoadTypeModule, only: StaticPkgLoadBaseType, &
                                  DynamicPkgLoadBaseType, &
                                  ModelDynamicPkgsType, &
-                                 input_models
+                                 model_inputs
   use InputDefinitionModule, only: InputParamDefinitionType
   use ModflowInputModule, only: ModflowInputType, getModflowInput
 
@@ -38,8 +38,8 @@ contains
     use InputLoadTypeModule, only: GetDynamicModelFromList
     class(ModelDynamicPkgsType), pointer :: model_dynamic_input
     integer(I4B) :: n
-    do n = 1, input_models%Count()
-      model_dynamic_input => GetDynamicModelFromList(input_models, n)
+    do n = 1, model_inputs%Count()
+      model_dynamic_input => GetDynamicModelFromList(model_inputs, n)
       call model_dynamic_input%df()
     end do
   end subroutine idm_df
@@ -50,8 +50,8 @@ contains
     use InputLoadTypeModule, only: GetDynamicModelFromList
     class(ModelDynamicPkgsType), pointer :: model_dynamic_input
     integer(I4B) :: n
-    do n = 1, input_models%Count()
-      model_dynamic_input => GetDynamicModelFromList(input_models, n)
+    do n = 1, model_inputs%Count()
+      model_dynamic_input => GetDynamicModelFromList(model_inputs, n)
       call model_dynamic_input%rp()
     end do
   end subroutine idm_rp
@@ -62,8 +62,8 @@ contains
     use InputLoadTypeModule, only: GetDynamicModelFromList
     class(ModelDynamicPkgsType), pointer :: model_dynamic_input
     integer(I4B) :: n
-    do n = 1, input_models%Count()
-      model_dynamic_input => GetDynamicModelFromList(input_models, n)
+    do n = 1, model_inputs%Count()
+      model_dynamic_input => GetDynamicModelFromList(model_inputs, n)
       call model_dynamic_input%ad()
     end do
   end subroutine idm_ad
@@ -478,8 +478,8 @@ contains
     nullify (model_dynamic_input)
 
     ! assign model loader object if found
-    do id = 1, input_models%Count()
-      temp => GetDynamicModelFromList(input_models, id)
+    do id = 1, model_inputs%Count()
+      temp => GetDynamicModelFromList(model_inputs, id)
       if (temp%modelname == modelname) then
         model_dynamic_input => temp
         exit
@@ -491,7 +491,7 @@ contains
       allocate (model_dynamic_input)
       call model_dynamic_input%init(modeltype, modelname, modelfname, &
                                     nc_fname, ncid, iout)
-      call AddDynamicModelToList(input_models, model_dynamic_input)
+      call AddDynamicModelToList(model_inputs, model_dynamic_input)
     end if
   end function dynamic_models
 
@@ -503,14 +503,14 @@ contains
     integer(I4B), intent(in) :: iout
     class(ModelDynamicPkgsType), pointer :: model_dynamic_input
     integer(I4B) :: n
-    do n = 1, input_models%Count()
-      model_dynamic_input => GetDynamicModelFromList(input_models, n)
+    do n = 1, model_inputs%Count()
+      model_dynamic_input => GetDynamicModelFromList(model_inputs, n)
       call nc_close(model_dynamic_input%ncid, model_dynamic_input%nc_fname)
       call model_dynamic_input%destroy()
       deallocate (model_dynamic_input)
       nullify (model_dynamic_input)
     end do
-    call input_models%Clear()
+    call model_inputs%Clear()
   end subroutine dynamic_da
 
   !> @brief return sim input context PRINT_INPUT value

--- a/src/Utilities/Idm/InputLoadType.f90
+++ b/src/Utilities/Idm/InputLoadType.f90
@@ -23,7 +23,7 @@ module InputLoadTypeModule
   public :: ModelDynamicPkgsType
   public :: AddDynamicModelToList, GetDynamicModelFromList
   public :: StaticPkgLoadType, DynamicPkgLoadType
-  public :: input_models
+  public :: model_inputs
 
   !> @brief type representing package subpackage list
   type :: SubPackageListType
@@ -143,7 +143,7 @@ module InputLoadTypeModule
     procedure :: destroy => dynamicpkgs_destroy
   end type ModelDynamicPkgsType
 
-  type(ListType) :: input_models
+  type(ListType) :: model_inputs
 
 contains
 

--- a/src/Utilities/Idm/InputLoadType.f90
+++ b/src/Utilities/Idm/InputLoadType.f90
@@ -23,7 +23,7 @@ module InputLoadTypeModule
   public :: ModelDynamicPkgsType
   public :: AddDynamicModelToList, GetDynamicModelFromList
   public :: StaticPkgLoadType, DynamicPkgLoadType
-  public :: model_dynamic_pkgs
+  public :: input_models
 
   !> @brief type representing package subpackage list
   type :: SubPackageListType
@@ -143,7 +143,7 @@ module InputLoadTypeModule
     procedure :: destroy => dynamicpkgs_destroy
   end type ModelDynamicPkgsType
 
-  type(ListType) :: model_dynamic_pkgs
+  type(ListType) :: input_models
 
 contains
 


### PR DESCRIPTION
Idm maintains a model inputs list so stress period data can be loaded at the right time.  To this point, input models have been added to the list only if it contains packages with dynamic data.  The NetCDF export capability uses this model list as well but in this case all input models are relevant so a NetCDF output file can be created whether or not the model has dynamic data.

Checklist of items for pull request

- [X] Replaced section above with description of pull request
- [X] Formatted new and modified Fortran source files with `fprettify`
- [X] Removed checklist items not relevant to this pull request

For additional information see [instructions for contributing](/MODFLOW-USGS/modflow6/.github/CONTRIBUTING.md) and [instructions for developing](/MODFLOW-USGS/modflow6/.github/DEVELOPER.md).